### PR TITLE
feat: audit findings verification step before issue creation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3089,3 +3089,78 @@ body::after {
   text-transform: none;
 }
 .audit-refresh-btn { padding: var(--sp-1) var(--sp-2); min-height: 28px; }
+
+/* ── Audit verification ── */
+.apc-verify-summary {
+  display: flex;
+  gap: var(--sp-3);
+  align-items: center;
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--text-xs);
+  background: var(--color-surface-subtle, rgba(0,0,0,0.03));
+  border-radius: 4px;
+  margin-top: var(--sp-2);
+}
+.apc-verify-label { color: var(--color-text-muted); font-weight: 600; }
+.apc-verify-stat { font-weight: 600; }
+
+.verify-summary {
+  display: flex;
+  gap: var(--sp-4);
+  padding: var(--sp-3);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--sp-3);
+}
+.verify-summary-item { flex: 1; text-align: center; }
+.verify-summary-count { font-size: var(--text-2xl); font-weight: 700; line-height: 1; }
+.verify-summary-label {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin-top: var(--sp-1);
+}
+
+.verify-tabs {
+  display: flex;
+  gap: var(--sp-1);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--sp-3);
+}
+.verify-tab {
+  padding: var(--sp-2) var(--sp-3);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+}
+.verify-tab--active { color: var(--color-text); }
+
+.verify-results {
+  max-height: 400px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+.verify-result {
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--color-surface-subtle, rgba(0,0,0,0.03));
+  border-radius: 4px;
+  font-size: var(--text-sm);
+}
+.verify-result summary { cursor: pointer; }
+.verify-result summary code { font-weight: 600; }
+.verify-result-reason { color: var(--color-text-muted); }
+.verify-result-code {
+  margin-top: var(--sp-2);
+  padding: var(--sp-2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-size: var(--text-xs);
+  overflow-x: auto;
+  white-space: pre;
+}

--- a/src/components/AuditIssuesDialog.tsx
+++ b/src/components/AuditIssuesDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import type { AuditProjectStatus, GeneratedIssue } from "../types";
-import { fetchAuditFindings } from "../utils/auditor";
+import type { AuditProjectStatus, AuditFinding, GeneratedIssue, Verdict } from "../types";
+import { fetchAuditFindings, fetchAuditVerification } from "../utils/auditor";
 import { generateIssuesFromFindings } from "../utils/claude";
 import { createIssue, addIssueToProject } from "../utils/github-actions";
 import { getToken, getClaudeKey, GITHUB_OWNER, GITHUB_PROJECT_NUMBER } from "../utils/config";
@@ -52,13 +52,33 @@ export function AuditIssuesDialog({ project, onClose, onComplete }: Props) {
         const findings = await fetchAuditFindings(project.name);
         if (cancelled) return;
 
+        // Load verification and filter out FALSE_POSITIVE findings
+        let filteredFindings: AuditFinding[] = findings.findings;
+        const verdictByFinding = new Map<AuditFinding, Verdict>();
+        try {
+          const verification = await fetchAuditVerification(project.name);
+          if (cancelled) return;
+          const verdictByIdx = new Map(verification.results.map((r) => [r.finding_index, r.verdict]));
+          filteredFindings = findings.findings.filter((_, idx) => {
+            const verdict = verdictByIdx.get(idx);
+            return verdict !== "FALSE_POSITIVE";
+          });
+          for (let i = 0; i < findings.findings.length; i++) {
+            const v = verdictByIdx.get(i);
+            if (v) verdictByFinding.set(findings.findings[i], v);
+          }
+        } catch {
+          // No verification available — proceed with all findings (backward compat)
+        }
+
         const generated = await generateIssuesFromFindings(
-          findings.findings,
+          filteredFindings,
           repoName,
           claudeKey,
           (current, total, label) => {
             if (!cancelled) setGenProgress({ current, total, label });
           },
+          verdictByFinding,
         );
         if (cancelled) return;
 

--- a/src/components/AuditProjectCard.tsx
+++ b/src/components/AuditProjectCard.tsx
@@ -6,13 +6,16 @@ interface Props {
   auditIssueProgress?: { total: number; closed: number };
   onRun?: () => void;
   onCancel?: () => void;
+  onVerify?: () => void;
   onCreateIssues?: () => void;
 }
 
-export function AuditProjectCard({ project, status, auditIssueProgress, onRun, onCancel, onCreateIssues }: Props) {
+export function AuditProjectCard({ project, status, auditIssueProgress, onRun, onCancel, onVerify, onCreateIssues }: Props) {
   const isRunning = status?.state === "running";
   const isFailed = status?.state === "failed";
   const hasRun = Boolean(project.last_run);
+  const verification = project.last_run?.verification ?? null;
+  const isVerified = verification !== null;
   const repoName = project.repo.split('/')[1] || project.name;
   const repoOwner = project.repo.split('/')[0] || "Unknown";
 
@@ -150,6 +153,22 @@ export function AuditProjectCard({ project, status, auditIssueProgress, onRun, o
         </>
       )}
 
+      {/* Verification summary strip (only when verified) */}
+      {!isRunning && hasRun && isVerified && verification && (
+        <div className="pc-slot apc-verify-summary">
+          <span className="apc-verify-label">Верифицировано:</span>
+          <span className="apc-verify-stat" style={{ color: "var(--color-danger)" }}>
+            ✓ {verification.confirmed}
+          </span>
+          <span className="apc-verify-stat" style={{ color: "var(--color-success)" }}>
+            ✗ {verification.false_positive}
+          </span>
+          <span className="apc-verify-stat" style={{ color: "var(--color-warning)" }}>
+            ? {verification.uncertain}
+          </span>
+        </div>
+      )}
+
       {/* Row 4: Actions */}
       <div className="apc-actions">
         {isRunning ? (
@@ -163,9 +182,23 @@ export function AuditProjectCard({ project, status, auditIssueProgress, onRun, o
         )}
         {!isRunning && hasRun && (
           <button
+            className={`btn btn-sm apc-btn-full ${isVerified ? "btn-success" : ""}`}
+            onClick={onVerify}
+            title={isVerified
+              ? "Результаты верификации сохранены. Нажмите для повторной верификации."
+              : "Верифицировать findings перед созданием issues"}
+          >
+            {isVerified ? "✓ Верифицировано" : "◈ Верифицировать"}
+          </button>
+        )}
+        {!isRunning && hasRun && (
+          <button
             className="btn btn-primary btn-sm apc-btn-full"
             onClick={onCreateIssues}
-            title="Создать GitHub Issues из результатов аудита"
+            disabled={!isVerified}
+            title={!isVerified
+              ? "Сначала выполните верификацию"
+              : "Создать GitHub Issues из результатов аудита"}
           >
             ✦ Issues
           </button>

--- a/src/components/AuditTab.tsx
+++ b/src/components/AuditTab.tsx
@@ -3,6 +3,7 @@ import { useAudit } from "../hooks/useAudit";
 import { AuditProjectCard } from "./AuditProjectCard";
 import { AuditConfirmDialog } from "./AuditConfirmDialog";
 import { AuditIssuesDialog } from "./AuditIssuesDialog";
+import { AuditVerifyDialog } from "./AuditVerifyDialog";
 import { postAuditMeta } from "../utils/auditor";
 import type { AuditProjectStatus, ProjectData } from "../types";
 
@@ -14,6 +15,7 @@ export function AuditTab({ dashboardProjects = [] }: Props) {
   const { projects, runStatuses, auditorAvailable, loading, refresh, startRun, cancelRun } = useAudit();
   const [confirmingProject, setConfirmingProject] = useState<AuditProjectStatus | null>(null);
   const [issuesDialogProject, setIssuesDialogProject] = useState<string | null>(null);
+  const [verifyDialogProject, setVerifyDialogProject] = useState<string | null>(null);
 
   if (loading) {
     return (
@@ -78,6 +80,7 @@ export function AuditTab({ dashboardProjects = [] }: Props) {
                 auditIssueProgress={auditIssueProgress}
                 onRun={() => setConfirmingProject(p)}
                 onCancel={() => cancelRun(p.name)}
+                onVerify={() => setVerifyDialogProject(p.name)}
                 onCreateIssues={() => setIssuesDialogProject(p.name)}
               />
             );
@@ -98,6 +101,21 @@ export function AuditTab({ dashboardProjects = [] }: Props) {
           }}
         />
       )}
+
+      {verifyDialogProject && (() => {
+        const dialogProject = projects.find((p) => p.name === verifyDialogProject);
+        if (!dialogProject) return null;
+        return (
+          <AuditVerifyDialog
+            project={dialogProject}
+            onClose={() => setVerifyDialogProject(null)}
+            onComplete={() => {
+              setVerifyDialogProject(null);
+              refresh();
+            }}
+          />
+        );
+      })()}
 
       {issuesDialogProject && (() => {
         const dialogProject = projects.find((p) => p.name === issuesDialogProject);

--- a/src/components/AuditVerifyDialog.tsx
+++ b/src/components/AuditVerifyDialog.tsx
@@ -1,0 +1,282 @@
+import { useEffect, useRef, useState } from "react";
+import type { AuditProjectStatus, VerificationReport } from "../types";
+import { fetchAuditFindings, postAuditVerification } from "../utils/auditor";
+import { verifyFindings, buildSkippedVerification, type VerifyProgress } from "../utils/verification";
+import { getToken, getClaudeKey, GITHUB_OWNER } from "../utils/config";
+
+interface Props {
+  project: AuditProjectStatus;
+  onClose: () => void;
+  onComplete: () => void;
+}
+
+type DialogState = "verifying" | "preview" | "saving" | "error" | "skip-confirm";
+
+const VERDICT_COLOR: Record<string, string> = {
+  CONFIRMED: "var(--color-danger)",
+  FALSE_POSITIVE: "var(--color-success)",
+  UNCERTAIN: "var(--color-warning)",
+};
+
+const VERDICT_LABEL: Record<string, string> = {
+  CONFIRMED: "Confirmed",
+  FALSE_POSITIVE: "False positive",
+  UNCERTAIN: "Uncertain",
+};
+
+export function AuditVerifyDialog({ project, onClose, onComplete }: Props) {
+  const [state, setState] = useState<DialogState>("verifying");
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<VerifyProgress | null>(null);
+  const [report, setReport] = useState<VerificationReport | null>(null);
+  const [activeTab, setActiveTab] = useState<"CONFIRMED" | "UNCERTAIN" | "FALSE_POSITIVE">("CONFIRMED");
+  const abortRef = useRef<AbortController | null>(null);
+
+  const repoOwner = project.repo.split("/")[0] || GITHUB_OWNER;
+  const repoName = project.repo.split("/")[1] || project.name;
+
+  useEffect(() => {
+    const controller = new AbortController();
+    abortRef.current = controller;
+    let cancelled = false;
+
+    async function run() {
+      try {
+        const claudeKey = getClaudeKey();
+        if (!claudeKey) throw new Error("Claude API key не настроен.");
+        const ghToken = getToken();
+        if (!ghToken) throw new Error("GitHub token не настроен.");
+
+        const findings = await fetchAuditFindings(project.name);
+        if (cancelled) return;
+
+        const result = await verifyFindings(
+          findings.findings,
+          repoOwner,
+          repoName,
+          findings.timestamp,
+          ghToken,
+          claudeKey,
+          project.name,
+          (p) => { if (!cancelled) setProgress(p); },
+          controller.signal,
+        );
+        if (cancelled) return;
+
+        setReport(result);
+        setState("preview");
+      } catch (e) {
+        if (cancelled) return;
+        if (e instanceof DOMException && e.name === "AbortError") return;
+        setError(e instanceof Error ? e.message : String(e));
+        setState("error");
+      }
+    }
+
+    run();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [project.name, repoOwner, repoName]);
+
+  function stripProject<T extends { project: string }>(r: T): Omit<T, "project"> {
+    const copy = { ...r };
+    delete (copy as Partial<T>).project;
+    return copy;
+  }
+
+  async function handleSave() {
+    if (!report) return;
+    setState("saving");
+    try {
+      await postAuditVerification(project.name, stripProject(report));
+      onComplete();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setState("error");
+    }
+  }
+
+  async function handleSkip() {
+    try {
+      const findings = await fetchAuditFindings(project.name);
+      const skipped = buildSkippedVerification(findings.findings, project.name, findings.timestamp);
+      setState("saving");
+      await postAuditVerification(project.name, stripProject(skipped));
+      onComplete();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setState("error");
+    }
+  }
+
+  function handleClose() {
+    abortRef.current?.abort();
+    onClose();
+  }
+
+  const tabResults = report?.results.filter((r) => r.verdict === activeTab) ?? [];
+
+  return (
+    <div
+      className="dialog-overlay"
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
+    >
+      <div className="dialog">
+        <div className="dialog-header">
+          <h3 className="dialog-title">
+            {state === "verifying" && `Верификация ${project.name}...`}
+            {state === "preview" && `Результаты верификации: ${project.name}`}
+            {state === "saving" && "Сохраняю результаты..."}
+            {state === "error" && "Ошибка верификации"}
+            {state === "skip-confirm" && "Пропустить верификацию?"}
+          </h3>
+          <button className="dialog-close" onClick={handleClose}>✕</button>
+        </div>
+
+        <div className="dialog-body">
+          {state === "verifying" && (
+            <div className="dialog-spinner-wrap">
+              <div className="dialog-spinner" />
+              {progress ? (
+                <>
+                  <p className="dialog-hint">
+                    Проверяется {progress.current} / {progress.total}: <code>{progress.currentFile}{progress.currentLine ? `:${progress.currentLine}` : ""}</code>
+                  </p>
+                  <div className="dialog-progress-track" style={{ marginTop: 8 }}>
+                    <div
+                      className="dialog-progress-fill"
+                      style={{ width: `${(progress.current / Math.max(progress.total, 1)) * 100}%` }}
+                    />
+                  </div>
+                  <p className="dialog-hint" style={{ marginTop: 12, fontSize: 13 }}>
+                    <span style={{ color: "var(--color-danger)" }}>✓ {progress.confirmed} confirmed</span>
+                    {" · "}
+                    <span style={{ color: "var(--color-success)" }}>✗ {progress.falsePositive} FP</span>
+                    {" · "}
+                    <span style={{ color: "var(--color-warning)" }}>? {progress.uncertain} uncertain</span>
+                    {progress.errors > 0 && <> · <span style={{ color: "var(--color-text-muted)" }}>⚠ {progress.errors} errors</span></>}
+                  </p>
+                </>
+              ) : (
+                <p className="dialog-hint">Подготовка findings...</p>
+              )}
+            </div>
+          )}
+
+          {state === "preview" && report && (
+            <div>
+              <div className="verify-summary">
+                <div className="verify-summary-item" style={{ color: VERDICT_COLOR.CONFIRMED }}>
+                  <div className="verify-summary-count">{report.confirmed_count}</div>
+                  <div className="verify-summary-label">Confirmed</div>
+                </div>
+                <div className="verify-summary-item" style={{ color: VERDICT_COLOR.FALSE_POSITIVE }}>
+                  <div className="verify-summary-count">{report.false_positive_count}</div>
+                  <div className="verify-summary-label">False positive</div>
+                </div>
+                <div className="verify-summary-item" style={{ color: VERDICT_COLOR.UNCERTAIN }}>
+                  <div className="verify-summary-count">{report.uncertain_count}</div>
+                  <div className="verify-summary-label">Uncertain</div>
+                </div>
+                {report.error_count > 0 && (
+                  <div className="verify-summary-item" style={{ color: "var(--color-text-muted)" }}>
+                    <div className="verify-summary-count">{report.error_count}</div>
+                    <div className="verify-summary-label">Errors</div>
+                  </div>
+                )}
+              </div>
+
+              <div className="verify-tabs">
+                {(["CONFIRMED", "UNCERTAIN", "FALSE_POSITIVE"] as const).map((tab) => {
+                  const count = tab === "CONFIRMED" ? report.confirmed_count
+                    : tab === "FALSE_POSITIVE" ? report.false_positive_count
+                    : report.uncertain_count;
+                  return (
+                    <button
+                      key={tab}
+                      className={`verify-tab ${activeTab === tab ? "verify-tab--active" : ""}`}
+                      onClick={() => setActiveTab(tab)}
+                      style={activeTab === tab ? { borderBottomColor: VERDICT_COLOR[tab] } : undefined}
+                    >
+                      {VERDICT_LABEL[tab]} ({count})
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div className="verify-results">
+                {tabResults.length === 0 ? (
+                  <p className="dialog-hint">Нет findings в этой категории.</p>
+                ) : (
+                  tabResults.map((r) => (
+                    <details key={r.finding_index} className="verify-result">
+                      <summary>
+                        <code>{r.file}{r.line ? `:${r.line}` : ""}</code>
+                        <span className="verify-result-reason"> — {r.reason}</span>
+                      </summary>
+                      {r.code_snippet && (
+                        <pre className="verify-result-code">{r.code_snippet}</pre>
+                      )}
+                    </details>
+                  ))
+                )}
+              </div>
+            </div>
+          )}
+
+          {state === "saving" && (
+            <div className="dialog-spinner-wrap">
+              <div className="dialog-spinner" />
+              <p className="dialog-hint">Сохраняю результаты на сервер...</p>
+            </div>
+          )}
+
+          {state === "error" && (
+            <div className="dialog-error">
+              <strong>Ошибка:</strong> {error}
+            </div>
+          )}
+
+          {state === "skip-confirm" && (
+            <div>
+              <p className="dialog-hint">
+                Вы уверены? Все findings будут помечены как UNCERTAIN и создадут issues с лейблом <code>needs-human</code>.
+                Это безопасный режим — ни один finding не будет отброшен, но и false positives не отфильтруются.
+              </p>
+            </div>
+          )}
+        </div>
+
+        {state === "preview" && (
+          <div className="dialog-footer">
+            <button className="btn btn-sm" onClick={() => setState("skip-confirm")}>
+              Пропустить верификацию
+            </button>
+            <div style={{ flex: 1 }} />
+            <button className="btn btn-sm" onClick={handleClose}>Отмена</button>
+            <button className="btn btn-primary btn-sm" onClick={handleSave}>
+              Сохранить
+            </button>
+          </div>
+        )}
+
+        {state === "error" && (
+          <div className="dialog-footer dialog-footer--end">
+            <button className="btn btn-sm" onClick={handleClose}>Закрыть</button>
+          </div>
+        )}
+
+        {state === "skip-confirm" && (
+          <div className="dialog-footer dialog-footer--end">
+            <button className="btn btn-sm" onClick={() => setState("preview")}>Назад</button>
+            <button className="btn btn-warning btn-sm" onClick={handleSkip}>
+              Да, пропустить
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -127,6 +127,15 @@ export interface AuditLastRun {
   severity_counts: { critical: number; high: number; medium: number; low: number };
   gist_url: string | null;
   issues_created: number | null;
+  verification: AuditVerificationSummary | null;
+}
+
+export interface AuditVerificationSummary {
+  verified_at: string;
+  confirmed: number;
+  false_positive: number;
+  uncertain: number;
+  errors: number;
 }
 
 export interface AuditProjectStatus {
@@ -176,4 +185,32 @@ export interface GeneratedIssue {
   labels: string[];
   severity: "critical" | "high" | "medium" | "low";
   finding_index: number;
+}
+
+// Verification types
+export type Verdict = "CONFIRMED" | "FALSE_POSITIVE" | "UNCERTAIN";
+
+export interface VerificationResult {
+  finding_index: number;
+  verdict: Verdict;
+  reason: string;
+  code_snippet: string | null;
+  file: string;
+  line: number | null;
+  verified_at: string;
+  model: string;
+  error: string | null;
+}
+
+export interface VerificationReport {
+  project: string;
+  audit_timestamp: string;
+  verified_at: string;
+  model: string;
+  total_findings: number;
+  confirmed_count: number;
+  false_positive_count: number;
+  uncertain_count: number;
+  error_count: number;
+  results: VerificationResult[];
 }

--- a/src/utils/auditor.ts
+++ b/src/utils/auditor.ts
@@ -1,4 +1,4 @@
-import type { AuditProjectStatus, AuditRunStatus, AuditFindings } from "../types";
+import type { AuditProjectStatus, AuditRunStatus, AuditFindings, VerificationReport } from "../types";
 
 const AUDITOR_BASE_URL =
   (window as any).__MAKEIT_CONFIG__?.AUDITOR_URL ?? "http://127.0.0.1:8765";
@@ -69,6 +69,36 @@ export async function postAuditMeta(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ issues_created: issuesCreated, issue_urls: issueUrls }),
   });
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => ({ detail: "Unknown error" }));
+    throw new Error(errorData.detail || `HTTP error: ${res.status}`);
+  }
+}
+
+export async function fetchAuditVerification(project: string): Promise<VerificationReport> {
+  const res = await fetch(
+    `${AUDITOR_BASE_URL}/api/audit/${encodeURIComponent(project)}/verification`,
+    { cache: "no-store" },
+  );
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => ({ detail: "Unknown error" }));
+    throw new Error(errorData.detail || `HTTP error: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function postAuditVerification(
+  project: string,
+  report: Omit<VerificationReport, "project">,
+): Promise<void> {
+  const res = await fetch(
+    `${AUDITOR_BASE_URL}/api/audit/${encodeURIComponent(project)}/verification`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(report),
+    },
+  );
   if (!res.ok) {
     const errorData = await res.json().catch(() => ({ detail: "Unknown error" }));
     throw new Error(errorData.detail || `HTTP error: ${res.status}`);

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -1,5 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
-import type { ProjectData, SummaryMetrics, Issue, AuditFinding, GeneratedIssue } from "../types";
+import type { ProjectData, SummaryMetrics, Issue, AuditFinding, GeneratedIssue, Verdict } from "../types";
 import { GITHUB_OWNER, GITHUB_PROJECT_NUMBER, getToken } from "./config";
 import {
   listRepoFiles,
@@ -546,6 +546,7 @@ export async function generateIssuesFromFindings(
   repoName: string,
   anthropicApiKey: string,
   onProgress?: (current: number, total: number, groupLabel: string) => void,
+  verdictByFinding?: Map<AuditFinding, Verdict>,
 ): Promise<GeneratedIssue[]> {
   // Include critical + high; expand to medium if fewer than 30
   let filtered = findings.filter((f) => f.severity === "critical" || f.severity === "high");
@@ -565,6 +566,11 @@ export async function generateIssuesFromFindings(
 
     // Per-group cap: 100 findings max (enough for 1-5 issues, output stays small)
     const batch = groupFindings.slice(0, 100);
+
+    // Check if any finding in this batch is UNCERTAIN — those groups get needs-human
+    const hasUncertain = verdictByFinding
+      ? batch.some((f) => verdictByFinding.get(f) === "UNCERTAIN")
+      : false;
 
     const findingsJson = JSON.stringify(
       batch.map((f, idx) => ({
@@ -598,7 +604,15 @@ export async function generateIssuesFromFindings(
       const jsonMatch = text.match(/\[[\s\S]*\]/);
       if (jsonMatch) {
         const parsed = JSON.parse(jsonMatch[0]) as GeneratedIssue[];
-        if (Array.isArray(parsed)) allIssues.push(...parsed);
+        if (Array.isArray(parsed)) {
+          // Inject needs-human label for groups with UNCERTAIN findings
+          if (hasUncertain) {
+            for (const issue of parsed) {
+              if (!issue.labels.includes("needs-human")) issue.labels.push("needs-human");
+            }
+          }
+          allIssues.push(...parsed);
+        }
       }
     } catch (e) {
       // One group failing shouldn't abort everything — log and continue

--- a/src/utils/verification.ts
+++ b/src/utils/verification.ts
@@ -1,0 +1,148 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { AuditFinding, VerificationReport, VerificationResult } from "../types";
+import { createFileCache, verifyFinding } from "./verify-agent";
+
+const VERIFY_MODEL = "claude-sonnet-4-20250514";
+
+export interface VerifyProgress {
+  current: number; // 1-based count of findings processed
+  total: number;
+  currentFile: string;
+  currentLine: number | null;
+  confirmed: number;
+  falsePositive: number;
+  uncertain: number;
+  errors: number;
+}
+
+/** Subset of findings actually sent to issues — mirrors `generateIssuesFromFindings`. */
+export function selectFindingsForVerification(
+  findings: AuditFinding[],
+): { finding: AuditFinding; index: number }[] {
+  // Start with critical + high, expand to medium if < 30 (same rule as issue generation)
+  const indexed = findings.map((f, index) => ({ finding: f, index }));
+  let filtered = indexed.filter(
+    (f) => f.finding.severity === "critical" || f.finding.severity === "high",
+  );
+  if (filtered.length < 30) {
+    filtered = indexed.filter(
+      (f) =>
+        f.finding.severity === "critical" ||
+        f.finding.severity === "high" ||
+        f.finding.severity === "medium",
+    );
+  }
+  return filtered;
+}
+
+/**
+ * Verify a batch of findings against actual code in the repo.
+ *
+ * Processes findings in parallel batches of `batchSize`. Each finding gets its
+ * own Claude call with tool access to read code at specific file:line. Partial
+ * progress reported via `onProgress` after every finding completes.
+ *
+ * On abort: throws AbortError; caller discards partial results.
+ */
+export async function verifyFindings(
+  findings: AuditFinding[],
+  repoOwner: string,
+  repoName: string,
+  auditTimestamp: string,
+  githubToken: string,
+  anthropicApiKey: string,
+  project: string,
+  onProgress: (p: VerifyProgress) => void,
+  signal: AbortSignal,
+  batchSize = 5,
+): Promise<VerificationReport> {
+  const selected = selectFindingsForVerification(findings);
+  const client = new Anthropic({ apiKey: anthropicApiKey, dangerouslyAllowBrowser: true });
+  const cache = createFileCache();
+
+  const results: VerificationResult[] = [];
+  let confirmed = 0;
+  let falsePositive = 0;
+  let uncertain = 0;
+  let errors = 0;
+
+  for (let i = 0; i < selected.length; i += batchSize) {
+    if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+
+    const batch = selected.slice(i, i + batchSize);
+    const batchResults = await Promise.all(
+      batch.map(({ finding, index }) =>
+        verifyFinding(client, finding, index, githubToken, repoOwner, repoName, cache),
+      ),
+    );
+
+    for (const r of batchResults) {
+      results.push(r);
+      if (r.error) errors++;
+      if (r.verdict === "CONFIRMED") confirmed++;
+      else if (r.verdict === "FALSE_POSITIVE") falsePositive++;
+      else uncertain++;
+    }
+
+    const last = batch[batch.length - 1];
+    onProgress({
+      current: Math.min(i + batch.length, selected.length),
+      total: selected.length,
+      currentFile: last.finding.file,
+      currentLine: last.finding.line,
+      confirmed,
+      falsePositive,
+      uncertain,
+      errors,
+    });
+  }
+
+  return {
+    project,
+    audit_timestamp: auditTimestamp,
+    verified_at: new Date().toISOString(),
+    model: VERIFY_MODEL,
+    total_findings: selected.length,
+    confirmed_count: confirmed,
+    false_positive_count: falsePositive,
+    uncertain_count: uncertain,
+    error_count: errors,
+    results,
+  };
+}
+
+/**
+ * Build a synthetic "skipped" verification report — all findings marked UNCERTAIN
+ * so they pass through with needs-human label.
+ */
+export function buildSkippedVerification(
+  findings: AuditFinding[],
+  project: string,
+  auditTimestamp: string,
+): VerificationReport {
+  const selected = selectFindingsForVerification(findings);
+  const now = new Date().toISOString();
+  const results: VerificationResult[] = selected.map(({ finding, index }) => ({
+    finding_index: index,
+    verdict: "UNCERTAIN" as const,
+    reason: "skipped by user — verification bypassed",
+    code_snippet: null,
+    file: finding.file,
+    line: finding.line,
+    verified_at: now,
+    model: "skipped",
+    error: null,
+  }));
+  return {
+    project,
+    audit_timestamp: auditTimestamp,
+    verified_at: now,
+    model: "skipped",
+    total_findings: selected.length,
+    confirmed_count: 0,
+    false_positive_count: 0,
+    uncertain_count: selected.length,
+    error_count: 0,
+    results,
+  };
+}

--- a/src/utils/verify-agent.ts
+++ b/src/utils/verify-agent.ts
@@ -1,0 +1,315 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { AuditFinding, Verdict, VerificationResult } from "../types";
+import { readRepoFile } from "./github-actions";
+
+const VERIFY_MODEL = "claude-sonnet-4-20250514";
+
+const VERIFY_SYSTEM_PROMPT = `You are a skeptical senior code reviewer verifying an automated audit finding.
+
+Your task: determine whether the reported issue EXISTS in the CURRENT code at the
+reported location. Automated audits have a ~50% false positive rate because they
+miss existing mitigations (validators called earlier in the stack, type guards,
+SQLAlchemy-provided escaping, framework protections, dead code paths, etc).
+
+## Your process
+1. Call read_code_at_location(file, line, context_lines=15) to fetch the actual
+   code around the reported finding.
+2. If the issue spans multiple functions or requires understanding the caller,
+   call read_code_at_location again on other relevant files/lines (max 3 reads).
+3. Decide whether the reported problem is real in CURRENT code.
+
+## Default stance: SKEPTICAL
+Assume the finding MIGHT be a false positive. Look actively for mitigations:
+- Input validation earlier in the request path (middleware, dependency, decorator)
+- ORM-provided protections (parameter binding, identifier quoting)
+- Framework defaults (CSRF tokens, auth guards, serialization)
+- Type annotations enforcing invariants
+- Surrounding try/except, if-guards, early returns
+- Wrappers like SecretStr, sanitize_*, escape_*
+- Already-fixed code at that line (the finding may be stale)
+
+## Verdicts (choose exactly one)
+
+CONFIRMED — The bug exists in current code with no existing mitigation.
+  Require: you can point to the specific line that fails, AND name the attack/scenario.
+
+FALSE_POSITIVE — The code already handles this case correctly.
+  Require: you can point to the specific mitigation (which line protects against
+  the reported problem).
+
+UNCERTAIN — Cannot determine statically without runtime context, architectural
+  discussion, or calling-convention analysis that exceeds what is visible.
+  Use when: you would need to know external inputs, when something is called,
+  or what the author's intent was.
+
+## Output
+Reply with ONLY this JSON, no markdown, no prose:
+
+{
+  "verdict": "CONFIRMED" | "FALSE_POSITIVE" | "UNCERTAIN",
+  "reason": "<1-3 sentences, quote the key line number(s)>",
+  "code_snippet": "<the relevant ±10 lines of code you based your decision on>"
+}
+
+Important: reason MUST cite specific line numbers. If CONFIRMED, name the
+attack/failure mode. If FALSE_POSITIVE, name the mitigation and where it lives.`;
+
+const VERIFY_TOOL: Anthropic.Tool = {
+  name: "read_code_at_location",
+  description:
+    "Read the actual file contents at a specific line with surrounding context. Use this to verify whether a reported audit finding actually exists in current code.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      file: {
+        type: "string",
+        description: "File path relative to repo root (e.g. src/sanitize.py)",
+      },
+      line: {
+        type: "number",
+        description: "Center line number (1-based)",
+      },
+      context_lines: {
+        type: "number",
+        description: "Lines before and after to include (default 15, max 40)",
+      },
+    },
+    required: ["file", "line"],
+  },
+};
+
+/** Render file content with line numbers in ±context_lines window. */
+function renderCodeWindow(
+  filePath: string,
+  content: string,
+  line: number,
+  contextLines: number,
+): string {
+  const lines = content.split("\n");
+  const ctx = Math.min(contextLines, 40);
+  const start = Math.max(0, line - ctx - 1);
+  const end = Math.min(lines.length, line + ctx);
+  const numbered = lines
+    .slice(start, end)
+    .map((l, i) => `${String(start + i + 1).padStart(4, " ")}  ${l}`)
+    .join("\n");
+  return `// ${filePath} (lines ${start + 1}-${end})\n${numbered}`;
+}
+
+/** Strip common prefixes that auditor may add but don't exist in repo path. */
+function candidatePaths(path: string): string[] {
+  const candidates = new Set<string>([path]);
+  // Strip ./ prefix
+  if (path.startsWith("./")) candidates.add(path.slice(2));
+  // Try without common top-level dirs
+  for (const prefix of ["backend/", "frontend/", "src/"]) {
+    if (path.startsWith(prefix)) candidates.add(path.slice(prefix.length));
+  }
+  return Array.from(candidates);
+}
+
+export interface FileCache {
+  /** Map of `${owner}/${repo}:${path}` → file content, or null for not-found. */
+  files: Map<string, string | null>;
+}
+
+export function createFileCache(): FileCache {
+  return { files: new Map() };
+}
+
+async function fetchFileWithCache(
+  githubToken: string,
+  owner: string,
+  repo: string,
+  path: string,
+  cache: FileCache,
+): Promise<{ content: string; resolvedPath: string } | null> {
+  for (const candidate of candidatePaths(path)) {
+    const key = `${owner}/${repo}:${candidate}`;
+    const cached = cache.files.get(key);
+    if (cached !== undefined) {
+      if (cached === null) continue;
+      return { content: cached, resolvedPath: candidate };
+    }
+    try {
+      const content = await readRepoFile(githubToken, owner, repo, candidate);
+      cache.files.set(key, content);
+      return { content, resolvedPath: candidate };
+    } catch {
+      cache.files.set(key, null);
+      continue;
+    }
+  }
+  return null;
+}
+
+interface VerifyToolResult {
+  text: string;
+  error: boolean;
+}
+
+async function executeReadCodeTool(
+  input: { file?: string; line?: number; context_lines?: number },
+  githubToken: string,
+  owner: string,
+  repo: string,
+  cache: FileCache,
+): Promise<VerifyToolResult> {
+  if (!input.file || typeof input.line !== "number") {
+    return { text: "ERROR: missing 'file' or 'line' argument", error: true };
+  }
+  const result = await fetchFileWithCache(githubToken, owner, repo, input.file, cache);
+  if (!result) {
+    return { text: `ERROR: could not read ${input.file} (tried path variants)`, error: true };
+  }
+  const rendered = renderCodeWindow(
+    result.resolvedPath,
+    result.content,
+    input.line,
+    input.context_lines ?? 15,
+  );
+  return { text: rendered, error: false };
+}
+
+interface VerifyAgentResponse {
+  verdict: Verdict;
+  reason: string;
+  code_snippet: string | null;
+}
+
+/** Extract JSON object from Claude text response (tolerates surrounding prose). */
+function parseVerifyResponse(text: string): VerifyAgentResponse | null {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[0]) as Record<string, unknown>;
+    const verdict = parsed.verdict;
+    const reason = parsed.reason;
+    if (
+      (verdict !== "CONFIRMED" && verdict !== "FALSE_POSITIVE" && verdict !== "UNCERTAIN") ||
+      typeof reason !== "string"
+    ) {
+      return null;
+    }
+    return {
+      verdict,
+      reason,
+      code_snippet: typeof parsed.code_snippet === "string" ? parsed.code_snippet : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify a single audit finding against actual code.
+ *
+ * Returns a VerificationResult with verdict. On transient errors, retries once.
+ * On persistent failure, returns a result with `error` set.
+ */
+export async function verifyFinding(
+  client: Anthropic,
+  finding: AuditFinding,
+  findingIndex: number,
+  githubToken: string,
+  owner: string,
+  repo: string,
+  cache: FileCache,
+): Promise<VerificationResult> {
+  const verifiedAt = new Date().toISOString();
+  const base: Omit<VerificationResult, "verdict" | "reason" | "code_snippet" | "error"> = {
+    finding_index: findingIndex,
+    file: finding.file,
+    line: finding.line,
+    verified_at: verifiedAt,
+    model: VERIFY_MODEL,
+  };
+
+  const userMessage = `Finding to verify:
+  File: ${finding.file}
+  Line: ${finding.line ?? "(unknown)"}
+  Severity: ${finding.severity}
+  Tool: ${finding.tool}
+  Description: ${finding.description}
+  Recommendation: ${finding.recommendation}
+
+Verify it now.`;
+
+  let currentMessages: Anthropic.MessageParam[] = [
+    { role: "user", content: userMessage },
+  ];
+
+  // Up to 4 iterations = 1 initial + 3 tool reads
+  let lastError: string | null = null;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      for (let iter = 0; iter < 4; iter++) {
+        const response = await client.messages.create({
+          model: VERIFY_MODEL,
+          max_tokens: 1024,
+          system: VERIFY_SYSTEM_PROMPT,
+          tools: [VERIFY_TOOL],
+          messages: currentMessages,
+        });
+
+        if (response.stop_reason === "tool_use") {
+          currentMessages = [
+            ...currentMessages,
+            { role: "assistant", content: response.content },
+          ];
+          const toolResults: Anthropic.ToolResultBlockParam[] = [];
+          for (const block of response.content) {
+            if (block.type === "tool_use" && block.name === "read_code_at_location") {
+              const result = await executeReadCodeTool(
+                block.input as { file?: string; line?: number; context_lines?: number },
+                githubToken,
+                owner,
+                repo,
+                cache,
+              );
+              toolResults.push({
+                type: "tool_result",
+                tool_use_id: block.id,
+                content: result.text,
+                is_error: result.error,
+              });
+            }
+          }
+          currentMessages = [
+            ...currentMessages,
+            { role: "user", content: toolResults },
+          ];
+          continue;
+        }
+
+        // end_turn — parse verdict JSON
+        const text = response.content
+          .filter((b) => b.type === "text")
+          .map((b) => (b.type === "text" ? b.text : ""))
+          .join("\n");
+        const parsed = parseVerifyResponse(text);
+        if (parsed) {
+          return { ...base, ...parsed, error: null };
+        }
+        lastError = "invalid JSON response from model";
+        break;
+      }
+      // Exhausted iterations without end_turn
+      lastError = lastError ?? "verification did not converge within 4 iterations";
+    } catch (e) {
+      lastError = e instanceof Error ? e.message : String(e);
+      // Reset messages and retry once
+      currentMessages = [{ role: "user", content: userMessage }];
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+  }
+
+  // Persistent failure — return error result; caller treats as needs-human downstream
+  return {
+    ...base,
+    verdict: "UNCERTAIN",
+    reason: `verification failed: ${lastError}`,
+    code_snippet: null,
+    error: lastError,
+  };
+}


### PR DESCRIPTION
Introduces mandatory verification between audit and issue creation to filter false positives (~50% of audit findings in recent triage). **Issues button is disabled until verification completes.**

## User flow

1. User runs audit → finds 87 issues
2. Clicks **◈ Верифицировать** → progress: `Проверяется 23/87: sanitize.py:42`
3. AI reads actual code for each finding, returns verdict: CONFIRMED / FALSE_POSITIVE / UNCERTAIN
4. Preview shows 3 tabs with reasons + code snippets
5. Click **Сохранить** → verification persisted, **✦ Issues** button enabled
6. FALSE_POSITIVE findings excluded; UNCERTAIN findings get `needs-human` label

## Components

### New files
- `utils/verify-agent.ts` — per-finding Claude call with `read_code_at_location` tool, skeptical system prompt
- `utils/verification.ts` — batch orchestration (parallel batches of 5)
- `components/AuditVerifyDialog.tsx` — progress UI + preview with verdict tabs

### Modified
- `AuditProjectCard` — 3-button row: Rerun | Verify | Issues (Issues disabled until verified)
- `AuditIssuesDialog` — fetches verification, filters FPs, passes verdict map to generator
- `claude.ts` — `generateIssuesFromFindings` adds `needs-human` label for groups containing UNCERTAIN findings

## Skeptical verification prompt

AI is instructed to look for existing mitigations before confirming:
- Input validation in middleware/decorators
- ORM-provided protections (parameter binding)
- Framework defaults (CSRF, auth guards)
- Wrappers like SecretStr, sanitize_*, escape_*

Returns CONFIRMED only when it can name both the failing line AND the attack scenario.

## Escape hatch

"Skip verification" button produces a synthetic all-UNCERTAIN report — all findings pass through with `needs-human` label. Safety fallback when verification API is broken.

Paired with auditor backend PR.