### PR TITLE
fix: verification retry, abort propagation, index-based verdict lookup

### DIFF
--- a/src/components/AuditIssuesDialog.tsx
+++ b/src/components/AuditIssuesDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { AuditProjectStatus, AuditFinding, GeneratedIssue, Verdict } from "../types";
+import type { AuditProjectStatus, GeneratedIssue, Verdict } from "../types";
 import { fetchAuditFindings, fetchAuditVerification } from "../utils/auditor";
 import { generateIssuesFromFindings } from "../utils/claude";
 import { createIssue, addIssueToProject } from "../utils/github-actions";
@@ -52,21 +52,23 @@ export function AuditIssuesDialog({ project, onClose, onComplete }: Props) {
         const findings = await fetchAuditFindings(project.name);
         if (cancelled) return;
 
-        // Load verification and filter out FALSE_POSITIVE findings
-        let filteredFindings: AuditFinding[] = findings.findings;
-        const verdictByFinding = new Map<AuditFinding, Verdict>();
+        // Load verification, filter out FALSE_POSITIVE findings, and build a
+        // lookup from finding → original index so the generator can flag
+        // UNCERTAIN groups with needs-human.
+        const originalIndex = new WeakMap<object, number>();
+        findings.findings.forEach((f, idx) => originalIndex.set(f, idx));
+
+        let filteredFindings = findings.findings;
+        let verdictByIndex: Map<number, Verdict> | undefined;
         try {
           const verification = await fetchAuditVerification(project.name);
           if (cancelled) return;
-          const verdictByIdx = new Map(verification.results.map((r) => [r.finding_index, r.verdict]));
+          verdictByIndex = new Map(
+            verification.results.map((r) => [r.finding_index, r.verdict as Verdict]),
+          );
           filteredFindings = findings.findings.filter((_, idx) => {
-            const verdict = verdictByIdx.get(idx);
-            return verdict !== "FALSE_POSITIVE";
+            return verdictByIndex!.get(idx) !== "FALSE_POSITIVE";
           });
-          for (let i = 0; i < findings.findings.length; i++) {
-            const v = verdictByIdx.get(i);
-            if (v) verdictByFinding.set(findings.findings[i], v);
-          }
         } catch {
           // No verification available — proceed with all findings (backward compat)
         }
@@ -78,7 +80,8 @@ export function AuditIssuesDialog({ project, onClose, onComplete }: Props) {
           (current, total, label) => {
             if (!cancelled) setGenProgress({ current, total, label });
           },
-          verdictByFinding,
+          verdictByIndex,
+          (f) => originalIndex.get(f),
         );
         if (cancelled) return;
 

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -541,12 +541,22 @@ Never average or downgrade — one critical finding makes the whole issue P1-cri
 
 Rules: list ALL file:line pairs in Findings checklist; labels exactly as shown above.`;
 
+/**
+ * Caller must supply findings with `original_index` attached if `verdictByIndex`
+ * is provided, so we can look up each finding's verdict after grouping.
+ */
+export interface IndexedFinding {
+  finding: AuditFinding;
+  originalIndex: number;
+}
+
 export async function generateIssuesFromFindings(
   findings: AuditFinding[],
   repoName: string,
   anthropicApiKey: string,
   onProgress?: (current: number, total: number, groupLabel: string) => void,
-  verdictByFinding?: Map<AuditFinding, Verdict>,
+  verdictByIndex?: Map<number, Verdict>,
+  originalIndexOf?: (f: AuditFinding) => number | undefined,
 ): Promise<GeneratedIssue[]> {
   // Include critical + high; expand to medium if fewer than 30
   let filtered = findings.filter((f) => f.severity === "critical" || f.severity === "high");
@@ -568,8 +578,11 @@ export async function generateIssuesFromFindings(
     const batch = groupFindings.slice(0, 100);
 
     // Check if any finding in this batch is UNCERTAIN — those groups get needs-human
-    const hasUncertain = verdictByFinding
-      ? batch.some((f) => verdictByFinding.get(f) === "UNCERTAIN")
+    const hasUncertain = verdictByIndex && originalIndexOf
+      ? batch.some((f) => {
+          const idx = originalIndexOf(f);
+          return idx !== undefined && verdictByIndex.get(idx) === "UNCERTAIN";
+        })
       : false;
 
     const findingsJson = JSON.stringify(

--- a/src/utils/verification.ts
+++ b/src/utils/verification.ts
@@ -72,7 +72,7 @@ export async function verifyFindings(
     const batch = selected.slice(i, i + batchSize);
     const batchResults = await Promise.all(
       batch.map(({ finding, index }) =>
-        verifyFinding(client, finding, index, githubToken, repoOwner, repoName, cache),
+        verifyFinding(client, finding, index, githubToken, repoOwner, repoName, cache, signal),
       ),
     );
 

--- a/src/utils/verify-agent.ts
+++ b/src/utils/verify-agent.ts
@@ -204,8 +204,11 @@ function parseVerifyResponse(text: string): VerifyAgentResponse | null {
 /**
  * Verify a single audit finding against actual code.
  *
- * Returns a VerificationResult with verdict. On transient errors, retries once.
+ * Returns a VerificationResult with verdict. On transient errors (API failure
+ * or invalid JSON), retries once with 2s backoff and fresh message history.
  * On persistent failure, returns a result with `error` set.
+ *
+ * AbortError is rethrown so the caller can discard partial batch results.
  */
 export async function verifyFinding(
   client: Anthropic,
@@ -215,6 +218,7 @@ export async function verifyFinding(
   owner: string,
   repo: string,
   cache: FileCache,
+  signal?: AbortSignal,
 ): Promise<VerificationResult> {
   const verifiedAt = new Date().toISOString();
   const base: Omit<VerificationResult, "verdict" | "reason" | "code_snippet" | "error"> = {
@@ -226,31 +230,36 @@ export async function verifyFinding(
   };
 
   const userMessage = `Finding to verify:
-  File: ${finding.file}
-  Line: ${finding.line ?? "(unknown)"}
-  Severity: ${finding.severity}
-  Tool: ${finding.tool}
-  Description: ${finding.description}
-  Recommendation: ${finding.recommendation}
+File: ${finding.file}
+Line: ${finding.line ?? "(unknown)"}
+Severity: ${finding.severity}
+Tool: ${finding.tool}
+Description: ${finding.description}
+Recommendation: ${finding.recommendation}
 
 Verify it now.`;
 
-  let currentMessages: Anthropic.MessageParam[] = [
-    { role: "user", content: userMessage },
-  ];
-
-  // Up to 4 iterations = 1 initial + 3 tool reads
+  // Up to 2 attempts × 4 iterations each. Each attempt starts with fresh message
+  // history so a bad assistant reply in attempt 1 doesn't poison attempt 2.
   let lastError: string | null = null;
   for (let attempt = 0; attempt < 2; attempt++) {
+    let currentMessages: Anthropic.MessageParam[] = [
+      { role: "user", content: userMessage },
+    ];
+    let iterationDidFail = false;
+
     try {
       for (let iter = 0; iter < 4; iter++) {
-        const response = await client.messages.create({
-          model: VERIFY_MODEL,
-          max_tokens: 1024,
-          system: VERIFY_SYSTEM_PROMPT,
-          tools: [VERIFY_TOOL],
-          messages: currentMessages,
-        });
+        const response = await client.messages.create(
+          {
+            model: VERIFY_MODEL,
+            max_tokens: 1024,
+            system: VERIFY_SYSTEM_PROMPT,
+            tools: [VERIFY_TOOL],
+            messages: currentMessages,
+          },
+          { signal },
+        );
 
         if (response.stop_reason === "tool_use") {
           currentMessages = [
@@ -292,15 +301,35 @@ Verify it now.`;
           return { ...base, ...parsed, error: null };
         }
         lastError = "invalid JSON response from model";
+        iterationDidFail = true;
         break;
       }
-      // Exhausted iterations without end_turn
-      lastError = lastError ?? "verification did not converge within 4 iterations";
+      if (!iterationDidFail) {
+        lastError = "verification did not converge within 4 iterations";
+      }
     } catch (e) {
+      // Propagate abort up so caller can discard the whole batch
+      if (e instanceof Error && (e.name === "AbortError" || signal?.aborted)) {
+        throw e;
+      }
       lastError = e instanceof Error ? e.message : String(e);
-      // Reset messages and retry once
-      currentMessages = [{ role: "user", content: userMessage }];
-      await new Promise((r) => setTimeout(r, 2000));
+    }
+
+    // Backoff before second attempt
+    if (attempt === 0) {
+      await new Promise((resolve, reject) => {
+        const timer = setTimeout(resolve, 2000);
+        if (signal) {
+          signal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(new DOMException("Aborted", "AbortError"));
+            },
+            { once: true },
+          );
+        }
+      });
     }
   }
 


### PR DESCRIPTION
Code review follow-up on #10. Addresses 3 issues found in review:

### #1+#2: Retry logic on invalid JSON
Previous: on JSON parse failure, break exited inner loop but messages
weren't reset — second attempt saw same bad assistant reply. Also
`lastError` got overwritten with "did not converge" message.

Fixed: message history reset on each attempt, `iterationDidFail` flag
preserves the correct failure reason. Backoff now respects abort signal.

### #3: Abort signal not propagated
Previous: Cancel during verification waited up to ~30s for the current
batch of 5 parallel Claude calls to drain, since signal wasn't passed
into `client.messages.create`.

Fixed: signal threaded through `verifyFindings` → `verifyFinding` →
`client.messages.create(body, { signal })`. AbortError rethrown so
caller discards batch results.

### #6: Fragile object-identity Map
Previous: `Map<AuditFinding, Verdict>` worked because `.filter()`
preserves references, but if anyone cloned findings upstream the
`needs-human` label would silently be lost.

Fixed: use `Map<number, Verdict>` keyed by original finding index.
Caller passes an `originalIndexOf` resolver built from a WeakMap at
ingestion. Survives any downstream map/clone/filter.