### PR TITLE
feat: category-based finding grouping + realistic audit estimates

### DIFF
--- a/src/components/AuditConfirmDialog.tsx
+++ b/src/components/AuditConfirmDialog.tsx
@@ -2,13 +2,31 @@ interface Props {
   projectName: string;
   maxPrice: number;
   timeoutHours: number;
+  lastRunCost: number | null;
+  lastRunDuration: number | null;
   onConfirm: () => void;
   onCancel: () => void;
 }
 
-export function AuditConfirmDialog({ projectName, maxPrice, timeoutHours, onConfirm, onCancel }: Props) {
-  const estimatedMin = (maxPrice * 0.5).toFixed(2);
-  const estimatedMax = (maxPrice * timeoutHours).toFixed(2);
+export function AuditConfirmDialog({ projectName, maxPrice, timeoutHours, lastRunCost, lastRunDuration, onConfirm, onCancel }: Props) {
+  let estimatedMin: string;
+  let estimatedMax: string;
+  let estimatedTime: string;
+
+  if (lastRunCost != null && lastRunCost > 0 && lastRunDuration != null && lastRunDuration > 0) {
+    // Based on real data: ±30% range around last run
+    const min = lastRunCost * 0.7;
+    const max = lastRunCost * 1.3;
+    estimatedMin = min.toFixed(2);
+    estimatedMax = max.toFixed(2);
+    const mins = Math.round(lastRunDuration / 60);
+    estimatedTime = `~${mins} мин`;
+  } else {
+    // No history — conservative estimate based on GPU config
+    estimatedMin = (maxPrice * 0.3).toFixed(2);
+    estimatedMax = (maxPrice * 1.5).toFixed(2);
+    estimatedTime = `до ${timeoutHours} ч.`;
+  }
 
   return (
     <div className="modal-overlay">
@@ -21,12 +39,12 @@ export function AuditConfirmDialog({ projectName, maxPrice, timeoutHours, onConf
 
         <div className="modal-info-block">
           <div className="modal-info-row">
-            <span className="modal-info-label">Лимит стоимости</span>
+            <span className="modal-info-label">Ожидаемая стоимость</span>
             <span style={{ fontWeight: 600, color: 'var(--color-caution)' }}>~${estimatedMin} – ${estimatedMax}</span>
           </div>
           <div className="modal-info-row">
-            <span className="modal-info-label">Макс. время</span>
-            <span style={{ fontWeight: 600 }}>{timeoutHours} ч.</span>
+            <span className="modal-info-label">Ожидаемое время</span>
+            <span style={{ fontWeight: 600 }}>{estimatedTime}</span>
           </div>
           <div className="modal-info-row">
             <span className="modal-info-label">Уведомления</span>

--- a/src/components/AuditTab.tsx
+++ b/src/components/AuditTab.tsx
@@ -61,9 +61,13 @@ export function AuditTab({ dashboardProjects = [] }: Props) {
             const dashProject = dashboardProjects.find(
               (dp) => dp.repo.toLowerCase() === (p.repo.split("/")[1] || p.repo).toLowerCase(),
             );
-            const auditIssues = dashProject?.issues.filter((i) =>
-              i.labels.some((l) => l.toLowerCase() === "audit"),
-            ) ?? [];
+            // Show issue progress only for issues created in the current audit run
+            const currentIssueUrls = p.last_run?.issue_urls ?? [];
+            const auditIssues = currentIssueUrls.length > 0
+              ? (dashProject?.issues.filter((i) =>
+                  currentIssueUrls.includes(i.url)
+                ) ?? [])
+              : [];
             const auditIssueProgress =
               auditIssues.length > 0
                 ? {
@@ -92,6 +96,8 @@ export function AuditTab({ dashboardProjects = [] }: Props) {
         <AuditConfirmDialog
           projectName={confirmingProject.name}
           maxPrice={confirmingProject.gpu_config.max_price_per_hour}
+          lastRunCost={confirmingProject.last_run?.cost_usd ?? null}
+          lastRunDuration={confirmingProject.last_run?.duration_seconds ?? null}
           timeoutHours={confirmingProject.gpu_config.timeout_hours}
           onCancel={() => setConfirmingProject(null)}
           onConfirm={async () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -127,6 +127,7 @@ export interface AuditLastRun {
   severity_counts: { critical: number; high: number; medium: number; low: number };
   gist_url: string | null;
   issues_created: number | null;
+  issue_urls: string[] | null;
   verification: AuditVerificationSummary | null;
 }
 
@@ -159,6 +160,7 @@ export interface AuditRunStatus {
 }
 
 export interface AuditFinding {
+  category?: "bug" | "security" | "business_logic" | "architecture" | "performance" | "data_integrity";
   severity: "critical" | "high" | "medium" | "low";
   source: "deterministic" | "llm" | "both";
   tool: string;

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -452,46 +452,12 @@ interface AuditTheme {
 }
 
 const AUDIT_THEMES: AuditTheme[] = [
-  {
-    key: "security",
-    label: "Security vulnerabilities",
-    keywords: ["path traversal", "traversal", "injection", "xss", "csrf", "credential", "secret"],
-  },
-  {
-    key: "race_condition",
-    label: "Race conditions & concurrency",
-    keywords: ["race condition", "race", "concurrent", "deadlock"],
-  },
-  {
-    key: "float_decimal",
-    label: "Float vs Decimal in financial calculations",
-    keywords: ["float", "decimal", "округл", "monetary", "денег", "деньг"],
-  },
-  {
-    key: "transaction",
-    label: "Missing database transactions",
-    keywords: ["транзакц", "transaction", "db.begin", "rollback", "atomicit"],
-  },
-  {
-    key: "auth",
-    label: "Missing authentication & authorization",
-    keywords: ["auth", "права", "доступ", "permission", "role", "require_role", "unauthorized"],
-  },
-  {
-    key: "error_handling",
-    label: "Unhandled exceptions & error handling",
-    keywords: ["исключен", "exception", "unhandled", "error handling"],
-  },
-  {
-    key: "data_integrity",
-    label: "Data integrity & validation",
-    keywords: ["integrity", "constraint", "валидац", "validation", "refresh", "flush", "foreign key"],
-  },
-  {
-    key: "other",
-    label: "Other code quality issues",
-    keywords: [],
-  },
+  { key: "security", label: "Security vulnerabilities", keywords: [] },
+  { key: "business_logic", label: "Business logic violations", keywords: [] },
+  { key: "architecture", label: "Architecture issues", keywords: [] },
+  { key: "performance", label: "Performance issues", keywords: [] },
+  { key: "data_integrity", label: "Data integrity risks", keywords: [] },
+  { key: "bug", label: "Bugs & error handling", keywords: [] },
 ];
 
 function groupFindingsByTheme(
@@ -500,16 +466,13 @@ function groupFindingsByTheme(
   const groups = new Map<string, AuditFinding[]>(AUDIT_THEMES.map((t) => [t.key, []]));
 
   for (const finding of findings) {
-    const text = (finding.description + " " + (finding.recommendation ?? "")).toLowerCase();
-    let assigned = false;
-    for (const theme of AUDIT_THEMES.slice(0, -1)) {
-      if (theme.keywords.some((kw) => text.includes(kw))) {
-        groups.get(theme.key)!.push(finding);
-        assigned = true;
-        break;
-      }
+    const cat = finding.category || "bug";
+    const theme = AUDIT_THEMES.find((t) => t.key === cat);
+    if (theme) {
+      groups.get(theme.key)!.push(finding);
+    } else {
+      groups.get("bug")!.push(finding);
     }
-    if (!assigned) groups.get("other")!.push(finding);
   }
 
   return AUDIT_THEMES.map((theme) => ({ theme, findings: groups.get(theme.key)! })).filter(
@@ -527,7 +490,7 @@ Return JSON array only — no markdown fences, no prose:
 [{
   "title": "<≤80 chars: area + problem>",
   "body": "**Problem:** <why risky in production>\\n\\n**Findings:**\\n- [ ] \`file:line\` — description\\n\\n**Recommendation:** <concrete fix>",
-  "labels": ["audit", "<P1-critical|P2-high|P3-medium>", "<bug|security|tech-debt>"],
+  "labels": ["audit", "<P1-critical|P2-high|P3-medium>", "<bug|security|tech-debt|business_logic|architecture|performance|data_integrity>"],
   "severity": "<critical|high|medium|low>",
   "finding_index": <index of first finding in group>
 }]
@@ -589,6 +552,7 @@ export async function generateIssuesFromFindings(
       batch.map((f, idx) => ({
         index: idx,
         severity: f.severity,
+        category: f.category || "bug",
         file: f.file.replace(/^backend\/app\//, "").replace(/^frontend\/src\//, "fe/"),
         line: f.line,
         description: f.description,


### PR DESCRIPTION
Ports fixes that were made directly on the VPS production server so they are properly tracked in git.

## Changes

### 1. AuditConfirmDialog — realistic estimates
Was: `maxPrice * 0.5` to `maxPrice * timeoutHours` (theoretical max from GPU pricing config)
Now: if history exists, ±30% around actual last run cost, with real duration. Falls back to GPU config only when no history.

### 2. AuditTab — scoped issue progress counter
Was: counted every `audit`-labeled issue ever created
Now: counts only issues from the current audit run (matches by `issue_urls` from last_run metadata)

### 3. types — category field + issue_urls
- Adds `issue_urls: string[] | null` to `AuditLastRun` (backend already returns this)
- Adds optional `category` field to `AuditFinding` matching backend FindingCategory enum

### 4. claude.ts — category-based grouping
Was: keyword-matching on description+recommendation text to assign findings to themes
Now: use backend-assigned `category` field directly. More reliable, no keyword drift.

## Merged cleanly with verification feature
Type conflict in AuditLastRun (issue_urls + verification fields) resolved by keeping both.