### PR TITLE
fix: use GitHub API issue counts instead of project board counts

### DIFF
--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -479,14 +479,16 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
             </span>
           </div>
           {(() => {
-            // Merge queue items with live stage data; prefer issue_stages as source of truth
-            const stageIssueNums = Object.keys(issueStages).map(Number);
+            // Merge queue items with live stage data; prefer issue_stages as source of truth.
+            // Exclude issues already in results (completed) so only truly active tasks show.
+            const completedNums = new Set(status.results.map((r) => r.issue_number));
+            const stageIssueNums = Object.keys(issueStages).map(Number).filter((n) => !completedNums.has(n));
             const queueNums = new Set(status.queue.map((q) => q.number));
             // Issues that have stages but aren't in queue (already running)
             const extraNums = stageIssueNums.filter((n) => !queueNums.has(n));
             const allItems = [
               ...extraNums.map((n) => ({ number: n, title: `Issue #${n}`, status: "in_progress", priority: 0 })),
-              ...status.queue,
+              ...status.queue.filter((q) => !completedNums.has(q.number)),
             ];
             if (allItems.length === 0) {
               return (

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -75,7 +75,9 @@ export function ProjectCard({ project, monitor }: Props) {
             ))}
             {(() => {
               const labeled = project.priorityCounts.P1 + project.priorityCounts.P2 + project.priorityCounts.P3 + project.priorityCounts.P4;
-              const noLabel = project.openCount - labeled;
+              // Count open board issues (not GitHub total) for accurate "no priority" count
+              const boardOpen = project.issues.filter((i) => i.status !== "Done").length;
+              const noLabel = boardOpen - labeled;
               return noLabel > 0 ? (
                 <span className="pc-pri pc-pri--none">? {noLabel}</span>
               ) : null;

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -12,7 +12,7 @@ function compactUSD(n: number): string {
 
 export function Summary({ metrics, onFinanceClick }: Props) {
   const hasFinances = metrics.totalBudget > 0;
-  const totalOpen = metrics.todoCount + metrics.inProgressCount + metrics.reviewCount;
+  const totalOpen = metrics.openCount;
   const pctDone = metrics.totalIssues > 0
     ? Math.round((metrics.doneCount / metrics.totalIssues) * 100)
     : 0;

--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -65,6 +65,7 @@ export function useDashboard() {
 
   const summary: SummaryMetrics = useMemo(() => ({
     totalIssues: projects.reduce((s, p) => s + p.totalCount, 0),
+    openCount: projects.reduce((s, p) => s + p.openCount, 0),
     todoCount: projects.reduce((s, p) => s + p.issues.filter((i) => i.status === "Todo").length, 0),
     inProgressCount: projects.reduce((s, p) => s + p.issues.filter((i) => i.status === "In Progress").length, 0),
     reviewCount: projects.reduce((s, p) => s + p.issues.filter((i) => i.status === "Review").length, 0),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,6 +60,7 @@ export interface ProjectData {
 
 export interface SummaryMetrics {
   totalIssues: number;
+  openCount: number;
   todoCount: number;
   inProgressCount: number;
   reviewCount: number;

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -311,6 +311,8 @@ query($owner: String!, $repo: String!) {
       }
     }
     description
+    openIssueCount: issues(states: OPEN) { totalCount }
+    closedIssueCount: issues(states: CLOSED) { totalCount }
     openMilestones: milestones(first: 20, states: OPEN, orderBy: {field: DUE_DATE, direction: ASC}) {
       nodes {
         title
@@ -380,6 +382,8 @@ interface RepoInfoResponse {
       target: { committedDate: string };
     } | null;
     description: string | null;
+    openIssueCount: { totalCount: number };
+    closedIssueCount: { totalCount: number };
     openMilestones: { nodes: MilestoneNode[] };
     closedMilestones: { nodes: MilestoneNode[] };
   };
@@ -390,6 +394,8 @@ interface RepoInfo {
   description: string;
   milestones: Milestone[];
   commitActivity: CommitActivity;
+  openIssueCount: number;
+  closedIssueCount: number;
 }
 
 async function fetchRepoInfo(token: string, owner: string, repo: string): Promise<RepoInfo> {
@@ -399,7 +405,7 @@ async function fetchRepoInfo(token: string, owner: string, repo: string): Promis
   ]);
 
   if (!graphqlResult) {
-    return { lastCommitDate: null, description: "", milestones: [], commitActivity };
+    return { lastCommitDate: null, description: "", milestones: [], commitActivity, openIssueCount: 0, closedIssueCount: 0 };
   }
 
   const allMs = [
@@ -427,6 +433,8 @@ async function fetchRepoInfo(token: string, owner: string, repo: string): Promis
       })),
     })),
     commitActivity,
+    openIssueCount: graphqlResult.repository.openIssueCount.totalCount,
+    closedIssueCount: graphqlResult.repository.closedIssueCount.totalCount,
   };
 }
 
@@ -464,8 +472,11 @@ export async function fetchDashboardData(token: string, forceRefresh = false): P
       if (issue.priority && issue.status !== "Done") priorityCounts[issue.priority]++;
     }
 
-    const doneCount = repoIssues.filter((i) => i.status === "Done").length;
-    const totalCount = repoIssues.length;
+    // Use real GitHub issue counts (not project board) for accurate totals.
+    // Board may not contain all issues; GitHub API is the source of truth.
+    const openCount = repoInfo.openIssueCount;
+    const doneCount = repoInfo.closedIssueCount;
+    const totalCount = openCount + doneCount;
     const progress = totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0;
 
     // Calculate last activity: most recent of last commit or last issue update
@@ -480,7 +491,11 @@ export async function fetchDashboardData(token: string, forceRefresh = false): P
       ? Math.floor((Date.now() - new Date(lastActivityDate).getTime()) / 86400000)
       : null;
 
-    // Calculate velocity: issues per ACTIVE day (days with at least 1 closure)
+    // Calculate velocity: issues per ACTIVE day (days with at least 1 closure).
+    // Velocity is derived from project board closures (repoIssues), while openCount
+    // comes from GitHub API. This is intentional: velocity = observed closure rate,
+    // openCount = real remaining work. ETA is capped at 365 days to avoid misleading
+    // values when board has few closures relative to total open issues.
     const now = Date.now();
     const closedWithDates = repoIssues.filter((i) => i.closedAt);
 
@@ -495,8 +510,8 @@ export async function fetchDashboardData(token: string, forceRefresh = false): P
     const velocity7d = calcVelocity(7 * 86400000);
     const velocity14d = calcVelocity(14 * 86400000);
     const bestVelocity = Math.max(velocity7d, velocity14d, 0.001);
-    const openCount = totalCount - doneCount;
-    const etaDays = openCount > 0 ? Math.ceil(openCount / bestVelocity * 1.25) : null; // 25% buffer
+    const rawEtaDays = openCount > 0 ? Math.ceil(openCount / bestVelocity * 1.25) : null; // 25% buffer
+    const etaDays = rawEtaDays !== null ? Math.min(rawEtaDays, 365) : null;
     const etaDate = etaDays !== null
       ? new Date(now + etaDays * 86400000).toISOString()
       : null;


### PR DESCRIPTION
## Summary
- Added `openIssueCount`/`closedIssueCount` to GraphQL query for accurate counts from GitHub
- Summary "Открыто" uses real GitHub open count, not board status sum
- Active Tasks filters completed issues (defense-in-depth with pipeline backend)
- Priority "no label" count uses board-only data to avoid mixing sources
- ETA capped at 365 days

## Test plan
- [ ] Verify "Открыто" matches real GitHub open issue count per repo
- [ ] Verify priority bar doesn't show inflated "no label" segment
- [ ] Verify active tasks panel shows only running tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)