### PR TITLE
fix: surface issue creation errors to the user

### DIFF
--- a/src/components/AuditIssuesDialog.tsx
+++ b/src/components/AuditIssuesDialog.tsx
@@ -128,6 +128,7 @@ export function AuditIssuesDialog({ project, onClose, onComplete }: Props) {
     setCreatingIndex(0);
 
     const urls: string[] = [];
+    const failures: { title: string; error: string }[] = [];
     for (let i = 0; i < selectedIssues.length; i++) {
       const issue = selectedIssues[i];
       setCreatingIndex(i);
@@ -145,8 +146,12 @@ export function AuditIssuesDialog({ project, onClose, onComplete }: Props) {
         try {
           await addIssueToProject(token, repoOwner, repoName, created.number, GITHUB_PROJECT_NUMBER);
         } catch { /* non-fatal — issue exists even if project board add fails */ }
-      } catch {
+      } catch (e) {
         urls.push("");
+        failures.push({
+          title: issue.title,
+          error: e instanceof Error ? e.message : String(e),
+        });
       }
       if (i < selectedIssues.length - 1) {
         await new Promise((r) => setTimeout(r, 200));
@@ -154,6 +159,24 @@ export function AuditIssuesDialog({ project, onClose, onComplete }: Props) {
     }
 
     const successUrls = urls.filter(Boolean);
+
+    // If every attempt failed, surface the errors instead of closing silently.
+    if (successUrls.length === 0 && failures.length > 0) {
+      const preview = failures
+        .slice(0, 3)
+        .map((f) => `• ${f.title}: ${f.error}`)
+        .join("\n");
+      const more = failures.length > 3 ? `\n(и ещё ${failures.length - 3})` : "";
+      setError(`Не удалось создать ни одного issue (${failures.length} ошибок):\n${preview}${more}`);
+      setState("error");
+      return;
+    }
+
+    // Partial failure — log and continue; successes get saved.
+    if (failures.length > 0) {
+      console.warn(`${failures.length} issue(s) failed to create:`, failures);
+    }
+
     onComplete(successUrls.length, successUrls);
   }
 

--- a/src/components/AuditTab.tsx
+++ b/src/components/AuditTab.tsx
@@ -133,8 +133,11 @@ export function AuditTab({ dashboardProjects = [] }: Props) {
             onComplete={async (issuesCreated, issueUrls) => {
               try {
                 await postAuditMeta(issuesDialogProject, issuesCreated, issueUrls);
-              } catch {
-                // Non-critical: meta save failure doesn't block the user
+              } catch (e) {
+                // Non-critical: issues are already created in GitHub even if
+                // auditor meta save fails. Surface to console so the user can
+                // diagnose (audit card may show "0 issues" despite success).
+                console.error("Failed to save audit meta (issues still exist in GitHub):", e);
               }
               setIssuesDialogProject(null);
               refresh();


### PR DESCRIPTION
## Summary
Silent catches in the audit issue creation flow were hiding every failure — users saw "0 issues created" with no diagnostic info. After today's Phase B deploy, moliyakg produced 0 GitHub issues despite a successful verification + preview flow; the user couldn't see why.

## Changes
- \`AuditIssuesDialog.handleCreate\` — collect failures, show error dialog with first 3 messages when all attempts fail
- \`AuditTab.onComplete\` — log postAuditMeta failure instead of silently ignoring (explains "issues in GitHub but dashboard shows 0")

No behavior change on the happy path.

## Test plan
- [x] tsc + lint clean
- [ ] Redeploy, re-attempt issue creation on moliyakg, see the actual GitHub API error