### PR TITLE
chore: raise verification target from 30 to 200 findings

### DIFF
--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { ProjectData, SummaryMetrics, Issue, AuditFinding, GeneratedIssue, Verdict } from "../types";
 import { GITHUB_OWNER, GITHUB_PROJECT_NUMBER, getToken } from "./config";
+import { VERIFICATION_TARGET_COUNT } from "./verification";
 import {
   listRepoFiles,
   readRepoFile,
@@ -521,9 +522,11 @@ export async function generateIssuesFromFindings(
   verdictByIndex?: Map<number, Verdict>,
   originalIndexOf?: (f: AuditFinding) => number | undefined,
 ): Promise<GeneratedIssue[]> {
-  // Include critical + high; expand to medium if fewer than 30
+  // Include critical + high; expand to medium until reaching the target.
+  // Must mirror selectFindingsForVerification so the same set is verified
+  // and converted to issues.
   let filtered = findings.filter((f) => f.severity === "critical" || f.severity === "high");
-  if (filtered.length < 30) {
+  if (filtered.length < VERIFICATION_TARGET_COUNT) {
     filtered = findings.filter(
       (f) => f.severity === "critical" || f.severity === "high" || f.severity === "medium",
     );

--- a/src/utils/verification.ts
+++ b/src/utils/verification.ts
@@ -42,16 +42,23 @@ export interface VerifyProgress {
   cacheHits: number;
 }
 
+// Upper bound on findings included in verification / issue generation.
+// Post-Phase-A audits are much cleaner (moliyakg: 352 → 81), so we can
+// afford to verify medium severity too. When critical+high alone cover
+// enough ground we stop there; otherwise we extend to medium up to this
+// target. Applied identically in `generateIssuesFromFindings`.
+export const VERIFICATION_TARGET_COUNT = 200;
+
 /** Subset of findings actually sent to issues — mirrors `generateIssuesFromFindings`. */
 export function selectFindingsForVerification(
   findings: AuditFinding[],
 ): { finding: AuditFinding; index: number }[] {
-  // Start with critical + high, expand to medium if < 30 (same rule as issue generation)
+  // Start with critical + high, expand to medium until reaching the target.
   const indexed = findings.map((f, index) => ({ finding: f, index }));
   let filtered = indexed.filter(
     (f) => f.finding.severity === "critical" || f.finding.severity === "high",
   );
-  if (filtered.length < 30) {
+  if (filtered.length < VERIFICATION_TARGET_COUNT) {
     filtered = indexed.filter(
       (f) =>
         f.finding.severity === "critical" ||


### PR DESCRIPTION
## Summary
Raises the verify-and-issue target from 30 to 200. After Phase A cleaned up noise (moliyakg 352 → 81, sewing-erp ~156), both projects fit well under 200 — which means medium severity now gets verified and issue-generated instead of being silently dropped when crit+high already ≥ 30.

Introduces \`VERIFICATION_TARGET_COUNT = 200\` in verification.ts and imports it in claude.ts so the selection rule stays shared between verification and issue generation.

## Expected impact
- moliyakg (81 total): all 81 get verified instead of just 33
- sewing-erp (~156): all get verified
- Larger projects still cap at crit+high if they exceed 200 there

## Test plan
- [x] tsc + lint clean