### PR TITLE
fix: project_context field name в transcript upload

### DIFF
--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -93,7 +93,7 @@ export async function uploadTranscript(
 ): Promise<TranscriptUploadResponse> {
   const form = new FormData();
   form.append("file", file);
-  form.append("project", project);
+  form.append("project_context", project);
 
   const res = await fetch(`${getBaseUrl()}/transcript/upload`, {
     method: "POST",


### PR DESCRIPTION
Dashboard отправлял 'project', API ожидает 'project_context'.