### PR TITLE
feat: rich progress UI for transcript processing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3366,10 +3366,47 @@ body::after {
   flex-direction: column;
   gap: var(--sp-4);
 }
+.tpc-progress-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
 .tpc-progress-title {
   font-size: var(--text-lg);
   font-weight: 700;
   color: var(--color-text);
+}
+.tpc-progress-elapsed {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-1) var(--sp-2);
+  white-space: nowrap;
+}
+.tpc-progress-detail {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--text-sm);
+  color: var(--color-primary);
+  font-weight: 500;
+}
+.tpc-progress-detail-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  animation: tpc-pulse-dot 1.5s ease-in-out infinite;
+  flex-shrink: 0;
+}
+@keyframes tpc-pulse-dot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
 }
 
 .tpc-stepper {
@@ -3468,7 +3505,10 @@ body::after {
   height: 100%;
   background: var(--color-primary);
   border-radius: 4px;
-  transition: width 0.3s ease;
+  transition: width 0.5s ease;
+}
+.tpc-progress-bar-fill--done {
+  background: var(--color-success);
 }
 .tpc-progress-pct {
   font-family: var(--font-mono);
@@ -3495,6 +3535,43 @@ body::after {
 }
 .tpc-progress-error .btn {
   align-self: flex-start;
+}
+.tpc-progress-error-context {
+  font-style: italic;
+  opacity: 0.8;
+}
+.tpc-progress-error--network {
+  background: color-mix(in srgb, var(--color-warning, #f59e0b) 8%, transparent);
+  color: var(--color-warning, #f59e0b);
+}
+
+/* Intermediate stats (shown after transcription) */
+.tpc-progress-stats {
+  display: flex;
+  gap: var(--sp-4);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+.tpc-progress-stat {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+  font-size: var(--text-sm);
+}
+.tpc-progress-stat-icon {
+  display: flex;
+  color: var(--color-text-muted);
+}
+.tpc-progress-stat-label {
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+.tpc-progress-stat-value {
+  color: var(--color-text);
+  font-weight: 700;
+  font-family: var(--font-mono);
 }
 
 /* Transcript BRIEF Display */
@@ -3744,6 +3821,24 @@ body::after {
 .tpc-status--failed {
   background: color-mix(in srgb, var(--color-danger) 15%, transparent);
   color: var(--color-danger);
+}
+.tpc-status--active {
+  background: color-mix(in srgb, var(--color-primary) 15%, transparent);
+  color: var(--color-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.tpc-status-pulse {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: tpc-pulse-dot 1.5s ease-in-out infinite;
+}
+.tpc-history-row--active {
+  background: color-mix(in srgb, var(--color-primary) 4%, transparent);
 }
 
 /* Transcript Editor */

--- a/src/components/TranscriptHistory.tsx
+++ b/src/components/TranscriptHistory.tsx
@@ -3,27 +3,35 @@ import { fetchTranscriptList, type TranscriptListItem } from "../utils/transcrip
 
 interface Props {
   onOpen: (taskId: string) => void;
+  onResume: (taskId: string) => void;
   refreshKey: number; // increment to trigger refresh
 }
 
 const STATUS_LABELS: Record<string, string> = {
   done: "Готово",
-  processing: "В обработке",
-  failed: "Ошибка",
+  queued: "В очереди",
+  transcribing: "Транскрипция",
+  processing: "Обработка",
+  error: "Ошибка",
 };
 
 const STATUS_CLASS: Record<string, string> = {
   done: "tpc-status--done",
-  processing: "tpc-status--processing",
-  failed: "tpc-status--failed",
+  queued: "tpc-status--active",
+  transcribing: "tpc-status--active",
+  processing: "tpc-status--active",
+  error: "tpc-status--failed",
 };
 
-export function TranscriptHistory({ onOpen, refreshKey }: Props) {
+const ACTIVE_STATUSES = new Set(["queued", "transcribing", "processing"]);
+
+export function TranscriptHistory({ onOpen, onResume, refreshKey }: Props) {
   const [items, setItems] = useState<TranscriptListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filterProject, setFilterProject] = useState("");
   const prevRefreshKey = useRef(refreshKey);
+  const autoRefreshRef = useRef<ReturnType<typeof setInterval>>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -50,6 +58,24 @@ export function TranscriptHistory({ onOpen, refreshKey }: Props) {
     }
   }, [refreshKey, load]);
 
+  // Auto-refresh while there are active jobs
+  const hasActive = useMemo(
+    () => items.some((i) => ACTIVE_STATUSES.has(i.status)),
+    [items],
+  );
+
+  useEffect(() => {
+    if (hasActive) {
+      autoRefreshRef.current = setInterval(load, 5000);
+    }
+    return () => {
+      if (autoRefreshRef.current) {
+        clearInterval(autoRefreshRef.current);
+        autoRefreshRef.current = null;
+      }
+    };
+  }, [hasActive, load]);
+
   const projects = useMemo(
     () => [...new Set(items.map((i) => i.project))].sort(),
     [items],
@@ -59,9 +85,13 @@ export function TranscriptHistory({ onOpen, refreshKey }: Props) {
     const list = filterProject
       ? items.filter((i) => i.project === filterProject)
       : items;
-    return [...list].sort(
-      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-    );
+    // Active jobs first, then by date
+    return [...list].sort((a, b) => {
+      const aActive = ACTIVE_STATUSES.has(a.status) ? 0 : 1;
+      const bActive = ACTIVE_STATUSES.has(b.status) ? 0 : 1;
+      if (aActive !== bActive) return aActive - bActive;
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    });
   }, [items, filterProject]);
 
   if (loading) {
@@ -116,36 +146,48 @@ export function TranscriptHistory({ onOpen, refreshKey }: Props) {
               </tr>
             </thead>
             <tbody>
-              {filtered.map((item) => (
-                <tr key={item.task_id}>
-                  <td className="tpc-history-date">
-                    {new Date(item.created_at).toLocaleString("ru-RU", {
-                      day: "2-digit",
-                      month: "2-digit",
-                      year: "2-digit",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
-                  </td>
-                  <td className="tpc-history-project">{item.project}</td>
-                  <td className="tpc-history-file">{item.filename}</td>
-                  <td>
-                    <span className={`tpc-status ${STATUS_CLASS[item.status] ?? ""}`}>
-                      {STATUS_LABELS[item.status] ?? item.status}
-                    </span>
-                  </td>
-                  <td>
-                    {item.status === "done" && (
-                      <button
-                        className="btn btn-sm btn-primary"
-                        onClick={() => onOpen(item.task_id)}
-                      >
-                        Открыть
-                      </button>
-                    )}
-                  </td>
-                </tr>
-              ))}
+              {filtered.map((item) => {
+                const isActive = ACTIVE_STATUSES.has(item.status);
+                return (
+                  <tr key={item.task_id} className={isActive ? "tpc-history-row--active" : ""}>
+                    <td className="tpc-history-date">
+                      {new Date(item.created_at).toLocaleString("ru-RU", {
+                        day: "2-digit",
+                        month: "2-digit",
+                        year: "2-digit",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </td>
+                    <td className="tpc-history-project">{item.project}</td>
+                    <td className="tpc-history-file">{item.filename}</td>
+                    <td>
+                      <span className={`tpc-status ${STATUS_CLASS[item.status] ?? ""}`}>
+                        {isActive && <span className="tpc-status-pulse" />}
+                        {STATUS_LABELS[item.status] ?? item.status}
+                      </span>
+                    </td>
+                    <td>
+                      {item.status === "done" && (
+                        <button
+                          className="btn btn-sm btn-primary"
+                          onClick={() => onOpen(item.task_id)}
+                        >
+                          Открыть
+                        </button>
+                      )}
+                      {isActive && (
+                        <button
+                          className="btn btn-sm"
+                          onClick={() => onResume(item.task_id)}
+                        >
+                          Следить
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/src/components/TranscriptProgress.tsx
+++ b/src/components/TranscriptProgress.tsx
@@ -1,18 +1,32 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchTranscriptStatus, type TranscriptStage, type TranscriptStatus } from "../utils/transcript";
 
-const POLL_INTERVAL = 3000;
+const POLL_INTERVAL = 2000;
 const MAX_POLL_FAILURES = 5;
 
-const STAGES: { key: TranscriptStage; label: string }[] = [
-  { key: "upload", label: "Загрузка" },
-  { key: "transcription", label: "Транскрипция" },
-  { key: "processing", label: "Обработка" },
-  { key: "done", label: "Готово" },
+const STAGES: { key: TranscriptStage; label: string; icon: string }[] = [
+  { key: "upload", label: "Загрузка", icon: "1" },
+  { key: "transcription", label: "Транскрипция", icon: "2" },
+  { key: "processing", label: "Обработка", icon: "3" },
+  { key: "done", label: "Готово", icon: "4" },
 ];
 
 function stageIndex(stage: TranscriptStage): number {
   return STAGES.findIndex((s) => s.key === stage);
+}
+
+function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  if (m === 0) return `${s} сек`;
+  return `${m} мин ${s} сек`;
+}
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  if (m === 0) return `${s} сек`;
+  return `${m}:${String(s).padStart(2, "0")}`;
 }
 
 interface Props {
@@ -25,13 +39,19 @@ export function TranscriptProgress({ taskId, onDone, onRetry }: Props) {
   const [status, setStatus] = useState<TranscriptStatus | null>(null);
   const [pollError, setPollError] = useState<string | null>(null);
   const [pollExhausted, setPollExhausted] = useState(false);
+  const [elapsed, setElapsed] = useState(0);
   const timerRef = useRef<ReturnType<typeof setInterval>>(null);
+  const elapsedRef = useRef<ReturnType<typeof setInterval>>(null);
   const failCountRef = useRef(0);
 
   const stopPolling = useCallback(() => {
     if (timerRef.current) {
       clearInterval(timerRef.current);
       timerRef.current = null;
+    }
+    if (elapsedRef.current) {
+      clearInterval(elapsedRef.current);
+      elapsedRef.current = null;
     }
   }, []);
 
@@ -58,8 +78,10 @@ export function TranscriptProgress({ taskId, onDone, onRetry }: Props) {
 
   useEffect(() => {
     failCountRef.current = 0;
+    setElapsed(0);
     const initial = setTimeout(poll, 0);
     timerRef.current = setInterval(poll, POLL_INTERVAL);
+    elapsedRef.current = setInterval(() => setElapsed((e) => e + 1), 1000);
     return () => {
       clearTimeout(initial);
       stopPolling();
@@ -69,51 +91,109 @@ export function TranscriptProgress({ taskId, onDone, onRetry }: Props) {
   const currentIdx = status ? stageIndex(status.stage) : 0;
   const hasError = !!status?.error;
   const pct = status ? Math.min(100, Math.max(0, status.progress)) : 0;
+  const isDone = status?.stage === "done";
 
   return (
     <div className="tpc-progress">
-      <div className="tpc-progress-title">
-        {hasError ? "Ошибка обработки" : status?.stage === "done" ? "Обработка завершена" : "Обработка..."}
+      {/* Header with file name and elapsed time */}
+      <div className="tpc-progress-header">
+        <div className="tpc-progress-title">
+          {hasError
+            ? "Ошибка обработки"
+            : isDone
+              ? "Обработка завершена"
+              : status?.file_name
+                ? `Обработка: ${status.file_name}`
+                : "Обработка..."}
+        </div>
+        {!isDone && !hasError && (
+          <div className="tpc-progress-elapsed">
+            {formatElapsed(elapsed)}
+          </div>
+        )}
       </div>
 
-      {/* Stepper */}
+      {/* Progress bar */}
+      {!hasError && (
+        <div className="tpc-progress-bar-wrap">
+          <div className="tpc-progress-bar">
+            <div
+              className={`tpc-progress-bar-fill${isDone ? " tpc-progress-bar-fill--done" : ""}`}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <span className="tpc-progress-pct">{pct}%</span>
+        </div>
+      )}
+
+      {/* Current stage detail */}
+      {status?.stage_detail && !hasError && !isDone && (
+        <div className="tpc-progress-detail">
+          <div className="tpc-progress-detail-dot" />
+          <span>{status.stage_detail}</span>
+        </div>
+      )}
+
+      {/* Stepper timeline */}
       <div className="tpc-stepper">
         {STAGES.map((s, i) => {
-          const isDone = i < currentIdx || (i === currentIdx && status?.stage === "done");
-          const isActive = i === currentIdx && !hasError && status?.stage !== "done";
+          const stepDone = i < currentIdx || (i === currentIdx && isDone);
+          const isActive = i === currentIdx && !hasError && !isDone;
           const isFailed = i === currentIdx && hasError;
 
           return (
             <div key={s.key} className="tpc-step-wrapper">
-              <div className={`tpc-step${isDone ? " tpc-step--done" : ""}${isActive ? " tpc-step--active" : ""}${isFailed ? " tpc-step--error" : ""}`}>
+              <div className={`tpc-step${stepDone ? " tpc-step--done" : ""}${isActive ? " tpc-step--active" : ""}${isFailed ? " tpc-step--error" : ""}`}>
                 <div className="tpc-step-dot">
-                  {isDone ? (
+                  {stepDone ? (
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
                       <polyline points="20 6 9 17 4 12" />
                     </svg>
                   ) : isFailed ? (
                     "!"
                   ) : (
-                    <span>{i + 1}</span>
+                    <span>{s.icon}</span>
                   )}
                 </div>
                 <span className="tpc-step-label">{s.label}</span>
               </div>
               {i < STAGES.length - 1 && (
-                <div className={`tpc-step-line${isDone ? " tpc-step-line--done" : ""}`} />
+                <div className={`tpc-step-line${stepDone ? " tpc-step-line--done" : ""}`} />
               )}
             </div>
           );
         })}
       </div>
 
-      {/* Progress bar for active stage */}
-      {status && !hasError && status.stage !== "done" && (
-        <div className="tpc-progress-bar-wrap">
-          <div className="tpc-progress-bar">
-            <div className="tpc-progress-bar-fill" style={{ width: `${pct}%` }} />
-          </div>
-          <span className="tpc-progress-pct">{pct}%</span>
+      {/* Intermediate stats (shown after transcription completes) */}
+      {status && (status.duration_seconds > 0 || status.speaker_count > 0) && (
+        <div className="tpc-progress-stats">
+          {status.duration_seconds > 0 && (
+            <div className="tpc-progress-stat">
+              <span className="tpc-progress-stat-icon">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 6 12 12 16 14" />
+                </svg>
+              </span>
+              <span className="tpc-progress-stat-label">Длительность:</span>
+              <span className="tpc-progress-stat-value">{formatDuration(status.duration_seconds)}</span>
+            </div>
+          )}
+          {status.speaker_count > 0 && (
+            <div className="tpc-progress-stat">
+              <span className="tpc-progress-stat-icon">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                  <circle cx="9" cy="7" r="4" />
+                  <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+                  <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+                </svg>
+              </span>
+              <span className="tpc-progress-stat-label">Спикеров:</span>
+              <span className="tpc-progress-stat-value">{status.speaker_count}</span>
+            </div>
+          )}
         </div>
       )}
 
@@ -121,6 +201,11 @@ export function TranscriptProgress({ taskId, onDone, onRetry }: Props) {
       {hasError && (
         <div className="tpc-progress-error">
           <p>{status?.error}</p>
+          {status?.stage_detail && (
+            <p className="tpc-progress-error-context">
+              Этап: {status.stage_detail}
+            </p>
+          )}
           <button className="btn btn-primary" onClick={onRetry}>
             Повторить
           </button>
@@ -129,7 +214,7 @@ export function TranscriptProgress({ taskId, onDone, onRetry }: Props) {
 
       {/* Poll error (network issue, not task error) */}
       {pollError && !hasError && (
-        <div className="tpc-progress-error">
+        <div className="tpc-progress-error tpc-progress-error--network">
           <p>Соединение потеряно: {pollError}</p>
           {pollExhausted && (
             <button className="btn btn-primary" onClick={onRetry}>

--- a/src/components/TranscriptsTab.tsx
+++ b/src/components/TranscriptsTab.tsx
@@ -116,6 +116,13 @@ export function TranscriptsTab({ projects }: Props) {
     }
   }, []);
 
+  const onResumeFromHistory = useCallback((taskId: string) => {
+    setBriefResult(null);
+    setEditing(false);
+    setResult(null);
+    setActiveTaskId(taskId);
+  }, []);
+
   const onEditSave = useCallback((updatedBrief: string) => {
     setBriefResult((prev) => prev ? { ...prev, brief: updatedBrief } : prev);
     setEditing(false);
@@ -255,7 +262,7 @@ export function TranscriptsTab({ projects }: Props) {
 
       {/* History table (hidden when BRIEF is shown or loading) */}
       {!briefResult && !activeTaskId && !loadingBrief && (
-        <TranscriptHistory onOpen={onOpenFromHistory} refreshKey={historyRefreshKey} />
+        <TranscriptHistory onOpen={onOpenFromHistory} onResume={onResumeFromHistory} refreshKey={historyRefreshKey} />
       )}
     </div>
   );

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -17,9 +17,37 @@ export type TranscriptStage = "upload" | "transcription" | "processing" | "done"
 export interface TranscriptStatus {
   task_id: string;
   stage: TranscriptStage;
+  stage_detail: string;
   progress: number; // 0–100
   error: string | null;
   result_url: string | null;
+  file_name: string;
+  started_at: string | null;
+  duration_seconds: number;
+  speaker_count: number;
+}
+
+/** Map backend status string to frontend stage.
+ *  For errors, use the backend `stage` field to determine where the failure occurred. */
+function mapStatusToStage(status: string, backendStage?: string): TranscriptStage {
+  switch (status) {
+    case "queued":
+      return "upload";
+    case "transcribing":
+      return "transcription";
+    case "processing":
+      return "processing";
+    case "done":
+      return "done";
+    case "error": {
+      // Determine which stage the error occurred in
+      const s = (backendStage || "").toLowerCase();
+      if (s.includes("транскрипц")) return "transcription";
+      return "processing";
+    }
+    default:
+      return "upload";
+  }
 }
 
 export async function fetchTranscriptStatus(taskId: string): Promise<TranscriptStatus> {
@@ -30,7 +58,19 @@ export async function fetchTranscriptStatus(taskId: string): Promise<TranscriptS
     const text = await res.text().catch(() => "");
     throw new Error(`Status check failed (${res.status}): ${text}`);
   }
-  return res.json();
+  const data = await res.json();
+  return {
+    task_id: data.job_id,
+    stage: mapStatusToStage(data.status, data.stage),
+    stage_detail: data.stage_detail || data.stage || "",
+    progress: data.progress ?? 0,
+    error: data.error || null,
+    result_url: null,
+    file_name: data.file_name || "",
+    started_at: data.started_at || null,
+    duration_seconds: data.duration_seconds ?? 0,
+    speaker_count: data.speaker_count ?? 0,
+  };
 }
 
 export interface TranscriptResult {
@@ -47,14 +87,19 @@ export async function fetchTranscriptResult(taskId: string): Promise<TranscriptR
     const text = await res.text().catch(() => "");
     throw new Error(`Failed to load result (${res.status}): ${text}`);
   }
-  return res.json();
+  const data = await res.json();
+  return {
+    task_id: data.job_id,
+    brief: data.brief_content || "",
+    transcript: data.transcript_text || "",
+  };
 }
 
 export interface TranscriptListItem {
   task_id: string;
   project: string;
   filename: string;
-  status: "done" | "processing" | "failed";
+  status: "done" | "queued" | "transcribing" | "processing" | "error";
   created_at: string; // ISO timestamp
 }
 
@@ -66,7 +111,14 @@ export async function fetchTranscriptList(): Promise<TranscriptListItem[]> {
     const text = await res.text().catch(() => "");
     throw new Error(`Failed to load history (${res.status}): ${text}`);
   }
-  return res.json();
+  const data: Array<Record<string, string>> = await res.json();
+  return data.map((item) => ({
+    task_id: item.job_id,
+    project: item.project || "",
+    filename: item.file_name || "",
+    status: item.status as TranscriptListItem["status"],
+    created_at: item.created_at || "",
+  }));
 }
 
 export async function saveTranscriptBrief(
@@ -103,5 +155,6 @@ export async function uploadTranscript(
     const text = await res.text().catch(() => "");
     throw new Error(`Upload failed (${res.status}): ${text}`);
   }
-  return res.json();
+  const data = await res.json();
+  return { task_id: data.job_id, status: data.status };
 }


### PR DESCRIPTION
## Summary
- Map backend status fields (stage_detail, progress, duration_seconds, speaker_count) to frontend
- Elapsed timer, intermediate stats, granular sub-stage display
- Auto-refresh history table while active jobs exist, "Следить" button
- Network error vs task error visual distinction

## Test plan
- [ ] Upload audio → verify progress bar, elapsed timer, sub-stage detail
- [ ] Check history auto-refreshes during processing
- [ ] Verify "Следить" resumes progress tracking from history

🤖 Generated with [Claude Code](https://claude.com/claude-code)