### PR TITLE
feat: Research/Discovery tab

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4351,3 +4351,332 @@ body::after {
   text-align: center;
   padding: var(--sp-4);
 }
+
+/* ── Research / Discovery Tab ── */
+
+.rsh-loading {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-6);
+  color: var(--gray-400);
+  font-size: var(--text-sm);
+}
+
+.rsh-summary {
+  display: flex;
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-5);
+}
+
+.rsh-summary-item {
+  background: var(--gray-100);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-3) var(--sp-4);
+  min-width: 120px;
+  text-align: center;
+}
+
+.rsh-summary-value {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.rsh-summary-label {
+  font-size: var(--text-xs);
+  color: var(--gray-400);
+  margin-top: var(--sp-1);
+}
+
+.rsh-summary-qw .rsh-summary-value {
+  color: var(--green-400);
+}
+
+.rsh-projects {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.rsh-project {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--gray-100);
+  overflow: hidden;
+  transition: border-color 0.15s;
+}
+
+.rsh-project:hover {
+  border-color: var(--gray-500);
+}
+
+.rsh-project-expanded {
+  border-color: var(--color-primary);
+}
+
+.rsh-project-header {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  cursor: pointer;
+  user-select: none;
+}
+
+.rsh-project-name {
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.rsh-loading-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  animation: rsh-pulse 1s infinite;
+}
+
+@keyframes rsh-pulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+.rsh-project-stats {
+  display: flex;
+  gap: var(--sp-2);
+  margin-left: auto;
+}
+
+.rsh-stat {
+  font-size: var(--text-xs);
+  color: var(--gray-400);
+  background: var(--gray-200);
+  padding: 2px var(--sp-2);
+  border-radius: var(--radius-full);
+}
+
+.rsh-stat-qw {
+  color: var(--green-400);
+  background: rgba(52, 211, 153, 0.1);
+}
+
+.rsh-stat-empty {
+  color: var(--gray-500);
+  background: none;
+  font-style: italic;
+}
+
+.rsh-chevron {
+  font-size: var(--text-xs);
+  color: var(--gray-500);
+  width: 16px;
+  text-align: center;
+}
+
+.rsh-project-body {
+  padding: 0 var(--sp-4) var(--sp-4);
+  border-top: 1px solid var(--color-border);
+}
+
+/* Sections */
+
+.rsh-section {
+  margin-top: var(--sp-4);
+}
+
+.rsh-section-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--gray-300);
+  margin-bottom: var(--sp-2);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.rsh-title-qw { color: var(--green-400); }
+.rsh-title-sb { color: var(--color-primary); }
+.rsh-title-nth { color: var(--gray-500); }
+
+/* Feature Matrix Table */
+
+.rsh-table-wrap {
+  overflow-x: auto;
+  margin-top: var(--sp-2);
+}
+
+.rsh-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-xs);
+}
+
+.rsh-table th,
+.rsh-table td {
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--color-border);
+  text-align: left;
+}
+
+.rsh-table th {
+  background: var(--gray-200);
+  color: var(--gray-300);
+  font-weight: 600;
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.rsh-feature-name {
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.rsh-cell-yes {
+  color: var(--green-400);
+}
+
+.rsh-cell-no {
+  color: var(--gray-600);
+}
+
+/* Competitor Cards */
+
+.rsh-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--sp-3);
+}
+
+.rsh-card {
+  background: var(--gray-200);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-3);
+}
+
+.rsh-card-title {
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  margin-bottom: var(--sp-1);
+}
+
+.rsh-card-url {
+  font-size: var(--text-xs);
+  color: var(--color-primary);
+  margin-bottom: var(--sp-1);
+  word-break: break-all;
+}
+
+.rsh-card-meta {
+  font-size: var(--text-xs);
+  color: var(--gray-400);
+}
+
+.rsh-card-features {
+  margin: var(--sp-2) 0 0;
+  padding-left: var(--sp-4);
+  font-size: var(--text-xs);
+  color: var(--gray-300);
+}
+
+.rsh-card-features li {
+  margin-bottom: 2px;
+}
+
+/* Lists: Pain Points & Opportunities */
+
+.rsh-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.rsh-list-item {
+  font-size: var(--text-sm);
+  padding: var(--sp-2) var(--sp-3);
+  border-left: 3px solid var(--color-border);
+  margin-bottom: var(--sp-1);
+  color: var(--gray-300);
+}
+
+.rsh-pain {
+  border-left-color: var(--color-danger);
+}
+
+.rsh-opp {
+  border-left-color: var(--green-400);
+}
+
+/* Discovery Suggestions */
+
+.rsh-suggestions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.rsh-suggestion {
+  background: var(--gray-200);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-3);
+}
+
+.rsh-suggestion-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+}
+
+.rsh-suggestion-name {
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--color-text);
+}
+
+.rsh-suggestion-badges {
+  display: flex;
+  gap: var(--sp-1);
+  flex-shrink: 0;
+}
+
+.rsh-badge {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: var(--radius-full);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.rsh-effort-s { background: rgba(52, 211, 153, 0.15); color: var(--green-400); }
+.rsh-effort-m { background: rgba(96, 165, 250, 0.15); color: var(--blue-400); }
+.rsh-effort-l { background: rgba(251, 191, 36, 0.15); color: var(--orange-400); }
+.rsh-effort-xl { background: rgba(239, 68, 68, 0.15); color: var(--red-400); }
+
+.rsh-impact-critical { background: rgba(239, 68, 68, 0.15); color: var(--red-400); }
+.rsh-impact-high { background: rgba(251, 191, 36, 0.15); color: var(--orange-400); }
+.rsh-impact-medium { background: rgba(96, 165, 250, 0.15); color: var(--blue-400); }
+.rsh-impact-low { background: rgba(148, 163, 184, 0.15); color: var(--gray-400); }
+
+.rsh-suggestion-desc {
+  font-size: var(--text-xs);
+  color: var(--gray-300);
+  margin-top: var(--sp-1);
+}
+
+.rsh-suggestion-evidence {
+  font-size: var(--text-xs);
+  color: var(--gray-500);
+  margin-top: var(--sp-1);
+  font-style: italic;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { AuditTab } from "./components/AuditTab";
 import { UXAuditTab } from "./components/UXAuditTab";
 import { PipelineControlPanel } from "./components/PipelineControlPanel";
 import { TranscriptsTab } from "./components/TranscriptsTab";
+import { ResearchTab } from "./components/ResearchTab";
 import { useDashboard } from "./hooks/useDashboard";
 import { useMonitors } from "./hooks/useMonitors";
 import { getToken, clearToken, getAuth, clearAuth, clearClaudeKey, MONITOR_MATCH, PROJECTS } from "./utils/config";
@@ -104,6 +105,7 @@ function AppInner() {
               { id: "transcripts" as TabId, label: "Транскрипты" },
               { id: "audit" as TabId, label: "Аудит" },
               { id: "ux-audit" as TabId, label: "UX Аудит" },
+              { id: "research" as TabId, label: "Research" },
             ]).map((t) => (
               <button
                 key={t.id}
@@ -299,6 +301,9 @@ function AppInner() {
           </div>
           <div className="bento-grid" style={{ display: tab === "transcripts" ? undefined : "none" }}>
             {visitedTabs.has("transcripts") && <TranscriptsTab projects={PROJECTS} />}
+          </div>
+          <div className="bento-grid" style={{ display: tab === "research" ? undefined : "none" }}>
+            {visitedTabs.has("research") && <ResearchTab repos={projects.map((p) => p.repo)} />}
           </div>
         </>
       )}

--- a/src/components/ResearchTab.tsx
+++ b/src/components/ResearchTab.tsx
@@ -1,0 +1,312 @@
+import { useEffect, useRef, useState } from "react";
+import { useResearch } from "../hooks/useResearch";
+import type { ProjectResearch, ResearchData, DiscoveryData, DiscoverySuggestion } from "../types";
+
+interface Props {
+  repos: string[];
+}
+
+const EFFORT_BADGE: Record<string, string> = {
+  S: "rsh-effort-s",
+  M: "rsh-effort-m",
+  L: "rsh-effort-l",
+  XL: "rsh-effort-xl",
+};
+
+const IMPACT_BADGE: Record<string, string> = {
+  critical: "rsh-impact-critical",
+  high: "rsh-impact-high",
+  medium: "rsh-impact-medium",
+  low: "rsh-impact-low",
+};
+
+function EffortBadge({ effort }: { effort: string }) {
+  if (!effort) return null;
+  return <span className={`rsh-badge ${EFFORT_BADGE[effort] ?? ""}`}>{effort}</span>;
+}
+
+function ImpactBadge({ impact }: { impact: string }) {
+  if (!impact) return null;
+  return <span className={`rsh-badge ${IMPACT_BADGE[impact] ?? ""}`}>{impact}</span>;
+}
+
+// ── Competitor Matrix ──
+
+function CompetitorMatrix({ research }: { research: ResearchData }) {
+  const { featureMatrix, competitors } = research;
+  const features = Object.keys(featureMatrix);
+  if (!features.length && !competitors.length) return null;
+
+  // If we have a matrix table, show it
+  if (features.length > 0) {
+    const compNames = new Set<string>();
+    for (const row of Object.values(featureMatrix)) {
+      for (const key of Object.keys(row)) compNames.add(key);
+    }
+    const headers = Array.from(compNames);
+
+    return (
+      <div className="rsh-section">
+        <h3 className="rsh-section-title">Матрица функций</h3>
+        <div className="rsh-table-wrap">
+          <table className="rsh-table">
+            <thead>
+              <tr>
+                <th>Функция</th>
+                {headers.map((h) => <th key={h}>{h}</th>)}
+              </tr>
+            </thead>
+            <tbody>
+              {features.map((f) => (
+                <tr key={f}>
+                  <td className="rsh-feature-name">{f}</td>
+                  {headers.map((h) => {
+                    const val = featureMatrix[f]?.[h] ?? "—";
+                    const isYes = /✅|yes|да|\+/i.test(val);
+                    const isNo = /❌|no|нет|−|-/i.test(val);
+                    return (
+                      <td key={h} className={isYes ? "rsh-cell-yes" : isNo ? "rsh-cell-no" : ""}>
+                        {val}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+
+  // Fallback: show competitor cards
+  return (
+    <div className="rsh-section">
+      <h3 className="rsh-section-title">Конкуренты ({competitors.length})</h3>
+      <div className="rsh-cards">
+        {competitors.map((c) => (
+          <div key={c.name} className="rsh-card">
+            <div className="rsh-card-title">{c.name}</div>
+            {c.url && <div className="rsh-card-url">{c.url}</div>}
+            {c.pricing && <div className="rsh-card-meta">Цена: {c.pricing}</div>}
+            {c.audience && <div className="rsh-card-meta">Аудитория: {c.audience}</div>}
+            {c.features.length > 0 && (
+              <ul className="rsh-card-features">
+                {c.features.map((f, i) => <li key={i}>{f}</li>)}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Pain Points ──
+
+function PainPoints({ research }: { research: ResearchData }) {
+  if (!research.painPoints.length) return null;
+  return (
+    <div className="rsh-section">
+      <h3 className="rsh-section-title">Болевые точки ({research.painPoints.length})</h3>
+      <ul className="rsh-list">
+        {research.painPoints.map((p, i) => (
+          <li key={i} className="rsh-list-item rsh-pain">{p.theme}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ── Opportunities ──
+
+function Opportunities({ research }: { research: ResearchData }) {
+  if (!research.opportunities.length) return null;
+  return (
+    <div className="rsh-section">
+      <h3 className="rsh-section-title">Возможности ({research.opportunities.length})</h3>
+      <ul className="rsh-list">
+        {research.opportunities.map((o, i) => (
+          <li key={i} className="rsh-list-item rsh-opp">{o}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ── Discovery Suggestions ──
+
+function SuggestionCard({ s }: { s: DiscoverySuggestion }) {
+  return (
+    <div className="rsh-suggestion">
+      <div className="rsh-suggestion-header">
+        <span className="rsh-suggestion-name">{s.name}</span>
+        <span className="rsh-suggestion-badges">
+          <EffortBadge effort={s.effort} />
+          <ImpactBadge impact={s.impact} />
+        </span>
+      </div>
+      {s.description && <div className="rsh-suggestion-desc">{s.description}</div>}
+      {s.evidence && <div className="rsh-suggestion-evidence">Источник: {s.evidence}</div>}
+    </div>
+  );
+}
+
+function DiscoverySection({ discovery }: { discovery: DiscoveryData }) {
+  const { quickWins, strategicBets, niceToHaves } = discovery;
+  if (!quickWins.length && !strategicBets.length && !niceToHaves.length) return null;
+
+  return (
+    <>
+      {quickWins.length > 0 && (
+        <div className="rsh-section">
+          <h3 className="rsh-section-title rsh-title-qw">
+            Quick Wins ({quickWins.length})
+          </h3>
+          <div className="rsh-suggestions">
+            {quickWins.map((s, i) => <SuggestionCard key={i} s={s} />)}
+          </div>
+        </div>
+      )}
+      {strategicBets.length > 0 && (
+        <div className="rsh-section">
+          <h3 className="rsh-section-title rsh-title-sb">
+            Strategic Bets ({strategicBets.length})
+          </h3>
+          <div className="rsh-suggestions">
+            {strategicBets.map((s, i) => <SuggestionCard key={i} s={s} />)}
+          </div>
+        </div>
+      )}
+      {niceToHaves.length > 0 && (
+        <div className="rsh-section">
+          <h3 className="rsh-section-title rsh-title-nth">
+            Nice to Have ({niceToHaves.length})
+          </h3>
+          <div className="rsh-suggestions">
+            {niceToHaves.map((s, i) => <SuggestionCard key={i} s={s} />)}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+// ── Project Panel ──
+
+function ProjectPanel({ pr }: { pr: ProjectResearch }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasData = pr.research || pr.discovery;
+
+  const stats = {
+    competitors: pr.research?.competitors.length ?? 0,
+    painPoints: pr.research?.painPoints.length ?? 0,
+    suggestions: pr.discovery?.suggestions.length ?? 0,
+    quickWins: pr.discovery?.quickWins.length ?? 0,
+  };
+
+  return (
+    <div className={`rsh-project ${expanded ? "rsh-project-expanded" : ""}`}>
+      <div className="rsh-project-header" onClick={() => hasData && setExpanded(!expanded)}>
+        <div className="rsh-project-name">
+          {pr.repo}
+          {pr.loading && <span className="rsh-loading-dot" />}
+        </div>
+        <div className="rsh-project-stats">
+          {hasData ? (
+            <>
+              {stats.competitors > 0 && <span className="rsh-stat">{stats.competitors} конкур.</span>}
+              {stats.painPoints > 0 && <span className="rsh-stat">{stats.painPoints} проблем</span>}
+              {stats.suggestions > 0 && <span className="rsh-stat">{stats.suggestions} идей</span>}
+              {stats.quickWins > 0 && <span className="rsh-stat rsh-stat-qw">{stats.quickWins} QW</span>}
+            </>
+          ) : (
+            <span className="rsh-stat rsh-stat-empty">{pr.error ?? "Нет данных"}</span>
+          )}
+        </div>
+        {hasData && (
+          <span className="rsh-chevron">{expanded ? "▾" : "▸"}</span>
+        )}
+      </div>
+
+      {expanded && hasData && (
+        <div className="rsh-project-body">
+          {pr.research && (
+            <>
+              <CompetitorMatrix research={pr.research} />
+              <PainPoints research={pr.research} />
+              <Opportunities research={pr.research} />
+            </>
+          )}
+          {pr.discovery && <DiscoverySection discovery={pr.discovery} />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main Tab ──
+
+export function ResearchTab({ repos }: Props) {
+  const { projects, loading, refresh } = useResearch();
+  const loadedRef = useRef(false);
+
+  useEffect(() => {
+    if (!loadedRef.current && repos.length > 0) {
+      loadedRef.current = true;
+      refresh(repos);
+    }
+  }, [repos, refresh]);
+
+  const totalSuggestions = projects.reduce((n, p) => n + (p.discovery?.suggestions.length ?? 0), 0);
+  const totalQuickWins = projects.reduce((n, p) => n + (p.discovery?.quickWins.length ?? 0), 0);
+  const projectsWithData = projects.filter((p) => p.research || p.discovery).length;
+
+  return (
+    <div className="bento-panel span-12 panel-projects">
+      <div className="bento-panel-title">
+        <div>
+          Research / Discovery
+          <span className="audit-header-sub">RESEARCH.md + DISCOVERY.md из репозиториев</span>
+        </div>
+        <button className="btn btn-sm btn-primary" onClick={() => refresh(repos)} disabled={loading}>
+          {loading ? "Загрузка..." : "Обновить"}
+        </button>
+      </div>
+
+      {loading && projects.length === 0 && (
+        <div className="rsh-loading">
+          <div className="audit-spinner" />
+          Загрузка данных из репозиториев...
+        </div>
+      )}
+
+      {!loading && projects.length === 0 && (
+        <div className="empty-state">Нажмите «Обновить» для загрузки данных</div>
+      )}
+
+      {projects.length > 0 && (
+        <>
+          <div className="rsh-summary">
+            <div className="rsh-summary-item">
+              <div className="rsh-summary-value">{projectsWithData}</div>
+              <div className="rsh-summary-label">проектов с данными</div>
+            </div>
+            <div className="rsh-summary-item">
+              <div className="rsh-summary-value">{totalSuggestions}</div>
+              <div className="rsh-summary-label">идей всего</div>
+            </div>
+            <div className="rsh-summary-item rsh-summary-qw">
+              <div className="rsh-summary-value">{totalQuickWins}</div>
+              <div className="rsh-summary-label">quick wins</div>
+            </div>
+          </div>
+
+          <div className="rsh-projects">
+            {projects.map((pr) => <ProjectPanel key={pr.repo} pr={pr} />)}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useResearch.ts
+++ b/src/hooks/useResearch.ts
@@ -1,0 +1,67 @@
+import { useState, useCallback } from "react";
+import { readRepoFile } from "../utils/github-actions";
+import { parseResearchMd, parseDiscoveryMd } from "../utils/research-parser";
+import { getToken } from "../utils/config";
+import type { ProjectResearch, ResearchData, DiscoveryData } from "../types";
+
+const OWNER = "Sergio1990-1";
+
+interface UseResearchReturn {
+  projects: ProjectResearch[];
+  loading: boolean;
+  refresh: (repos: string[]) => Promise<void>;
+}
+
+async function loadFileOrNull(token: string, repo: string, path: string): Promise<string | null> {
+  try {
+    return await readRepoFile(token, OWNER, repo, path);
+  } catch {
+    return null;
+  }
+}
+
+export function useResearch(): UseResearchReturn {
+  const [projects, setProjects] = useState<ProjectResearch[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async (repos: string[]) => {
+    const token = getToken();
+    if (!token) return;
+
+    setLoading(true);
+
+    // Initialize all as loading
+    setProjects(repos.map((repo) => ({ repo, research: null, discovery: null, loading: true, error: null })));
+
+    const results = await Promise.allSettled(
+      repos.map(async (repo): Promise<ProjectResearch> => {
+        const [researchMd, discoveryMd] = await Promise.all([
+          loadFileOrNull(token, repo, "RESEARCH.md"),
+          loadFileOrNull(token, repo, "DISCOVERY.md"),
+        ]);
+
+        let research: ResearchData | null = null;
+        let discovery: DiscoveryData | null = null;
+
+        if (researchMd) research = parseResearchMd(researchMd);
+        if (discoveryMd) discovery = parseDiscoveryMd(discoveryMd);
+
+        if (!research && !discovery) {
+          return { repo, research: null, discovery: null, loading: false, error: "Нет RESEARCH.md / DISCOVERY.md" };
+        }
+        return { repo, research, discovery, loading: false, error: null };
+      })
+    );
+
+    setProjects(
+      results.map((r, i) => {
+        if (r.status === "fulfilled") return r.value;
+        return { repo: repos[i], research: null, discovery: null, loading: false, error: String(r.reason) };
+      })
+    );
+
+    setLoading(false);
+  }, []);
+
+  return { projects, loading, refresh };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,7 +97,60 @@ export interface Filters {
   status: IssueStatus | null;
 }
 
-export type TabId = "dashboard" | "projects" | "milestones" | "uptime" | "audit" | "ux-audit" | "pipeline" | "transcripts";
+export type TabId = "dashboard" | "projects" | "milestones" | "uptime" | "audit" | "ux-audit" | "pipeline" | "transcripts" | "research";
+
+// ── Research / Discovery ──
+
+export interface ResearchCompetitor {
+  name: string;
+  url: string;
+  features: string[];
+  pricing: string;
+  audience: string;
+}
+
+export interface ResearchPainPoint {
+  theme: string;
+  frequency: string;
+  source: string;
+  description: string;
+}
+
+/** Parsed RESEARCH.md data */
+export interface ResearchData {
+  competitors: ResearchCompetitor[];
+  featureMatrix: Record<string, Record<string, string>>;
+  painPoints: ResearchPainPoint[];
+  opportunities: string[];
+  regulatoryNotes: string[];
+  rawMarkdown: string;
+}
+
+export interface DiscoverySuggestion {
+  name: string;
+  description: string;
+  effort: string;   // S / M / L / XL
+  impact: string;   // low / medium / high / critical
+  evidence: string;
+  category: string; // quick_win / strategic_bet / nice_to_have
+}
+
+/** Parsed DISCOVERY.md data */
+export interface DiscoveryData {
+  suggestions: DiscoverySuggestion[];
+  quickWins: DiscoverySuggestion[];
+  strategicBets: DiscoverySuggestion[];
+  niceToHaves: DiscoverySuggestion[];
+  rawMarkdown: string;
+}
+
+export interface ProjectResearch {
+  repo: string;
+  research: ResearchData | null;
+  discovery: DiscoveryData | null;
+  loading: boolean;
+  error: string | null;
+}
 
 export type MonitorStatus = "up" | "down" | "paused" | "pending";
 

--- a/src/utils/research-parser.ts
+++ b/src/utils/research-parser.ts
@@ -1,0 +1,308 @@
+/**
+ * Parsers for RESEARCH.md and DISCOVERY.md files.
+ * Mirrors the Python parsers in makeit-pipeline (research.py / discovery.py).
+ */
+
+import type {
+  ResearchCompetitor,
+  ResearchPainPoint,
+  ResearchData,
+  DiscoverySuggestion,
+  DiscoveryData,
+} from "../types";
+
+// ── RESEARCH.md parsing ──
+
+function parseCompetitors(md: string): ResearchCompetitor[] {
+  const competitors: ResearchCompetitor[] = [];
+  let current: ResearchCompetitor | null = null;
+  let inSection = false;
+
+  for (const line of md.split("\n")) {
+    const stripped = line.trim();
+    const lower = stripped.toLowerCase();
+
+    if (stripped.startsWith("## ") && (lower.includes("конкурент") || lower.includes("competitor"))) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && stripped.startsWith("## ")) break;
+    if (!inSection) continue;
+
+    if (stripped.startsWith("### ")) {
+      if (current) competitors.push(current);
+      current = { name: stripped.slice(4).trim(), url: "", features: [], pricing: "", audience: "" };
+    } else if (current) {
+      if (lower.startsWith("- url:") || lower.startsWith("- сайт:")) {
+        current.url = stripped.split(":", 2).slice(1).join(":").trim();
+      } else if (lower.startsWith("- pricing:") || lower.startsWith("- цена:")) {
+        current.pricing = stripped.split(":", 2).slice(1).join(":").trim();
+      } else if (lower.startsWith("- audience:") || lower.startsWith("- аудитория:")) {
+        current.audience = stripped.split(":", 2).slice(1).join(":").trim();
+      } else if (lower.startsWith("- feature:") || lower.startsWith("- фича:")) {
+        current.features.push(stripped.split(":", 2).slice(1).join(":").trim());
+      }
+    }
+  }
+  if (current) competitors.push(current);
+  return competitors;
+}
+
+function parseFeatureMatrix(md: string): Record<string, Record<string, string>> {
+  const matrix: Record<string, Record<string, string>> = {};
+  let inSection = false;
+  let headers: string[] = [];
+
+  for (const line of md.split("\n")) {
+    const stripped = line.trim();
+    const lower = stripped.toLowerCase();
+
+    if (stripped.startsWith("## ") && (lower.includes("матрица") || lower.includes("feature matrix"))) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && stripped.startsWith("## ")) break;
+    if (!inSection || !stripped.includes("|")) continue;
+
+    const cells = stripped.split("|").map((c) => c.trim()).filter(Boolean);
+    if (!cells.length) continue;
+    if (cells.every((c) => /^[-:]+$/.test(c))) continue;
+
+    if (!headers.length) {
+      headers = cells;
+      continue;
+    }
+    if (cells.length >= 2) {
+      const feature = cells[0];
+      const row: Record<string, string> = {};
+      for (let i = 1; i < cells.length && i < headers.length; i++) {
+        row[headers[i]] = cells[i];
+      }
+      if (Object.keys(row).length) matrix[feature] = row;
+    }
+  }
+  return matrix;
+}
+
+function parsePainPoints(md: string): ResearchPainPoint[] {
+  const points: ResearchPainPoint[] = [];
+  let inSection = false;
+
+  for (const line of md.split("\n")) {
+    const stripped = line.trim();
+    const lower = stripped.toLowerCase();
+    if (lower.includes("pain point") || lower.includes("болевые точки") || lower.includes("проблемы пользователей")) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && stripped.startsWith("## ")) { inSection = false; continue; }
+    if (inSection && stripped.startsWith("- ")) {
+      points.push({ theme: stripped.slice(2).trim(), frequency: "", source: "", description: "" });
+    }
+  }
+  return points;
+}
+
+function parseOpportunities(md: string): string[] {
+  const opps: string[] = [];
+  let inSection = false;
+
+  for (const line of md.split("\n")) {
+    const stripped = line.trim();
+    const lower = stripped.toLowerCase();
+    if (lower.includes("opportunit") || lower.includes("возможност")) { inSection = true; continue; }
+    if (inSection && stripped.startsWith("## ")) { inSection = false; continue; }
+    if (inSection && stripped.startsWith("- ")) opps.push(stripped.slice(2).trim());
+  }
+  return opps;
+}
+
+function parseRegulatory(md: string): string[] {
+  const notes: string[] = [];
+  let inSection = false;
+
+  for (const line of md.split("\n")) {
+    const stripped = line.trim();
+    const lower = stripped.toLowerCase();
+    if (lower.includes("regulat") || lower.includes("нормативн") || lower.includes("регулиров")) { inSection = true; continue; }
+    if (inSection && stripped.startsWith("## ")) { inSection = false; continue; }
+    if (inSection && stripped.startsWith("- ")) notes.push(stripped.slice(2).trim());
+  }
+  return notes;
+}
+
+export function parseResearchMd(md: string): ResearchData {
+  return {
+    competitors: parseCompetitors(md),
+    featureMatrix: parseFeatureMatrix(md),
+    painPoints: parsePainPoints(md),
+    opportunities: parseOpportunities(md),
+    regulatoryNotes: parseRegulatory(md),
+    rawMarkdown: md,
+  };
+}
+
+// ── DISCOVERY.md parsing ──
+
+const EFFORT_RE = /\b(XL|[SML])\b/;
+const IMPACT_RE = /\b(low|medium|high|critical)\b/i;
+const CATEGORY_RE = /\b(quick[_\s]?win|strategic[_\s]?bet|nice[_\s]?to[_\s]?have|deprioritized)\b/i;
+
+function normalizeCategory(raw: string): string {
+  return raw.toLowerCase().replace(/[\s-]/g, "_");
+}
+
+function parseSuggestions(md: string): DiscoverySuggestion[] {
+  const suggestions: DiscoverySuggestion[] = [];
+  let current: DiscoverySuggestion | null = null;
+  let inSection = false;
+
+  const CATEGORY_KEYWORDS = ["quick win", "strategic bet", "nice to have", "deprioritiz", "бэклог", "планировать", "делать первыми"];
+
+  for (const line of md.split("\n")) {
+    const stripped = line.trim();
+    const lower = stripped.toLowerCase();
+
+    if (stripped.startsWith("## ") && (lower.includes("рекомендац") || lower.includes("suggestion") || lower.includes("предложен") || lower.includes("feature"))) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && stripped.startsWith("## ") && !["quick", "strateg", "nice", "depriori", "feature"].some((kw) => lower.includes(kw))) {
+      if (current) { suggestions.push(current); current = null; }
+      inSection = false;
+      continue;
+    }
+    if (!inSection) continue;
+
+    if (stripped.startsWith("### ")) {
+      const rawName = stripped.slice(4).trim();
+      if (CATEGORY_KEYWORDS.some((kw) => rawName.toLowerCase().includes(kw))) continue;
+      if (current) suggestions.push(current);
+      const name = rawName.replace(/^\d+[.)]\s*/, "");
+      current = { name, description: "", effort: "", impact: "", evidence: "", category: "" };
+      continue;
+    }
+    if (!current) continue;
+
+    if (lower.startsWith("- effort:") || lower.startsWith("- трудозатрат")) {
+      const m = EFFORT_RE.exec(stripped);
+      if (m) current.effort = m[1];
+    } else if (lower.startsWith("- impact:") || lower.startsWith("- влияни")) {
+      const m = IMPACT_RE.exec(stripped);
+      if (m) current.impact = m[1].toLowerCase();
+    } else if (lower.startsWith("- evidence:") || lower.startsWith("- источник")) {
+      current.evidence = stripped.split(":").slice(1).join(":").trim();
+    } else if (lower.startsWith("- category:") || lower.startsWith("- категори")) {
+      const m = CATEGORY_RE.exec(stripped);
+      if (m) current.category = normalizeCategory(m[1]);
+    } else if (lower.startsWith("- description:") || lower.startsWith("- описани")) {
+      current.description = stripped.split(":").slice(1).join(":").trim();
+    } else if (stripped.startsWith("- ") && !current.description) {
+      current.description = stripped.slice(2).trim();
+    }
+  }
+  if (current) suggestions.push(current);
+  return suggestions;
+}
+
+function parseMatrixRows(md: string): DiscoverySuggestion[] {
+  const suggestions: DiscoverySuggestion[] = [];
+  let inMatrix = false;
+  let headers: string[] = [];
+
+  for (const line of md.split("\n")) {
+    const stripped = line.trim();
+    const lower = stripped.toLowerCase();
+
+    if (stripped.startsWith("## ") && (lower.includes("матриц") || lower.includes("matrix"))) {
+      inMatrix = true;
+      continue;
+    }
+    if (inMatrix && stripped.startsWith("## ")) break;
+    if (!inMatrix || !stripped.includes("|")) continue;
+
+    const cells = stripped.split("|").map((c) => c.trim()).filter(Boolean);
+    if (!cells.length) continue;
+    if (cells.every((c) => /^[-:]+$/.test(c))) continue;
+
+    if (!headers.length) {
+      headers = cells.map((h) => h.toLowerCase());
+      continue;
+    }
+    if (cells.length >= 3) {
+      let effort = "";
+      let impact = "";
+      let category = "";
+
+      for (let i = 1; i < cells.length && i < headers.length; i++) {
+        const h = headers[i];
+        if (h.includes("effort") || h.includes("трудо")) {
+          const m = EFFORT_RE.exec(cells[i]);
+          effort = m ? m[1] : cells[i].trim();
+        } else if (h.includes("impact") || h.includes("влияни")) {
+          const m = IMPACT_RE.exec(cells[i]);
+          impact = m ? m[1].toLowerCase() : cells[i].trim().toLowerCase();
+        } else if (h.includes("categ") || h.includes("категор")) {
+          const m = CATEGORY_RE.exec(cells[i]);
+          category = m ? normalizeCategory(m[1]) : "";
+        }
+      }
+      suggestions.push({ name: cells[0], description: "", effort, impact, evidence: "", category });
+    }
+  }
+  return suggestions;
+}
+
+function categorizeSuggestions(suggestions: DiscoverySuggestion[]): DiscoveryData {
+  const quickWins: DiscoverySuggestion[] = [];
+  const strategicBets: DiscoverySuggestion[] = [];
+  const niceToHaves: DiscoverySuggestion[] = [];
+
+  for (const s of suggestions) {
+    if (s.category === "quick_win") {
+      quickWins.push(s);
+    } else if (s.category === "strategic_bet") {
+      strategicBets.push(s);
+    } else if (s.category === "nice_to_have" || s.category === "deprioritized") {
+      niceToHaves.push(s);
+    } else {
+      // Auto-categorize by effort/impact
+      if ((s.effort === "S" || s.effort === "M") && (s.impact === "high" || s.impact === "critical")) {
+        s.category = "quick_win";
+        quickWins.push(s);
+      } else if ((s.effort === "L" || s.effort === "XL") && (s.impact === "high" || s.impact === "critical")) {
+        s.category = "strategic_bet";
+        strategicBets.push(s);
+      } else {
+        s.category = "nice_to_have";
+        niceToHaves.push(s);
+      }
+    }
+  }
+  return { suggestions, quickWins, strategicBets, niceToHaves, rawMarkdown: "" };
+}
+
+export function parseDiscoveryMd(md: string): DiscoveryData {
+  const suggestions = parseSuggestions(md);
+  const matrixRows = parseMatrixRows(md);
+
+  // Merge matrix data into suggestions
+  for (const ms of matrixRows) {
+    const match = suggestions.find(
+      (s) => s.name.toLowerCase() === ms.name.toLowerCase()
+        || s.name.toLowerCase().startsWith(ms.name.toLowerCase())
+        || ms.name.toLowerCase().startsWith(s.name.toLowerCase())
+    );
+    if (!match) {
+      suggestions.push(ms);
+    } else {
+      if (!match.effort && ms.effort) match.effort = ms.effort;
+      if (!match.impact && ms.impact) match.impact = ms.impact;
+      if (!match.category && ms.category) match.category = ms.category;
+    }
+  }
+
+  const result = categorizeSuggestions(suggestions);
+  result.rawMarkdown = md;
+  return result;
+}


### PR DESCRIPTION
Closes Sergio1990-1/makeit-pipeline#82

## Что сделано
- Новая вкладка **Research** в навигации дашборда
- Загрузка `RESEARCH.md` и `DISCOVERY.md` из репозиториев через GitHub API
- Парсер markdown-файлов (зеркалирует Python-парсеры из makeit-pipeline)
- Competitor matrix table, pain points, opportunities
- Discovery suggestions: Quick Wins / Strategic Bets / Nice to Have с badges effort/impact
- Expandable панели по проектам с summary stats

## Новые файлы
- `src/components/ResearchTab.tsx` — основной компонент
- `src/hooks/useResearch.ts` — hook для загрузки данных
- `src/utils/research-parser.ts` — парсеры RESEARCH.md / DISCOVERY.md
- Типы в `src/types/index.ts`
- CSS `.rsh-*` в `App.css`

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён
- [x] P1 issues: 0
- [x] ESLint clean
- [x] TypeScript strict clean
- [x] Build succeeds