### PR TITLE
docs: PRD-002 Pipeline Hardening v2 dashboard support

### DIFF
--- a/docs/epics/epic-002.md
+++ b/docs/epics/epic-002.md
@@ -1,0 +1,41 @@
+# Epic-002: Dashboard — Pipeline Hardening v2 Support
+
+## Метаданные
+- PRD: PRD-002
+- Статус: planning
+- Приоритет: P2-high
+
+## Цель
+
+Расширить dashboard для отображения данных из pipeline v3: phase_machine стадии, PhaseResult fields, quality KPIs, timeline, risk classification.
+
+## Архитектурные решения
+- Все новые поля — optional TypeScript types, backward-compatible
+- Новые API calls добавляются в utils/pipeline.ts
+- Новые компоненты: QualityPanel.tsx, IssueTimeline.tsx
+- Существующий PipelineControlPanel.tsx расширяется (не заменяется)
+
+## Задачи
+
+| # | Задача | Pipeline зависимость | Wave | Размер |
+|---|--------|---------------------|------|--------|
+| 01 | Dashboard types + STAGE_ORDER (11 стадий) | pipeline #385 (API models) | 1 | M |
+| 02 | Cost display, retry budget, quality KPI panel | pipeline #387 (API endpoints) | 2 | M |
+| 03 | Issue timeline modal | pipeline #387 (API endpoints) | 2 | M |
+| 04 | Risk badges + execution policy display | pipeline #363-#365 (risk_classifier) | 3 | M |
+
+## Критерии приёмки
+- [ ] STAGE_ORDER обновлён для 11 phase_machine стадий
+- [ ] Cost и attempts видны для каждого issue
+- [ ] QualityPanel показывает weekly KPIs
+- [ ] Timeline modal работает
+- [ ] Risk badges отображаются
+- [ ] Dark/light theme для всех новых элементов
+- [ ] Нет regression для existing v2 data
+
+## Риски
+
+| Риск | Влияние | Митигация |
+|------|---------|-----------|
+| Pipeline API ещё не расширен когда dashboard готов | Средний | Optional fields + graceful fallback |
+| Stage names изменятся в pipeline | Низкий | Dashboard использует labels dict, не hardcoded strings |

--- a/docs/epics/epic-002/task-01.md
+++ b/docs/epics/epic-002/task-01.md
@@ -1,0 +1,75 @@
+# Task-01: Dashboard types + STAGE_ORDER для phase_machine
+
+## Epic: epic-002
+## Зависимости: makeit-pipeline #385 (API response models)
+
+## Описание
+
+Обновить TypeScript типы для поддержки новых полей из PhaseResult и обновить
+STAGE_ORDER для 11 стадий phase_machine.
+
+### Что изменить
+
+**src/types/index.ts — extend interfaces:**
+```typescript
+interface PipelineStageEntry {
+  stage: string;  // "queued"|"dev"|"self_check"|"pr_opened"|"in_review"|"qa_verifying"|"ready_to_merge"|"merged"|"needs_human"
+  status: string;
+  ts: number;
+  detail?: string;
+  elapsed?: number;
+  cost_usd?: number;           // NEW
+  duration_seconds?: number;   // NEW
+}
+
+interface PipelineResult {
+  // existing fields unchanged
+  cost_usd?: number;           // NEW
+  phase_status?: string;       // NEW
+  human_summary?: string;      // NEW
+  attempt_number?: number;     // NEW
+  max_attempts?: number;       // NEW
+  budget_remaining_usd?: number; // NEW
+  risk_level?: "low" | "medium" | "high";  // NEW (Wave 3)
+  execution_policy?: string;   // NEW (Wave 3)
+}
+
+interface PipelineStats {
+  // existing fields unchanged
+  first_pass_rate?: number;    // NEW
+  avg_duration_seconds?: number; // NEW
+  cost_per_task_usd?: number;  // NEW
+}
+```
+
+**src/components/PipelineControlPanel.tsx:**
+```typescript
+const STAGE_ORDER = [
+  "queued", "dev", "self_check", "pr_opened",
+  "in_review", "qa_verifying", "ready_to_merge", "merged"
+];
+
+const STAGE_LABELS: Record<string, string> = {
+  queued: "Очередь",
+  dev: "Разработка",
+  self_check: "Самопроверка",
+  pr_opened: "PR создан",
+  in_review: "Ревью",
+  qa_verifying: "QA",
+  ready_to_merge: "К мержу",
+  merged: "Замержен",
+  needs_human: "Нужен человек",
+};
+```
+
+### Контекст для Claude Code
+- src/types/index.ts (строки 21-48)
+- src/components/PipelineControlPanel.tsx (STAGE_ORDER, StageProgress)
+
+## Критерии выполнения
+- [ ] Все новые поля optional (?) — не ломают v2 данные
+- [ ] STAGE_ORDER обновлён на 8 стадий (+ needs_human как terminal)
+- [ ] STAGE_LABELS с русскими названиями
+- [ ] Dashboard рендерит v2 данные без ошибок
+- [ ] Dashboard рендерит v3 данные с новыми стадиями
+- [ ] Линтер чист

--- a/docs/epics/epic-002/task-02.md
+++ b/docs/epics/epic-002/task-02.md
@@ -1,0 +1,56 @@
+# Task-02: Cost display, retry budget, quality KPI panel
+
+## Epic: epic-002
+## Зависимости: task-01, makeit-pipeline #387 (API endpoints)
+
+## Описание
+
+Добавить отображение стоимости, retry budget и quality KPIs.
+
+### Изменения в PipelineControlPanel.tsx
+
+**Results table — новые колонки:**
+- Cost: `$0.45` (из PipelineResult.cost_usd)
+- Attempts: `1/3` (attempt_number / max_attempts)
+- Warning icon если budget_remaining_usd < 0.30
+
+**Statistics panel — расширить:**
+- Добавить: first_pass_rate (%), avg duration (m:ss), cost/task ($)
+
+### Новый компонент: QualityPanel.tsx
+
+Панель с weekly KPIs:
+```
+┌─ Quality (last 7 days) ─────────────────┐
+│ First pass rate:  87%  ████████░░       │
+│ Avg duration:     18m                   │
+│ Cost/task:        $0.25                 │
+│ Retry rate:       13%                   │
+│ QA pass rate:     94%                   │
+│ Top errors: push_rejected (3)           │
+└─────────────────────────────────────────┘
+```
+
+### Новый API call: fetchQualitySnapshot()
+
+В src/utils/pipeline.ts:
+```typescript
+export async function fetchQualitySnapshot(project: string): Promise<QualitySnapshot> {
+  return fetchJSON(`/pipeline/quality/snapshot?project=${project}`);
+}
+```
+
+### Контекст для Claude Code
+- src/components/PipelineControlPanel.tsx
+- src/utils/pipeline.ts — добавить fetchQualitySnapshot()
+- src/hooks/usePipeline.ts — добавить quality state
+
+## Критерии выполнения
+- [ ] Cost отображается для каждого result ($X.XX)
+- [ ] Attempts отображается (N/M)
+- [ ] Warning при budget < $0.30
+- [ ] first_pass_rate, avg_duration, cost в statistics panel
+- [ ] QualityPanel показывает weekly KPIs
+- [ ] Graceful fallback если данные недоступны
+- [ ] Dark/light theme
+- [ ] Линтер чист

--- a/docs/epics/epic-002/task-03.md
+++ b/docs/epics/epic-002/task-03.md
@@ -1,0 +1,52 @@
+# Task-03: Issue timeline modal
+
+## Epic: epic-002
+## Зависимости: task-01, makeit-pipeline #387 (timeline API endpoint)
+
+## Описание
+
+Клик по issue number в results table → modal с детальным логом фаз.
+
+### Новый компонент: IssueTimeline.tsx
+
+```
+┌─ Issue #42: Fix login validation ──────────────┐
+│                                                 │
+│ ● queued        10:15:03  —                    │
+│ ● dev           10:15:05  $0.18  3m 24s        │
+│ ● self_check    10:18:29  —      12s           │
+│ ● pr_opened     10:18:41  —      2s            │
+│ ● in_review     10:18:43  $0.05  45s  APPROVED │
+│ ● qa_verifying  10:19:28  $0.02  30s  PASS     │
+│ ● merged        10:19:58  —      3s            │
+│                                                 │
+│ Total: $0.25 | Duration: 4m 55s | Attempt 1/3  │
+└─────────────────────────────────────────────────┘
+```
+
+- Colored dots: green=success, yellow=partial, red=failure
+- Footer: total cost, total duration, attempt number
+- Loading/empty states
+- Close: Escape, click outside
+
+### Новый API call: fetchTimeline()
+
+```typescript
+export async function fetchTimeline(repo: string, issue: number): Promise<TimelineEntry[]> {
+  return fetchJSON(`/pipeline/timeline/${repo}/${issue}`);
+}
+```
+
+### Контекст для Claude Code
+- src/components/ — новый IssueTimeline.tsx
+- src/utils/pipeline.ts — fetchTimeline()
+- src/components/PipelineControlPanel.tsx — onClick на issue number
+
+## Критерии выполнения
+- [ ] Клик по issue → timeline modal
+- [ ] Фазы с timestamps, cost, duration
+- [ ] Colored dots по status
+- [ ] Loading/empty states
+- [ ] Close по Escape и клику вне modal
+- [ ] Dark/light theme
+- [ ] Линтер чист

--- a/docs/epics/epic-002/task-04.md
+++ b/docs/epics/epic-002/task-04.md
@@ -1,0 +1,35 @@
+# Task-04: Risk badges и execution policy display
+
+## Epic: epic-002
+## Зависимости: task-01, makeit-pipeline epic-020/task-04-06 (risk_classifier)
+
+## Описание
+
+Отобразить risk level и execution policy для каждого issue.
+
+### Изменения в PipelineControlPanel.tsx
+
+**Results table — risk badge:**
+- `low` → зелёный бейдж "auto"
+- `medium` → оранжевый бейдж "guarded"
+- `high` → красный бейдж "gated"
+
+**Tooltip с пояснением:**
+- full_auto: "Автоматический merge"
+- guarded_auto: "Merge после подтверждения"
+- human_gated: "Останавливается на PR"
+
+**Queue display:**
+- Показать risk level для задач в очереди
+
+### Контекст для Claude Code
+- src/types/index.ts — risk_level и execution_policy уже добавлены в task-01
+- src/components/PipelineControlPanel.tsx — results row, queue display
+
+## Критерии выполнения
+- [ ] Risk badge (green/orange/red) в results table
+- [ ] Tooltip с execution policy
+- [ ] Risk indicator в queue
+- [ ] Graceful fallback если risk_level отсутствует
+- [ ] Dark/light theme
+- [ ] Линтер чист

--- a/docs/prds/PRD-002.md
+++ b/docs/prds/PRD-002.md
@@ -1,0 +1,56 @@
+# PRD-002: Dashboard — Pipeline Hardening v2 Support
+
+## Метаданные
+- Статус: draft
+- Автор: Sergei
+- Дата: 2026-04-09
+- Приоритет: P2-high
+- Scope: medium (4 задачи, 3 wave)
+- Связан с: makeit-pipeline PRD-011
+
+## Проблема
+
+makeit-pipeline PRD-011 вводит phase_machine (11 стадий вместо 3), PhaseResult (typed contracts для всех agent calls), retry budget, risk classification, quality KPIs и per-issue timeline logs. Dashboard не отображает эти данные.
+
+Текущее состояние dashboard:
+- STAGE_ORDER: 3 стадии (`dev`, `review`, `merge`)
+- PipelineResult: нет cost_usd, phase_status, risk_level, attempt tracking
+- PipelineStats: нет first_pass_rate, avg_duration, cost_per_task
+- Нет timeline view, нет quality panel, нет risk badges
+
+## Решение
+
+Поэтапное расширение dashboard для отображения новых данных из pipeline API.
+
+## Функциональные требования
+
+| ID | Требование | Wave | Приоритет |
+|----|-----------|------|-----------|
+| FR-1 | Обновить TypeScript types: PipelineResult, PipelineStageEntry, PipelineStats с новыми optional полями | 1 | must-have |
+| FR-2 | STAGE_ORDER: 11 стадий phase_machine с русскими labels | 1 | must-have |
+| FR-3 | Backward-compatible: dashboard рендерит и v2 и v3 данные без ошибок | 1 | must-have |
+| FR-4 | Cost display per issue ($X.XX) в results table | 2 | must-have |
+| FR-5 | Attempts display (N/M) с warning при budget < $0.30 | 2 | must-have |
+| FR-6 | Statistics panel: first_pass_rate %, avg_duration, cost/task | 2 | must-have |
+| FR-7 | QualityPanel: weekly KPIs из /pipeline/quality/snapshot | 2 | should-have |
+| FR-8 | IssueTimeline modal: клик по issue → детальный лог фаз | 2 | should-have |
+| FR-9 | Risk badges (green/orange/red) в results table | 3 | should-have |
+| FR-10 | Execution policy tooltip (full_auto/guarded_auto/human_gated) | 3 | should-have |
+
+## Нефункциональные требования
+- Все новые поля optional (?) — не ломают при отсутствии данных
+- Dark/light theme для всех новых элементов
+- Graceful fallback: если API endpoint недоступен — не крашить UI
+
+## Критерии приёмки
+- [ ] Dashboard рендерит v2 данные (старые) без ошибок
+- [ ] Dashboard рендерит v3 данные с новыми полями
+- [ ] Cost и attempts видны в results table
+- [ ] Quality KPIs отображаются
+- [ ] Timeline modal работает при клике на issue
+- [ ] Risk badges отображаются для v3 задач
+
+## Зависимости от makeit-pipeline
+- makeit-pipeline #385: API response models (Wave 1)
+- makeit-pipeline #387: Timeline + quality endpoints (Wave 2)
+- makeit-pipeline epic-020/task-04-06: risk_classifier (Wave 3)


### PR DESCRIPTION
## Summary
- PRD-002 + Epic-002: dashboard changes for makeit-pipeline PRD-011
- 4 tasks: types (#83), quality KPIs (#84), timeline modal (#85), risk badges (#86)

## Test plan
- [ ] Verify task specs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)