### PR TITLE
feat: dashboard types + STAGE_ORDER for phase_machine

### DIFF
--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -48,12 +48,21 @@ function ComplexityBadge({ complexity, model }: { complexity?: ComplexityLevel; 
   );
 }
 
-const STAGE_ORDER = ["dev", "review", "merge"] as const;
+const STAGE_ORDER = [
+  "queued", "dev", "self_check", "pr_opened",
+  "in_review", "qa_verifying", "ready_to_merge", "merged",
+] as const;
 
 const STAGE_LABEL: Record<string, string> = {
-  dev: "Dev",
-  review: "Review",
-  merge: "Merge",
+  queued: "Очередь",
+  dev: "Разработка",
+  self_check: "Самопроверка",
+  pr_opened: "PR создан",
+  in_review: "Ревью",
+  qa_verifying: "QA",
+  ready_to_merge: "К мержу",
+  merged: "Замержен",
+  needs_human: "Нужен человек",
 };
 
 const STATUS_LABEL: Record<string, string> = {
@@ -85,12 +94,13 @@ function formatDuration(seconds: number): string {
 }
 
 function isTaskFinished(stages: PipelineStageEntry[]): boolean {
-  // Task is done when merge completed/failed, or qa_verify/dev/review failed terminally
   const last = stages[stages.length - 1];
   if (!last) return false;
+  if (last.stage === "merged") return last.status === "completed" || last.status === "failed";
+  // Legacy: "merge" stage name
   if (last.stage === "merge") return last.status === "completed" || last.status === "failed";
-  if (last.status === "failed" && ["dev", "review", "qa_verify"].includes(last.stage)) return true;
-  // needs_human is a terminal status
+  if (last.stage === "needs_human") return true;
+  if (last.status === "failed" && ["dev", "self_check", "in_review", "qa_verifying", "review", "qa_verify"].includes(last.stage)) return true;
   return false;
 }
 
@@ -217,7 +227,7 @@ function StageProgress({
                   }}
                 >
                   {STAGE_LABEL[name] ?? name}
-                  {detail && s === "completed" && name === "review" && (
+                  {detail && s === "completed" && (name === "review" || name === "in_review") && (
                     <span
                       style={{
                         marginLeft: 3,

--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { usePipeline } from "../hooks/usePipeline";
 import { GITHUB_OWNER, PROJECTS } from "../utils/config";
 import type { PipelineStageEntry, ComplexityFilter, ComplexityLevel, ClassifyProgress, ClassifyResponse } from "../utils/pipeline";
-import { classifyIssues } from "../utils/pipeline";
+import { classifyIssues, STAGE_ORDER, STAGE_LABEL } from "../utils/pipeline";
 import type { ProjectData } from "../types";
 import { PipelineClosedChart } from "./PipelineClosedChart";
 
@@ -48,22 +48,7 @@ function ComplexityBadge({ complexity, model }: { complexity?: ComplexityLevel; 
   );
 }
 
-const STAGE_ORDER = [
-  "queued", "dev", "self_check", "pr_opened",
-  "in_review", "qa_verifying", "ready_to_merge", "merged",
-] as const;
-
-const STAGE_LABEL: Record<string, string> = {
-  queued: "Очередь",
-  dev: "Разработка",
-  self_check: "Самопроверка",
-  pr_opened: "PR создан",
-  in_review: "Ревью",
-  qa_verifying: "QA",
-  ready_to_merge: "К мержу",
-  merged: "Замержен",
-  needs_human: "Нужен человек",
-};
+/* STAGE_ORDER and STAGE_LABEL imported from ../utils/pipeline */
 
 const STATUS_LABEL: Record<string, string> = {
   queued: "В очереди",
@@ -227,7 +212,7 @@ function StageProgress({
                   }}
                 >
                   {STAGE_LABEL[name] ?? name}
-                  {detail && s === "completed" && (name === "review" || name === "in_review") && (
+                  {detail && s === "completed" && name === "in_review" && (
                     <span
                       style={{
                         marginLeft: 3,

--- a/src/utils/pipeline.ts
+++ b/src/utils/pipeline.ts
@@ -17,6 +17,8 @@ export interface PipelineStageEntry {
   ts: number;
   detail?: string;
   elapsed?: number;
+  cost_usd?: number;
+  duration_seconds?: number;
 }
 
 export type ComplexityLevel = "auto" | "assisted" | "manual";
@@ -33,6 +35,14 @@ export interface PipelineResult {
   review_summary?: string;
   complexity?: ComplexityLevel;
   model_used?: string;
+  cost_usd?: number;
+  phase_status?: string;
+  human_summary?: string;
+  attempt_number?: number;
+  max_attempts?: number;
+  budget_remaining_usd?: number;
+  risk_level?: "low" | "medium" | "high";
+  execution_policy?: string;
 }
 
 export interface PipelineQueueItem {
@@ -71,6 +81,9 @@ export interface PipelineStats {
   manual_completed: number;
   complexity_breakdown?: ComplexityBreakdown;
   model_usage?: ModelUsage[];
+  first_pass_rate?: number;
+  avg_duration_seconds?: number;
+  cost_per_task_usd?: number;
 }
 
 export async function isPipelineRunning(): Promise<boolean> {

--- a/src/utils/pipeline.ts
+++ b/src/utils/pipeline.ts
@@ -86,6 +86,25 @@ export interface PipelineStats {
   cost_per_task_usd?: number;
 }
 
+/* ── Shared stage constants ── */
+
+export const STAGE_ORDER = [
+  "queued", "dev", "self_check", "pr_opened",
+  "in_review", "qa_verifying", "ready_to_merge", "merged",
+] as const;
+
+export const STAGE_LABEL: Record<string, string> = {
+  queued: "Очередь",
+  dev: "Разработка",
+  self_check: "Самопроверка",
+  pr_opened: "PR создан",
+  in_review: "Ревью",
+  qa_verifying: "QA",
+  ready_to_merge: "К мержу",
+  merged: "Замержен",
+  needs_human: "Нужен человек",
+};
+
 export async function isPipelineRunning(): Promise<boolean> {
   try {
     const controller = new AbortController();


### PR DESCRIPTION
Closes #83

## Что сделано
- Добавлены optional поля в `PipelineStageEntry`: `cost_usd`, `duration_seconds`
- Добавлены optional поля в `PipelineResult`: `cost_usd`, `phase_status`, `human_summary`, `attempt_number`, `max_attempts`, `budget_remaining_usd`, `risk_level`, `execution_policy`
- Добавлены optional поля в `PipelineStats`: `first_pass_rate`, `avg_duration_seconds`, `cost_per_task_usd`
- STAGE_ORDER обновлён: 8 стадий (`queued` → `merged`) + `needs_human` как terminal
- STAGE_LABELS с русскими названиями
- `isTaskFinished` обновлён для новых стадий (backward compatible)

## Тесты
- [x] `tsc --noEmit` — чисто
- [x] Все новые поля optional — v2 данные не ломаются

## Самопроверка
- [x] 13 пунктов пройдены
- [x] P1 issues: 0