### PR TITLE
feat: risk badges and execution policy display

### DIFF
--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { usePipeline } from "../hooks/usePipeline";
 import { GITHUB_OWNER, PROJECTS } from "../utils/config";
-import type { PipelineStageEntry, ComplexityFilter, ComplexityLevel, ClassifyProgress, ClassifyResponse } from "../utils/pipeline";
+import type { PipelineStageEntry, PipelineQueueItem, ComplexityFilter, ComplexityLevel, ClassifyProgress, ClassifyResponse } from "../utils/pipeline";
 import { classifyIssues, STAGE_ORDER, STAGE_LABEL } from "../utils/pipeline";
 import type { ProjectData } from "../types";
 import { PipelineClosedChart } from "./PipelineClosedChart";
@@ -746,7 +746,7 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
             // Issues that have stages but aren't in queue (already running)
             const extraNums = stageIssueNums.filter((n) => !queueNums.has(n));
             const allItems = [
-              ...extraNums.map((n) => ({ number: n, title: `Issue #${n}`, status: "in_progress", priority: 0 })),
+              ...extraNums.map((n): PipelineQueueItem => ({ number: n, title: `Issue #${n}`, status: "in_progress", priority: 0 })),
               ...status.queue.filter((q) => !completedNums.has(q.number)),
             ];
             if (allItems.length === 0) {
@@ -781,7 +781,7 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
                       }}>
                         #{item.number}
                       </span>
-                      {"risk_level" in item && <RiskDot riskLevel={(item as unknown as { risk_level?: string }).risk_level} />}
+                      <RiskDot riskLevel={item.risk_level} />
                       <span style={{
                         flex: 1,
                         fontSize: "var(--text-sm)",

--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -21,6 +21,61 @@ const COMPLEXITY_STYLE: Record<string, { label: string; color: string; bg: strin
   manual: { label: "MANUAL", color: "var(--red-500)", bg: "rgba(239, 68, 68, 0.12)" },
 };
 
+const RISK_STYLE: Record<string, { label: string; color: string; bg: string }> = {
+  low: { label: "auto", color: "var(--green-500)", bg: "rgba(16, 185, 129, 0.12)" },
+  medium: { label: "guarded", color: "var(--orange-500)", bg: "rgba(245, 158, 11, 0.12)" },
+  high: { label: "gated", color: "var(--red-500)", bg: "rgba(239, 68, 68, 0.12)" },
+};
+
+const POLICY_TOOLTIP: Record<string, string> = {
+  full_auto: "Автоматический merge",
+  guarded_auto: "Merge после подтверждения",
+  human_gated: "Останавливается на PR",
+};
+
+function RiskBadge({ riskLevel, executionPolicy }: { riskLevel?: string; executionPolicy?: string }) {
+  if (!riskLevel) return null;
+  const style = RISK_STYLE[riskLevel] ?? RISK_STYLE.high;
+  const tooltip = executionPolicy ? POLICY_TOOLTIP[executionPolicy] ?? executionPolicy : undefined;
+  return (
+    <span
+      title={tooltip}
+      style={{
+        fontSize: "var(--text-xs)",
+        fontWeight: 700,
+        padding: "1px 6px",
+        borderRadius: 8,
+        background: style.bg,
+        color: style.color,
+        letterSpacing: "0.04em",
+        textTransform: "uppercase",
+        cursor: tooltip ? "help" : undefined,
+      }}
+    >
+      {style.label}
+    </span>
+  );
+}
+
+function RiskDot({ riskLevel }: { riskLevel?: string }) {
+  if (!riskLevel) return null;
+  const style = RISK_STYLE[riskLevel];
+  if (!style) return null;
+  return (
+    <span
+      title={`Риск: ${style.label}`}
+      style={{
+        display: "inline-block",
+        width: 7,
+        height: 7,
+        borderRadius: "50%",
+        background: style.color,
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
 function ComplexityBadge({ complexity, model }: { complexity?: ComplexityLevel; model?: string }) {
   if (!complexity) return null;
   const style = COMPLEXITY_STYLE[complexity] ?? COMPLEXITY_STYLE.manual;
@@ -726,6 +781,7 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
                       }}>
                         #{item.number}
                       </span>
+                      {"risk_level" in item && <RiskDot riskLevel={(item as unknown as { risk_level?: string }).risk_level} />}
                       <span style={{
                         flex: 1,
                         fontSize: "var(--text-sm)",
@@ -819,6 +875,9 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
 
                   {/* Complexity badge */}
                   <ComplexityBadge complexity={r.complexity} model={r.model_used} />
+
+                  {/* Risk badge */}
+                  <RiskBadge riskLevel={r.risk_level} executionPolicy={r.execution_policy} />
 
                   {/* Stage progress */}
                   <StageProgress stages={r.stages} compact />

--- a/src/utils/pipeline.ts
+++ b/src/utils/pipeline.ts
@@ -50,6 +50,7 @@ export interface PipelineQueueItem {
   title: string;
   status: string;
   priority: number;
+  risk_level?: "low" | "medium" | "high";
 }
 
 export interface PipelineStatus {


### PR DESCRIPTION
## Summary
- Add RiskBadge component (green/orange/red) for `low`/`medium`/`high` risk levels in pipeline results table
- Add RiskDot compact indicator in active tasks / queue display
- Tooltip shows execution policy explanation in Russian (full_auto / guarded_auto / human_gated)
- Add `risk_level` optional field to `PipelineQueueItem` interface
- Graceful fallback: badges hidden when `risk_level` is absent
- Dark/light theme support via CSS custom properties

Closes #86

## Test plan
- [ ] Verify risk badges render correctly for low/medium/high risk levels
- [ ] Verify tooltip shows correct execution policy text on hover
- [ ] Verify no badge shown when risk_level is absent (backward compatible)
- [ ] Verify dark and light theme appearance
- [ ] Verify no layout breakage in results table and queue display
- [ ] `npx tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)