### PR TITLE
feat: cost display, retry budget, quality KPI panel

### DIFF
--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -6,6 +6,7 @@ import { classifyIssues, STAGE_ORDER, STAGE_LABEL } from "../utils/pipeline";
 import type { ProjectData } from "../types";
 import { PipelineClosedChart } from "./PipelineClosedChart";
 import { IssueTimeline } from "./IssueTimeline";
+import { QualityPanel } from "./QualityPanel";
 
 const LABEL_OPTIONS = ["P1-critical", "P2-high", "P3-medium"] as const;
 type LabelOption = (typeof LABEL_OPTIONS)[number];
@@ -659,6 +660,48 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
               </div>
             ))}
           </div>
+          {/* Extended KPIs */}
+          {(stats.first_pass_rate != null || stats.avg_duration_seconds != null || stats.cost_per_task_usd != null) && (
+            <div style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 1fr)",
+              gap: 8,
+              marginTop: 10,
+              paddingTop: 8,
+              borderTop: "1px solid var(--color-border)",
+            }}>
+              {stats.first_pass_rate != null && (
+                <div style={{ textAlign: "center" }}>
+                  <div style={{ fontSize: "var(--text-data)", fontWeight: 700, color: stats.first_pass_rate >= 80 ? "var(--green-500)" : stats.first_pass_rate >= 60 ? "var(--orange-500)" : "var(--red-500)", lineHeight: 1.2 }}>
+                    {Math.round(stats.first_pass_rate)}%
+                  </div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--color-text-muted)", marginTop: 2 }}>
+                    First pass
+                  </div>
+                </div>
+              )}
+              {stats.avg_duration_seconds != null && (
+                <div style={{ textAlign: "center" }}>
+                  <div style={{ fontSize: "var(--text-data)", fontWeight: 700, color: "var(--color-text)", lineHeight: 1.2 }}>
+                    {formatDuration(stats.avg_duration_seconds)}
+                  </div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--color-text-muted)", marginTop: 2 }}>
+                    Ср. время
+                  </div>
+                </div>
+              )}
+              {stats.cost_per_task_usd != null && (
+                <div style={{ textAlign: "center" }}>
+                  <div style={{ fontSize: "var(--text-data)", fontWeight: 700, color: "var(--green-500)", lineHeight: 1.2 }}>
+                    ${stats.cost_per_task_usd.toFixed(2)}
+                  </div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--color-text-muted)", marginTop: 2 }}>
+                    $/задачу
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
 
@@ -722,6 +765,9 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
         </div>
         );
       })()}
+
+      {/* ── Quality KPI panel ── */}
+      {selectedProject && <QualityPanel project={selectedProject} />}
 
       {/* ── Live tasks ── */}
       {isRunning && status && (
@@ -891,6 +937,35 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
 
                   {/* Complexity badge */}
                   <ComplexityBadge complexity={r.complexity} model={r.model_used} />
+
+                  {/* Cost */}
+                  {r.cost_usd != null && (
+                    <span style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "var(--text-xs)",
+                      color: "var(--green-500)",
+                    }}>
+                      ${r.cost_usd.toFixed(2)}
+                    </span>
+                  )}
+
+                  {/* Attempts */}
+                  {r.attempt_number != null && r.max_attempts != null && (
+                    <span
+                      title={r.budget_remaining_usd != null ? `Остаток бюджета: $${r.budget_remaining_usd.toFixed(2)}` : undefined}
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "var(--text-xs)",
+                        color: r.budget_remaining_usd != null && r.budget_remaining_usd < 0.30
+                          ? "var(--orange-500)"
+                          : "var(--color-text-muted)",
+                        cursor: r.budget_remaining_usd != null ? "help" : undefined,
+                      }}
+                    >
+                      {r.attempt_number}/{r.max_attempts}
+                      {r.budget_remaining_usd != null && r.budget_remaining_usd < 0.30 && " ⚠"}
+                    </span>
+                  )}
 
                   {/* Risk badge */}
                   <RiskBadge riskLevel={r.risk_level} executionPolicy={r.execution_policy} />

--- a/src/components/QualityPanel.tsx
+++ b/src/components/QualityPanel.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from "react";
+import { fetchQualitySnapshot } from "../utils/quality";
+import type { QualitySnapshot } from "../types";
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  if (m < 60) return `${m}м`;
+  const h = Math.floor(m / 60);
+  return `${h}ч ${m % 60}м`;
+}
+
+function pctBar(value: number, color: string) {
+  return (
+    <div style={{
+      display: "flex",
+      alignItems: "center",
+      gap: 8,
+      width: "100%",
+    }}>
+      <div style={{
+        flex: 1,
+        height: 6,
+        borderRadius: 3,
+        background: "var(--color-surface)",
+        overflow: "hidden",
+      }}>
+        <div style={{
+          width: `${Math.min(100, Math.max(0, value))}%`,
+          height: "100%",
+          borderRadius: 3,
+          background: color,
+          transition: "width 0.3s ease",
+        }} />
+      </div>
+      <span style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "var(--text-xs)",
+        fontWeight: 700,
+        color,
+        minWidth: 36,
+        textAlign: "right",
+      }}>
+        {Math.round(value)}%
+      </span>
+    </div>
+  );
+}
+
+interface QualityPanelProps {
+  project: string;
+}
+
+export function QualityPanel({ project }: QualityPanelProps) {
+  const [snapshot, setSnapshot] = useState<QualitySnapshot | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(false);
+    fetchQualitySnapshot(project)
+      .then((data) => { if (!cancelled) setSnapshot(data); })
+      .catch(() => { if (!cancelled) setError(true); });
+    return () => { cancelled = true; };
+  }, [project]);
+
+  if (error || !snapshot) return null;
+
+  const rows: { label: string; value: React.ReactNode }[] = [
+    {
+      label: "First pass rate",
+      value: pctBar(
+        snapshot.first_pass_success_rate * 100,
+        snapshot.first_pass_success_rate >= 0.8 ? "var(--green-500)" : snapshot.first_pass_success_rate >= 0.6 ? "var(--orange-500)" : "var(--red-500)",
+      ),
+    },
+    {
+      label: "Ср. время",
+      value: (
+        <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-xs)", fontWeight: 600, color: "var(--color-text)" }}>
+          {formatDuration(snapshot.avg_duration_sec)}
+        </span>
+      ),
+    },
+    {
+      label: "Retry rate",
+      value: pctBar(
+        snapshot.retry_rate * 100,
+        snapshot.retry_rate <= 0.15 ? "var(--green-500)" : snapshot.retry_rate <= 0.3 ? "var(--orange-500)" : "var(--red-500)",
+      ),
+    },
+  ];
+
+  if (snapshot.qa_pass_rate != null) {
+    rows.push({
+      label: "QA pass rate",
+      value: pctBar(
+        snapshot.qa_pass_rate * 100,
+        snapshot.qa_pass_rate >= 0.9 ? "var(--green-500)" : snapshot.qa_pass_rate >= 0.7 ? "var(--orange-500)" : "var(--red-500)",
+      ),
+    });
+  }
+
+  if (snapshot.top_error_classes.length > 0) {
+    rows.push({
+      label: "Top ошибки",
+      value: (
+        <span style={{ fontSize: "var(--text-xs)", color: "var(--color-text-secondary)" }}>
+          {snapshot.top_error_classes.slice(0, 3).map(([cls, count]) => `${cls} (${count})`).join(", ")}
+        </span>
+      ),
+    });
+  }
+
+  return (
+    <div className="bento-panel span-6">
+      <div className="bento-panel-title">
+        Quality
+        <span style={{ textTransform: "none", fontWeight: 400, fontSize: "var(--text-xs)", color: "var(--color-text-muted)" }}>
+          {" "}за 7 дней
+        </span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {rows.map((row) => (
+          <div key={row.label} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <span style={{
+              fontSize: "var(--text-xs)",
+              color: "var(--color-text-muted)",
+              minWidth: 90,
+              flexShrink: 0,
+            }}>
+              {row.label}
+            </span>
+            <div style={{ flex: 1 }}>
+              {row.value}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #84

## Что сделано
- **Results table**: cost ($X.XX) и attempts (N/M) для каждого issue, предупреждение при budget < $0.30
- **Statistics panel**: first pass rate (%), среднее время, стоимость/задачу
- **QualityPanel** (новый компонент): weekly KPIs с прогресс-барами
  - First pass rate, retry rate, QA pass rate — цветовая индикация (зелёный/оранжевый/красный)
  - Среднее время обработки
  - Top ошибки
- Использует существующий `fetchQualitySnapshot` из quality.ts

## Тесты
- [x] `tsc --noEmit` — чисто
- [x] Все новые данные optional — graceful fallback
- [x] Dark/light theme через CSS custom properties

## Самопроверка
- [x] 13 пунктов пройдены
- [x] P1 issues: 0