### PR TITLE
fix: normalize pipeline stage names for dashboard compatibility

### DIFF
--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { usePipeline } from "../hooks/usePipeline";
 import { GITHUB_OWNER, PROJECTS } from "../utils/config";
 import type { PipelineStageEntry, PipelineQueueItem, ComplexityFilter, ComplexityLevel, ClassifyProgress, ClassifyResponse } from "../utils/pipeline";
-import { classifyIssues, STAGE_ORDER, STAGE_LABEL } from "../utils/pipeline";
+import { classifyIssues, STAGE_ORDER, STAGE_LABEL, normalizeStage } from "../utils/pipeline";
 import type { ProjectData } from "../types";
 import { PipelineClosedChart } from "./PipelineClosedChart";
 import { IssueTimeline } from "./IssueTimeline";
@@ -138,11 +138,10 @@ function formatDuration(seconds: number): string {
 function isTaskFinished(stages: PipelineStageEntry[]): boolean {
   const last = stages[stages.length - 1];
   if (!last) return false;
-  if (last.stage === "merged") return last.status === "completed" || last.status === "failed";
-  // Legacy: "merge" stage name
-  if (last.stage === "merge") return last.status === "completed" || last.status === "failed";
-  if (last.stage === "needs_human") return true;
-  if (last.status === "failed" && ["dev", "self_check", "in_review", "qa_verifying", "review", "qa_verify"].includes(last.stage)) return true;
+  const stage = normalizeStage(last.stage);
+  if (stage === "merged") return last.status === "completed" || last.status === "failed";
+  if (stage === "needs_human") return true;
+  if (last.status === "failed" && ["dev", "self_check", "in_review", "qa_verifying"].includes(stage)) return true;
   return false;
 }
 
@@ -194,7 +193,7 @@ function getStageStatus(
   stageName: string,
 ): "pending" | "started" | "completed" | "failed" {
   if (!stages?.length) return "pending";
-  const matching = stages.filter((s) => s.stage === stageName);
+  const matching = stages.filter((s) => normalizeStage(s.stage) === stageName);
   if (!matching.length) return "pending";
   const last = matching[matching.length - 1];
   if (last.status === "completed") return "completed";
@@ -207,7 +206,7 @@ function getStageDetail(
   stageName: string,
 ): string | undefined {
   if (!stages?.length) return undefined;
-  const matching = stages.filter((s) => s.stage === stageName);
+  const matching = stages.filter((s) => normalizeStage(s.stage) === stageName);
   const last = matching[matching.length - 1];
   return last?.detail;
 }

--- a/src/utils/pipeline.ts
+++ b/src/utils/pipeline.ts
@@ -94,6 +94,19 @@ export const STAGE_ORDER = [
   "in_review", "qa_verifying", "ready_to_merge", "merged",
 ] as const;
 
+/** Map pipeline API stage names to dashboard canonical names. */
+const STAGE_ALIAS: Record<string, string> = {
+  pr: "pr_opened",
+  review: "in_review",
+  qa_verify: "qa_verifying",
+  merge: "merged",
+};
+
+/** Normalize a stage name: resolve aliases to canonical dashboard names. */
+export function normalizeStage(stage: string): string {
+  return STAGE_ALIAS[stage] ?? stage;
+}
+
 export const STAGE_LABEL: Record<string, string> = {
   queued: "Очередь",
   dev: "Разработка",
@@ -104,6 +117,11 @@ export const STAGE_LABEL: Record<string, string> = {
   ready_to_merge: "К мержу",
   merged: "Замержен",
   needs_human: "Нужен человек",
+  // Aliases for pipeline API names (defense-in-depth)
+  pr: "PR создан",
+  review: "Ревью",
+  qa_verify: "QA",
+  merge: "Замержен",
 };
 
 export async function isPipelineRunning(): Promise<boolean> {


### PR DESCRIPTION
Closes #104

## Что сделано
- Добавлен `STAGE_ALIAS` map и `normalizeStage()` в `pipeline.ts` — трансляция API-имён стадий (`pr`, `review`, `qa_verify`, `merge`) в канонические dashboard-имена (`pr_opened`, `in_review`, `qa_verifying`, `merged`)
- `getStageStatus()`, `getStageDetail()`, `isTaskFinished()` теперь нормализуют stage name перед сравнением
- `STAGE_LABEL` дополнен алиасами для обратной совместимости
- Убран дублирующий legacy-код для `"merge"` в `isTaskFinished()`

## Тесты
- [x] `tsc --noEmit` — чисто
- [x] `eslint` — чисто
- [x] `vite build` — успешно

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён
- [x] P1 issues: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)