### PR TITLE
feat(verify): add grep_file and find_symbol_definition tools

### DIFF
--- a/src/utils/github-actions.ts
+++ b/src/utils/github-actions.ts
@@ -67,6 +67,94 @@ export async function readRepoFile(
   throw new Error(`Cannot read file: ${path}`);
 }
 
+// ── Code Search ──
+
+export interface CodeSearchHit {
+  path: string;
+  fragment: string;
+}
+
+export class CodeSearchUnavailableError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "CodeSearchUnavailableError";
+    this.status = status;
+  }
+}
+
+export class CodeSearchRateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CodeSearchRateLimitError";
+  }
+}
+
+/**
+ * Search for a Python symbol (class/function name) inside a repo using GitHub
+ * Code Search. Returns up to `perPage` hits with the first text-match fragment
+ * each. Uses the `symbol:` qualifier first, falling back to a bare-term query
+ * if that produces nothing.
+ *
+ * Throws CodeSearchRateLimitError (429) or CodeSearchUnavailableError (403
+ * with rate-limit body, 422 for not-indexed repos) so callers can fall back.
+ */
+export async function searchCodeSymbol(
+  token: string,
+  owner: string,
+  repo: string,
+  symbol: string,
+  perPage = 10
+): Promise<CodeSearchHit[]> {
+  const run = async (q: string): Promise<CodeSearchHit[] | null> => {
+    const url = `${GITHUB_REST}/search/code?q=${encodeURIComponent(q)}&per_page=${perPage}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `bearer ${token}`,
+        Accept: "application/vnd.github.text-match+json",
+      },
+    });
+    if (res.status === 401) {
+      throw new Error("GitHub token истёк или недостаточно прав. Сбросьте токен и введите новый.");
+    }
+    if (res.status === 429) {
+      throw new CodeSearchRateLimitError("GitHub code search rate limited");
+    }
+    if (res.status === 403) {
+      const body = await res.text();
+      if (/rate limit/i.test(body)) {
+        throw new CodeSearchRateLimitError("GitHub code search rate limited");
+      }
+      throw new CodeSearchUnavailableError(`GitHub code search forbidden: ${body}`, 403);
+    }
+    if (res.status === 422) {
+      // Repo not indexed by code search.
+      throw new CodeSearchUnavailableError("Repository not indexed by GitHub code search", 422);
+    }
+    if (!res.ok) {
+      throw new Error(`GitHub code search error: ${res.status}`);
+    }
+    const json = (await res.json()) as {
+      items?: Array<{
+        path: string;
+        text_matches?: Array<{ fragment: string }>;
+      }>;
+    };
+    if (!json.items || json.items.length === 0) return null;
+    return json.items.map((item) => ({
+      path: item.path,
+      fragment: item.text_matches?.[0]?.fragment ?? "",
+    }));
+  };
+
+  const qualified = `symbol:${symbol} repo:${owner}/${repo} language:python`;
+  const fallback = `${symbol} repo:${owner}/${repo} language:python`;
+  const first = await run(qualified);
+  if (first) return first;
+  const second = await run(fallback);
+  return second ?? [];
+}
+
 // ── Issue management ──
 
 export async function createIssue(

--- a/src/utils/verify-agent.ts
+++ b/src/utils/verify-agent.ts
@@ -1,6 +1,11 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { AuditFinding, Verdict, VerificationResult } from "../types";
-import { readRepoFile } from "./github-actions";
+import {
+  CodeSearchRateLimitError,
+  CodeSearchUnavailableError,
+  readRepoFile,
+  searchCodeSymbol,
+} from "./github-actions";
 
 export const VERIFY_MODEL = "claude-sonnet-4-20250514";
 
@@ -18,12 +23,39 @@ reported location. Automated audits have a ~50% false positive rate because they
 miss existing mitigations (validators called earlier in the stack, type guards,
 SQLAlchemy-provided escaping, framework protections, dead code paths, etc).
 
+## Known auditor problem: line number drift
+
+The auditor has a known bug where finding line numbers can be off by HUNDREDS of
+lines (observed drift of 2758 lines in one case). When read_code_at_location at
+the reported line shows code that does NOT match the finding's description, DO
+NOT immediately return FALSE_POSITIVE or UNCERTAIN. The described code likely
+exists elsewhere in the same file — you must search for it before giving up.
+
 ## Your process
 1. Call read_code_at_location(file, line, context_lines=15) to fetch the actual
    code around the reported finding.
-2. If the issue spans multiple functions or requires understanding the caller,
-   call read_code_at_location again on other relevant files/lines (max 3 reads).
-3. Decide whether the reported problem is real in CURRENT code.
+
+2. If the code at that line does NOT match the finding's description (e.g. finding
+   talks about "user_messages" but line contains cache init), DO NOT give up yet:
+   a. Extract a distinctive identifier from the description: function name, a
+      specific assignment, error string, class name.
+   b. Call grep_file(file, pattern) to find where that identifier actually lives
+      in the SAME file.
+   c. If matches found, call read_code_at_location at each match line to verify.
+   d. Only after grep_file returns zero matches can you conclude the code doesn't
+      exist in the file.
+
+3. If the finding references an external class or function (e.g. "QueueManager
+   logs the token" but the current file only imports QueueManager), use
+   find_symbol_definition(symbol, hint_file=current_file) to read the actual
+   implementation. You MUST check external implementations before returning
+   UNCERTAIN with reason "cannot locate X".
+
+4. If the issue spans multiple functions or requires understanding the caller,
+   call read_code_at_location again on other relevant files/lines (max 5 reads
+   total across all tools).
+
+5. Decide whether the reported problem is real in CURRENT code.
 
 ## Default stance: SKEPTICAL
 Assume the finding MIGHT be a false positive. Look actively for mitigations:
@@ -56,6 +88,10 @@ UNCERTAIN — Cannot determine statically without runtime context, architectural
   discussion, or calling-convention analysis that exceeds what is visible.
   Use when: you would need to know external inputs, when something is called,
   or what the author's intent was.
+  DO NOT use UNCERTAIN just because the initial read_code_at_location didn't
+  find the described code — you MUST try grep_file and/or find_symbol_definition
+  first. "Cannot locate X" is a valid UNCERTAIN reason ONLY if you searched for
+  X with grep_file or find_symbol_definition and still didn't find it.
 
 ## Output
 Reply with ONLY this JSON, no markdown, no prose:
@@ -91,6 +127,63 @@ const VERIFY_TOOL: Anthropic.Tool = {
       },
     },
     required: ["file", "line"],
+  },
+};
+
+const VERIFY_GREP_TOOL: Anthropic.Tool = {
+  name: "grep_file",
+  description:
+    "Search for a pattern within a file and return all matching line numbers with ±3 lines of context. " +
+    "Use this when read_code_at_location shows code that does NOT match what the finding describes — " +
+    "the auditor has known line-number drift, so the described function/pattern may exist elsewhere in " +
+    "the same file. Prefer a distinctive identifier from the finding description (function name, specific " +
+    "assignment like `user_messages = []`, error class name). Case-sensitive literal substring match.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      file: {
+        type: "string",
+        description: "File path relative to repo root (same format as read_code_at_location)",
+      },
+      pattern: {
+        type: "string",
+        description:
+          "Literal substring to search for. Choose something distinctive from the finding description — " +
+          "function/class name, a specific code pattern, or an error string. Avoid common words.",
+      },
+      max_matches: {
+        type: "number",
+        description: "Max matches to return (default 10, cap 20).",
+      },
+    },
+    required: ["file", "pattern"],
+  },
+};
+
+const VERIFY_FIND_SYMBOL_TOOL: Anthropic.Tool = {
+  name: "find_symbol_definition",
+  description:
+    "Find where a Python class or function is defined across the repo by symbol name, then read its body. " +
+    "Use when the finding references an external symbol (e.g. 'QueueManager logs the token') and the current " +
+    "file only imports it — you need to see the actual implementation to confirm or refute the claim. " +
+    "Returns up to 3 most likely definitions with ±20 lines of context each.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      symbol: {
+        type: "string",
+        description:
+          "Exact Python identifier: class name (e.g. 'QueueManager'), function name (e.g. 'sanitize_exception'). " +
+          "Do NOT include parentheses or module prefixes.",
+      },
+      hint_file: {
+        type: "string",
+        description:
+          "Optional: file that imports or references this symbol, to guide path resolution. " +
+          "The implementation uses this to narrow search to likely sibling paths first.",
+      },
+    },
+    required: ["symbol"],
   },
 };
 
@@ -185,6 +278,188 @@ async function executeReadCodeTool(
     input.context_lines ?? 15,
   );
   return { text: rendered, error: false };
+}
+
+/** Guard against runaway token use — never return more than this many lines. */
+const GREP_MAX_OUTPUT_LINES = 3000;
+
+/** Format a single grep hit as a ±3 line window in the same style as renderCodeWindow. */
+function renderGrepMatch(lines: string[], lineno: number): string {
+  const start = Math.max(0, lineno - 3 - 1);
+  const end = Math.min(lines.length, lineno + 3);
+  return lines
+    .slice(start, end)
+    .map((l, i) => `${String(start + i + 1).padStart(4, " ")}  ${l}`)
+    .join("\n");
+}
+
+async function executeGrepFileTool(
+  input: { file?: string; pattern?: string; max_matches?: number },
+  githubToken: string,
+  owner: string,
+  repo: string,
+  cache: FileCache,
+): Promise<VerifyToolResult> {
+  if (!input.file || !input.pattern) {
+    return { text: "ERROR: missing 'file' or 'pattern' argument", error: true };
+  }
+  const result = await fetchFileWithCache(githubToken, owner, repo, input.file, cache);
+  if (!result) {
+    return { text: `ERROR: could not read ${input.file} (tried path variants)`, error: true };
+  }
+  const lines = result.content.split("\n");
+  const matchLines: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(input.pattern)) {
+      matchLines.push(i + 1); // 1-based
+    }
+  }
+  if (matchLines.length === 0) {
+    return {
+      text: `No matches for '${input.pattern}' in ${result.resolvedPath}`,
+      error: false,
+    };
+  }
+  const cap = Math.min(Math.max(1, input.max_matches ?? 10), 20);
+  const shown = matchLines.slice(0, cap);
+  const omitted = matchLines.length - shown.length;
+  const header = `// ${result.resolvedPath} — ${matchLines.length} match${matchLines.length === 1 ? "" : "es"} for '${input.pattern}'`;
+  const blocks = shown.map((ln) => renderGrepMatch(lines, ln));
+  let body = [header, ...blocks].join("\n\n---\n\n");
+  if (omitted > 0) {
+    body += `\n\n... ${omitted} more match${omitted === 1 ? "" : "es"} omitted`;
+  }
+  // Hard cap total output size to protect token budget.
+  const outLines = body.split("\n");
+  if (outLines.length > GREP_MAX_OUTPUT_LINES) {
+    body =
+      outLines.slice(0, GREP_MAX_OUTPUT_LINES).join("\n") +
+      "\n\n... truncated, use read_code_at_location for specific lines";
+  }
+  return { text: body, error: false };
+}
+
+/**
+ * Try sequential path-guessing fallbacks when GitHub Code Search is unavailable
+ * (unindexed repo, 422). Returns candidate file paths in priority order.
+ */
+function guessSymbolPaths(symbol: string, hintFile?: string): string[] {
+  const lower = symbol.toLowerCase();
+  const out = new Set<string>();
+  if (hintFile) {
+    const lastSlash = hintFile.lastIndexOf("/");
+    const dir = lastSlash >= 0 ? hintFile.slice(0, lastSlash) : "";
+    if (dir) {
+      out.add(`${dir}/${lower}.py`);
+      // Walk up one directory level too.
+      const parentSlash = dir.lastIndexOf("/");
+      const parent = parentSlash >= 0 ? dir.slice(0, parentSlash) : "";
+      if (parent) {
+        out.add(`${parent}/${lower}.py`);
+        out.add(`${parent}/${lower}/__init__.py`);
+      }
+    }
+  }
+  out.add(`src/${lower}.py`);
+  out.add(`${lower}.py`);
+  return Array.from(out);
+}
+
+/** Find the first line number where the symbol is defined, or -1 if absent. */
+function findDefinitionLine(content: string, symbol: string): number {
+  const lines = content.split("\n");
+  // Match `class <sym>`, `def <sym>`, `async def <sym>` followed by ( or :  or space.
+  const re = new RegExp(`^(\\s*)(class|def|async\\s+def)\\s+${symbol}\\b`);
+  for (let i = 0; i < lines.length; i++) {
+    if (re.test(lines[i])) return i + 1;
+  }
+  return -1;
+}
+
+async function executeFindSymbolTool(
+  input: { symbol?: string; hint_file?: string },
+  githubToken: string,
+  owner: string,
+  repo: string,
+  cache: FileCache,
+): Promise<VerifyToolResult> {
+  const symbol = input.symbol?.trim();
+  if (!symbol || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(symbol)) {
+    return { text: "ERROR: missing or invalid 'symbol' argument (must be a bare Python identifier)", error: true };
+  }
+
+  // 1. Try GitHub Code Search.
+  let hits: { path: string; fragment: string }[] = [];
+  let searchUnavailable = false;
+  try {
+    hits = await searchCodeSymbol(githubToken, owner, repo, symbol, 10);
+  } catch (e) {
+    if (e instanceof CodeSearchRateLimitError) {
+      return { text: "GitHub code search rate limited, retry later", error: true };
+    }
+    if (e instanceof CodeSearchUnavailableError) {
+      searchUnavailable = true;
+    } else {
+      // Unknown error — propagate as tool error.
+      return {
+        text: `ERROR: code search failed: ${e instanceof Error ? e.message : String(e)}`,
+        error: true,
+      };
+    }
+  }
+
+  // 2. Filter hits to those that look like definitions (fragment contains class/def).
+  const defRe = new RegExp(`(class|def|async\\s+def)\\s+${symbol}\\b`);
+  const defHits = hits.filter((h) => defRe.test(h.fragment));
+
+  // Use defHits if we got any, otherwise fall through to path guessing below.
+  const rendered: string[] = [];
+  const seenPaths = new Set<string>();
+
+  for (const hit of defHits) {
+    if (rendered.length >= 3) break;
+    if (seenPaths.has(hit.path)) continue;
+    seenPaths.add(hit.path);
+    const file = await fetchFileWithCache(githubToken, owner, repo, hit.path, cache);
+    if (!file) continue;
+    const line = findDefinitionLine(file.content, symbol);
+    if (line < 0) continue;
+    rendered.push(renderCodeWindow(file.resolvedPath, file.content, line, 20));
+  }
+
+  // 3. If search returned nothing useful (either unavailable or no definitions),
+  //    fall back to sequential path guessing.
+  if (rendered.length === 0) {
+    for (const candidate of guessSymbolPaths(symbol, input.hint_file)) {
+      if (rendered.length >= 3) break;
+      if (seenPaths.has(candidate)) continue;
+      seenPaths.add(candidate);
+      const file = await fetchFileWithCache(githubToken, owner, repo, candidate, cache);
+      if (!file) continue;
+      const line = findDefinitionLine(file.content, symbol);
+      if (line < 0) continue;
+      rendered.push(renderCodeWindow(file.resolvedPath, file.content, line, 20));
+    }
+  }
+
+  if (rendered.length === 0) {
+    if (searchUnavailable) {
+      return {
+        text: `Symbol '${symbol}' not found via code search (repo may not be indexed). Consider using grep_file on a specific file.`,
+        error: false,
+      };
+    }
+    return {
+      text: `No definition of '${symbol}' found in repo. Try grep_file or check import statements in the current file.`,
+      error: false,
+    };
+  }
+
+  const header = `// find_symbol_definition('${symbol}') — ${rendered.length} definition${rendered.length === 1 ? "" : "s"}`;
+  return {
+    text: [header, ...rendered].join("\n\n=== next definition ===\n\n"),
+    error: false,
+  };
 }
 
 interface VerifyAgentResponse {
@@ -297,10 +572,13 @@ Recommendation: ${finding.recommendation}
 
 Verify it now.`;
 
-  // Up to 2 attempts × 8 iterations each. Each attempt starts with fresh message
-  // history so a bad assistant reply in attempt 1 doesn't poison attempt 2.
-  // Within an attempt, an invalid-JSON response gets ONE nudge back with the
-  // original reasoning preserved — after that we break and retry from scratch.
+  // Up to 2 attempts × MAX_ITERATIONS iterations each. Each attempt starts with
+  // fresh message history so a bad assistant reply in attempt 1 doesn't poison
+  // attempt 2. Within an attempt, an invalid-JSON response gets ONE nudge back
+  // with the original reasoning preserved — after that we break and retry from
+  // scratch. The iteration counter is the total tool-use loop budget across
+  // all tools (read_code_at_location, grep_file, find_symbol_definition).
+  const MAX_ITERATIONS = 12;
   let lastError: string | null = null;
   for (let attempt = 0; attempt < 2; attempt++) {
     let currentMessages: Anthropic.MessageParam[] = [
@@ -310,13 +588,13 @@ Verify it now.`;
     let jsonNudgeUsed = false;
 
     try {
-      for (let iter = 0; iter < 8; iter++) {
+      for (let iter = 0; iter < MAX_ITERATIONS; iter++) {
         const response = await client.messages.create(
           {
             model: VERIFY_MODEL,
             max_tokens: 1024,
             system: VERIFY_SYSTEM_PROMPT,
-            tools: [VERIFY_TOOL],
+            tools: [VERIFY_TOOL, VERIFY_GREP_TOOL, VERIFY_FIND_SYMBOL_TOOL],
             messages: currentMessages,
           },
           { signal },
@@ -329,21 +607,45 @@ Verify it now.`;
           ];
           const toolResults: Anthropic.ToolResultBlockParam[] = [];
           for (const block of response.content) {
-            if (block.type === "tool_use" && block.name === "read_code_at_location") {
-              const result = await executeReadCodeTool(
-                block.input as { file?: string; line?: number; context_lines?: number },
-                githubToken,
-                owner,
-                repo,
-                cache,
-              );
-              toolResults.push({
-                type: "tool_result",
-                tool_use_id: block.id,
-                content: result.text,
-                is_error: result.error,
-              });
+            if (block.type !== "tool_use") continue;
+            let result: VerifyToolResult;
+            switch (block.name) {
+              case "read_code_at_location":
+                result = await executeReadCodeTool(
+                  block.input as { file?: string; line?: number; context_lines?: number },
+                  githubToken,
+                  owner,
+                  repo,
+                  cache,
+                );
+                break;
+              case "grep_file":
+                result = await executeGrepFileTool(
+                  block.input as { file?: string; pattern?: string; max_matches?: number },
+                  githubToken,
+                  owner,
+                  repo,
+                  cache,
+                );
+                break;
+              case "find_symbol_definition":
+                result = await executeFindSymbolTool(
+                  block.input as { symbol?: string; hint_file?: string },
+                  githubToken,
+                  owner,
+                  repo,
+                  cache,
+                );
+                break;
+              default:
+                result = { text: `ERROR: unknown tool '${block.name}'`, error: true };
             }
+            toolResults.push({
+              type: "tool_result",
+              tool_use_id: block.id,
+              content: result.text,
+              is_error: result.error,
+            });
           }
           currentMessages = [
             ...currentMessages,
@@ -382,7 +684,7 @@ Verify it now.`;
         break;
       }
       if (!iterationDidFail) {
-        lastError = "verification did not converge within 8 iterations";
+        lastError = `verification did not converge within ${MAX_ITERATIONS} iterations`;
       }
     } catch (e) {
       // Propagate abort up so caller can discard the whole batch

--- a/src/utils/verify-agent.ts
+++ b/src/utils/verify-agent.ts
@@ -325,7 +325,8 @@ async function executeGrepFileTool(
   const omitted = matchLines.length - shown.length;
   const header = `// ${result.resolvedPath} — ${matchLines.length} match${matchLines.length === 1 ? "" : "es"} for '${input.pattern}'`;
   const blocks = shown.map((ln) => renderGrepMatch(lines, ln));
-  let body = [header, ...blocks].join("\n\n---\n\n");
+  // Header sits directly above the first block; `---` separates consecutive blocks only.
+  let body = blocks.length > 0 ? `${header}\n${blocks.join("\n\n---\n\n")}` : header;
   if (omitted > 0) {
     body += `\n\n... ${omitted} more match${omitted === 1 ? "" : "es"} omitted`;
   }


### PR DESCRIPTION
## Problem

The audit finding verifier gives up when `read_code_at_location` at the reported line shows code that does NOT match the finding's description. The auditor has a known line-number drift bug (observed drift of ~2758 lines in one case), so the described code often lives elsewhere in the same file — but the verifier has no way to keep looking.

Meta-verification of yesterday's makeit-pipeline run (182 findings, 25 sampled by hand against actual code) turned up **at least 4 real bugs** misclassified as FALSE_POSITIVE/UNCERTAIN purely because of this:

| Finding | Audit line | Actual line | Verdict was | Actual |
|---|---|---|---|---|
| `api.py` `user_messages` cleared before `engine.run()` | 1055 | 3813 | FALSE_POSITIVE | real bug |
| `api.py` unsanitized `job[\"error\"] = str(exc)` | 1020 | 3870 | UNCERTAIN | real bug |
| `auto_tuning.py` `apply_via_pr` non-atomic status | 520 | 652 | UNCERTAIN | real bug |
| `cli.py` `QueueManager` token handling | 108 | import → `queue.py:104` | UNCERTAIN | FP (token wrapped in `BearerAuth(SecretStr)`) |
| `contract_verifier.py` payload injection | 240 | same file, diff line | UNCERTAIN | FP (no LLM in `verify_http_contract`) |
| `queue.py` `sanitize_exception` | 156 | import → `sanitize.py:544` | UNCERTAIN | FP (literally does redaction) |

All of these were caused by the verifier only reading `read_code_at_location(file, line, ±15)` and nothing else. If that window doesn't contain the described pattern, there was no way to continue investigation.

## Changes

Adds two new tools to the verification agent (`src/utils/verify-agent.ts`) and updates the system prompt to require their use before concluding UNCERTAIN/FALSE_POSITIVE:

### 1. `grep_file(file, pattern, max_matches?)`
Literal case-sensitive substring search inside a single file, returning up to 10 matches (cap 20) with ±3 lines of context each, same `renderCodeWindow` line-number format as the existing tool. Reuses the `fetchFileWithCache` path so repeated reads are free.

### 2. `find_symbol_definition(symbol, hint_file?)`
Locates Python class/function definitions across the repo:
1. First via GitHub Code Search API (`symbol:<name>` qualifier, then bare fallback) — filters results to hits whose fragment contains `class`/`def`/`async def <symbol>`.
2. On 422 (repo not indexed) / empty search: falls back to sequential `fetchFileWithCache` on candidate paths derived from `hint_file` (sibling dirs, then parent dir, then `src/<lower>.py`, then `<lower>.py`).
3. Returns up to 3 definitions with ±20 lines of context each.

429 and rate-limit-flavored 403 responses surface as explicit tool errors; other code-search failures fall through to path guessing.

New helper `searchCodeSymbol` added in `src/utils/github-actions.ts` with `CodeSearchRateLimitError` and `CodeSearchUnavailableError` error classes.

### 3. System prompt updates
- New "Known auditor problem: line number drift" section before the process.
- "Your process" expanded from 3 steps → 5 steps explicitly requiring `grep_file` before giving up, and `find_symbol_definition` before returning UNCERTAIN with reason "cannot locate X".
- UNCERTAIN verdict description updated to forbid "code doesn't exist" conclusions without a grep/symbol search.

### 4. Iteration budget
`MAX_ITERATIONS` promoted to a named constant and raised from **8 → 12** to give room for the extra tool calls. The counter covers the total tool-use loop budget across all three tools.

### 5. Dispatcher
The tool-use loop now switches on `block.name` across all three tools instead of hard-coding `read_code_at_location`. Unknown tool names surface as explicit tool errors.

## Out of scope (deliberately not touched)
- `POST/GET /api/audit/{p}/verification` — server persistence works, not modified.
- `NOT_A_BUG` / SKEPTICAL sections of the prompt — working correctly per meta-verification.
- `VerificationResult` / `VerificationReport` TypeScript types — stay aligned with auditor Pydantic models.
- `read_code_at_location` tool definition/handler — untouched.
- Moving verifier to the server — separate large task for makeit-auditor.

## Verification

- `tsc -b` clean
- `npm run lint` clean
- Vite build transforms all 148 modules cleanly (the workbox/vite-plugin-pwa `closeBundle` error is preexisting on `main` and unrelated).

## TODO before merge (**do not auto-merge**)

- [ ] Manual smoke test: run verification on sewing-erp locally, confirm `tools` array in the Anthropic request payload has 3 entries, look for at least one reason mentioning `grep_file` / `find_symbol_definition` in the first 30 results.
- [ ] Regression run on makeit-pipeline (same 182 findings as yesterday) and attach the before/after counts:
  - UNCERTAIN: 25 → target ~5–10
  - FALSE_POSITIVE: 42 → expected ~45–50
  - CONFIRMED: should gain 2–4 (the #86 / #16 / #90 cases above)
- [ ] Hand-check that at least one of the 4 listed real bugs now converts to CONFIRMED.
- [ ] Sergey's review — DO NOT merge without it.

## Known unknowns
- GitHub Code Search does not index every private repo. The `find_symbol_definition` path-guessing fallback covers the "well-known module name" case; for everything else the tool will return "search unavailable, try grep_file" and the verifier will still have `grep_file` as a strong fallback.