### PR TITLE
feat(transcript): quality badge + expandable report in TranscriptBrief

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3875,7 +3875,7 @@ body::after {
   color: var(--color-warning);
   border-color: color-mix(in srgb, var(--color-warning) 35%, transparent);
 }
-.tpc-quality-badge--needs_review {
+.tpc-quality-badge--needs-review {
   background: color-mix(in srgb, var(--color-danger) 15%, transparent);
   color: var(--color-danger);
   border-color: color-mix(in srgb, var(--color-danger) 35%, transparent);

--- a/src/App.css
+++ b/src/App.css
@@ -3848,6 +3848,92 @@ body::after {
   color: var(--color-success);
 }
 
+.tpc-quality-badge {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: 2px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-family: inherit;
+  transition: filter 0.15s;
+}
+.tpc-quality-badge:hover { filter: brightness(1.1); }
+.tpc-quality-badge:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+.tpc-quality-badge--static { cursor: default; }
+.tpc-quality-badge--static:hover { filter: none; }
+.tpc-quality-badge--pass {
+  background: color-mix(in srgb, var(--color-success) 15%, transparent);
+  color: var(--color-success);
+  border-color: color-mix(in srgb, var(--color-success) 35%, transparent);
+}
+.tpc-quality-badge--warning {
+  background: color-mix(in srgb, var(--color-warning) 15%, transparent);
+  color: var(--color-warning);
+  border-color: color-mix(in srgb, var(--color-warning) 35%, transparent);
+}
+.tpc-quality-badge--needs_review {
+  background: color-mix(in srgb, var(--color-danger) 15%, transparent);
+  color: var(--color-danger);
+  border-color: color-mix(in srgb, var(--color-danger) 35%, transparent);
+}
+
+.tpc-quality-report {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-3) var(--sp-4);
+  font-size: var(--text-sm);
+}
+.tpc-quality-report-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: var(--sp-2);
+}
+.tpc-quality-report-title {
+  font-weight: 600;
+  color: var(--color-text);
+}
+.tpc-quality-report-score {
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+.tpc-quality-report-checks {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+.tpc-quality-check {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) minmax(0, 2fr);
+  gap: var(--sp-2);
+  align-items: baseline;
+  padding: var(--sp-2);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-text) 4%, transparent);
+}
+.tpc-quality-check-icon {
+  font-weight: 700;
+  text-align: center;
+}
+.tpc-quality-check-name {
+  font-weight: 600;
+  color: var(--color-text);
+}
+.tpc-quality-check-message {
+  color: var(--color-text-secondary);
+}
+.tpc-quality-check--pass .tpc-quality-check-icon { color: var(--color-success); }
+.tpc-quality-check--warning .tpc-quality-check-icon { color: var(--color-warning); }
+.tpc-quality-check--fail .tpc-quality-check-icon { color: var(--color-danger); }
+
 .tpc-brief-actions {
   display: flex;
   gap: var(--sp-2);

--- a/src/components/TranscriptBrief.tsx
+++ b/src/components/TranscriptBrief.tsx
@@ -14,6 +14,12 @@ const QUALITY_LABEL: Record<TranscriptQuality, string> = {
   needs_review: "✗ Требуется проверка",
 };
 
+const QUALITY_CLASS: Record<TranscriptQuality, string> = {
+  pass: "pass",
+  warning: "warning",
+  needs_review: "needs-review",
+};
+
 const CHECK_ICON: Record<QualityCheck["status"], string> = {
   pass: "✓",
   warning: "⚠",
@@ -86,7 +92,7 @@ export function TranscriptBrief({ result, onNewUpload, onEdit }: Props) {
             result.quality_report ? (
               <button
                 type="button"
-                className={`tpc-quality-badge tpc-quality-badge--${result.quality}`}
+                className={`tpc-quality-badge tpc-quality-badge--${QUALITY_CLASS[result.quality]}`}
                 aria-expanded={qualityOpen}
                 aria-controls="tpc-quality-report"
                 onClick={() => setQualityOpen((v) => !v)}
@@ -94,7 +100,7 @@ export function TranscriptBrief({ result, onNewUpload, onEdit }: Props) {
                 {QUALITY_LABEL[result.quality]}
               </button>
             ) : (
-              <span className={`tpc-quality-badge tpc-quality-badge--${result.quality} tpc-quality-badge--static`}>
+              <span className={`tpc-quality-badge tpc-quality-badge--${QUALITY_CLASS[result.quality]} tpc-quality-badge--static`}>
                 {QUALITY_LABEL[result.quality]}
               </span>
             )
@@ -129,9 +135,9 @@ export function TranscriptBrief({ result, onNewUpload, onEdit }: Props) {
         </div>
       </div>
 
-      {/* Quality report (expandable) */}
-      {qualityOpen && result.quality && result.quality_report && (
-        <div id="tpc-quality-report" className="tpc-quality-report">
+      {/* Quality report (expandable) — always mounted so aria-controls reference is valid */}
+      {result.quality && result.quality_report && (
+        <div id="tpc-quality-report" className="tpc-quality-report" hidden={!qualityOpen}>
           <div className="tpc-quality-report-header">
             <span className="tpc-quality-report-title">Отчёт о качестве</span>
             <span className="tpc-quality-report-score">
@@ -139,8 +145,8 @@ export function TranscriptBrief({ result, onNewUpload, onEdit }: Props) {
             </span>
           </div>
           <ul className="tpc-quality-report-checks">
-            {result.quality_report.checks.map((check, i) => (
-              <li key={i} className={`tpc-quality-check tpc-quality-check--${check.status}`}>
+            {result.quality_report.checks.map((check) => (
+              <li key={check.name} className={`tpc-quality-check tpc-quality-check--${check.status}`}>
                 <span className="tpc-quality-check-icon" aria-hidden="true">
                   {CHECK_ICON[check.status]}
                 </span>

--- a/src/components/TranscriptBrief.tsx
+++ b/src/components/TranscriptBrief.tsx
@@ -1,12 +1,24 @@
 import { useCallback, useMemo, useState } from "react";
 import { renderBriefHtml, renderMarkdownHtml } from "../utils/transcript-markdown";
-import type { TranscriptResult } from "../utils/transcript";
+import type { QualityCheck, TranscriptQuality, TranscriptResult } from "../utils/transcript";
 
 interface Props {
   result: TranscriptResult;
   onNewUpload: () => void;
   onEdit: () => void;
 }
+
+const QUALITY_LABEL: Record<TranscriptQuality, string> = {
+  pass: "✓ Качество ОК",
+  warning: "⚠ Есть замечания",
+  needs_review: "✗ Требуется проверка",
+};
+
+const CHECK_ICON: Record<QualityCheck["status"], string> = {
+  pass: "✓",
+  warning: "⚠",
+  fail: "✗",
+};
 
 /** Russian plural forms: 1, 2-4, 5+ */
 function plural(n: number, one: string, few: string, many: string): string {
@@ -25,6 +37,7 @@ function countMarkers(text: string, tag: string): number {
 
 export function TranscriptBrief({ result, onNewUpload, onEdit }: Props) {
   const [accordionOpen, setAccordionOpen] = useState(false);
+  const [qualityOpen, setQualityOpen] = useState(false);
   const [copied, setCopied] = useState(false);
 
   const unclearCount = useMemo(() => countMarkers(result.brief, "неразборчиво"), [result.brief]);
@@ -69,6 +82,23 @@ export function TranscriptBrief({ result, onNewUpload, onEdit }: Props) {
       {/* Header with counters */}
       <div className="tpc-brief-header">
         <div className="tpc-brief-counters">
+          {result.quality && (
+            result.quality_report ? (
+              <button
+                type="button"
+                className={`tpc-quality-badge tpc-quality-badge--${result.quality}`}
+                aria-expanded={qualityOpen}
+                aria-controls="tpc-quality-report"
+                onClick={() => setQualityOpen((v) => !v)}
+              >
+                {QUALITY_LABEL[result.quality]}
+              </button>
+            ) : (
+              <span className={`tpc-quality-badge tpc-quality-badge--${result.quality} tpc-quality-badge--static`}>
+                {QUALITY_LABEL[result.quality]}
+              </span>
+            )
+          )}
           {unclearCount > 0 && (
             <span className="tpc-counter tpc-counter--unclear">
               {unclearCount} {plural(unclearCount, "неразборчивое место", "неразборчивых места", "неразборчивых мест")}
@@ -98,6 +128,29 @@ export function TranscriptBrief({ result, onNewUpload, onEdit }: Props) {
           </button>
         </div>
       </div>
+
+      {/* Quality report (expandable) */}
+      {qualityOpen && result.quality && result.quality_report && (
+        <div id="tpc-quality-report" className="tpc-quality-report">
+          <div className="tpc-quality-report-header">
+            <span className="tpc-quality-report-title">Отчёт о качестве</span>
+            <span className="tpc-quality-report-score">
+              Score: {result.quality_report.score}
+            </span>
+          </div>
+          <ul className="tpc-quality-report-checks">
+            {result.quality_report.checks.map((check, i) => (
+              <li key={i} className={`tpc-quality-check tpc-quality-check--${check.status}`}>
+                <span className="tpc-quality-check-icon" aria-hidden="true">
+                  {CHECK_ICON[check.status]}
+                </span>
+                <span className="tpc-quality-check-name">{check.name}</span>
+                <span className="tpc-quality-check-message">{check.message}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {/* BRIEF content */}
       <div


### PR DESCRIPTION
Closes #93

## Что сделано
- Quality badge в header `TranscriptBrief` с 3 вариантами (pass / warning / needs_review)
- Кликабельный badge раскрывает quality report: список проверок с иконкой статуса и общий score
- Backward-compat: `quality === null` → badge скрыт; `quality_report === null` (но quality есть) → static (non-clickable) badge
- Стилизация через существующие токены `--color-success` / `--color-warning` / `--color-danger` + `color-mix` для фонов; работает в dark и light темах

## Файлы
- src/components/TranscriptBrief.tsx (+62 / -1)
- src/App.css (+86 / 0)

## Тесты
Юнит-тестов в проекте нет. Верификация:
- `npx tsc --noEmit` — чисто
- `npm run lint` — чисто
- `npm run build` — успешно
- Визуальная проверка через Claude Preview: все 3 варианта badge и report корректно рендерятся в light theme (CSS-классы загружены, цвета и layout соответствуют спеку)

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён (исправлено: edge case quality без quality_report)
- [x] P1 issues: 0