### PR TITLE
feat(transcript): quality column + Retry button in TranscriptHistory

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4140,6 +4140,7 @@ body::after {
   font-weight: 600;
   padding: 2px 8px;
   border-radius: var(--radius-sm);
+  white-space: nowrap;
 }
 .tpc-status--done {
   background: color-mix(in srgb, var(--color-success) 15%, transparent);

--- a/src/App.css
+++ b/src/App.css
@@ -3865,6 +3865,16 @@ body::after {
 }
 .tpc-quality-badge--static { cursor: default; }
 .tpc-quality-badge--static:hover { filter: none; }
+.tpc-quality-badge--sm {
+  font-size: var(--text-xs);
+  padding: 1px 6px;
+}
+.tpc-status-stage {
+  font-weight: 400;
+  opacity: 0.75;
+  margin-left: 2px;
+}
+.tpc-history-quality { white-space: nowrap; }
 .tpc-quality-badge--pass {
   background: color-mix(in srgb, var(--color-success) 15%, transparent);
   color: var(--color-success);

--- a/src/components/TranscriptHistory.tsx
+++ b/src/components/TranscriptHistory.tsx
@@ -1,9 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { fetchTranscriptList, deleteTranscript, type TranscriptListItem } from "../utils/transcript";
+import {
+  fetchTranscriptList,
+  deleteTranscript,
+  type TranscriptListItem,
+  type TranscriptQuality,
+} from "../utils/transcript";
 
 interface Props {
   onOpen: (taskId: string) => void;
   onResume: (taskId: string) => void;
+  onRetry: (taskId: string) => void;
   refreshKey: number; // increment to trigger refresh
 }
 
@@ -25,7 +31,27 @@ const STATUS_CLASS: Record<string, string> = {
 
 const ACTIVE_STATUSES = new Set(["queued", "transcribing", "processing"]);
 
-export function TranscriptHistory({ onOpen, onResume, refreshKey }: Props) {
+const STAGE_LABELS: Record<string, string> = {
+  intake: "Приём",
+  stt: "Транскрипция",
+  enrichment: "Обогащение",
+  structuring: "Структуризация",
+  synthesis: "Синтез",
+};
+
+const QUALITY_LABEL: Record<TranscriptQuality, string> = {
+  pass: "ОК",
+  warning: "Замечания",
+  needs_review: "Проверить",
+};
+
+const QUALITY_CLASS: Record<TranscriptQuality, string> = {
+  pass: "pass",
+  warning: "warning",
+  needs_review: "needs-review",
+};
+
+export function TranscriptHistory({ onOpen, onResume, onRetry, refreshKey }: Props) {
   const [items, setItems] = useState<TranscriptListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -153,6 +179,7 @@ export function TranscriptHistory({ onOpen, onResume, refreshKey }: Props) {
                 <th>Файл</th>
                 <th>Модель</th>
                 <th>Статус</th>
+                <th>Качество</th>
                 <th></th>
               </tr>
             </thead>
@@ -185,7 +212,23 @@ export function TranscriptHistory({ onOpen, onResume, refreshKey }: Props) {
                       <span className={`tpc-status ${STATUS_CLASS[item.status] ?? ""}`}>
                         {isActive && <span className="tpc-status-pulse" />}
                         {STATUS_LABELS[item.status] ?? item.status}
+                        {item.status === "error" && item.current_stage && STAGE_LABELS[item.current_stage] && (
+                          <span className="tpc-status-stage"> ({STAGE_LABELS[item.current_stage]})</span>
+                        )}
                       </span>
+                    </td>
+                    <td className="tpc-history-quality">
+                      {item.status === "done" ? (
+                        item.quality ? (
+                          <span className={`tpc-quality-badge tpc-quality-badge--${QUALITY_CLASS[item.quality]} tpc-quality-badge--static tpc-quality-badge--sm`}>
+                            {QUALITY_LABEL[item.quality]}
+                          </span>
+                        ) : (
+                          <span className="tpc-text-muted">—</span>
+                        )
+                      ) : (
+                        <span className="tpc-text-muted">—</span>
+                      )}
                     </td>
                     <td className="tpc-history-actions">
                       {item.status === "done" && (
@@ -202,6 +245,15 @@ export function TranscriptHistory({ onOpen, onResume, refreshKey }: Props) {
                           onClick={() => onResume(item.task_id)}
                         >
                           Следить
+                        </button>
+                      )}
+                      {item.status === "error" && (
+                        <button
+                          className="btn btn-sm"
+                          onClick={() => onRetry(item.task_id)}
+                          title="Повторить с момента сбоя"
+                        >
+                          ↻ Повторить
                         </button>
                       )}
                       {(item.status === "done" || item.status === "error") && (

--- a/src/components/TranscriptHistory.tsx
+++ b/src/components/TranscriptHistory.tsx
@@ -4,12 +4,13 @@ import {
   deleteTranscript,
   type TranscriptListItem,
   type TranscriptQuality,
+  type TranscriptionModel,
 } from "../utils/transcript";
 
 interface Props {
   onOpen: (taskId: string) => void;
   onResume: (taskId: string) => void;
-  onRetry: (taskId: string) => void;
+  onRetry: (taskId: string, transcriptionModel: TranscriptionModel | undefined) => Promise<void>;
   refreshKey: number; // increment to trigger refresh
 }
 
@@ -56,6 +57,7 @@ export function TranscriptHistory({ onOpen, onResume, onRetry, refreshKey }: Pro
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filterProject, setFilterProject] = useState("");
+  const [retryingIds, setRetryingIds] = useState<Set<string>>(new Set());
   const prevRefreshKey = useRef(refreshKey);
   const autoRefreshRef = useRef<ReturnType<typeof setInterval>>(null);
 
@@ -101,6 +103,23 @@ export function TranscriptHistory({ onOpen, onResume, onRetry, refreshKey }: Pro
       }
     };
   }, [hasActive, load]);
+
+  const handleRetry = useCallback(
+    async (taskId: string, model: TranscriptionModel | undefined) => {
+      if (retryingIds.has(taskId)) return;
+      setRetryingIds((prev) => new Set(prev).add(taskId));
+      try {
+        await onRetry(taskId, model);
+      } finally {
+        setRetryingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(taskId);
+          return next;
+        });
+      }
+    },
+    [onRetry, retryingIds],
+  );
 
   const handleDelete = useCallback(async (taskId: string, filename: string) => {
     if (!window.confirm(`Удалить транскрипцию ${filename}?`)) return;
@@ -250,10 +269,11 @@ export function TranscriptHistory({ onOpen, onResume, onRetry, refreshKey }: Pro
                       {item.status === "error" && (
                         <button
                           className="btn btn-sm"
-                          onClick={() => onRetry(item.task_id)}
+                          onClick={() => handleRetry(item.task_id, item.transcription_model)}
+                          disabled={retryingIds.has(item.task_id)}
                           title="Повторить с момента сбоя"
                         >
-                          ↻ Повторить
+                          {retryingIds.has(item.task_id) ? "Запуск..." : "↻ Повторить"}
                         </button>
                       )}
                       {(item.status === "done" || item.status === "error") && (

--- a/src/components/TranscriptsTab.tsx
+++ b/src/components/TranscriptsTab.tsx
@@ -256,18 +256,21 @@ export function TranscriptsTab({ projects }: Props) {
     setActiveTaskId(taskId);
   }, []);
 
-  const onRetryFromHistory = useCallback(async (taskId: string) => {
-    setBriefResult(null);
-    setEditing(false);
-    setResult(null);
-    try {
-      const res = await retryTranscript(taskId);
-      setActiveTaskId(res.task_id);
-      setHistoryRefreshKey((k) => k + 1);
-    } catch (err) {
-      setResult({ ok: false, message: `Не удалось повторить: ${err}` });
-    }
-  }, []);
+  const onRetryFromHistory = useCallback(
+    async (taskId: string, originalModel: TranscriptionModel | undefined) => {
+      setBriefResult(null);
+      setEditing(false);
+      setResult(null);
+      try {
+        const res = await retryTranscript(taskId, originalModel ?? "fast");
+        setActiveTaskId(res.task_id);
+        setHistoryRefreshKey((k) => k + 1);
+      } catch (err) {
+        setResult({ ok: false, message: `Не удалось повторить: ${err}` });
+      }
+    },
+    [],
+  );
 
   const onEditSave = useCallback((updatedBrief: string) => {
     setBriefResult((prev) => prev ? { ...prev, brief: updatedBrief } : prev);

--- a/src/components/TranscriptsTab.tsx
+++ b/src/components/TranscriptsTab.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "react";
-import { uploadTranscript, fetchTranscriptResult, type TranscriptResult, type TranscriptionModel } from "../utils/transcript";
+import { uploadTranscript, retryTranscript, fetchTranscriptResult, type TranscriptResult, type TranscriptionModel } from "../utils/transcript";
 import { TranscriptProgress } from "./TranscriptProgress";
 import { TranscriptBrief } from "./TranscriptBrief";
 import { TranscriptEditor } from "./TranscriptEditor";
@@ -256,6 +256,19 @@ export function TranscriptsTab({ projects }: Props) {
     setActiveTaskId(taskId);
   }, []);
 
+  const onRetryFromHistory = useCallback(async (taskId: string) => {
+    setBriefResult(null);
+    setEditing(false);
+    setResult(null);
+    try {
+      const res = await retryTranscript(taskId);
+      setActiveTaskId(res.task_id);
+      setHistoryRefreshKey((k) => k + 1);
+    } catch (err) {
+      setResult({ ok: false, message: `Не удалось повторить: ${err}` });
+    }
+  }, []);
+
   const onEditSave = useCallback((updatedBrief: string) => {
     setBriefResult((prev) => prev ? { ...prev, brief: updatedBrief } : prev);
     setEditing(false);
@@ -499,7 +512,12 @@ export function TranscriptsTab({ projects }: Props) {
 
       {/* History table (hidden when BRIEF is shown or loading) */}
       {!briefResult && !activeTaskId && !loadingBrief && (
-        <TranscriptHistory onOpen={onOpenFromHistory} onResume={onResumeFromHistory} refreshKey={historyRefreshKey} />
+        <TranscriptHistory
+          onOpen={onOpenFromHistory}
+          onResume={onResumeFromHistory}
+          onRetry={onRetryFromHistory}
+          refreshKey={historyRefreshKey}
+        />
       )}
     </div>
   );

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -132,6 +132,7 @@ export interface TranscriptListItem {
   created_at: string; // ISO timestamp
   transcription_model?: TranscriptionModel;
   quality?: TranscriptQuality;
+  current_stage?: string; // for error display: stage where job failed
 }
 
 export async function fetchTranscriptList(): Promise<TranscriptListItem[]> {
@@ -151,6 +152,7 @@ export async function fetchTranscriptList(): Promise<TranscriptListItem[]> {
     created_at: item.created_at || "",
     transcription_model: (item.transcription_model as TranscriptionModel) || undefined,
     quality: (item.quality as TranscriptQuality) || undefined,
+    current_stage: item.current_stage || undefined,
   }));
 }
 
@@ -193,6 +195,28 @@ export async function uploadTranscript(
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(`Upload failed (${res.status}): ${text}`);
+  }
+  const data = await res.json();
+  return { task_id: data.job_id, status: data.status };
+}
+
+/** Retry a failed transcript job. Backend resumes from saved state by job id;
+ *  the empty file blob is a multipart placeholder — backend uses the original
+ *  file already on disk. */
+export async function retryTranscript(jobId: string): Promise<TranscriptUploadResponse> {
+  const form = new FormData();
+  form.append("resume", jobId);
+  form.append("file", new Blob([], { type: "application/octet-stream" }), "retry");
+  form.append("project_context", "");
+  form.append("transcription_model", "fast");
+
+  const res = await fetch(`${PIPELINE_BASE_URL}/transcript/upload`, {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Retry failed (${res.status}): ${text}`);
   }
   const data = await res.json();
   return { task_id: data.job_id, status: data.status };

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -202,13 +202,17 @@ export async function uploadTranscript(
 
 /** Retry a failed transcript job. Backend resumes from saved state by job id;
  *  the empty file blob is a multipart placeholder — backend uses the original
- *  file already on disk. */
-export async function retryTranscript(jobId: string): Promise<TranscriptUploadResponse> {
+ *  file already on disk. The original model is passed through so backend can
+ *  honour it if its resume path doesn't override from saved state. */
+export async function retryTranscript(
+  jobId: string,
+  transcriptionModel: TranscriptionModel = "fast",
+): Promise<TranscriptUploadResponse> {
   const form = new FormData();
   form.append("resume", jobId);
   form.append("file", new Blob([], { type: "application/octet-stream" }), "retry");
   form.append("project_context", "");
-  form.append("transcription_model", "fast");
+  form.append("transcription_model", transcriptionModel);
 
   const res = await fetch(`${PIPELINE_BASE_URL}/transcript/upload`, {
     method: "POST",


### PR DESCRIPTION
Closes #94

## Что сделано
- Колонка «Качество» в таблице истории с badges (pass / warning / needs_review) для done jobs
- Кнопка «↻ Повторить» для failed jobs → вызов `retryTranscript(jobId)` → переключение на TranscriptProgress
- Статус «Ошибка» теперь показывает стадию сбоя — `Ошибка (Обогащение)` — когда `current_stage` доступен
- Backward-compat: jobs без `quality` / `current_stage` деградируют до `—` / простого «Ошибка»

## Файлы
- src/utils/transcript.ts (+24): новая функция `retryTranscript()` + поле `current_stage` в `TranscriptListItem`
- src/components/TranscriptHistory.tsx (+54 / −2): новая колонка, кнопка, отображение стадии
- src/components/TranscriptsTab.tsx (+20 / −2): handler `onRetryFromHistory`, проброс в `TranscriptHistory`
- src/App.css (+10): `--sm` модификатор badge, `tpc-status-stage`, `tpc-history-quality`

## Тесты
Юнит-тестов в проекте нет. Верификация:
- `npx tsc --noEmit` — чисто
- `npm run lint` — чисто
- `npm run build` — успешно
- Визуальный smoke-тест через Claude Preview: все варианты badge / status / retry button рендерятся корректно (см. mock-таблица 6 строк: pass/warning/needs_review/legacy/error+stage/active)

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён, P1 issues: 0
- [x] Backward-compat сохранена