### PR TITLE
feat: upgrade Claude model to Sonnet 4.6

### DIFF
--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -596,7 +596,7 @@ export async function generateIssuesFromFindings(
 
     try {
       const response = await client.messages.create({
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-4-6",
         max_tokens: 4096,
         system: _AUDIT_BATCH_PROMPT,
         messages: [
@@ -664,7 +664,7 @@ export async function sendChatMessage(
   // Tool use loop — max 20 iterations
   for (let i = 0; i < 20; i++) {
     const response = await client.messages.create({
-      model: "claude-sonnet-4-20250514",
+      model: "claude-sonnet-4-6",
       max_tokens: 4096,
       system: [
         { type: "text", text: SYSTEM_RULES, cache_control: { type: "ephemeral" } },

--- a/src/utils/verify-agent.ts
+++ b/src/utils/verify-agent.ts
@@ -7,7 +7,7 @@ import {
   searchCodeSymbol,
 } from "./github-actions";
 
-export const VERIFY_MODEL = "claude-sonnet-4-20250514";
+export const VERIFY_MODEL = "claude-sonnet-4-6";
 
 const VERIFY_SYSTEM_PROMPT = `You are a skeptical senior code reviewer verifying an automated audit finding.
 


### PR DESCRIPTION
## Summary

Bumps все три hardcoded callsite с устаревшего \`claude-sonnet-4-20250514\`
(Sonnet 4.0, deprecates 2026-06-15) на актуальный \`claude-sonnet-4-6\`.

- \`src/utils/verify-agent.ts\`: \`VERIFY_MODEL\` константа
- \`src/utils/claude.ts\`: 2 \`messages.create()\` callsite (audit batch + chat tool loop)

Pricing не меняется (\$3/\$15 per 1M).

## Test plan

- [x] \`npm run lint\` — passed
- [x] \`npm run build\` — passed (TS clean)
- [ ] Smoke test после deploy: chat panel + verify-agent на одном audit finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)