### PR TITLE
feat(dashboard): redesign V4 — sidebar shell + новый дашборд

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     <!-- Typography -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 
     <title>MakeIT Dashboard</title>
     <script src="config.js"></script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,12 @@
 import { useEffect, useState } from "react";
 import { TokenForm } from "./components/TokenForm";
-import { Summary } from "./components/Summary";
 import { ProjectCard } from "./components/ProjectCard";
-import { BlockedItems } from "./components/BlockedItems";
-import { StackedChart } from "./components/StackedChart";
-
 import { MilestoneCard } from "./components/MilestoneCard";
-import { UrgentDeadlines } from "./components/UrgentDeadlines";
-import { StaleAlert } from "./components/StaleAlert";
 import { ChatPanel } from "./components/ChatPanel";
 import { ChatButton } from "./components/ChatButton";
 import { FinanceEditor } from "./components/FinanceEditor";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { UptimeBar } from "./components/UptimeBar";
-import { ClosedChart } from "./components/ClosedChart";
 import { AuditCombinedTab } from "./components/AuditCombinedTab";
 import { PipelineControlPanel } from "./components/PipelineControlPanel";
 import { TranscriptsTab } from "./components/TranscriptsTab";
@@ -21,12 +14,30 @@ import { ResearchTab } from "./components/ResearchTab";
 import { SpecsTab } from "./components/SpecsTab";
 import { QualityTab } from "./components/QualityTab";
 import { DebateTab } from "./components/DebateTab";
+import { Sidebar } from "./components/v4/Sidebar";
+import { Topbar } from "./components/v4/Topbar";
+import { DashboardView } from "./components/v4/DashboardView";
 import { useDashboard } from "./hooks/useDashboard";
 import { useMonitors } from "./hooks/useMonitors";
 import { getToken, clearToken, getAuth, clearAuth, clearClaudeKey, MONITOR_MATCH, PROJECTS } from "./utils/config";
 import { PasswordGate } from "./components/PasswordGate";
 import type { TabId, Monitor } from "./types";
 import "./App.css";
+import "./styles/v4.css";
+
+const TAB_CRUMBS: Record<TabId, string> = {
+  dashboard: "Дашборд",
+  projects: "Проекты",
+  milestones: "Milestones",
+  uptime: "Мониторинг",
+  pipeline: "Pipeline",
+  transcripts: "Транскрипты",
+  audit: "Аудит",
+  research: "Research",
+  specs: "Specs",
+  quality: "Quality",
+  debate: "Debate",
+};
 
 function AppInner() {
   const {
@@ -68,6 +79,7 @@ function AppInner() {
   const [msTab, setMsTab] = useState<"open" | "done">("open");
   const [chatOpen, setChatOpen] = useState(false);
   const [financeOpen, setFinanceOpen] = useState(false);
+  const [sideOpen, setSideOpen] = useState(false);
 
   // Track visited tabs so stateful components mount lazily but stay alive
   const [visitedTabs, setVisitedTabs] = useState<Set<TabId>>(() => new Set(["dashboard", tab]));
@@ -77,6 +89,11 @@ function AppInner() {
       return new Set(prev).add(tab);
     });
   }, [tab]);
+
+  useEffect(() => {
+    document.body.classList.add("v4");
+    return () => { document.body.classList.remove("v4"); };
+  }, []);
 
   function getMonitorForRepo(repo: string): Monitor | undefined {
     const keywords = MONITOR_MATCH[repo];
@@ -104,303 +121,242 @@ function AppInner() {
   const openMilestones = allMilestones.filter((m) => !isMilestoneDone(m));
   const doneMilestones = allMilestones.filter((m) => isMilestoneDone(m));
 
-  return (
-    <div className="app">
-      <header className="header">
-        <div className="header-left">
-          <div className="header-logo">M</div>
-          <div className="header-title-group">
-            <h1>MakeIT</h1>
-            {lastUpdated && (
-              <span className="last-updated">
-                {lastUpdated.toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" })}
-              </span>
-            )}
+  // Token-form gate: classic experience until token is set
+  if (!hasToken) {
+    return (
+      <div className="v4-app" style={{ gridTemplateColumns: "1fr" }}>
+        <main className="v4-main">
+          <div className="v4-content" style={{ paddingTop: 60 }}>
+            <h1 style={{ fontSize: 28, marginBottom: 8 }}>MakeIT Dashboard</h1>
+            <p style={{ color: "var(--v4-ink-500)", marginBottom: 24 }}>
+              Укажите GitHub Token для начала работы.
+            </p>
+            <TokenForm onTokenSet={() => refresh(true)} />
           </div>
-        </div>
+        </main>
+      </div>
+    );
+  }
 
-        {hasToken && projects.length > 0 && (
-          <nav className="header-tabs">
-            {([
-              { id: "dashboard" as TabId, label: "Дашборд" },
-              { id: "projects" as TabId, label: `Проекты (${projects.length})` },
-              { id: "milestones" as TabId, label: `Milestones (${allMilestones.length})` },
-              { id: "uptime" as TabId, label: "Мониторинг" },
-              { id: "pipeline" as TabId, label: "Pipeline" },
-              { id: "transcripts" as TabId, label: "Транскрипты" },
-              { id: "audit" as TabId, label: "Аудит" },
-              { id: "research" as TabId, label: "Research" },
-              { id: "specs" as TabId, label: "Specs" },
-              { id: "quality" as TabId, label: "Quality" },
-              { id: "debate" as TabId, label: "Debate" },
-            ]).map((t) => (
-              <button
-                key={t.id}
-                onClick={() => setTab(t.id)}
-                className={`tab ${tab === t.id ? "tab-active" : ""}`}
-              >
-                {t.label}
-              </button>
-            ))}
-          </nav>
+  const handleLogout = () => {
+    clearAuth();
+    clearToken();
+    clearClaudeKey();
+    window.location.reload();
+  };
+
+  const crumbs = ["Все проекты", TAB_CRUMBS[tab] ?? tab];
+
+  // Audit alerts placeholder — could read from useAudit later. We expose a
+  // dot when there are critical findings; for now keep as undefined to avoid
+  // showing a stale badge.
+  const auditAlerts: number | undefined = undefined;
+
+  return (
+    <div className="v4-app">
+      <Sidebar
+        activeTab={tab}
+        onTabChange={setTab}
+        projectsCount={projects.length}
+        milestonesCount={allMilestones.length}
+        monitorsCount={monitors.length}
+        auditAlerts={auditAlerts}
+        isOpen={sideOpen}
+        onClose={() => setSideOpen(false)}
+      />
+      <main className="v4-main">
+        <Topbar
+          crumbs={crumbs}
+          showLive={true}
+          lastUpdated={lastUpdated}
+          onRefresh={() => {
+            refresh(true);
+            refreshMonitors();
+          }}
+          refreshing={loading}
+          onLogout={handleLogout}
+          onBurger={() => setSideOpen(true)}
+        />
+
+        {error && <div className="v4-error">{error}</div>}
+
+        {projects.length === 0 && loading && (
+          <div className="v4-loading">Загрузка данных…</div>
         )}
 
-        <div className="header-right">
-          {!hasToken && <TokenForm onTokenSet={() => refresh(true)} />}
-          {hasToken && (
-            <>
-              <button
-                onClick={() => refresh(true)}
-                disabled={loading}
-                className="header-icon-btn"
-                title="Обновить"
-                aria-label="Обновить данные"
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={loading ? "spin" : ""}>
-                  <path d="M21 12a9 9 0 1 1-6.22-8.56" />
-                  <path d="M21 3v6h-6" />
-                </svg>
-              </button>
-              <button
-                onClick={() => { clearAuth(); clearToken(); clearClaudeKey(); window.location.reload(); }}
-                className="header-icon-btn header-icon-btn--subtle"
-                title="Выйти"
-                aria-label="Выйти и очистить токены"
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="12" cy="12" r="3" />
-                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                </svg>
-              </button>
-            </>
-          )}
-        </div>
-      </header>
+        {projects.length === 0 && !loading && !error && (
+          <div className="v4-loading">Нажмите «Обновить» для загрузки данных</div>
+        )}
 
-      {error && <div className="error-banner">{error}</div>}
+        {projects.length > 0 && tab === "dashboard" && (
+          <ErrorBoundary fallback="Ошибка в дашборде">
+            <DashboardView
+              projects={projects}
+              summary={summary}
+              blockedIssues={blockedIssues}
+              getMonitor={getMonitorForRepo}
+              lastUpdated={lastUpdated}
+              onSeeAllProjects={() => setTab("projects")}
+              onFinanceClick={() => setFinanceOpen(true)}
+            />
+          </ErrorBoundary>
+        )}
 
-      {!hasToken && (
-        <div className="empty-state">
-          <p>Укажите GitHub Token для начала работы</p>
-        </div>
-      )}
-
-      {hasToken && projects.length > 0 && (
-        <>
-          {/* Simple data-display tabs — conditional rendering (no important local state) */}
-          {(tab === "dashboard" || tab === "projects" || tab === "milestones" || tab === "uptime") && (
-            <div className={`bento-grid ${tab === "dashboard" ? "dashboard-grid" : ""}`}>
-              {tab === "dashboard" && (
-                <>
-                  <ErrorBoundary fallback="Ошибка в метриках">
-                    <Summary metrics={summary} onFinanceClick={() => setFinanceOpen(true)} />
-                  </ErrorBoundary>
-
-                  <ErrorBoundary fallback="Ошибка в графике">
-                    <ClosedChart projects={projects} />
-                  </ErrorBoundary>
-
-                  {/*
-                    Layout (12-col grid):
-                      Row 1: Summary (1-4)   | ClosedChart (5-12)
-                      Row 2: Stale (1-4)     | ActiveProjects (5-12, rowspan=2)
-                      Row 3: Blocked (1-4)   | (active cont.)
-                      Row 4: Urgent? (1-4)   | StackedChart (5-12)
-                    panel-projects/StackedChart pinned to col 5 via inline
-                    style; auto-flow places narrow span-4 panels in the
-                    leftover column 1-4 slots.
-                  */}
-
-                  <ErrorBoundary fallback="Ошибка в мониторинге">
-                    <StaleAlert projects={projects} />
-                  </ErrorBoundary>
-
-                  <div
-                    className="bento-panel span-8 panel-projects"
-                    style={{ gridColumn: '5 / span 8', gridRow: 'span 2', display: 'flex', flexDirection: 'column' }}
-                  >
-                    <div className="bento-panel-title">
-                      Активные проекты
-                      <button
-                        type="button"
-                        onClick={() => setTab("projects")}
-                        className="link-button"
-                        style={{ color: "var(--color-primary)", fontSize: "var(--text-sm)", fontWeight: "normal" }}
-                      >
-                        Все проекты →
-                      </button>
-                    </div>
-                    <section className="projects-grid">
-                      {[...projects]
-                        .sort((a, b) => {
-                          const cutoff = Date.now() - 3 * 24 * 60 * 60 * 1000;
-                          const recentA = a.issues.filter(i => i.closedAt && new Date(i.closedAt).getTime() > cutoff).length;
-                          const recentB = b.issues.filter(i => i.closedAt && new Date(i.closedAt).getTime() > cutoff).length;
-                          return recentB - recentA;
-                        })
-                        .slice(0, 4)
-                        .map((p) => (
-                          <ProjectCard key={p.repo} project={p} monitor={getMonitorForRepo(p.repo)} />
-                        ))}
-                    </section>
-                  </div>
-
-                  <ErrorBoundary fallback="Ошибка в blocked items">
-                    <BlockedItems issues={blockedIssues} />
-                  </ErrorBoundary>
-
-                  <ErrorBoundary fallback="Ошибка в дедлайнах">
-                    <UrgentDeadlines milestones={allMilestones} />
-                  </ErrorBoundary>
-
-                  <ErrorBoundary fallback="Ошибка в диаграмме">
-                    <StackedChart projects={projects} />
-                  </ErrorBoundary>
-                </>
-              )}
-
-              {tab === "projects" && (
-                <>
-                  <div className="bento-panel span-12 panel-projects">
-                    <div className="bento-panel-title">
-                      Все проекты
-                    </div>
-                    <section className="projects-grid">
-                      {projects
-                        .map((p) => (
-                          <ProjectCard key={p.repo} project={p} monitor={getMonitorForRepo(p.repo)} />
-                        ))}
-                    </section>
-                  </div>
-                </>
-              )}
-
-              {tab === "milestones" && (() => {
-                const list = msTab === "open" ? openMilestones : doneMilestones;
-                const sorted = msTab === "open"
-                  ? [...list].sort((a, b) => {
-                      if (a.dueOn && b.dueOn) return new Date(a.dueOn).getTime() - new Date(b.dueOn).getTime();
-                      return a.dueOn ? -1 : b.dueOn ? 1 : 0;
-                    })
-                  : list;
-                const grouped = Object.entries(
-                  sorted.reduce<Record<string, typeof list>>((acc, m) => {
-                    (acc[m.repo] ??= []).push(m);
-                    return acc;
-                  }, {})
-                );
-                return (
-                  <div className="bento-panel span-12">
-                    <div className="milestones-sub-tabs">
-                      <button
-                        className={`milestones-sub-tab ${msTab === "open" ? "milestones-sub-tab-active" : ""}`}
-                        onClick={() => setMsTab("open")}
-                      >
-                        Открытые <span className="milestones-sub-tab-count">{openMilestones.length}</span>
-                      </button>
-                      <button
-                        className={`milestones-sub-tab ${msTab === "done" ? "milestones-sub-tab-active" : ""}`}
-                        onClick={() => setMsTab("done")}
-                      >
-                        Завершённые <span className="milestones-sub-tab-count">{doneMilestones.length}</span>
-                      </button>
-                    </div>
-                    {list.length === 0 && (
-                      <div className="empty-state">
-                        {msTab === "open" ? "Нет открытых milestones" : "Пока нет завершённых milestones"}
-                      </div>
-                    )}
-                    <div className="milestones-grouped" style={{ padding: 0 }}>
-                      {grouped.map(([repo, milestones]) => (
-                        <div key={repo} className="milestone-group">
-                          <h3 className="milestone-group-title">{repo} <span className="milestone-group-count">({milestones.length})</span></h3>
-                          <div className="milestones-grid">
-                            {milestones.map((m) => (
-                              <MilestoneCard key={m.url} milestone={m} />
-                            ))}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                );
-              })()}
-
-              {tab === "uptime" && (
-                <div className="bento-panel span-12">
-                  <div className="bento-panel-title">Мониторинг</div>
-                  <ErrorBoundary fallback="Ошибка в мониторинге">
-                    <UptimeBar monitors={monitors} loading={monitorsLoading} error={monitorsError} onRefresh={refreshMonitors} />
-                  </ErrorBoundary>
-                </div>
-              )}
+        {projects.length > 0 && tab === "projects" && (
+          <div className="v4-legacy-frame">
+            <div className="bento-grid">
+              <div className="bento-panel span-12 panel-projects">
+                <div className="bento-panel-title">Все проекты</div>
+                <section className="projects-grid">
+                  {projects.map((p) => (
+                    <ProjectCard key={p.repo} project={p} monitor={getMonitorForRepo(p.repo)} />
+                  ))}
+                </section>
+              </div>
             </div>
-          )}
+          </div>
+        )}
 
-          {/* Stateful tabs — mount lazily on first visit, keep alive via display:none */}
-          <div className="bento-grid" style={{ display: tab === "audit" ? undefined : "none" }}>
-            {visitedTabs.has("audit") && (
+        {projects.length > 0 && tab === "milestones" && (() => {
+          const list = msTab === "open" ? openMilestones : doneMilestones;
+          const sorted = msTab === "open"
+            ? [...list].sort((a, b) => {
+                if (a.dueOn && b.dueOn) return new Date(a.dueOn).getTime() - new Date(b.dueOn).getTime();
+                return a.dueOn ? -1 : b.dueOn ? 1 : 0;
+              })
+            : list;
+          const grouped = Object.entries(
+            sorted.reduce<Record<string, typeof list>>((acc, m) => {
+              (acc[m.repo] ??= []).push(m);
+              return acc;
+            }, {})
+          );
+          return (
+            <div className="v4-legacy-frame">
+              <div className="bento-grid">
+                <div className="bento-panel span-12">
+                  <div className="milestones-sub-tabs">
+                    <button
+                      className={`milestones-sub-tab ${msTab === "open" ? "milestones-sub-tab-active" : ""}`}
+                      onClick={() => setMsTab("open")}
+                    >
+                      Открытые <span className="milestones-sub-tab-count">{openMilestones.length}</span>
+                    </button>
+                    <button
+                      className={`milestones-sub-tab ${msTab === "done" ? "milestones-sub-tab-active" : ""}`}
+                      onClick={() => setMsTab("done")}
+                    >
+                      Завершённые <span className="milestones-sub-tab-count">{doneMilestones.length}</span>
+                    </button>
+                  </div>
+                  {list.length === 0 && (
+                    <div className="empty-state">
+                      {msTab === "open" ? "Нет открытых milestones" : "Пока нет завершённых milestones"}
+                    </div>
+                  )}
+                  <div className="milestones-grouped" style={{ padding: 0 }}>
+                    {grouped.map(([repo, milestones]) => (
+                      <div key={repo} className="milestone-group">
+                        <h3 className="milestone-group-title">
+                          {repo} <span className="milestone-group-count">({milestones.length})</span>
+                        </h3>
+                        <div className="milestones-grid">
+                          {milestones.map((m) => (
+                            <MilestoneCard key={m.url} milestone={m} />
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })()}
+
+        {projects.length > 0 && tab === "uptime" && (
+          <div className="v4-legacy-frame">
+            <div className="bento-grid">
+              <div className="bento-panel span-12">
+                <div className="bento-panel-title">Мониторинг</div>
+                <ErrorBoundary fallback="Ошибка в мониторинге">
+                  <UptimeBar
+                    monitors={monitors}
+                    loading={monitorsLoading}
+                    error={monitorsError}
+                    onRefresh={refreshMonitors}
+                  />
+                </ErrorBoundary>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Stateful tabs — mount lazily on first visit, keep alive via display:none */}
+        <div className="v4-legacy-frame" style={{ display: tab === "audit" ? undefined : "none" }}>
+          {visitedTabs.has("audit") && (
+            <div className="bento-grid">
               <ErrorBoundary fallback="Ошибка вкладки Аудит">
                 <AuditCombinedTab dashboardProjects={projects} />
               </ErrorBoundary>
-            )}
-          </div>
-          <div className="bento-grid" style={{ display: tab === "pipeline" ? undefined : "none" }}>
-            {visitedTabs.has("pipeline") && (
+            </div>
+          )}
+        </div>
+        <div className="v4-legacy-frame" style={{ display: tab === "pipeline" ? undefined : "none" }}>
+          {visitedTabs.has("pipeline") && (
+            <div className="bento-grid">
               <ErrorBoundary fallback="Ошибка вкладки Pipeline">
                 <PipelineControlPanel projects={projects} />
               </ErrorBoundary>
-            )}
-          </div>
-          <div className="bento-grid" style={{ display: tab === "transcripts" ? undefined : "none" }}>
-            {visitedTabs.has("transcripts") && (
+            </div>
+          )}
+        </div>
+        <div className="v4-legacy-frame" style={{ display: tab === "transcripts" ? undefined : "none" }}>
+          {visitedTabs.has("transcripts") && (
+            <div className="bento-grid">
               <ErrorBoundary fallback="Ошибка вкладки Транскрипты">
                 <TranscriptsTab projects={PROJECTS} />
               </ErrorBoundary>
-            )}
-          </div>
-          <div className="bento-grid" style={{ display: tab === "research" ? undefined : "none" }}>
-            {visitedTabs.has("research") && (
+            </div>
+          )}
+        </div>
+        <div className="v4-legacy-frame" style={{ display: tab === "research" ? undefined : "none" }}>
+          {visitedTabs.has("research") && (
+            <div className="bento-grid">
               <ErrorBoundary fallback="Ошибка вкладки Research">
                 <ResearchTab repos={projects.map((p) => p.repo)} />
               </ErrorBoundary>
-            )}
-          </div>
-          <div className="bento-grid" style={{ display: tab === "specs" ? undefined : "none" }}>
-            {visitedTabs.has("specs") && (
+            </div>
+          )}
+        </div>
+        <div className="v4-legacy-frame" style={{ display: tab === "specs" ? undefined : "none" }}>
+          {visitedTabs.has("specs") && (
+            <div className="bento-grid">
               <ErrorBoundary fallback="Ошибка вкладки Specs">
                 <SpecsTab />
               </ErrorBoundary>
-            )}
-          </div>
-          <div className="bento-grid" style={{ display: tab === "quality" ? undefined : "none" }}>
-            {visitedTabs.has("quality") && (
+            </div>
+          )}
+        </div>
+        <div className="v4-legacy-frame" style={{ display: tab === "quality" ? undefined : "none" }}>
+          {visitedTabs.has("quality") && (
+            <div className="bento-grid">
               <ErrorBoundary fallback="Ошибка вкладки Quality">
                 <QualityTab />
               </ErrorBoundary>
-            )}
-          </div>
-          <div className="bento-grid" style={{ display: tab === "debate" ? undefined : "none" }}>
-            {visitedTabs.has("debate") && (
+            </div>
+          )}
+        </div>
+        <div className="v4-legacy-frame" style={{ display: tab === "debate" ? undefined : "none" }}>
+          {visitedTabs.has("debate") && (
+            <div className="bento-grid">
               <ErrorBoundary fallback="Ошибка вкладки Debate">
                 <DebateTab />
               </ErrorBoundary>
-            )}
-          </div>
-        </>
-      )}
-
-      {hasToken && loading && projects.length === 0 && (
-        <div className="empty-state">
-          <p>Загрузка данных…</p>
+            </div>
+          )}
         </div>
-      )}
-
-      {hasToken && !loading && projects.length === 0 && !error && (
-        <div className="empty-state">
-          <p>Нажмите «Обновить» для загрузки данных</p>
-        </div>
-      )}
+      </main>
 
       <ChatButton onClick={() => setChatOpen(true)} isOpen={chatOpen} />
       <ChatPanel

--- a/src/components/v4/AIInsightsPanel.tsx
+++ b/src/components/v4/AIInsightsPanel.tsx
@@ -1,0 +1,180 @@
+import { useMemo } from "react";
+import type { ReactElement } from "react";
+import type { ProjectData, Issue } from "../../types";
+
+type InsightKind = "an" | "gr" | "rk" | "fc";
+
+interface Insight {
+  kind: InsightKind;
+  code: string;
+  title: string;
+  description: string;
+  /** 0..1 — confidence */
+  prob: number;
+}
+
+interface Props {
+  projects: ProjectData[];
+  blockedIssues: Issue[];
+}
+
+/**
+ * Heuristic placeholder insights, derived locally from dashboard data.
+ * Replaced by a real LLM-driven advisor in a follow-up task — see
+ * the linked GitHub issue tagged `feature` in makeit-dashboard.
+ */
+function generateInsights(projects: ProjectData[], blockedIssues: Issue[]): Insight[] {
+  const out: Insight[] = [];
+
+  // Slowing-down project (high open count, very low velocity)
+  const slowing = projects
+    .filter((p) => p.openCount >= 5 && p.velocity7d < 0.5)
+    .sort((a, b) => b.openCount - a.openCount)[0];
+  if (slowing) {
+    out.push({
+      kind: "rk",
+      code: "RSK-VEL",
+      title: `${slowing.repo} замедляется`,
+      description: `${slowing.openCount} открытых, velocity ${slowing.velocity7d.toFixed(2)}/д. Стоит провести debate-сессию или разблокировать.`,
+      prob: 0.82,
+    });
+  }
+
+  // Almost-done project (>=85% progress)
+  const nearlyDone = projects
+    .filter((p) => p.totalCount >= 5 && p.doneCount / p.totalCount >= 0.85)
+    .sort((a, b) => b.doneCount / b.totalCount - a.doneCount / a.totalCount)[0];
+  if (nearlyDone) {
+    const pct = Math.round((nearlyDone.doneCount / nearlyDone.totalCount) * 100);
+    out.push({
+      kind: "gr",
+      code: "GRO-CLS",
+      title: `${nearlyDone.repo} готов к закрытию фазы`,
+      description: `${pct}% задач закрыто. Можно переводить в support и фокусировать ресурсы на других проектах.`,
+      prob: 0.88,
+    });
+  }
+
+  // Stale P1 anomaly
+  if (blockedIssues.length > 0) {
+    const p1Blocked = blockedIssues.filter((i) => i.priority === "P1").length;
+    if (p1Blocked > 0) {
+      out.push({
+        kind: "an",
+        code: "ANO-P1B",
+        title: `${p1Blocked} P1-задач заблокировано`,
+        description: `Есть критичные задачи без движения. Возможно, требуется внешнее решение или переключение приоритета.`,
+        prob: 0.91,
+      });
+    }
+  }
+
+  // Forecast: portfolio progress trend
+  const totalIssues = projects.reduce((s, p) => s + p.totalCount, 0);
+  const totalDone = projects.reduce((s, p) => s + p.doneCount, 0);
+  if (totalIssues > 0) {
+    const pctDone = Math.round((totalDone / totalIssues) * 100);
+    const totalVelocity = projects.reduce((s, p) => s + p.velocity7d, 0);
+    if (totalVelocity > 0) {
+      const open = totalIssues - totalDone;
+      const daysToFinish = Math.round(open / totalVelocity);
+      const targetDate = new Date(Date.now() + daysToFinish * 86400000);
+      out.push({
+        kind: "fc",
+        code: "FCT-ETA",
+        title: `Прогноз: портфель ${pctDone}% → 100% к ${targetDate.toLocaleDateString("ru-RU", { day: "numeric", month: "short" })}`,
+        description: `При сохранении velocity ${totalVelocity.toFixed(1)}/день и без новых backlogged задач. Эвристика — не учитывает приоритеты.`,
+        prob: 0.74,
+      });
+    }
+  }
+
+  // Fallback if nothing actionable
+  if (out.length === 0) {
+    out.push({
+      kind: "fc",
+      code: "FCT-OK",
+      title: "Портфель в норме",
+      description: "Нет критических аномалий в данных. AI-анализ будет включён в следующем релизе.",
+      prob: 0.6,
+    });
+  }
+
+  return out.slice(0, 4);
+}
+
+const KIND_ICONS: Record<InsightKind, ReactElement> = {
+  rk: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0zM12 9v4M12 17h.01" />
+    </svg>
+  ),
+  gr: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M3 17l6-6 4 4 8-9" />
+    </svg>
+  ),
+  an: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+      <line x1="11" y1="8" x2="11" y2="14" />
+    </svg>
+  ),
+  fc: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <line x1="12" y1="20" x2="12" y2="10" />
+      <line x1="18" y1="20" x2="18" y2="4" />
+    </svg>
+  ),
+};
+
+export function AIInsightsPanel({ projects, blockedIssues }: Props) {
+  const insights = useMemo(
+    () => generateInsights(projects, blockedIssues),
+    [projects, blockedIssues]
+  );
+
+  const time = new Date().toLocaleTimeString("ru-RU", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
+  return (
+    <div className="v4-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">
+          <svg
+            style={{ width: 14, height: 14, color: "var(--v4-purple-500)" }}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M12 2a3 3 0 00-3 3v1.27A4 4 0 005 10v1.5a3.5 3.5 0 00-1 6.66V20a2 2 0 002 2h12a2 2 0 002-2v-1.84a3.5 3.5 0 00-1-6.66V10a4 4 0 00-4-3.73V5a3 3 0 00-3-3z" />
+          </svg>
+          AI-инсайты по портфелю
+          <span className="v4-tag">эвристика · MVP</span>
+        </div>
+        <div className="v4-panel-meta">{time}</div>
+      </div>
+      <div className="v4-ai-list">
+        {insights.map((it, idx) => (
+          <div key={idx} className={`v4-ai-item v4-ai-item--${it.kind}`}>
+            <div className="v4-ai-item-ic">{KIND_ICONS[it.kind]}</div>
+            <div>
+              <div className="v4-ai-item-ttl">{it.title}</div>
+              <div className="v4-ai-item-ds">{it.description}</div>
+            </div>
+            <div className="v4-ai-item-meta">
+              {it.code}
+              <br />
+              P {it.prob.toFixed(2).replace(".", ",")}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/AIInsightsPanel.tsx
+++ b/src/components/v4/AIInsightsPanel.tsx
@@ -130,16 +130,20 @@ const KIND_ICONS: Record<InsightKind, ReactElement> = {
 };
 
 export function AIInsightsPanel({ projects, blockedIssues }: Props) {
-  const insights = useMemo(
-    () => generateInsights(projects, blockedIssues),
+  // Compute insights and the "generated at" timestamp together — so the
+  // displayed time actually corresponds to when the insights were derived,
+  // not to the most recent unrelated parent re-render.
+  const { insights, time } = useMemo(
+    () => ({
+      insights: generateInsights(projects, blockedIssues),
+      time: new Date().toLocaleTimeString("ru-RU", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      }),
+    }),
     [projects, blockedIssues]
   );
-
-  const time = new Date().toLocaleTimeString("ru-RU", {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
 
   return (
     <div className="v4-panel">

--- a/src/components/v4/BlockedPanel.tsx
+++ b/src/components/v4/BlockedPanel.tsx
@@ -1,0 +1,46 @@
+import type { Issue } from "../../types";
+
+interface Props {
+  issues: Issue[];
+}
+
+const PRIORITY_TAG: Record<string, string> = {
+  P1: "v4-ptag--p1",
+  P2: "v4-ptag--p2",
+  P3: "v4-ptag--p3",
+  P4: "v4-ptag--p4",
+};
+
+export function BlockedPanel({ issues }: Props) {
+  return (
+    <div className="v4-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t v4-panel-t--danger">
+          🚫 Заблокировано <span className="v4-tag v4-tag--danger">{issues.length}</span>
+        </div>
+        {issues.length > 0 && <button className="v4-linkbtn">К списку →</button>}
+      </div>
+      {issues.length === 0 ? (
+        <div className="v4-empty">Нет заблокированных задач 🎉</div>
+      ) : (
+        <div className="v4-list">
+          {issues.map((issue) => (
+            <div key={issue.id} className="v4-litem">
+              <span className="v4-litem-repo">{issue.repo}</span>
+              <span className="v4-litem-ti">
+                <a href={issue.url} target="_blank" rel="noopener noreferrer">
+                  {issue.title}
+                </a>
+              </span>
+              {issue.priority && (
+                <span className={`v4-ptag ${PRIORITY_TAG[issue.priority] ?? "v4-ptag--p4"}`}>
+                  {issue.priority}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/ClosedChart30d.tsx
+++ b/src/components/v4/ClosedChart30d.tsx
@@ -1,0 +1,116 @@
+import { useMemo } from "react";
+import type { ProjectData } from "../../types";
+import { dailyClosedLastN, movingAverage } from "../../utils/dashboardMetrics";
+
+interface Props {
+  projects: ProjectData[];
+}
+
+const W = 600;
+const H = 200;
+const PAD_TOP = 20;
+const PAD_BOT = 20;
+const BAR_AREA = H - PAD_TOP - PAD_BOT; // 160
+
+export function ClosedChart30d({ projects }: Props) {
+  const { daily, total, peak, peakIdx, ma } = useMemo(() => {
+    const daily = dailyClosedLastN(projects, 30);
+    const total = daily.reduce((s, d) => s + d.count, 0);
+    let peak = 0;
+    let peakIdx = 0;
+    daily.forEach((d, i) => {
+      if (d.count > peak) {
+        peak = d.count;
+        peakIdx = i;
+      }
+    });
+    const ma = movingAverage(
+      daily.map((d) => d.count),
+      10
+    );
+    return { daily, total, peak, peakIdx, ma };
+  }, [projects]);
+
+  const max = Math.max(peak, ...ma, 1);
+  const colW = W / daily.length;
+  const barW = Math.max(8, colW - 6);
+
+  const trendPath = ma
+    .map((v, i) => {
+      const x = i * colW + colW / 2;
+      const y = PAD_TOP + BAR_AREA - (v / max) * BAR_AREA;
+      return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+
+  const peakDate = daily[peakIdx]
+    ? new Date(daily[peakIdx].day).toLocaleDateString("ru-RU", { day: "numeric", month: "short" })
+    : "—";
+
+  return (
+    <div className="v4-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">
+          Закрыто за 30 дней <span className="v4-tag">по дням</span>
+        </div>
+        <div className="v4-panel-meta">всего {total}</div>
+      </div>
+      <div className="v4-closed-chart">
+        <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none">
+          {/* gridlines */}
+          <g stroke="var(--v4-line-soft)" strokeWidth="1">
+            {[0.25, 0.5, 0.75, 1].map((f) => (
+              <line key={f} x1="0" y1={PAD_TOP + BAR_AREA * (1 - f)} x2={W} y2={PAD_TOP + BAR_AREA * (1 - f)} />
+            ))}
+          </g>
+          {/* bars */}
+          <g fill="var(--v4-accent-500)">
+            {daily.map((d, i) => {
+              const h = (d.count / max) * BAR_AREA;
+              const y = PAD_TOP + BAR_AREA - h;
+              const x = i * colW + (colW - barW) / 2;
+              return (
+                <rect
+                  key={d.day}
+                  x={x}
+                  y={y}
+                  width={barW}
+                  height={Math.max(2, h)}
+                  rx="2"
+                >
+                  <title>{`${d.day}: ${d.count}`}</title>
+                </rect>
+              );
+            })}
+          </g>
+          {/* trend (moving average) */}
+          {trendPath && (
+            <path
+              d={trendPath}
+              fill="none"
+              stroke="var(--v4-success-500)"
+              strokeWidth="2"
+              strokeDasharray="4 3"
+            />
+          )}
+        </svg>
+      </div>
+      <div className="v4-cc-legend">
+        <span className="v4-cc-lg">
+          <span className="v4-cc-sw" style={{ background: "var(--v4-accent-500)" }} />
+          Закрыто (шт.)
+        </span>
+        <span className="v4-cc-lg">
+          <span
+            className="v4-cc-sw"
+            style={{ background: "var(--v4-success-500)", height: 2, width: 14, borderRadius: 0 }}
+          />
+          Тренд (10-дн скользящее)
+        </span>
+        <span className="v4-cc-peak">
+          пик: <b>{peakDate} · {peak} шт.</b>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/CommitsHeatmapPanel.tsx
+++ b/src/components/v4/CommitsHeatmapPanel.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from "react";
+import type { ProjectData } from "../../types";
+import { getLastNDays } from "../../utils/dashboardMetrics";
+
+interface Props {
+  projects: ProjectData[];
+}
+
+const DAYS = 28;
+
+function bucket(count: number): string | undefined {
+  if (count === 0) return undefined;
+  if (count === 1) return "1";
+  if (count <= 3) return "2";
+  if (count <= 6) return "3";
+  return "4";
+}
+
+export function CommitsHeatmapPanel({ projects }: Props) {
+  const days = useMemo(() => getLastNDays(DAYS), []);
+
+  // Pick top-N projects by 28d total commits, but show at least all projects with any activity
+  const rows = useMemo(() => {
+    const enriched = projects.map((p) => {
+      const cells = days.map((d) => p.commitActivity?.byDate?.[d] ?? 0);
+      const total = cells.reduce((s, n) => s + n, 0);
+      return { repo: p.repo, cells, total };
+    });
+    return enriched
+      .sort((a, b) => b.total - a.total)
+      .slice(0, 8);
+  }, [projects, days]);
+
+  const grandTotal = rows.reduce((s, r) => s + r.total, 0);
+
+  return (
+    <div className="v4-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">
+          Активность · коммиты по дням <span className="v4-tag">{DAYS} дней</span>
+        </div>
+        <div className="v4-panel-meta">всего {grandTotal} коммит{grandTotal === 1 ? "" : "ов"}</div>
+      </div>
+      <div className="v4-heat-strip">
+        {rows.length === 0 || grandTotal === 0 ? (
+          <div className="v4-empty">Нет активности за {DAYS} дней</div>
+        ) : (
+          rows.map((row) => (
+            <div key={row.repo} className="v4-commit-row">
+              <span className="v4-nm">{row.repo}</span>
+              <div className="v4-commit-cells">
+                {row.cells.map((count, i) => {
+                  const v = bucket(count);
+                  return (
+                    <div
+                      key={i}
+                      className="v4-cc"
+                      data-v={v}
+                      title={`${days[i]}: ${count} коммит${count === 1 ? "" : count >= 2 && count <= 4 ? "а" : "ов"}`}
+                    />
+                  );
+                })}
+              </div>
+              <span className="v4-tot">{row.total}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/CommitsHeatmapPanel.tsx
+++ b/src/components/v4/CommitsHeatmapPanel.tsx
@@ -4,6 +4,9 @@ import { getLastNDays } from "../../utils/dashboardMetrics";
 
 interface Props {
   projects: ProjectData[];
+  /** Anchor for "last N days" — recomputed when data refreshes so the
+      heatmap doesn't go stale if the dashboard is left open past midnight. */
+  lastUpdated: Date | null;
 }
 
 const DAYS = 28;
@@ -16,8 +19,13 @@ function bucket(count: number): string | undefined {
   return "4";
 }
 
-export function CommitsHeatmapPanel({ projects }: Props) {
-  const days = useMemo(() => getLastNDays(DAYS), []);
+export function CommitsHeatmapPanel({ projects, lastUpdated }: Props) {
+  const days = useMemo(
+    () => getLastNDays(DAYS),
+    // recompute on every refresh — `lastUpdated` is the wall-clock anchor
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [lastUpdated?.getTime()]
+  );
 
   // Pick top-N projects by 28d total commits, but show at least all projects with any activity
   const rows = useMemo(() => {

--- a/src/components/v4/DashboardProjectCard.tsx
+++ b/src/components/v4/DashboardProjectCard.tsx
@@ -1,0 +1,178 @@
+import type { ProjectData, Monitor, MonitorStatus } from "../../types";
+import { calcRiskScore } from "../../utils/riskScore";
+
+interface Props {
+  project: ProjectData;
+  monitor?: Monitor;
+}
+
+const STATUS_LABEL: Record<MonitorStatus, string> = {
+  up: "alive",
+  down: "down",
+  paused: "paused",
+  pending: "pending",
+};
+
+const PHASE_CHIP: Record<string, { cls: string; icon: string; label: string }> = {
+  development: { cls: "v4-chip--dev", icon: "▶", label: "dev" },
+  support: { cls: "v4-chip--support", icon: "⏸", label: "support" },
+  "pre-dev": { cls: "v4-chip--predev", icon: "◻", label: "pre-dev" },
+};
+
+function compactUSD(n: number): string {
+  if (n >= 1000) {
+    const k = n / 1000;
+    return `$${k.toFixed(k % 1 === 0 ? 0 : 1).replace(".", ",")}k`;
+  }
+  return `$${n}`;
+}
+
+function formatNumber1d(n: number): string {
+  return (Math.round(n * 10) / 10).toString().replace(".", ",");
+}
+
+function formatEta(etaDays: number | null, etaDate: string | null): { label: string; sub?: string; danger?: boolean } {
+  if (etaDays === null) return { label: "—" };
+  if (etaDays > 365) return { label: "∞", sub: "нет ETA" };
+  const target = etaDate ? new Date(etaDate) : new Date(Date.now() + etaDays * 86400000);
+  const label = target.toLocaleDateString("ru-RU", { day: "numeric", month: "short" });
+  if (etaDays < 0) return { label, sub: `(+${Math.abs(etaDays)}д)`, danger: true };
+  return { label };
+}
+
+export function DashboardProjectCard({ project, monitor }: Props) {
+  const risk = calcRiskScore(project, monitor);
+  // Mockup uses 2 visible levels: med/high. Map: critical→high, high→high, medium→med, low→none.
+  const riskClass =
+    risk.level === "critical" || risk.level === "high"
+      ? "is-risk-high"
+      : risk.level === "medium"
+      ? "is-risk-med"
+      : "";
+
+  const phase = PHASE_CHIP[project.phase] ?? PHASE_CHIP["pre-dev"];
+
+  const total = project.totalCount;
+  const done = project.doneCount;
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+  const fillColor =
+    pct >= 75
+      ? "var(--v4-success-500)"
+      : pct >= 40
+      ? "var(--v4-accent-500)"
+      : "var(--v4-warn-500)";
+
+  const hasFinances = project.budget > 0;
+  const paid = project.paid;
+  const remaining = Math.max(0, project.budget - paid);
+  const fullyPaid = hasFinances && paid >= project.budget;
+
+  const eta = formatEta(project.etaDays, project.etaDate);
+
+  return (
+    <div className={`v4-pcard ${riskClass}`}>
+      <div className="v4-pcard-row">
+        <a className="v4-pcard-name" href={`https://github.com/${project.repo.includes("/") ? project.repo : `Sergio1990-1/${project.repo}`}`} target="_blank" rel="noopener noreferrer">
+          {project.repo}
+        </a>
+        <div className="v4-pcard-badges">
+          {monitor && monitor.status !== "paused" && (
+            <span className={`v4-chip v4-chip--${monitor.status === "up" ? "alive" : monitor.status === "down" ? "down" : "paused"}`}>
+              <span className="v4-chip-dot" />
+              {STATUS_LABEL[monitor.status]}
+            </span>
+          )}
+          <span className={`v4-chip ${phase.cls}`}>
+            {phase.icon} {phase.label}
+          </span>
+        </div>
+      </div>
+
+      <div className="v4-pcard-open-row">
+        <div className="v4-pcard-open-num num">
+          {project.openCount}
+          <span>открытых</span>
+        </div>
+        <div className="v4-pcard-pri-group">
+          {project.priorityCounts.P1 > 0 && (
+            <span className="v4-pcard-pri">
+              <span className="v4-pdot v4-pdot--p1" />
+              {project.priorityCounts.P1}
+            </span>
+          )}
+          {project.priorityCounts.P2 > 0 && (
+            <span className="v4-pcard-pri">
+              <span className="v4-pdot v4-pdot--p2" />
+              {project.priorityCounts.P2}
+            </span>
+          )}
+          {project.priorityCounts.P3 > 0 && (
+            <span className="v4-pcard-pri">
+              <span className="v4-pdot v4-pdot--p3" />
+              {project.priorityCounts.P3}
+            </span>
+          )}
+          {project.priorityCounts.P4 > 0 && (
+            <span className="v4-pcard-pri">
+              <span className="v4-pdot v4-pdot--p4" />
+              {project.priorityCounts.P4}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {total > 0 && (
+        <div className="v4-pcard-progress">
+          <div className="v4-ptrack">
+            <div className="v4-pfill" style={{ width: `${pct}%`, background: fillColor }} />
+          </div>
+          <span className="v4-ppct num">
+            {done}/{total} ({pct}%)
+          </span>
+        </div>
+      )}
+
+      {hasFinances && (
+        <div className="v4-pcard-finance">
+          <span className="v4-pcard-finance-l">
+            <b>{compactUSD(paid)}</b> / {compactUSD(project.budget)}
+          </span>
+          <span className={`v4-pcard-finance-r ${fullyPaid ? "" : "v4-pcard-finance-r--warn"}`}>
+            {fullyPaid ? "оплачен ✓" : `остаток ${compactUSD(remaining)}`}
+          </span>
+        </div>
+      )}
+
+      <div className="v4-pcard-stats">
+        <span className="v4-pcard-stat" title="Velocity (issues/день за 7 дней)">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+          </svg>
+          <b>{formatNumber1d(project.velocity7d)}</b>/д
+        </span>
+        {project.cycleTimeDays !== null && (
+          <span className="v4-pcard-stat" title="Медиана цикла закрытия (28 дней)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="12" cy="12" r="10" />
+              <polyline points="12 6 12 12 16 14" />
+            </svg>
+            <b>{formatNumber1d(project.cycleTimeDays)}</b>д
+          </span>
+        )}
+        {project.etaDays !== null && (
+          <span
+            className={`v4-pcard-stat ${eta.danger ? "v4-pcard-stat--danger" : ""}`}
+            title="Прогноз даты завершения"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="12" cy="12" r="10" />
+              <circle cx="12" cy="12" r="5" />
+            </svg>
+            <b>{eta.label}</b>
+            {eta.sub && <> {eta.sub}</>}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/DashboardProjectCard.tsx
+++ b/src/components/v4/DashboardProjectCard.tsx
@@ -1,5 +1,6 @@
 import type { ProjectData, Monitor, MonitorStatus } from "../../types";
 import { calcRiskScore } from "../../utils/riskScore";
+import { GITHUB_OWNER } from "../../utils/config";
 
 interface Props {
   project: ProjectData;
@@ -29,6 +30,16 @@ function compactUSD(n: number): string {
 
 function formatNumber1d(n: number): string {
   return (Math.round(n * 10) / 10).toString().replace(".", ",");
+}
+
+function buildRepoUrl(repo: string): string {
+  // `repo` may already be `owner/name` or just `name`. Encode each segment
+  // separately so any unusual chars don't break the URL.
+  if (repo.includes("/")) {
+    const [owner, name] = repo.split("/", 2);
+    return `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+  }
+  return `https://github.com/${encodeURIComponent(GITHUB_OWNER)}/${encodeURIComponent(repo)}`;
 }
 
 function formatEta(etaDays: number | null, etaDate: string | null): { label: string; sub?: string; danger?: boolean } {
@@ -72,7 +83,7 @@ export function DashboardProjectCard({ project, monitor }: Props) {
   return (
     <div className={`v4-pcard ${riskClass}`}>
       <div className="v4-pcard-row">
-        <a className="v4-pcard-name" href={`https://github.com/${project.repo.includes("/") ? project.repo : `Sergio1990-1/${project.repo}`}`} target="_blank" rel="noopener noreferrer">
+        <a className="v4-pcard-name" href={buildRepoUrl(project.repo)} target="_blank" rel="noopener noreferrer">
           {project.repo}
         </a>
         <div className="v4-pcard-badges">

--- a/src/components/v4/DashboardView.tsx
+++ b/src/components/v4/DashboardView.tsx
@@ -159,13 +159,13 @@ export function DashboardView({
 
       {/* Row: deadlines + closed chart */}
       <div className="v4-grid v4-grid--rev">
-        <UrgentDeadlinesPanel milestones={allMilestones} />
+        <UrgentDeadlinesPanel milestones={allMilestones} lastUpdated={lastUpdated} />
         <ClosedChart30d projects={filtered} />
       </div>
 
-      <MilestonesStrip milestones={allMilestones} />
+      <MilestonesStrip milestones={allMilestones} lastUpdated={lastUpdated} />
 
-      <CommitsHeatmapPanel projects={filtered} />
+      <CommitsHeatmapPanel projects={filtered} lastUpdated={lastUpdated} />
 
       <StaleBanner projects={filtered} onOpenList={onSeeAllProjects} />
     </div>

--- a/src/components/v4/DashboardView.tsx
+++ b/src/components/v4/DashboardView.tsx
@@ -1,0 +1,173 @@
+import { useMemo, useState } from "react";
+import type { ProjectData, SummaryMetrics, Issue, Monitor } from "../../types";
+import { KpiRow } from "./KpiRow";
+import { DashboardProjectCard } from "./DashboardProjectCard";
+import { AIInsightsPanel } from "./AIInsightsPanel";
+import { StackedDistribution } from "./StackedDistribution";
+import { BlockedPanel } from "./BlockedPanel";
+import { UrgentDeadlinesPanel } from "./UrgentDeadlinesPanel";
+import { ClosedChart30d } from "./ClosedChart30d";
+import { MilestonesStrip } from "./MilestonesStrip";
+import { CommitsHeatmapPanel } from "./CommitsHeatmapPanel";
+import { StaleBanner } from "./StaleBanner";
+
+interface Props {
+  projects: ProjectData[];
+  summary: SummaryMetrics;
+  blockedIssues: Issue[];
+  getMonitor: (repo: string) => Monitor | undefined;
+  lastUpdated: Date | null;
+  /** Switch to "projects" tab */
+  onSeeAllProjects: () => void;
+  onFinanceClick?: () => void;
+}
+
+type PhaseFilter = "all" | "pre-dev" | "development" | "support";
+
+const PHASE_LABELS: Record<PhaseFilter, string> = {
+  all: "Все",
+  "pre-dev": "Pre-dev",
+  development: "Dev",
+  support: "Support",
+};
+
+export function DashboardView({
+  projects,
+  summary,
+  blockedIssues,
+  getMonitor,
+  lastUpdated,
+  onSeeAllProjects,
+  onFinanceClick,
+}: Props) {
+  const [phaseFilter, setPhaseFilter] = useState<PhaseFilter>("all");
+
+  const filtered = useMemo(
+    () =>
+      phaseFilter === "all"
+        ? projects
+        : projects.filter((p) => p.phase === phaseFilter),
+    [projects, phaseFilter]
+  );
+
+  const allMilestones = useMemo(
+    () => projects.flatMap((p) => p.milestones),
+    [projects]
+  );
+
+  // Top-4 active by recent closed activity (last 3 days). Uses lastUpdated as
+  // the time anchor so sorting is stable until the data refreshes — avoids
+  // calling Date.now() inside useMemo (react-hooks/purity).
+  const top4 = useMemo(() => {
+    const anchor = lastUpdated ? lastUpdated.getTime() : 0;
+    const cutoff = anchor > 0 ? anchor - 3 * 24 * 60 * 60 * 1000 : 0;
+    return [...filtered]
+      .sort((a, b) => {
+        const recentA = cutoff
+          ? a.issues.filter((i) => i.closedAt && new Date(i.closedAt).getTime() > cutoff).length
+          : 0;
+        const recentB = cutoff
+          ? b.issues.filter((i) => i.closedAt && new Date(i.closedAt).getTime() > cutoff).length
+          : 0;
+        if (recentB !== recentA) return recentB - recentA;
+        return b.openCount - a.openCount;
+      })
+      .slice(0, 4);
+  }, [filtered, lastUpdated]);
+
+  const subText = useMemo(() => {
+    const parts = [`${filtered.length} активных проектов`];
+    if (lastUpdated) {
+      parts.push(`обновлено ${lastUpdated.toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" })}`);
+    }
+    return parts.join(" · ");
+  }, [filtered.length, lastUpdated]);
+
+  return (
+    <div className="v4-content">
+      <div className="v4-ph">
+        <div>
+          <h1>MakeIT · сводка по проектам</h1>
+          <div className="v4-sub">{subText}</div>
+        </div>
+        <div className="v4-ph-right">
+          <div className="v4-pillgrp">
+            {(Object.keys(PHASE_LABELS) as PhaseFilter[]).map((p) => (
+              <button
+                key={p}
+                type="button"
+                className={phaseFilter === p ? "is-active" : ""}
+                onClick={() => setPhaseFilter(p)}
+              >
+                {PHASE_LABELS[p]}
+              </button>
+            ))}
+          </div>
+          <button type="button" className="v4-btn" onClick={onFinanceClick} title="Редактировать финансы">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M12 1v22M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6" />
+            </svg>
+            Финансы
+          </button>
+          <button type="button" className="v4-btn v4-btn--pri" onClick={onSeeAllProjects}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M3 7h18M3 12h18M3 17h18" />
+            </svg>
+            Все проекты
+          </button>
+        </div>
+      </div>
+
+      <div style={{ height: 10 }} />
+
+      <KpiRow projects={filtered} summary={summary} onFinanceClick={onFinanceClick} />
+
+      {/* Row: top-4 projects + AI insights */}
+      <div className="v4-grid">
+        <div className="v4-panel">
+          <div className="v4-panel-h">
+            <div className="v4-panel-t">
+              Активные проекты <span className="v4-tag">{filtered.length} репо</span>
+            </div>
+            <button className="v4-linkbtn" onClick={onSeeAllProjects}>
+              Все проекты →
+            </button>
+          </div>
+          {top4.length === 0 ? (
+            <div className="v4-empty">Нет проектов в текущем фильтре</div>
+          ) : (
+            <div className="v4-proj-grid">
+              {top4.map((p) => (
+                <DashboardProjectCard
+                  key={p.repo}
+                  project={p}
+                  monitor={getMonitor(p.repo)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <AIInsightsPanel projects={filtered} blockedIssues={blockedIssues} />
+      </div>
+
+      {/* Row: stacked + blocked */}
+      <div className="v4-grid">
+        <StackedDistribution projects={filtered} />
+        <BlockedPanel issues={blockedIssues} />
+      </div>
+
+      {/* Row: deadlines + closed chart */}
+      <div className="v4-grid v4-grid--rev">
+        <UrgentDeadlinesPanel milestones={allMilestones} />
+        <ClosedChart30d projects={filtered} />
+      </div>
+
+      <MilestonesStrip milestones={allMilestones} />
+
+      <CommitsHeatmapPanel projects={filtered} />
+
+      <StaleBanner projects={filtered} onOpenList={onSeeAllProjects} />
+    </div>
+  );
+}

--- a/src/components/v4/KpiRow.tsx
+++ b/src/components/v4/KpiRow.tsx
@@ -1,0 +1,251 @@
+import { useMemo } from "react";
+import type { ProjectData, SummaryMetrics } from "../../types";
+import {
+  calcPortfolioVelocity,
+  calcOpenDelta,
+  calcProgressDelta,
+  sumOpenPriorities,
+} from "../../utils/dashboardMetrics";
+
+interface Props {
+  projects: ProjectData[];
+  summary: SummaryMetrics;
+  onFinanceClick?: () => void;
+}
+
+function compactUSD(n: number): string {
+  if (n >= 1000) {
+    const k = n / 1000;
+    return `$${k.toFixed(k % 1 === 0 ? 0 : 1).replace(".", ",")}k`;
+  }
+  return `$${n}`;
+}
+
+function formatNumber1d(n: number): string {
+  return (Math.round(n * 10) / 10).toString().replace(".", ",");
+}
+
+function buildSparkPath(values: number[], width: number, height: number): { line: string; area: string } {
+  if (values.length === 0) return { line: "", area: "" };
+  const max = Math.max(...values, 1);
+  const stepX = values.length > 1 ? width / (values.length - 1) : width;
+  const points = values.map((v, i) => {
+    const x = i * stepX;
+    const y = height - (v / max) * (height - 2) - 1;
+    return [x, y] as const;
+  });
+  const line = points
+    .map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`)
+    .join(" ");
+  const area = `${line} L${points[points.length - 1][0].toFixed(1)},${height} L0,${height} Z`;
+  return { line, area };
+}
+
+export function KpiRow({ projects, summary, onFinanceClick }: Props) {
+  const velocity = useMemo(() => calcPortfolioVelocity(projects), [projects]);
+  const openDelta = useMemo(() => calcOpenDelta(projects), [projects]);
+  const progressDelta = useMemo(() => calcProgressDelta(projects), [projects]);
+  const priorityTotals = useMemo(() => sumOpenPriorities(projects), [projects]);
+
+  const pctDone = summary.totalIssues > 0
+    ? Math.round((summary.doneCount / summary.totalIssues) * 100)
+    : 0;
+
+  const spark = buildSparkPath(velocity.daily28d, 200, 42);
+
+  const hasFinances = summary.totalBudget > 0;
+  const paidPct = hasFinances ? Math.round((summary.totalPaid / summary.totalBudget) * 100) : 0;
+  const remainingPct = hasFinances ? 100 - paidPct : 0;
+
+  const monthName = new Date().toLocaleDateString("ru-RU", { month: "long", year: "numeric" });
+
+  const velocityDeltaSign = velocity.delta7dVsPrev >= 0 ? "↑" : "↓";
+  const velocityDeltaAbs = Math.abs(velocity.delta7dVsPrev);
+
+  const openDeltaSign = openDelta.netDelta7d > 0 ? "↑" : openDelta.netDelta7d < 0 ? "↓" : "→";
+  const openDeltaClass =
+    openDelta.netDelta7d > 0 ? "v4-kpi-delta--neg" : "v4-kpi-delta--pos";
+
+  return (
+    <div className="v4-kpi-row">
+      {/* 1. Прогресс портфеля (accent) */}
+      <div className="v4-kpi v4-kpi--acc">
+        <div className="v4-kpi-lbl">
+          <span className="v4-kpi-ic">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polyline points="9 11 12 14 22 4" />
+              <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" />
+            </svg>
+          </span>
+          Прогресс портфеля
+        </div>
+        <div className="v4-kpi-val num">
+          {pctDone}
+          <span className="v4-u">%</span>
+        </div>
+        <div className="v4-kpi-meta">
+          {progressDelta.pointsDelta7d !== 0 ? (
+            <>
+              <span className={progressDelta.pointsDelta7d >= 0 ? "v4-kpi-delta--pos" : "v4-kpi-delta--neg"}>
+                {progressDelta.pointsDelta7d >= 0 ? "↑" : "↓"}{" "}
+                {Math.abs(progressDelta.pointsDelta7d).toString().replace(".", ",")} п.п.
+              </span>
+              <span className="v4-kpi-vs">за 7 дней</span>
+            </>
+          ) : (
+            <span className="v4-kpi-vs">без изменений за 7 дней</span>
+          )}
+        </div>
+        <div className="v4-kpi-splits">
+          <div className="v4-kpi-split">
+            <div className="v4-kpi-split-n">{summary.totalIssues}</div>
+            <div className="v4-kpi-split-l">Всего</div>
+          </div>
+          <div className="v4-kpi-split">
+            <div className="v4-kpi-split-n">{summary.doneCount}</div>
+            <div className="v4-kpi-split-l">Сделано</div>
+          </div>
+          <div className="v4-kpi-split">
+            <div className="v4-kpi-split-n">{summary.openCount}</div>
+            <div className="v4-kpi-split-l">Открыто</div>
+          </div>
+        </div>
+      </div>
+
+      {/* 2. Открытые задачи */}
+      <div className="v4-kpi">
+        <div className="v4-kpi-lbl">
+          <span className="v4-kpi-ic v4-kpi-ic--b">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M9 12l2 2 4-4M12 22a10 10 0 110-20 10 10 0 010 20z" />
+            </svg>
+          </span>
+          Открытые задачи
+        </div>
+        <div className="v4-kpi-val num">{summary.openCount}</div>
+        <div className="v4-kpi-meta">
+          {openDelta.netDelta7d !== 0 ? (
+            <>
+              <span className={openDeltaClass}>
+                {openDeltaSign} {Math.abs(openDelta.netDelta7d)}
+              </span>
+              <span className="v4-kpi-vs">net за 7 дней</span>
+            </>
+          ) : (
+            <span className="v4-kpi-vs">без изменений за 7 дней</span>
+          )}
+        </div>
+        <div className="v4-kpi-splits">
+          <div className="v4-kpi-split">
+            <div className="v4-kpi-split-n" style={{ color: "var(--v4-p1)" }}>{priorityTotals.P1}</div>
+            <div className="v4-kpi-split-l">P1</div>
+          </div>
+          <div className="v4-kpi-split">
+            <div className="v4-kpi-split-n" style={{ color: "var(--v4-p2)" }}>{priorityTotals.P2}</div>
+            <div className="v4-kpi-split-l">P2</div>
+          </div>
+          <div className="v4-kpi-split">
+            <div className="v4-kpi-split-n" style={{ color: "var(--v4-p3)" }}>{priorityTotals.P3}</div>
+            <div className="v4-kpi-split-l">P3</div>
+          </div>
+        </div>
+      </div>
+
+      {/* 3. Velocity 7д + sparkline */}
+      <div className="v4-kpi">
+        <div className="v4-kpi-lbl">
+          <span className="v4-kpi-ic v4-kpi-ic--p">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+            </svg>
+          </span>
+          Velocity · 7 дней
+        </div>
+        <div className="v4-kpi-val num">
+          {formatNumber1d(velocity.perDay7d)}
+          <span className="v4-u">/день</span>
+        </div>
+        <div className="v4-kpi-meta">
+          {velocity.delta7dVsPrev !== 0 ? (
+            <>
+              <span className={velocity.delta7dVsPrev >= 0 ? "v4-kpi-delta--pos" : "v4-kpi-delta--neg"}>
+                {velocityDeltaSign} {velocityDeltaAbs}%
+              </span>
+              <span className="v4-kpi-vs">vs. предыдущая неделя</span>
+            </>
+          ) : (
+            <span className="v4-kpi-vs">28-дн. ритм закрытия</span>
+          )}
+        </div>
+        <div className="v4-kpi-spark">
+          <svg viewBox="0 0 200 42" preserveAspectRatio="none">
+            {spark.area && <path d={spark.area} fill="rgba(18,183,106,0.12)" />}
+            {spark.line && (
+              <path d={spark.line} fill="none" stroke="var(--v4-success-500)" strokeWidth="2" />
+            )}
+          </svg>
+        </div>
+      </div>
+
+      {/* 4. Бюджет */}
+      <div
+        className="v4-kpi"
+        onClick={onFinanceClick}
+        role={onFinanceClick ? "button" : undefined}
+        tabIndex={onFinanceClick ? 0 : undefined}
+        onKeyDown={(e) => {
+          if (onFinanceClick && (e.key === "Enter" || e.key === " ")) {
+            e.preventDefault();
+            onFinanceClick();
+          }
+        }}
+        style={onFinanceClick ? { cursor: "pointer" } : undefined}
+        aria-label={onFinanceClick ? "Открыть редактор финансов" : undefined}
+      >
+        <div className="v4-kpi-lbl">
+          <span className="v4-kpi-ic v4-kpi-ic--g">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M12 1v22M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6" />
+            </svg>
+          </span>
+          Бюджет портфеля
+        </div>
+        <div className="v4-kpi-val num">{compactUSD(summary.totalBudget)}</div>
+        <div className="v4-kpi-meta">
+          <span className="v4-kpi-vs">
+            {monthName} · оплачено {paidPct}%
+          </span>
+        </div>
+        {hasFinances ? (
+          <div className="v4-fin-bar">
+            <div className="v4-fin-bar-stk">
+              <div className="v4-pp" style={{ width: `${paidPct}%` }} />
+              <div className="v4-ip" style={{ width: `${remainingPct}%`, background: "var(--v4-surface-3)" }} />
+            </div>
+            <div className="v4-fin-lg">
+              <span className="v4-fin-lg-i">
+                <span className="v4-fin-lg-sw" style={{ background: "var(--v4-success-500)" }} />
+                Оплачено <b>{compactUSD(summary.totalPaid)}</b>
+              </span>
+              <span className="v4-fin-lg-i">
+                <span className="v4-fin-lg-sw" style={{ background: "var(--v4-surface-3)" }} />
+                Остаток <b>{compactUSD(summary.totalRemaining)}</b>
+              </span>
+            </div>
+          </div>
+        ) : (
+          <div className="v4-kpi-splits">
+            <div className="v4-kpi-split">
+              <div className="v4-kpi-split-n" style={{ color: "var(--v4-success-700)" }}>{compactUSD(summary.totalPaid)}</div>
+              <div className="v4-kpi-split-l">Оплачено</div>
+            </div>
+            <div className="v4-kpi-split">
+              <div className="v4-kpi-split-n">{compactUSD(summary.totalRemaining)}</div>
+              <div className="v4-kpi-split-l">Остаток</div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/MilestonesStrip.tsx
+++ b/src/components/v4/MilestonesStrip.tsx
@@ -1,0 +1,161 @@
+import { useMemo, useState } from "react";
+import type { Milestone } from "../../types";
+import { daysUntil, formatShortDate } from "../../utils/date";
+
+interface Props {
+  milestones: Milestone[];
+}
+
+type Sub = "open" | "done";
+
+const PRIORITY_TAG: Record<string, string> = {
+  P1: "v4-ptag--p1",
+  P2: "v4-ptag--p2",
+  P3: "v4-ptag--p3",
+  P4: "v4-ptag--p4",
+};
+
+function inferPriority(m: Milestone): string | null {
+  // milestones don't carry priority directly — use the highest priority of
+  // their issues' labels as a heuristic.
+  const labelMatch = (m.issues ?? []).flatMap((i) => i.labels);
+  for (const p of ["P1", "P2", "P3", "P4"]) {
+    if (labelMatch.some((l) => l.startsWith(p))) return p;
+  }
+  return null;
+}
+
+function classify(m: Milestone): "done" | "over" | "warn" | "norm" {
+  const total = m.openIssues + m.closedIssues;
+  if (m.state === "CLOSED" || (total > 0 && m.openIssues === 0)) return "done";
+  if (!m.dueOn) return "norm";
+  const d = daysUntil(m.dueOn);
+  if (d < 0) return "over";
+  if (d <= 1) return "warn";
+  return "norm";
+}
+
+export function MilestonesStrip({ milestones }: Props) {
+  const [sub, setSub] = useState<Sub>("open");
+
+  const isDone = (m: Milestone): boolean => {
+    const total = m.openIssues + m.closedIssues;
+    return m.state === "CLOSED" || (total > 0 && m.openIssues === 0);
+  };
+
+  const open = useMemo(
+    () =>
+      milestones
+        .filter((m) => !isDone(m))
+        .sort((a, b) => {
+          if (a.dueOn && b.dueOn) return daysUntil(a.dueOn) - daysUntil(b.dueOn);
+          return a.dueOn ? -1 : b.dueOn ? 1 : 0;
+        }),
+    [milestones]
+  );
+
+  const done = useMemo(() => milestones.filter(isDone), [milestones]);
+
+  const list = (sub === "open" ? open : done).slice(0, 6);
+
+  return (
+    <div className="v4-panel" style={{ marginBottom: 14 }}>
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">
+          Ближайшие milestones <span className="v4-tag">≤ 30 дней</span>
+        </div>
+        <div className="v4-panel-actions">
+          <div className="v4-pillgrp">
+            <button
+              type="button"
+              className={sub === "open" ? "is-active" : ""}
+              onClick={() => setSub("open")}
+            >
+              Открытые · {open.length}
+            </button>
+            <button
+              type="button"
+              className={sub === "done" ? "is-active" : ""}
+              onClick={() => setSub("done")}
+            >
+              Завершённые · {done.length}
+            </button>
+          </div>
+        </div>
+      </div>
+      {list.length === 0 ? (
+        <div className="v4-empty">
+          {sub === "open" ? "Нет открытых milestones" : "Пока нет завершённых milestones"}
+        </div>
+      ) : (
+        <div className="v4-ms-grid">
+          {list.map((m) => {
+            const total = m.openIssues + m.closedIssues;
+            const pct = total > 0 ? Math.round((m.closedIssues / total) * 100) : 0;
+            const cls = classify(m);
+            const fillColor =
+              cls === "done"
+                ? "var(--v4-success-500)"
+                : cls === "over"
+                ? "var(--v4-warn-500)"
+                : cls === "warn"
+                ? "var(--v4-success-500)"
+                : "var(--v4-accent-500)";
+            const priority = inferPriority(m);
+            const days = m.dueOn ? daysUntil(m.dueOn) : null;
+            const dueLabel = !m.dueOn
+              ? "—"
+              : cls === "done"
+              ? formatShortDate(m.dueOn)
+              : days === 0
+              ? "сегодня"
+              : days! < 0
+              ? `${formatShortDate(m.dueOn)} · ${days}д`
+              : `${formatShortDate(m.dueOn)} · +${days}д`;
+
+            return (
+              <div key={m.url} className={`v4-mscard v4-mscard--${cls}`}>
+                <div className="v4-mscard-h">
+                  <div>
+                    <div className="v4-mscard-r">{m.repo}</div>
+                    <a
+                      href={m.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="v4-mscard-t"
+                      style={{ color: "inherit", textDecoration: "none" }}
+                    >
+                      {m.title}
+                    </a>
+                  </div>
+                  {cls === "done" ? (
+                    <span className="v4-mscard-done-chip">done ✓</span>
+                  ) : priority ? (
+                    <span className={`v4-ptag ${PRIORITY_TAG[priority] ?? "v4-ptag--p4"}`}>
+                      {priority}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="v4-mscard-p">
+                  <div className="v4-mscard-track">
+                    <div
+                      className="v4-mscard-fill"
+                      style={{ width: `${pct}%`, background: fillColor }}
+                    />
+                  </div>
+                  <span className="v4-mscard-pct num">
+                    {m.closedIssues}/{total} ({pct}%)
+                  </span>
+                </div>
+                <div className="v4-mscard-due">
+                  <span>{cls === "done" ? "Закрыт" : "Дедлайн"}</span>
+                  <b>{dueLabel}</b>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/MilestonesStrip.tsx
+++ b/src/components/v4/MilestonesStrip.tsx
@@ -4,6 +4,14 @@ import { daysUntil, formatShortDate } from "../../utils/date";
 
 interface Props {
   milestones: Milestone[];
+  /** Anchor for "days until" calculations — recomputed on data refresh. */
+  lastUpdated: Date | null;
+}
+
+interface MilestoneRow {
+  m: Milestone;
+  days: number | null;
+  cls: "done" | "over" | "warn" | "norm";
 }
 
 type Sub = "open" | "done";
@@ -25,36 +33,44 @@ function inferPriority(m: Milestone): string | null {
   return null;
 }
 
-function classify(m: Milestone): "done" | "over" | "warn" | "norm" {
+function isDone(m: Milestone): boolean {
   const total = m.openIssues + m.closedIssues;
-  if (m.state === "CLOSED" || (total > 0 && m.openIssues === 0)) return "done";
-  if (!m.dueOn) return "norm";
-  const d = daysUntil(m.dueOn);
-  if (d < 0) return "over";
-  if (d <= 1) return "warn";
+  return m.state === "CLOSED" || (total > 0 && m.openIssues === 0);
+}
+
+function classify(m: Milestone, days: number | null): "done" | "over" | "warn" | "norm" {
+  if (isDone(m)) return "done";
+  if (days === null) return "norm";
+  if (days < 0) return "over";
+  if (days <= 1) return "warn";
   return "norm";
 }
 
-export function MilestonesStrip({ milestones }: Props) {
+export function MilestonesStrip({ milestones, lastUpdated }: Props) {
   const [sub, setSub] = useState<Sub>("open");
 
-  const isDone = (m: Milestone): boolean => {
-    const total = m.openIssues + m.closedIssues;
-    return m.state === "CLOSED" || (total > 0 && m.openIssues === 0);
-  };
+  // Compute days/cls once per refresh — avoids calling daysUntil() (impure)
+  // multiple times per milestone in the sort comparator and render body.
+  const rows: MilestoneRow[] = useMemo(() => {
+    return milestones.map((m) => {
+      const days = m.dueOn ? daysUntil(m.dueOn) : null;
+      return { m, days, cls: classify(m, days) };
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [milestones, lastUpdated?.getTime()]);
 
   const open = useMemo(
     () =>
-      milestones
-        .filter((m) => !isDone(m))
+      rows
+        .filter((r) => r.cls !== "done")
         .sort((a, b) => {
-          if (a.dueOn && b.dueOn) return daysUntil(a.dueOn) - daysUntil(b.dueOn);
-          return a.dueOn ? -1 : b.dueOn ? 1 : 0;
+          if (a.days !== null && b.days !== null) return a.days - b.days;
+          return a.days !== null ? -1 : b.days !== null ? 1 : 0;
         }),
-    [milestones]
+    [rows]
   );
 
-  const done = useMemo(() => milestones.filter(isDone), [milestones]);
+  const done = useMemo(() => rows.filter((r) => r.cls === "done"), [rows]);
 
   const list = (sub === "open" ? open : done).slice(0, 6);
 
@@ -89,10 +105,9 @@ export function MilestonesStrip({ milestones }: Props) {
         </div>
       ) : (
         <div className="v4-ms-grid">
-          {list.map((m) => {
+          {list.map(({ m, days, cls }) => {
             const total = m.openIssues + m.closedIssues;
             const pct = total > 0 ? Math.round((m.closedIssues / total) * 100) : 0;
-            const cls = classify(m);
             const fillColor =
               cls === "done"
                 ? "var(--v4-success-500)"
@@ -102,14 +117,13 @@ export function MilestonesStrip({ milestones }: Props) {
                 ? "var(--v4-success-500)"
                 : "var(--v4-accent-500)";
             const priority = inferPriority(m);
-            const days = m.dueOn ? daysUntil(m.dueOn) : null;
             const dueLabel = !m.dueOn
               ? "—"
               : cls === "done"
               ? formatShortDate(m.dueOn)
               : days === 0
               ? "сегодня"
-              : days! < 0
+              : days !== null && days < 0
               ? `${formatShortDate(m.dueOn)} · ${days}д`
               : `${formatShortDate(m.dueOn)} · +${days}д`;
 

--- a/src/components/v4/Sidebar.tsx
+++ b/src/components/v4/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import type { ReactElement } from "react";
 import type { TabId } from "../../types";
 
@@ -132,16 +133,29 @@ export function Sidebar({
     onClose?.();
   };
 
+  // Close mobile drawer on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose]);
+
   return (
     <>
-      {isOpen && <div className="v4-side-backdrop" onClick={onClose} />}
-      <aside className={`v4-side ${isOpen ? "is-open" : ""}`}>
+      {isOpen && <div className="v4-side-backdrop" onClick={onClose} aria-hidden="true" />}
+      <aside
+        className={`v4-side ${isOpen ? "is-open" : ""}`}
+        aria-label="Основная навигация"
+      >
         <div className="v4-brand">
           <div className="v4-brand-logo">M</div>
           <div className="v4-brand-name">MakeIT</div>
           <div className="v4-brand-ver">v4</div>
         </div>
-        <nav className="v4-nav">
+        <nav className="v4-nav" aria-label="Разделы">
           {sections.map((section, sIdx) => (
             <div key={sIdx}>
               {section.title && <div className="v4-nav-section">{section.title}</div>}
@@ -150,6 +164,7 @@ export function Sidebar({
                   key={item.id}
                   type="button"
                   className={`v4-nav-item ${activeTab === item.id ? "is-active" : ""}`}
+                  aria-current={activeTab === item.id ? "page" : undefined}
                   onClick={() => handleClick(item.id)}
                 >
                   {item.icon}

--- a/src/components/v4/Sidebar.tsx
+++ b/src/components/v4/Sidebar.tsx
@@ -1,0 +1,176 @@
+import type { ReactElement } from "react";
+import type { TabId } from "../../types";
+
+interface NavItem {
+  id: TabId;
+  label: string;
+  count?: number;
+  badge?: number;
+  icon: ReactElement;
+}
+
+interface NavSection {
+  title?: string;
+  items: NavItem[];
+}
+
+interface Props {
+  activeTab: TabId;
+  onTabChange: (tab: TabId) => void;
+  projectsCount: number;
+  milestonesCount: number;
+  monitorsCount: number;
+  auditAlerts?: number;
+  user?: { initials: string; name: string; role: string };
+  isOpen?: boolean;
+  onClose?: () => void;
+}
+
+const ICON_DASH = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <rect x="3" y="3" width="7" height="9" />
+    <rect x="14" y="3" width="7" height="5" />
+    <rect x="14" y="12" width="7" height="9" />
+    <rect x="3" y="16" width="7" height="5" />
+  </svg>
+);
+const ICON_LIST = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M3 7h18M3 12h18M3 17h18" />
+  </svg>
+);
+const ICON_CLOCK = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7v5l3 2" />
+  </svg>
+);
+const ICON_MONITOR = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+  </svg>
+);
+const ICON_PIPELINE = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M3 6h18M3 12h18M3 18h12" />
+  </svg>
+);
+const ICON_TRANSCRIPT = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" />
+  </svg>
+);
+const ICON_SEARCH = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="11" cy="11" r="8" />
+    <path d="M21 21l-4.35-4.35" />
+  </svg>
+);
+const ICON_SPECS = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+    <path d="M14 2v6h6M9 13h6M9 17h6" />
+  </svg>
+);
+const ICON_AUDIT = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M9 12l2 2 4-4M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z" />
+  </svg>
+);
+const ICON_QUALITY = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M3 12l9-9 9 9-9 9-9-9z" />
+  </svg>
+);
+const ICON_DEBATE = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M21 11.5a8.38 8.38 0 01-9 8.5 8.5 8.5 0 01-7.6-4.7L3 21l1.7-2.4A8.5 8.5 0 0121 11.5z" />
+  </svg>
+);
+
+export function Sidebar({
+  activeTab,
+  onTabChange,
+  projectsCount,
+  milestonesCount,
+  monitorsCount,
+  auditAlerts,
+  user = { initials: "SK", name: "Сергей К.", role: "owner · MakeIT" },
+  isOpen,
+  onClose,
+}: Props) {
+  const sections: NavSection[] = [
+    {
+      items: [
+        { id: "dashboard", label: "Дашборд", icon: ICON_DASH },
+        { id: "projects", label: "Проекты", count: projectsCount, icon: ICON_LIST },
+        { id: "milestones", label: "Milestones", count: milestonesCount, icon: ICON_CLOCK },
+        { id: "uptime", label: "Мониторинг", count: monitorsCount || undefined, icon: ICON_MONITOR },
+      ],
+    },
+    {
+      title: "Workflow",
+      items: [
+        { id: "pipeline", label: "Pipeline", icon: ICON_PIPELINE },
+        { id: "transcripts", label: "Транскрипты", icon: ICON_TRANSCRIPT },
+        { id: "research", label: "Research", icon: ICON_SEARCH },
+        { id: "specs", label: "Specs", icon: ICON_SPECS },
+      ],
+    },
+    {
+      title: "Контроль",
+      items: [
+        { id: "audit", label: "Аудит", badge: auditAlerts, icon: ICON_AUDIT },
+        { id: "quality", label: "Quality", icon: ICON_QUALITY },
+        { id: "debate", label: "Debate", icon: ICON_DEBATE },
+      ],
+    },
+  ];
+
+  const handleClick = (id: TabId) => {
+    onTabChange(id);
+    onClose?.();
+  };
+
+  return (
+    <>
+      {isOpen && <div className="v4-side-backdrop" onClick={onClose} />}
+      <aside className={`v4-side ${isOpen ? "is-open" : ""}`}>
+        <div className="v4-brand">
+          <div className="v4-brand-logo">M</div>
+          <div className="v4-brand-name">MakeIT</div>
+          <div className="v4-brand-ver">v4</div>
+        </div>
+        <nav className="v4-nav">
+          {sections.map((section, sIdx) => (
+            <div key={sIdx}>
+              {section.title && <div className="v4-nav-section">{section.title}</div>}
+              {section.items.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  className={`v4-nav-item ${activeTab === item.id ? "is-active" : ""}`}
+                  onClick={() => handleClick(item.id)}
+                >
+                  {item.icon}
+                  {item.label}
+                  {item.count !== undefined && <span className="v4-nav-count">{item.count}</span>}
+                  {item.badge !== undefined && item.badge > 0 && (
+                    <span className="v4-nav-badge">{item.badge}</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          ))}
+        </nav>
+        <div className="v4-side-foot">
+          <div className="v4-ava">{user.initials}</div>
+          <div>
+            <b>{user.name}</b>
+            <span>{user.role}</span>
+          </div>
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/src/components/v4/StackedDistribution.tsx
+++ b/src/components/v4/StackedDistribution.tsx
@@ -1,0 +1,57 @@
+import type { ProjectData } from "../../types";
+
+interface Props {
+  projects: ProjectData[];
+}
+
+export function StackedDistribution({ projects }: Props) {
+  if (projects.length === 0) {
+    return (
+      <div className="v4-panel">
+        <div className="v4-panel-h">
+          <div className="v4-panel-t">
+            Распределение задач по проектам <span className="v4-tag">по приоритетам</span>
+          </div>
+        </div>
+        <div className="v4-empty">Нет данных</div>
+      </div>
+    );
+  }
+
+  // Sort: by total desc
+  const sorted = [...projects]
+    .filter((p) => p.totalCount > 0)
+    .sort((a, b) => b.totalCount - a.totalCount);
+
+  return (
+    <div className="v4-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">
+          Распределение задач по проектам <span className="v4-tag">по приоритетам</span>
+        </div>
+        <div className="v4-panel-meta">сортировка: всего ↓</div>
+      </div>
+      <div className="v4-stack-list">
+        {sorted.map((p) => {
+          const total = p.totalCount;
+          const segP1 = (p.priorityCounts.P1 / total) * 100;
+          const segP2 = (p.priorityCounts.P2 / total) * 100;
+          const segP3 = (p.priorityCounts.P3 / total) * 100;
+          const segDone = (p.doneCount / total) * 100;
+          return (
+            <div key={p.repo} className="v4-stack-row">
+              <span className="v4-nm">{p.repo}</span>
+              <div className="v4-stack-bar" title={`P1:${p.priorityCounts.P1} · P2:${p.priorityCounts.P2} · P3:${p.priorityCounts.P3} · Done:${p.doneCount}`}>
+                {segP1 > 0 && <div className="v4-seg v4-seg--p1" style={{ width: `${segP1}%` }} />}
+                {segP2 > 0 && <div className="v4-seg v4-seg--p2" style={{ width: `${segP2}%` }} />}
+                {segP3 > 0 && <div className="v4-seg v4-seg--p3" style={{ width: `${segP3}%` }} />}
+                {segDone > 0 && <div className="v4-seg v4-seg--done" style={{ width: `${segDone}%` }} />}
+              </div>
+              <span className="v4-tot">{total}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/StaleBanner.tsx
+++ b/src/components/v4/StaleBanner.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import type { ProjectData } from "../../types";
+
+interface Props {
+  projects: ProjectData[];
+  onOpenList?: () => void;
+  /** Days since activity threshold; default 2 */
+  threshold?: number;
+}
+
+export function StaleBanner({ projects, onOpenList, threshold = 2 }: Props) {
+  const [dismissed, setDismissed] = useState(false);
+
+  const stale = projects.filter(
+    (p) =>
+      p.daysSinceActivity !== null &&
+      p.daysSinceActivity >= threshold &&
+      p.openCount > 0
+  );
+
+  if (stale.length === 0 || dismissed) return null;
+
+  const repos = stale.slice(0, 5).map((p) => p.repo).join(" · ");
+  const more = stale.length > 5 ? ` (+${stale.length - 5})` : "";
+
+  return (
+    <div className="v4-banner" style={{ marginTop: 14 }}>
+      <div className="v4-banner-bi">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <circle cx="12" cy="12" r="10" />
+          <path d="M12 16v-4M12 8h.01" />
+        </svg>
+      </div>
+      <div className="v4-banner-bt">
+        <b>
+          {stale.length} проект{stale.length === 1 ? "" : stale.length < 5 ? "а" : "ов"} без активности более {threshold} дней
+        </b>
+        <span>
+          {repos}{more} — стоит обсудить статус и разблокировать
+        </span>
+      </div>
+      <div className="v4-banner-bact">
+        <button type="button" className="v4-btn" onClick={() => setDismissed(true)}>
+          Отложить
+        </button>
+        {onOpenList && (
+          <button type="button" className="v4-btn v4-btn--pri" onClick={onOpenList}>
+            Открыть список
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/Topbar.tsx
+++ b/src/components/v4/Topbar.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from "react";
+
+interface Props {
+  /** Crumb segments — last is bold (current page) */
+  crumbs: string[];
+  /** Show "GitHub API · live" pill */
+  showLive?: boolean;
+  /** Last refresh time */
+  lastUpdated: Date | null;
+  /** Refresh handler */
+  onRefresh: () => void;
+  /** Whether refresh is in flight */
+  refreshing?: boolean;
+  /** Logout handler */
+  onLogout: () => void;
+  /** Mobile sidebar toggle */
+  onBurger?: () => void;
+  /** Optional search submit (Ctrl/Cmd-K focuses) */
+  onSearch?: (query: string) => void;
+}
+
+export function Topbar({
+  crumbs,
+  showLive = true,
+  lastUpdated,
+  onRefresh,
+  refreshing,
+  onLogout,
+  onBurger,
+  onSearch,
+}: Props) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  return (
+    <div className="v4-top">
+      <div className="v4-crumbs">
+        <button
+          type="button"
+          className="v4-ibtn v4-burger"
+          onClick={onBurger}
+          aria-label="Открыть меню"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M3 6h18M3 12h18M3 18h18" />
+          </svg>
+        </button>
+        {crumbs.map((c, i) => {
+          const isLast = i === crumbs.length - 1;
+          return (
+            <span key={i} style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+              {i > 0 && <span className="v4-sep">/</span>}
+              {isLast ? <b>{c}</b> : <span>{c}</span>}
+            </span>
+          );
+        })}
+        {showLive && (
+          <span className="v4-live" title={lastUpdated ? `Обновлено в ${lastUpdated.toLocaleTimeString("ru-RU")}` : "Нет данных"}>
+            <span className="v4-live-dot" />
+            GitHub API · live
+          </span>
+        )}
+      </div>
+      <div className="v4-top-right">
+        <form
+          className="v4-search"
+          onSubmit={(e) => {
+            e.preventDefault();
+            onSearch?.(query);
+          }}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" />
+            <path d="M21 21l-4.35-4.35" />
+          </svg>
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Поиск по issues, milestones, проектам…"
+            aria-label="Поиск"
+          />
+          <span className="v4-kbd">⌘K</span>
+        </form>
+        <button
+          type="button"
+          className={`v4-ibtn ${refreshing ? "is-spin" : ""}`}
+          onClick={onRefresh}
+          disabled={refreshing}
+          aria-label="Обновить"
+          title="Обновить"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M21 12a9 9 0 11-6.22-8.56" />
+            <path d="M21 3v6h-6" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          className="v4-ibtn"
+          onClick={onLogout}
+          aria-label="Выйти"
+          title="Выйти и очистить токены"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4M16 17l5-5-5-5M21 12H9" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/UrgentDeadlinesPanel.tsx
+++ b/src/components/v4/UrgentDeadlinesPanel.tsx
@@ -1,0 +1,65 @@
+import type { Milestone } from "../../types";
+import { daysUntil, formatShortDate } from "../../utils/date";
+
+interface Props {
+  milestones: Milestone[];
+}
+
+export function UrgentDeadlinesPanel({ milestones }: Props) {
+  const items = milestones
+    .filter((m) => {
+      if (!m.dueOn || m.state === "CLOSED") return false;
+      const total = m.openIssues + m.closedIssues;
+      if (total > 0 && m.openIssues === 0) return false;
+      const days = daysUntil(m.dueOn);
+      return days <= 7;
+    })
+    .map((m) => ({ milestone: m, days: daysUntil(m.dueOn!) }))
+    .sort((a, b) => a.days - b.days);
+
+  return (
+    <div className="v4-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t v4-panel-t--danger">
+          🔥 Горящие дедлайны <span className="v4-tag v4-tag--danger">≤ 7 дней</span>
+        </div>
+      </div>
+      {items.length === 0 ? (
+        <div className="v4-empty">Нет дедлайнов на ближайшие 7 дней</div>
+      ) : (
+        <div className="v4-list">
+          {items.map(({ milestone: m, days }) => {
+            const isOverdue = days < 0;
+            const isToday = days === 0;
+            const cls = isOverdue
+              ? "v4-litem--over"
+              : isToday
+              ? "v4-litem--today"
+              : "v4-litem--soon";
+            const badgeCls = isOverdue
+              ? "v4-litem-badge--danger"
+              : isToday
+              ? "v4-litem-badge--warn"
+              : "v4-litem-badge--primary";
+            const badgeText = isOverdue
+              ? `просрочено ${Math.abs(days)}д`
+              : isToday
+              ? "сегодня"
+              : `через ${days}д · ${formatShortDate(m.dueOn!)}`;
+            return (
+              <div key={m.url} className={`v4-litem v4-litem--dl ${cls}`}>
+                <span className="v4-litem-repo">{m.repo}</span>
+                <span className="v4-litem-ti">
+                  <a href={m.url} target="_blank" rel="noopener noreferrer">
+                    {m.title}
+                  </a>
+                </span>
+                <span className={`v4-litem-badge ${badgeCls}`}>{badgeText}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/UrgentDeadlinesPanel.tsx
+++ b/src/components/v4/UrgentDeadlinesPanel.tsx
@@ -1,21 +1,29 @@
+import { useMemo } from "react";
 import type { Milestone } from "../../types";
 import { daysUntil, formatShortDate } from "../../utils/date";
 
 interface Props {
   milestones: Milestone[];
+  /** Anchor for "days until" — recomputed on data refresh. */
+  lastUpdated: Date | null;
 }
 
-export function UrgentDeadlinesPanel({ milestones }: Props) {
-  const items = milestones
-    .filter((m) => {
-      if (!m.dueOn || m.state === "CLOSED") return false;
-      const total = m.openIssues + m.closedIssues;
-      if (total > 0 && m.openIssues === 0) return false;
-      const days = daysUntil(m.dueOn);
-      return days <= 7;
-    })
-    .map((m) => ({ milestone: m, days: daysUntil(m.dueOn!) }))
-    .sort((a, b) => a.days - b.days);
+export function UrgentDeadlinesPanel({ milestones, lastUpdated }: Props) {
+  // Compute `daysUntil` once per milestone (it calls Date.now() under the
+  // hood) — avoids the previous .filter()→.map() double-call pattern.
+  const items = useMemo(() => {
+    return milestones
+      .filter((m) => {
+        if (!m.dueOn || m.state === "CLOSED") return false;
+        const total = m.openIssues + m.closedIssues;
+        if (total > 0 && m.openIssues === 0) return false;
+        return true;
+      })
+      .map((m) => ({ milestone: m, days: daysUntil(m.dueOn!) }))
+      .filter(({ days }) => days <= 7)
+      .sort((a, b) => a.days - b.days);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [milestones, lastUpdated?.getTime()]);
 
   return (
     <div className="v4-panel">

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -1,0 +1,1397 @@
+/* ══════════════════════════════════════════
+   MakeIT Dashboard — V4 Design System
+   Light theme · Inter + JetBrains Mono
+   Implementation of design handoff:
+   moliyakg/project/MakeIT Dashboard.html
+   ══════════════════════════════════════════ */
+
+:root {
+  /* Surfaces / ink */
+  --v4-bg: #F6F7F9;
+  --v4-paper: #FFFFFF;
+  --v4-surface-2: #F4F5F8;
+  --v4-surface-3: #EDEFF3;
+  --v4-ink-900: #0E1320;
+  --v4-ink-800: #1B2235;
+  --v4-ink-700: #2F3850;
+  --v4-ink-600: #4A5570;
+  --v4-ink-500: #6B7691;
+  --v4-ink-400: #94A0B8;
+  --v4-ink-300: #C5CCDA;
+  --v4-line: #E4E8EF;
+  --v4-line-soft: #EEF1F6;
+  --v4-line-strong: #D6DBE5;
+
+  /* Accent (brand blue) */
+  --v4-accent-50: #EEF4FF;
+  --v4-accent-100: #DCE7FF;
+  --v4-accent-500: #2563EB;
+  --v4-accent-600: #1D4ED8;
+  --v4-accent-700: #1E40AF;
+
+  /* Semantic */
+  --v4-success-50: #ECFDF3;
+  --v4-success-100: #D1FADF;
+  --v4-success-500: #12B76A;
+  --v4-success-700: #067647;
+  --v4-warn-50: #FFFAEB;
+  --v4-warn-100: #FEDF89;
+  --v4-warn-500: #F79009;
+  --v4-warn-700: #B54708;
+  --v4-danger-50: #FEF2F2;
+  --v4-danger-100: #FEE4E2;
+  --v4-danger-500: #EF4444;
+  --v4-danger-700: #B91C1C;
+  --v4-purple-50: #F5F0FF;
+  --v4-purple-500: #7C3AED;
+  --v4-purple-700: #5B21B6;
+
+  /* Priority palette */
+  --v4-p1: #EF4444;
+  --v4-p2: #F79009;
+  --v4-p3: #2563EB;
+  --v4-p4: #94A0B8;
+
+  /* Radii */
+  --v4-r-sm: 6px;
+  --v4-r-md: 8px;
+  --v4-r-lg: 12px;
+  --v4-r-xl: 16px;
+
+  /* Fonts */
+  --v4-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --v4-mono: 'JetBrains Mono', "SF Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* ── Body / global reset for V4 ── */
+body.v4 {
+  background: var(--v4-bg);
+  color: var(--v4-ink-800);
+  font-family: var(--v4-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  margin: 0;
+}
+body.v4 *,
+body.v4 *::before,
+body.v4 *::after { box-sizing: border-box; }
+body.v4 .v4 { font-family: var(--v4-sans); }
+body.v4 .num,
+body.v4 .v4-mono { font-variant-numeric: tabular-nums; }
+body.v4 .v4-mono { font-family: var(--v4-mono); }
+
+/* ────────────────────────────────────────
+   APP SHELL
+   ──────────────────────────────────────── */
+.v4-app {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+  background: var(--v4-bg);
+  color: var(--v4-ink-800);
+  font-family: var(--v4-sans);
+  font-size: 13px;
+}
+
+/* Sidebar */
+.v4-side {
+  background: var(--v4-paper);
+  border-right: 1px solid var(--v4-line);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.v4-brand {
+  height: 56px;
+  padding: 0 18px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--v4-line-soft);
+  flex-shrink: 0;
+}
+.v4-brand-logo {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: var(--v4-ink-900);
+  color: #fff;
+  font-weight: 800;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--v4-mono);
+}
+.v4-brand-name {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--v4-ink-900);
+  letter-spacing: -0.01em;
+}
+.v4-brand-ver {
+  margin-left: auto;
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  color: var(--v4-ink-400);
+  background: var(--v4-surface-2);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.v4-nav {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px;
+  min-height: 0;
+}
+.v4-nav-section {
+  padding: 14px 12px 6px;
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--v4-ink-400);
+}
+.v4-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px;
+  border-radius: var(--v4-r-sm);
+  color: var(--v4-ink-700);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  background: transparent;
+  border: 0;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 120ms, color 120ms;
+}
+.v4-nav-item:hover {
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
+}
+.v4-nav-item.is-active {
+  background: var(--v4-accent-500);
+  color: #fff;
+}
+.v4-nav-item.is-active svg { color: #fff; }
+.v4-nav-item svg {
+  width: 15px;
+  height: 15px;
+  color: var(--v4-ink-400);
+  flex-shrink: 0;
+}
+.v4-nav-count {
+  margin-left: auto;
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  color: var(--v4-ink-400);
+  font-weight: 500;
+}
+.v4-nav-item.is-active .v4-nav-count { color: rgba(255, 255, 255, 0.85); }
+.v4-nav-badge {
+  margin-left: auto;
+  font-family: var(--v4-mono);
+  font-size: 9px;
+  font-weight: 700;
+  background: var(--v4-danger-500);
+  color: #fff;
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.v4-side-foot {
+  padding: 14px 16px;
+  border-top: 1px solid var(--v4-line-soft);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+.v4-ava {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--v4-ink-900);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--v4-mono);
+}
+.v4-side-foot b {
+  font-size: 12px;
+  color: var(--v4-ink-900);
+  display: block;
+  line-height: 1.2;
+}
+.v4-side-foot span {
+  font-size: 10px;
+  color: var(--v4-ink-500);
+}
+
+/* Main column */
+.v4-main { min-width: 0; }
+.v4-top {
+  height: 56px;
+  border-bottom: 1px solid var(--v4-line);
+  background: var(--v4-paper);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 28px;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  gap: 16px;
+}
+.v4-crumbs {
+  font-size: 13px;
+  color: var(--v4-ink-500);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.v4-crumbs b {
+  color: var(--v4-ink-900);
+  font-weight: 600;
+}
+.v4-crumbs .v4-sep { color: var(--v4-ink-300); }
+.v4-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 14px;
+  padding: 3px 10px;
+  border-radius: 99px;
+  background: var(--v4-success-50);
+  color: var(--v4-success-700);
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 600;
+}
+.v4-live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--v4-success-500);
+  box-shadow: 0 0 0 3px rgba(18, 183, 106, 0.18);
+  animation: v4-pulse 2s infinite;
+}
+@keyframes v4-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+.v4-top-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.v4-search {
+  position: relative;
+  width: 280px;
+}
+.v4-search input {
+  width: 100%;
+  height: 32px;
+  padding: 0 12px 0 32px;
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-sm);
+  background: var(--v4-surface-2);
+  font: inherit;
+  font-size: 12px;
+  color: var(--v4-ink-900);
+  outline: none;
+  font-family: var(--v4-sans);
+}
+.v4-search input::placeholder { color: var(--v4-ink-400); }
+.v4-search input:focus {
+  border-color: var(--v4-accent-500);
+  background: var(--v4-paper);
+}
+.v4-search svg {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
+  color: var(--v4-ink-400);
+}
+.v4-search .v4-kbd {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  color: var(--v4-ink-400);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.v4-ibtn {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--v4-r-sm);
+  background: transparent;
+  border: 1px solid transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--v4-ink-600);
+  cursor: pointer;
+  position: relative;
+}
+.v4-ibtn:hover {
+  background: var(--v4-surface-2);
+  border-color: var(--v4-line);
+}
+.v4-ibtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.v4-ibtn svg { width: 16px; height: 16px; }
+.v4-ibtn .v4-ibtn-dot {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--v4-danger-500);
+  border: 2px solid var(--v4-paper);
+}
+.v4-ibtn.is-spin svg {
+  animation: v4-spin 0.9s linear infinite;
+}
+@keyframes v4-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ────────────────────────────────────────
+   PAGE HEAD
+   ──────────────────────────────────────── */
+.v4-content { padding: 0 28px 40px; }
+.v4-ph {
+  padding: 14px 0 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.v4-ph h1 {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--v4-ink-900);
+  margin: 0;
+}
+.v4-ph .v4-sub {
+  font-size: 13px;
+  color: var(--v4-ink-500);
+  margin-top: 4px;
+}
+.v4-ph-right {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.v4-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 14px;
+  border-radius: var(--v4-r-sm);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  color: var(--v4-ink-700);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: var(--v4-sans);
+  transition: border-color 120ms, color 120ms, background 120ms;
+}
+.v4-btn:hover {
+  border-color: var(--v4-line-strong);
+  color: var(--v4-ink-900);
+}
+.v4-btn--pri {
+  background: var(--v4-ink-900);
+  border-color: var(--v4-ink-900);
+  color: #fff;
+}
+.v4-btn--pri:hover {
+  background: var(--v4-ink-800);
+  color: #fff;
+}
+.v4-btn svg { width: 14px; height: 14px; }
+
+.v4-pillgrp {
+  display: inline-flex;
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
+  padding: 2px;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 600;
+}
+.v4-pillgrp button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--v4-ink-500);
+  padding: 5px 12px;
+  border-radius: 5px;
+  cursor: pointer;
+  font: inherit;
+  font-family: var(--v4-mono);
+}
+.v4-pillgrp button.is-active {
+  background: #fff;
+  color: var(--v4-ink-900);
+  box-shadow: 0 1px 2px rgba(11, 16, 32, 0.08);
+}
+
+/* ────────────────────────────────────────
+   KPI ROW
+   ──────────────────────────────────────── */
+.v4-kpi-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  margin-bottom: 14px;
+  align-items: stretch;
+}
+.v4-kpi {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  padding: 16px 18px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 178px;
+  gap: 10px;
+}
+.v4-kpi-lbl {
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--v4-ink-500);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 0;
+}
+.v4-kpi-ic {
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.v4-kpi-ic svg { width: 12px; height: 12px; }
+.v4-kpi-ic--b { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.v4-kpi-ic--g { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-kpi-ic--o { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-kpi-ic--p { background: var(--v4-purple-50); color: var(--v4-purple-700); }
+
+.v4-kpi-val {
+  font-size: 36px;
+  font-weight: 800;
+  color: var(--v4-ink-900);
+  letter-spacing: -0.03em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.v4-kpi-val .v4-u {
+  font-size: 14px;
+  color: var(--v4-ink-400);
+  font-weight: 500;
+}
+.v4-kpi-meta {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 6px;
+  row-gap: 2px;
+  align-items: baseline;
+  margin-top: 0;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  min-height: 14px;
+  line-height: 1.3;
+}
+.v4-kpi-meta > span { white-space: nowrap; }
+.v4-kpi-delta--pos { color: var(--v4-success-700); }
+.v4-kpi-delta--neg { color: var(--v4-danger-700); }
+.v4-kpi-vs { color: var(--v4-ink-400); font-size: 10px; }
+
+.v4-kpi--acc {
+  background: linear-gradient(135deg, var(--v4-accent-600), var(--v4-accent-700));
+  border-color: var(--v4-accent-700);
+  color: #fff;
+}
+.v4-kpi--acc::before {
+  content: '';
+  position: absolute;
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.18), transparent 70%);
+  right: -60px;
+  top: -80px;
+  pointer-events: none;
+}
+.v4-kpi--acc .v4-kpi-lbl { color: rgba(255, 255, 255, 0.7); }
+.v4-kpi--acc .v4-kpi-ic { background: rgba(255, 255, 255, 0.16); color: #fff; }
+.v4-kpi--acc .v4-kpi-val { color: #fff; }
+.v4-kpi--acc .v4-kpi-val .v4-u { color: rgba(255, 255, 255, 0.7); }
+.v4-kpi--acc .v4-kpi-vs { color: rgba(255, 255, 255, 0.6); }
+.v4-kpi--acc .v4-kpi-delta--pos { color: #A6F4C5; }
+
+.v4-kpi-splits {
+  display: flex;
+  gap: 0;
+  margin-top: auto;
+  background: var(--v4-surface-2);
+  border: 1px solid var(--v4-line-soft);
+  border-radius: 8px;
+  overflow: hidden;
+  align-self: stretch;
+}
+.v4-kpi-split {
+  flex: 1;
+  padding: 9px 6px;
+  background: transparent;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  border-right: 1px solid var(--v4-line-soft);
+}
+.v4-kpi-split:last-child { border-right: 0; }
+.v4-kpi-split-n {
+  font-family: var(--v4-mono);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--v4-ink-900);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  letter-spacing: -0.01em;
+}
+.v4-kpi-split-l {
+  font-size: 9px;
+  color: var(--v4-ink-500);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.v4-kpi--acc .v4-kpi-splits {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+.v4-kpi--acc .v4-kpi-split { border-right-color: rgba(255, 255, 255, 0.18); }
+.v4-kpi--acc .v4-kpi-split-n { color: #fff; }
+.v4-kpi--acc .v4-kpi-split-l { color: rgba(255, 255, 255, 0.78); }
+
+.v4-kpi-spark { margin-top: auto; padding-top: 0; }
+.v4-kpi-spark svg {
+  width: 100%;
+  height: 42px;
+  display: block;
+}
+
+/* Finance KPI: stacked bar + paid/remain */
+.v4-fin-bar { margin-top: auto; padding-top: 0; }
+.v4-fin-bar-stk {
+  height: 8px;
+  border-radius: 99px;
+  background: var(--v4-surface-3);
+  overflow: hidden;
+  display: flex;
+}
+.v4-fin-bar-stk .v4-pp { height: 100%; background: var(--v4-success-500); }
+.v4-fin-bar-stk .v4-ip { height: 100%; background: var(--v4-accent-500); }
+.v4-fin-lg {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-700);
+}
+.v4-fin-lg-i {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.v4-fin-lg-sw {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+.v4-fin-lg b { color: var(--v4-ink-900); font-weight: 700; }
+
+/* ────────────────────────────────────────
+   PANELS / GRID
+   ──────────────────────────────────────── */
+.v4-grid {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+.v4-grid--rev { grid-template-columns: 1fr 1.6fr; }
+
+.v4-panel {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.v4-panel-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--v4-line-soft);
+  gap: 12px;
+  flex-wrap: wrap;
+  row-gap: 8px;
+}
+.v4-panel-t {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.v4-panel-t--danger { color: var(--v4-danger-700); }
+.v4-tag {
+  font-family: var(--v4-mono);
+  font-size: 9px;
+  font-weight: 600;
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-500);
+  padding: 2px 7px;
+  border-radius: 99px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.v4-tag--danger { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-panel-meta {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-400);
+}
+.v4-panel-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.v4-linkbtn {
+  font-size: 12px;
+  color: var(--v4-accent-600);
+  font-weight: 500;
+  text-decoration: none;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+  padding: 0;
+}
+.v4-linkbtn:hover {
+  color: var(--v4-accent-700);
+  text-decoration: underline;
+}
+
+/* ────────────────────────────────────────
+   PROJECT CARDS GRID (dashboard top-4)
+   ──────────────────────────────────────── */
+.v4-proj-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  padding: 14px;
+}
+.v4-pcard {
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  padding: 14px 14px 14px 17px;
+  background: var(--v4-paper);
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+  position: relative;
+  overflow: hidden;
+  min-width: 0;
+}
+.v4-pcard.is-risk-high::before,
+.v4-pcard.is-risk-med::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+}
+.v4-pcard.is-risk-high::before { background: var(--v4-danger-500); }
+.v4-pcard.is-risk-med::before { background: var(--v4-warn-500); }
+
+.v4-pcard-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex-wrap: wrap;
+  row-gap: 6px;
+}
+.v4-pcard-name {
+  font-family: var(--v4-mono);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--v4-ink-900);
+  letter-spacing: -0.01em;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.v4-pcard-name:hover { color: var(--v4-accent-600); }
+.v4-pcard-badges {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.v4-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--v4-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 99px;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.v4-chip-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+.v4-chip--alive { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-chip--alive .v4-chip-dot {
+  background: var(--v4-success-500);
+  box-shadow: 0 0 0 2px rgba(18, 183, 106, 0.2);
+}
+.v4-chip--down { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-chip--down .v4-chip-dot { background: var(--v4-danger-500); }
+.v4-chip--paused { background: var(--v4-surface-2); color: var(--v4-ink-500); }
+.v4-chip--paused .v4-chip-dot { background: var(--v4-ink-400); }
+.v4-chip--dev { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.v4-chip--support { background: var(--v4-purple-50); color: var(--v4-purple-700); }
+.v4-chip--predev { background: var(--v4-surface-2); color: var(--v4-ink-600); }
+
+.v4-pcard-open-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+.v4-pcard-open-num {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--v4-ink-900);
+  font-variant-numeric: tabular-nums;
+}
+.v4-pcard-open-num span {
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  font-weight: 500;
+  margin-left: 4px;
+}
+.v4-pcard-pri-group {
+  display: flex;
+  gap: 8px;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-700);
+}
+.v4-pcard-pri {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.v4-pdot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+.v4-pdot--p1 { background: var(--v4-p1); }
+.v4-pdot--p2 { background: var(--v4-p2); }
+.v4-pdot--p3 { background: var(--v4-p3); }
+.v4-pdot--p4 { background: var(--v4-p4); }
+
+.v4-pcard-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.v4-ptrack {
+  flex: 1;
+  height: 6px;
+  background: var(--v4-surface-3);
+  border-radius: 99px;
+  overflow: hidden;
+}
+.v4-pfill {
+  height: 100%;
+  border-radius: 99px;
+}
+.v4-ppct {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 600;
+  min-width: 64px;
+  text-align: right;
+}
+.v4-pcard-finance {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 8px;
+  border-top: 1px dashed var(--v4-line);
+  gap: 8px;
+}
+.v4-pcard-finance-l {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-700);
+}
+.v4-pcard-finance-l b { color: var(--v4-ink-900); }
+.v4-pcard-finance-r {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-success-700);
+  font-weight: 600;
+}
+.v4-pcard-finance-r--warn { color: var(--v4-warn-700); }
+
+.v4-pcard-stats {
+  display: flex;
+  gap: 14px;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-600);
+  flex-wrap: wrap;
+}
+.v4-pcard-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.v4-pcard-stat b { color: var(--v4-ink-900); font-weight: 600; }
+.v4-pcard-stat svg {
+  width: 11px;
+  height: 11px;
+  color: var(--v4-ink-400);
+  flex-shrink: 0;
+}
+.v4-pcard-stat--danger { color: var(--v4-danger-700); }
+.v4-pcard-stat--danger svg { color: var(--v4-danger-700); }
+
+/* ────────────────────────────────────────
+   AI INSIGHTS LIST
+   ──────────────────────────────────────── */
+.v4-ai-list { padding: 6px 0; }
+.v4-ai-item {
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  gap: 12px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--v4-line-soft);
+  align-items: start;
+}
+.v4-ai-item:last-child { border-bottom: 0; }
+.v4-ai-item-ic {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.v4-ai-item-ic svg { width: 13px; height: 13px; }
+.v4-ai-item--an .v4-ai-item-ic { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-ai-item--gr .v4-ai-item-ic { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-ai-item--rk .v4-ai-item-ic { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-ai-item--fc .v4-ai-item-ic { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.v4-ai-item-ttl {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  margin-bottom: 3px;
+}
+.v4-ai-item-ds {
+  font-size: 12px;
+  color: var(--v4-ink-600);
+  line-height: 1.5;
+}
+.v4-ai-item-meta {
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  color: var(--v4-ink-400);
+  text-align: right;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+/* ────────────────────────────────────────
+   STACKED LIST CHART (priority distribution)
+   ──────────────────────────────────────── */
+.v4-stack-list {
+  padding: 14px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.v4-stack-row {
+  display: grid;
+  grid-template-columns: 130px 1fr 50px;
+  align-items: center;
+  gap: 12px;
+  font-size: 12px;
+}
+.v4-stack-row .v4-nm {
+  font-family: var(--v4-mono);
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.v4-stack-bar {
+  display: flex;
+  height: 18px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--v4-surface-2);
+}
+.v4-stack-bar .v4-seg { height: 100%; }
+.v4-stack-bar .v4-seg--p1 { background: var(--v4-p1); }
+.v4-stack-bar .v4-seg--p2 { background: var(--v4-p2); }
+.v4-stack-bar .v4-seg--p3 { background: var(--v4-p3); }
+.v4-stack-bar .v4-seg--done { background: #A0AEC8; }
+.v4-stack-row .v4-tot {
+  font-family: var(--v4-mono);
+  text-align: right;
+  font-weight: 600;
+  color: var(--v4-ink-700);
+}
+
+/* ────────────────────────────────────────
+   LISTS: blocked + deadlines
+   ──────────────────────────────────────── */
+.v4-list { padding: 6px 0; }
+.v4-litem {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 10px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--v4-line-soft);
+  align-items: center;
+}
+.v4-litem:last-child { border-bottom: 0; }
+.v4-litem--dl {
+  border-left: 3px solid transparent;
+  padding-left: 14px;
+}
+.v4-litem--over {
+  border-left-color: var(--v4-danger-500);
+  background: var(--v4-danger-50);
+}
+.v4-litem--today { border-left-color: var(--v4-warn-500); }
+.v4-litem--soon { border-left-color: var(--v4-accent-500); }
+.v4-litem-repo {
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  color: var(--v4-ink-500);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.v4-litem-ti {
+  font-size: 13px;
+  color: var(--v4-ink-900);
+  font-weight: 500;
+  min-width: 0;
+}
+.v4-litem-ti a {
+  color: inherit;
+  text-decoration: none;
+}
+.v4-litem-ti a:hover { color: var(--v4-accent-600); }
+.v4-litem-badge {
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: 99px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.v4-litem-badge--danger { background: var(--v4-danger-500); color: #fff; }
+.v4-litem-badge--warn { background: var(--v4-warn-500); color: #fff; }
+.v4-litem-badge--primary { background: var(--v4-accent-500); color: #fff; }
+.v4-empty {
+  padding: 24px 18px;
+  text-align: center;
+  color: var(--v4-ink-400);
+  font-size: 12px;
+}
+
+.v4-ptag {
+  display: inline-block;
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: 99px;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+.v4-ptag--p1 { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-ptag--p2 { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-ptag--p3 { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.v4-ptag--p4 { background: var(--v4-surface-2); color: var(--v4-ink-600); }
+
+/* ────────────────────────────────────────
+   CLOSED CHART (30 days)
+   ──────────────────────────────────────── */
+.v4-closed-chart {
+  padding: 14px 18px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+.v4-closed-chart svg {
+  width: 100%;
+  flex: 1;
+  min-height: 220px;
+  display: block;
+}
+.v4-cc-legend {
+  display: flex;
+  gap: 14px;
+  padding: 0 18px 14px;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-600);
+  flex-wrap: wrap;
+}
+.v4-cc-lg {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.v4-cc-lg .v4-cc-sw {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+}
+.v4-cc-peak {
+  margin-left: auto;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-500);
+}
+.v4-cc-peak b { color: var(--v4-ink-900); }
+
+/* ────────────────────────────────────────
+   MILESTONES STRIP
+   ──────────────────────────────────────── */
+.v4-ms-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  padding: 14px;
+}
+.v4-mscard {
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.v4-mscard--done { border-left: 3px solid var(--v4-success-500); }
+.v4-mscard--over { border-left: 3px solid var(--v4-danger-500); }
+.v4-mscard--warn { border-left: 3px solid var(--v4-warn-500); }
+.v4-mscard--norm { border-left: 3px solid var(--v4-accent-500); }
+.v4-mscard-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+.v4-mscard-t {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  line-height: 1.3;
+}
+.v4-mscard-r {
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  color: var(--v4-ink-500);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 2px;
+}
+.v4-mscard-p {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: auto;
+}
+.v4-mscard-track {
+  flex: 1;
+  height: 5px;
+  background: var(--v4-surface-3);
+  border-radius: 99px;
+  overflow: hidden;
+}
+.v4-mscard-fill {
+  height: 100%;
+  border-radius: 99px;
+}
+.v4-mscard-pct {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 600;
+  min-width: 64px;
+  text-align: right;
+  color: var(--v4-ink-700);
+}
+.v4-mscard-due {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.v4-mscard-due b { color: var(--v4-ink-900); }
+.v4-mscard-done-chip {
+  background: var(--v4-success-50);
+  color: var(--v4-success-700);
+  border: 1px solid var(--v4-success-100);
+  width: auto;
+  height: 18px;
+  border-radius: 99px;
+  padding: 0 8px;
+  font-size: 10px;
+  font-weight: 700;
+  font-family: var(--v4-mono);
+  display: inline-flex;
+  align-items: center;
+}
+
+/* ────────────────────────────────────────
+   COMMITS HEATMAP STRIP (28 days)
+   ──────────────────────────────────────── */
+.v4-heat-strip { padding: 14px 18px; }
+.v4-commit-row {
+  display: grid;
+  grid-template-columns: 130px 1fr 60px;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 0;
+  font-size: 12px;
+}
+.v4-commit-row .v4-nm {
+  font-family: var(--v4-mono);
+  font-weight: 600;
+  color: var(--v4-ink-800);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.v4-commit-cells {
+  display: grid;
+  grid-template-columns: repeat(28, 1fr);
+  gap: 2px;
+}
+.v4-cc {
+  height: 12px;
+  border-radius: 2px;
+  background: var(--v4-surface-3);
+}
+.v4-cc[data-v="1"] { background: #DCE7FF; }
+.v4-cc[data-v="2"] { background: #92B0F5; }
+.v4-cc[data-v="3"] { background: #3F73E8; }
+.v4-cc[data-v="4"] { background: var(--v4-accent-700); }
+.v4-commit-row .v4-tot {
+  font-family: var(--v4-mono);
+  text-align: right;
+  color: var(--v4-ink-700);
+  font-weight: 600;
+}
+
+/* ────────────────────────────────────────
+   BANNER
+   ──────────────────────────────────────── */
+.v4-banner {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  background: linear-gradient(90deg, var(--v4-accent-50), transparent);
+  border: 1px solid var(--v4-accent-100);
+  border-radius: var(--v4-r-lg);
+  margin-bottom: 14px;
+}
+.v4-banner-bi {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: var(--v4-accent-500);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.v4-banner-bi svg { width: 18px; height: 18px; }
+.v4-banner-bt { flex: 1; min-width: 0; }
+.v4-banner-bt b {
+  display: block;
+  color: var(--v4-ink-900);
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 1px;
+}
+.v4-banner-bt span {
+  font-size: 12px;
+  color: var(--v4-ink-600);
+}
+.v4-banner-bact {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+/* ────────────────────────────────────────
+   LEGACY-CONTENT FRAME
+   For non-dashboard tabs that still use the
+   old dark-theme styles. Wraps them in a
+   light "card" so they don't look broken
+   sitting in a light shell.
+   ──────────────────────────────────────── */
+.v4-legacy-frame {
+  padding: 18px 28px 40px;
+}
+.v4-legacy-frame .header,
+.v4-legacy-frame .header-tabs { display: none; }
+
+/* Error banner inside the new shell */
+.v4-error {
+  margin: 14px 28px 0;
+  padding: 12px 16px;
+  background: var(--v4-danger-50);
+  border: 1px solid var(--v4-danger-100);
+  border-radius: var(--v4-r-md);
+  color: var(--v4-danger-700);
+  font-size: 13px;
+}
+
+/* Empty / loading state inside new shell */
+.v4-loading {
+  padding: 60px 28px;
+  text-align: center;
+  color: var(--v4-ink-500);
+  font-size: 14px;
+}
+
+/* ────────────────────────────────────────
+   RESPONSIVE
+   ──────────────────────────────────────── */
+@media (max-width: 1100px) {
+  .v4-app { grid-template-columns: 1fr; }
+  .v4-side {
+    position: fixed;
+    z-index: 50;
+    transform: translateX(-100%);
+    transition: transform 200ms;
+    width: 240px;
+  }
+  .v4-side.is-open { transform: translateX(0); }
+  .v4-side-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(11, 16, 32, 0.4);
+    z-index: 40;
+  }
+  .v4-burger {
+    display: inline-flex !important;
+  }
+  .v4-kpi-row { grid-template-columns: repeat(2, 1fr); }
+  .v4-grid,
+  .v4-grid--rev { grid-template-columns: 1fr; }
+  .v4-proj-grid { grid-template-columns: 1fr; }
+  .v4-ms-grid { grid-template-columns: repeat(2, 1fr); }
+  .v4-search { width: 200px; }
+}
+.v4-burger { display: none; }
+@media (max-width: 700px) {
+  .v4-content { padding: 0 14px 28px; }
+  .v4-top { padding: 0 14px; }
+  .v4-kpi-row { grid-template-columns: 1fr; }
+  .v4-ms-grid { grid-template-columns: 1fr; }
+  .v4-stack-row {
+    grid-template-columns: 90px 1fr 40px;
+    gap: 8px;
+  }
+  .v4-commit-row {
+    grid-template-columns: 90px 1fr 40px;
+    gap: 8px;
+  }
+  .v4-search { display: none; }
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -52,6 +52,12 @@
   --v4-p3: #2563EB;
   --v4-p4: #94A0B8;
 
+  /* Commit-heatmap intensity steps (4 buckets, light → dark accent) */
+  --v4-heat-1: #DCE7FF;
+  --v4-heat-2: #92B0F5;
+  --v4-heat-3: #3F73E8;
+  --v4-heat-4: var(--v4-accent-700);
+
   /* Radii */
   --v4-r-sm: 6px;
   --v4-r-md: 8px;
@@ -76,7 +82,6 @@ body.v4 {
 body.v4 *,
 body.v4 *::before,
 body.v4 *::after { box-sizing: border-box; }
-body.v4 .v4 { font-family: var(--v4-sans); }
 body.v4 .num,
 body.v4 .v4-mono { font-variant-numeric: tabular-nums; }
 body.v4 .v4-mono { font-family: var(--v4-mono); }
@@ -1264,10 +1269,10 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   border-radius: 2px;
   background: var(--v4-surface-3);
 }
-.v4-cc[data-v="1"] { background: #DCE7FF; }
-.v4-cc[data-v="2"] { background: #92B0F5; }
-.v4-cc[data-v="3"] { background: #3F73E8; }
-.v4-cc[data-v="4"] { background: var(--v4-accent-700); }
+.v4-cc[data-v="1"] { background: var(--v4-heat-1); }
+.v4-cc[data-v="2"] { background: var(--v4-heat-2); }
+.v4-cc[data-v="3"] { background: var(--v4-heat-3); }
+.v4-cc[data-v="4"] { background: var(--v4-heat-4); }
 .v4-commit-row .v4-tot {
   font-family: var(--v4-mono);
   text-align: right;

--- a/src/utils/dashboardMetrics.ts
+++ b/src/utils/dashboardMetrics.ts
@@ -101,8 +101,12 @@ export function calcProgressDelta(projects: ProjectData[]): ProgressDelta {
   const closedInWindow = allIssues.filter(
     (i) => i.closedAt && new Date(i.closedAt).getTime() > cutoff
   ).length;
-  // Approximation: assume total was unchanged; previous done = current done − closedInWindow
-  const prevPct = ((totals.done - closedInWindow) / totals.total) * 100;
+  // Approximation: assume total was unchanged; previous done = current done − closedInWindow.
+  // Clamp at 0 — when the dashboard is filtered (by phase), `closedInWindow` may
+  // exceed `totals.done` for the filtered subset, which would otherwise yield a
+  // negative prevPct and an inflated delta.
+  const prevDone = Math.max(0, totals.done - closedInWindow);
+  const prevPct = (prevDone / totals.total) * 100;
   const nowPct = (totals.done / totals.total) * 100;
   return { pointsDelta7d: Math.round((nowPct - prevPct) * 10) / 10 };
 }

--- a/src/utils/dashboardMetrics.ts
+++ b/src/utils/dashboardMetrics.ts
@@ -1,0 +1,162 @@
+import type { ProjectData, Issue } from "../types";
+import { toLocalDay } from "./date";
+
+/** Last N days as YYYY-MM-DD, oldest first, ending with today. */
+export function getLastNDays(n: number): string[] {
+  const days: string[] = [];
+  for (let i = n - 1; i >= 0; i--) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    days.push(toLocalDay(d));
+  }
+  return days;
+}
+
+/** Issues closed within the trailing window of `days`, optionally with a back-shift. */
+function closedInWindow(issues: Issue[], days: number, shiftBackDays = 0): number {
+  const now = Date.now();
+  const end = now - shiftBackDays * 86400000;
+  const start = end - days * 86400000;
+  let n = 0;
+  for (const i of issues) {
+    if (!i.closedAt) continue;
+    const t = new Date(i.closedAt).getTime();
+    if (t > start && t <= end) n++;
+  }
+  return n;
+}
+
+export interface PortfolioVelocity {
+  perDay7d: number;
+  perDay14d: number;
+  /** percent change of 7d vs the prior 7d period (positive = improving) */
+  delta7dVsPrev: number;
+  /** counts per day for the trailing N days, oldest first (used for sparkline) */
+  daily28d: number[];
+}
+
+export function calcPortfolioVelocity(projects: ProjectData[]): PortfolioVelocity {
+  const allIssues = projects.flatMap((p) => p.issues);
+
+  const closed7d = closedInWindow(allIssues, 7);
+  const closed14d = closedInWindow(allIssues, 14);
+  const closedPrev7d = closedInWindow(allIssues, 7, 7);
+
+  const perDay7d = closed7d / 7;
+  const perDay14d = closed14d / 14;
+
+  const delta7dVsPrev =
+    closedPrev7d === 0
+      ? closed7d > 0 ? 100 : 0
+      : Math.round(((closed7d - closedPrev7d) / closedPrev7d) * 100);
+
+  const days = getLastNDays(28);
+  const counts: Record<string, number> = {};
+  for (const d of days) counts[d] = 0;
+  for (const i of allIssues) {
+    if (!i.closedAt) continue;
+    const day = toLocalDay(new Date(i.closedAt));
+    if (day in counts) counts[day]++;
+  }
+  const daily28d = days.map((d) => counts[d]);
+
+  return { perDay7d, perDay14d, delta7dVsPrev, daily28d };
+}
+
+export interface OpenDelta {
+  /** Net change in open count over last 7 days (closed in window − created in window) */
+  netDelta7d: number;
+}
+
+export function calcOpenDelta(projects: ProjectData[]): OpenDelta {
+  const allIssues = projects.flatMap((p) => p.issues);
+  const now = Date.now();
+  const cutoff = now - 7 * 86400000;
+  let createdInWindow = 0;
+  let closedInWindow = 0;
+  for (const i of allIssues) {
+    if (new Date(i.createdAt).getTime() > cutoff) createdInWindow++;
+    if (i.closedAt && new Date(i.closedAt).getTime() > cutoff) closedInWindow++;
+  }
+  return { netDelta7d: createdInWindow - closedInWindow };
+}
+
+export interface ProgressDelta {
+  /** % point change in done/total ratio over last 7 days */
+  pointsDelta7d: number;
+}
+
+export function calcProgressDelta(projects: ProjectData[]): ProgressDelta {
+  const totals = projects.reduce(
+    (acc, p) => {
+      acc.total += p.totalCount;
+      acc.done += p.doneCount;
+      return acc;
+    },
+    { total: 0, done: 0 }
+  );
+  if (totals.total === 0) return { pointsDelta7d: 0 };
+  const cutoff = Date.now() - 7 * 86400000;
+  const allIssues = projects.flatMap((p) => p.issues);
+  const closedInWindow = allIssues.filter(
+    (i) => i.closedAt && new Date(i.closedAt).getTime() > cutoff
+  ).length;
+  // Approximation: assume total was unchanged; previous done = current done − closedInWindow
+  const prevPct = ((totals.done - closedInWindow) / totals.total) * 100;
+  const nowPct = (totals.done / totals.total) * 100;
+  return { pointsDelta7d: Math.round((nowPct - prevPct) * 10) / 10 };
+}
+
+export interface PriorityTotals {
+  P1: number;
+  P2: number;
+  P3: number;
+  P4: number;
+}
+
+export function sumOpenPriorities(projects: ProjectData[]): PriorityTotals {
+  return projects.reduce<PriorityTotals>(
+    (acc, p) => {
+      acc.P1 += p.priorityCounts.P1;
+      acc.P2 += p.priorityCounts.P2;
+      acc.P3 += p.priorityCounts.P3;
+      acc.P4 += p.priorityCounts.P4;
+      return acc;
+    },
+    { P1: 0, P2: 0, P3: 0, P4: 0 }
+  );
+}
+
+export interface DailyClosed {
+  day: string;
+  count: number;
+}
+
+export function dailyClosedLastN(projects: ProjectData[], n: number): DailyClosed[] {
+  const days = getLastNDays(n);
+  const counts: Record<string, number> = {};
+  for (const d of days) counts[d] = 0;
+  for (const p of projects) {
+    for (const i of p.issues) {
+      if (!i.closedAt) continue;
+      const day = toLocalDay(new Date(i.closedAt));
+      if (day in counts) counts[day]++;
+    }
+  }
+  return days.map((day) => ({ day, count: counts[day] }));
+}
+
+/** Centered moving average of `window` length over the series. */
+export function movingAverage(values: number[], window: number): number[] {
+  if (window <= 1) return values.slice();
+  const half = Math.floor(window / 2);
+  const out: number[] = [];
+  for (let i = 0; i < values.length; i++) {
+    const lo = Math.max(0, i - half);
+    const hi = Math.min(values.length - 1, i + half);
+    let sum = 0;
+    for (let j = lo; j <= hi; j++) sum += values[j];
+    out.push(sum / (hi - lo + 1));
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Реализация дизайн-хэндофа `moliyakg/project/MakeIT Dashboard.html` (Claude Design):

- **Глобальный shell** — левый сайдбар 240px (с группами Workflow/Контроль) + sticky-топбар (search ⌘K + breadcrumbs + live-индикатор + refresh/logout). Применён ко всем 11 табам.
- **Полный редизайн вкладки «Дашборд»** — светлая палитра, Inter / JetBrains Mono.
- **Все остальные табы** (Проекты, Pipeline, Аудит, Quality, …) сохраняют текущую функциональность внутри `.v4-legacy-frame` — внутренний редизайн каждого таба → отдельные тикеты.

## Что нового на дашборде

| Блок | Источник данных |
|---|---|
| KPI: Прогресс портфеля (gradient, +Δ п.п. за 7д, splits Всего/Сделано/Открыто) | `useDashboard()` |
| KPI: Открытые задачи (+net Δ за 7д, splits P1/P2/P3) | `priorityCounts` |
| KPI: **Velocity 7д + 28-точечный sparkline** | новый `dashboardMetrics.calcPortfolioVelocity` (closedAt-based) |
| KPI: Бюджет (stacked bar Оплачено/Остаток) | финансы из localStorage |
| Active projects (top-4) | recent-closed sort + новая `DashboardProjectCard` (risk-полоса, P1/P2/P3 точки, finance, velocity/cycle/eta) |
| **AI-инсайты** | эвристика-заглушка → #113 LLM-замена |
| Распределение задач (стек по приоритетам) | `priorityCounts` |
| Заблокировано | `blockedIssues` (исключая Done) |
| Горящие дедлайны (≤7 дней) | milestones |
| **Закрыто за 30 дней + 10-дн скользящий тренд** | новый `dailyClosedLastN` + `movingAverage` |
| Milestones strip (3-кол сетка, Open/Done под-табы) | milestones |
| **Commits heatmap (28 дней × top-репо)** | существующий `commitActivity.byDate` |
| Stale-баннер | `daysSinceActivity ≥ 2` |

## Технические детали

- Новые файлы: `src/components/v4/*` (12 шт.), `src/styles/v4.css`, `src/utils/dashboardMetrics.ts`.
- Risk-классификация переиспользует `utils/riskScore.ts` (medium → жёлтая полоса, high/critical → красная — соответствует мокапу).
- `body.v4` класс изолирует light-тему дашборда от старых dark-стилей других табов.
- Адаптив: 1440+ (full), 1100+ (KPI 2-кол, projects 1-кол), 700+ (мобильный drawer для сайдбара).
- JetBrains Mono веса 500/600 добавлены в `index.html`.

## Verified locally

- ✅ `npx tsc --noEmit` — 0 errors
- ✅ `npm run lint` — 0 errors
- ✅ `npm run build` — clean
- ✅ Preview at 1440×900 — все секции рендерятся, консоль чистая
- ✅ Переключение на другие табы (Проекты, Pipeline, Аудит и т.д.) работает внутри нового shell

## Связанные

- Issue: #113 — AI-инсайты: заменить эвристику на LLM (создан в этой сессии)
- Design source: `moliyakg/project/MakeIT Dashboard.html` (Claude Design handoff)

## Test plan

- [ ] Открыть дашборд с реальным GitHub-токеном — проверить что 4 KPI считаются корректно
- [ ] Velocity sparkline — должен повторять реальный паттерн закрытий за 28 дней
- [ ] Active projects: top-4 — те же 4 проекта что были на старом дашборде
- [ ] Risk-полосы (med/high) — соответствуют существующему `calcRiskScore`
- [ ] Closed-30d chart — пик и тренд корректны
- [ ] Milestones strip — Open/Done переключаются, deadlines корректны
- [ ] Commits heatmap — всплывающие подсказки работают
- [ ] Stale banner — появляется/прячется кнопкой «Отложить»
- [ ] Финансы (кнопка в header + клик по KPI «Бюджет») — открывается FinanceEditor
- [ ] Все 10 остальных табов — переключаются и не падают
- [ ] Адаптив: проверить на 1100px и 700px
- [ ] Мобильный burger-меню — открывается/закрывается с backdrop

🤖 Generated with [Claude Code](https://claude.com/claude-code)