### PR TITLE
feat(projects): redesign V4 — rich cards + toolbar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { TokenForm } from "./components/TokenForm";
-import { ProjectCard } from "./components/ProjectCard";
 import { MilestoneCard } from "./components/MilestoneCard";
 import { ChatPanel } from "./components/ChatPanel";
 import { ChatButton } from "./components/ChatButton";
@@ -17,6 +16,7 @@ import { DebateTab } from "./components/DebateTab";
 import { Sidebar } from "./components/v4/Sidebar";
 import { Topbar } from "./components/v4/Topbar";
 import { DashboardView } from "./components/v4/DashboardView";
+import { ProjectsView } from "./components/v4/ProjectsView";
 import { useDashboard } from "./hooks/useDashboard";
 import { useMonitors } from "./hooks/useMonitors";
 import { getToken, clearToken, getAuth, clearAuth, clearClaudeKey, MONITOR_MATCH, PROJECTS } from "./utils/config";
@@ -203,18 +203,14 @@ function AppInner() {
         )}
 
         {projects.length > 0 && tab === "projects" && (
-          <div className="v4-legacy-frame">
-            <div className="bento-grid">
-              <div className="bento-panel span-12 panel-projects">
-                <div className="bento-panel-title">Все проекты</div>
-                <section className="projects-grid">
-                  {projects.map((p) => (
-                    <ProjectCard key={p.repo} project={p} monitor={getMonitorForRepo(p.repo)} />
-                  ))}
-                </section>
-              </div>
-            </div>
-          </div>
+          <ErrorBoundary fallback="Ошибка вкладки Проекты">
+            <ProjectsView
+              projects={projects}
+              getMonitor={getMonitorForRepo}
+              onFinanceClick={() => setFinanceOpen(true)}
+              onJumpToTab={(t) => setTab(t)}
+            />
+          </ErrorBoundary>
         )}
 
         {projects.length > 0 && tab === "milestones" && (() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { TokenForm } from "./components/TokenForm";
 import { MilestoneCard } from "./components/MilestoneCard";
 import { ChatPanel } from "./components/ChatPanel";
@@ -95,17 +95,22 @@ function AppInner() {
     return () => { document.body.classList.remove("v4"); };
   }, []);
 
-  function getMonitorForRepo(repo: string): Monitor | undefined {
-    const keywords = MONITOR_MATCH[repo];
-    if (!keywords || monitors.length === 0) return undefined;
-    return monitors.find((m) =>
-      keywords.some(
-        (kw) =>
-          m.name.toLowerCase().includes(kw.toLowerCase()) ||
-          m.url.toLowerCase().includes(kw.toLowerCase())
-      )
-    );
-  }
+  // Memoized so child components (e.g. ProjectsView) can include this in
+  // memo dep arrays without re-running on every parent render.
+  const getMonitorForRepo = useCallback(
+    (repo: string): Monitor | undefined => {
+      const keywords = MONITOR_MATCH[repo];
+      if (!keywords || monitors.length === 0) return undefined;
+      return monitors.find((m) =>
+        keywords.some(
+          (kw) =>
+            m.name.toLowerCase().includes(kw.toLowerCase()) ||
+            m.url.toLowerCase().includes(kw.toLowerCase())
+        )
+      );
+    },
+    [monitors]
+  );
 
   useEffect(() => {
     if (getToken()) refresh(false); // use cache on initial load

--- a/src/components/v4/ProjectCardV4.tsx
+++ b/src/components/v4/ProjectCardV4.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ProjectData, Priority, Monitor, MonitorStatus } from "../../types";
 import { calcRiskScore } from "../../utils/riskScore";
 import { GITHUB_OWNER } from "../../utils/config";
@@ -101,7 +101,11 @@ export function ProjectCardV4({ project, monitor, onJumpToTab, onEditFinance }: 
       : "var(--v4-warn-500)";
 
   const hasFinances = project.budget > 0;
-  const paymentPct = hasFinances ? Math.round((project.paid / project.budget) * 100) : 0;
+  // Cap visual width at 100% — paid can exceed budget (edge case) and would
+  // otherwise overflow the bar track.
+  const paymentPct = hasFinances
+    ? Math.min(100, Math.round((project.paid / project.budget) * 100))
+    : 0;
   const fullyPaid = hasFinances && project.paid >= project.budget;
 
   // Count of open board issues without any P1-P4 label
@@ -121,14 +125,17 @@ export function ProjectCardV4({ project, monitor, onJumpToTab, onEditFinance }: 
 
   const showRisks = risk.level !== "low" && risk.factors.length > 0;
 
-  // 28-day heatmap cells (in render — would need lastUpdated for purity, but
-  // ProjectCardV4 is rendered in a tab that re-mounts when navigated, so this
-  // is acceptable. The expanded heatmap is opt-in.)
-  const heatDays = heatmapOpen ? getLastNDays(28) : [];
-  const heatCells = heatDays.map((d) => ({
-    d,
-    count: project.commitActivity?.byDate?.[d] ?? 0,
-  }));
+  // 28-day heatmap cells. Memoised so getLastNDays() (impure — calls
+  // new Date()) only runs on toggle, not on every render. The Projects tab
+  // re-mounts on navigation so the date window can't go stale within a tab
+  // session.
+  const heatCells = useMemo(() => {
+    if (!heatmapOpen) return [];
+    return getLastNDays(28).map((d) => ({
+      d,
+      count: project.commitActivity?.byDate?.[d] ?? 0,
+    }));
+  }, [heatmapOpen, project.commitActivity?.byDate]);
 
   return (
     <div className={`v4-pcard v4-pcard--full ${riskClass}`}>
@@ -364,14 +371,22 @@ export function ProjectCardV4({ project, monitor, onJumpToTab, onEditFinance }: 
             </span>
           )}
           {project.etaDate && (() => {
-            const overdue = project.etaDays !== null && project.etaDays > 0;
+            // ETA semantics: `etaDays` is "days UNTIL completion" (positive
+            // = future, see types/index.ts). Treat far-out forecasts as a
+            // schedule risk — matches legacy thresholds (>60 = danger,
+            // >30 = warn). Soon-completion = neutral/good.
+            const d = project.etaDays;
+            const danger = d !== null && d > 60;
+            const warn = d !== null && d > 30 && d <= 60;
             const target = new Date(project.etaDate).toLocaleDateString("ru-RU", {
               day: "numeric",
               month: "short",
             });
             return (
               <span
-                className={`v4-pcard-stat ${overdue ? "v4-pcard-stat--danger" : ""}`}
+                className={`v4-pcard-stat ${
+                  danger ? "v4-pcard-stat--danger" : warn ? "v4-pcard-stat--warn" : ""
+                }`}
                 title="Прогноз даты завершения"
               >
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -379,11 +394,11 @@ export function ProjectCardV4({ project, monitor, onJumpToTab, onEditFinance }: 
                   <circle cx="12" cy="12" r="5" />
                 </svg>
                 <b>{target}</b>
-                {project.etaDays !== null && project.etaDays !== 0 && (
+                {d !== null && d !== 0 && (
                   <>
                     {" "}
-                    ({project.etaDays > 0 ? "+" : ""}
-                    {project.etaDays}д)
+                    ({d > 0 ? "+" : ""}
+                    {d}д)
                   </>
                 )}
               </span>

--- a/src/components/v4/ProjectCardV4.tsx
+++ b/src/components/v4/ProjectCardV4.tsx
@@ -1,0 +1,458 @@
+import { useEffect, useRef, useState } from "react";
+import type { ProjectData, Priority, Monitor, MonitorStatus } from "../../types";
+import { calcRiskScore } from "../../utils/riskScore";
+import { GITHUB_OWNER } from "../../utils/config";
+import { getLastNDays } from "../../utils/dashboardMetrics";
+
+interface Props {
+  project: ProjectData;
+  monitor?: Monitor;
+  onJumpToTab?: (tab: "pipeline" | "audit") => void;
+  onEditFinance?: () => void;
+}
+
+const STATUS_LABEL: Record<MonitorStatus, string> = {
+  up: "alive",
+  down: "down",
+  paused: "paused",
+  pending: "pending",
+};
+
+const PHASE_CHIP: Record<string, { cls: string; icon: string; label: string }> = {
+  development: { cls: "v4-chip--dev", icon: "▶", label: "dev" },
+  support: { cls: "v4-chip--support", icon: "⏸", label: "support" },
+  "pre-dev": { cls: "v4-chip--predev", icon: "◻", label: "pre-dev" },
+};
+
+function compactUSD(n: number): string {
+  if (n >= 1000) {
+    const k = n / 1000;
+    return `$${k.toFixed(k % 1 === 0 ? 0 : 1).replace(".", ",")}k`;
+  }
+  return `$${n}`;
+}
+
+function formatNumber1d(n: number): string {
+  return (Math.round(n * 10) / 10).toString().replace(".", ",");
+}
+
+function buildRepoUrl(repo: string): string {
+  if (repo.includes("/")) {
+    const [owner, name] = repo.split("/", 2);
+    return `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+  }
+  return `https://github.com/${encodeURIComponent(GITHUB_OWNER)}/${encodeURIComponent(repo)}`;
+}
+
+function bucket(count: number): string | undefined {
+  if (count === 0) return undefined;
+  if (count === 1) return "1";
+  if (count <= 3) return "2";
+  if (count <= 6) return "3";
+  return "4";
+}
+
+const PRIORITY_DOT_CLASS: Record<Priority, string> = {
+  P1: "v4-pdot--p1",
+  P2: "v4-pdot--p2",
+  P3: "v4-pdot--p3",
+  P4: "v4-pdot--p4",
+};
+
+export function ProjectCardV4({ project, monitor, onJumpToTab, onEditFinance }: Props) {
+  const [heatmapOpen, setHeatmapOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) setMenuOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMenuOpen(false);
+    };
+    window.addEventListener("mousedown", onDoc);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDoc);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [menuOpen]);
+
+  const risk = calcRiskScore(project, monitor);
+  const riskClass =
+    risk.level === "critical" || risk.level === "high"
+      ? "is-risk-high"
+      : risk.level === "medium"
+      ? "is-risk-med"
+      : "";
+
+  const phase = PHASE_CHIP[project.phase] ?? PHASE_CHIP["pre-dev"];
+
+  const total = project.totalCount;
+  const done = project.doneCount;
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+  const progressColor =
+    pct >= 75
+      ? "var(--v4-success-500)"
+      : pct >= 40
+      ? "var(--v4-accent-500)"
+      : "var(--v4-warn-500)";
+
+  const hasFinances = project.budget > 0;
+  const paymentPct = hasFinances ? Math.round((project.paid / project.budget) * 100) : 0;
+  const fullyPaid = hasFinances && project.paid >= project.budget;
+
+  // Count of open board issues without any P1-P4 label
+  const labeled =
+    project.priorityCounts.P1 +
+    project.priorityCounts.P2 +
+    project.priorityCounts.P3 +
+    project.priorityCounts.P4;
+  const boardOpen = project.issues.filter((i) => i.status !== "Done").length;
+  const noLabel = Math.max(0, boardOpen - labeled);
+
+  const showStats =
+    project.openCount > 0 &&
+    (project.velocity7d > 0 ||
+      project.cycleTimeDays !== null ||
+      !!project.etaDate);
+
+  const showRisks = risk.level !== "low" && risk.factors.length > 0;
+
+  // 28-day heatmap cells (in render — would need lastUpdated for purity, but
+  // ProjectCardV4 is rendered in a tab that re-mounts when navigated, so this
+  // is acceptable. The expanded heatmap is opt-in.)
+  const heatDays = heatmapOpen ? getLastNDays(28) : [];
+  const heatCells = heatDays.map((d) => ({
+    d,
+    count: project.commitActivity?.byDate?.[d] ?? 0,
+  }));
+
+  return (
+    <div className={`v4-pcard v4-pcard--full ${riskClass}`}>
+      {/* Section: header */}
+      <div className="v4-pcard-row">
+        <div className="v4-pcard-name-wrap">
+          <a
+            className="v4-pcard-name"
+            href={buildRepoUrl(project.repo)}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {project.repo}
+          </a>
+          {project.client && (
+            <span className="v4-pcard-client">{project.client}</span>
+          )}
+        </div>
+        <div className="v4-pcard-badges">
+          {monitor && monitor.status !== "paused" && (
+            <span
+              className={`v4-chip v4-chip--${
+                monitor.status === "up"
+                  ? "alive"
+                  : monitor.status === "down"
+                  ? "down"
+                  : "paused"
+              }`}
+            >
+              <span className="v4-chip-dot" />
+              {STATUS_LABEL[monitor.status]}
+            </span>
+          )}
+          <span className={`v4-chip ${phase.cls}`}>
+            {phase.icon} {phase.label}
+          </span>
+          <span
+            className={`v4-pcard-risk-chip v4-pcard-risk-chip--${risk.level}`}
+            title={`Score: ${risk.score}/100`}
+          >
+            риск: {risk.label.toLowerCase()}
+          </span>
+          <div className="v4-pcard-menu" ref={menuRef}>
+            <button
+              type="button"
+              className="v4-pcard-menu-btn"
+              onClick={() => setMenuOpen((v) => !v)}
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              aria-label="Действия с проектом"
+              title="Действия"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="5" r="1.5" />
+                <circle cx="12" cy="12" r="1.5" />
+                <circle cx="12" cy="19" r="1.5" />
+              </svg>
+            </button>
+            {menuOpen && (
+              <div className="v4-pcard-menu-list" role="menu">
+                <a
+                  href={buildRepoUrl(project.repo)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  role="menuitem"
+                  onClick={() => setMenuOpen(false)}
+                >
+                  Открыть в GitHub ↗
+                </a>
+                {onJumpToTab && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      onJumpToTab("pipeline");
+                      setMenuOpen(false);
+                    }}
+                  >
+                    Открыть Pipeline →
+                  </button>
+                )}
+                {onJumpToTab && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      onJumpToTab("audit");
+                      setMenuOpen(false);
+                    }}
+                  >
+                    Открыть Аудит →
+                  </button>
+                )}
+                {onEditFinance && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      onEditFinance();
+                      setMenuOpen(false);
+                    }}
+                  >
+                    Редактировать финансы…
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Section: issues + progress */}
+      <div className="v4-pcard-section">
+        <div className="v4-pcard-open-row">
+          <div className="v4-pcard-open-num num">
+            {project.openCount}
+            <span>открытых</span>
+          </div>
+          <div className="v4-pcard-pri-group">
+            {(["P1", "P2", "P3", "P4"] as Priority[]).map((p) =>
+              project.priorityCounts[p] > 0 ? (
+                <span key={p} className="v4-pcard-pri">
+                  <span className={`v4-pdot ${PRIORITY_DOT_CLASS[p]}`} />
+                  {project.priorityCounts[p]}
+                </span>
+              ) : null
+            )}
+            {noLabel > 0 && (
+              <span
+                className="v4-pcard-pri v4-pcard-pri--unlabeled"
+                title="Без приоритета"
+              >
+                ? {noLabel}
+              </span>
+            )}
+          </div>
+        </div>
+        {total > 0 && (
+          <div className="v4-pcard-progress">
+            <div className="v4-ptrack">
+              <div
+                className="v4-pfill"
+                style={{ width: `${pct}%`, background: progressColor }}
+              />
+            </div>
+            <span className="v4-ppct num">
+              {done}/{total} ({pct}%)
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Section: finance */}
+      {hasFinances && (
+        <div className="v4-pcard-section">
+          <div className="v4-pcard-finance-line">
+            <span>
+              <b className="num">{compactUSD(project.paid)}</b>
+              <span className="v4-pcard-finance-sep"> / </span>
+              <span className="num">{compactUSD(project.budget)}</span>
+            </span>
+            <span
+              className={`v4-pcard-finance-r ${
+                fullyPaid ? "" : "v4-pcard-finance-r--warn"
+              }`}
+            >
+              {fullyPaid
+                ? "оплачен ✓"
+                : `остаток ${compactUSD(project.remaining)}`}
+            </span>
+          </div>
+          <div className="v4-ptrack v4-pcard-finance-bar">
+            <div
+              className="v4-pfill"
+              style={{
+                width: `${paymentPct}%`,
+                background: fullyPaid
+                  ? "var(--v4-success-500)"
+                  : "var(--v4-accent-500)",
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Section: stats */}
+      {showStats && (
+        <div className="v4-pcard-section v4-pcard-stats">
+          {project.velocity7d > 0 && (() => {
+            // Trend: 7d vs 14d. >5% delta is meaningful, otherwise neutral.
+            const v7 = project.velocity7d;
+            const v14 = project.velocity14d;
+            let trend: "up" | "down" | "flat" = "flat";
+            if (v14 > 0) {
+              const change = (v7 - v14) / v14;
+              if (change > 0.05) trend = "up";
+              else if (change < -0.05) trend = "down";
+            }
+            return (
+              <span
+                className="v4-pcard-stat"
+                title={`Velocity 7д vs 14д (${formatNumber1d(v14)}/д)`}
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+                </svg>
+                <b>{formatNumber1d(v7)}</b>/д
+                {trend !== "flat" && (
+                  <span
+                    className={`v4-trend v4-trend--${trend}`}
+                    aria-hidden="true"
+                  >
+                    {trend === "up" ? "↗" : "↘"}
+                  </span>
+                )}
+              </span>
+            );
+          })()}
+          {project.cycleTimeDays !== null && (
+            <span
+              className="v4-pcard-stat"
+              title="Медиана времени закрытия issue (последние 28 дней)"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+              <b>
+                {project.cycleTimeDays < 1
+                  ? `${Math.round(project.cycleTimeDays * 24)}ч`
+                  : `${formatNumber1d(project.cycleTimeDays)}д`}
+              </b>
+            </span>
+          )}
+          {project.etaDate && (() => {
+            const overdue = project.etaDays !== null && project.etaDays > 0;
+            const target = new Date(project.etaDate).toLocaleDateString("ru-RU", {
+              day: "numeric",
+              month: "short",
+            });
+            return (
+              <span
+                className={`v4-pcard-stat ${overdue ? "v4-pcard-stat--danger" : ""}`}
+                title="Прогноз даты завершения"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <circle cx="12" cy="12" r="10" />
+                  <circle cx="12" cy="12" r="5" />
+                </svg>
+                <b>{target}</b>
+                {project.etaDays !== null && project.etaDays !== 0 && (
+                  <>
+                    {" "}
+                    ({project.etaDays > 0 ? "+" : ""}
+                    {project.etaDays}д)
+                  </>
+                )}
+              </span>
+            );
+          })()}
+          {project.daysSinceActivity !== null &&
+            project.daysSinceActivity >= 2 &&
+            project.openCount > 0 && (
+              <span
+                className="v4-pcard-stat v4-pcard-stat--danger"
+                title="Дней с последней активности"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <circle cx="12" cy="12" r="10" />
+                  <line x1="12" y1="8" x2="12" y2="12" />
+                  <line x1="12" y1="16" x2="12.01" y2="16" />
+                </svg>
+                stale <b>{project.daysSinceActivity}д</b>
+              </span>
+            )}
+        </div>
+      )}
+
+      {/* Section: risk factors */}
+      {showRisks && (
+        <div className="v4-pcard-section v4-pcard-risk-factors">
+          {risk.factors.map((f, i) => (
+            <span
+              key={i}
+              className={`v4-risk-factor v4-risk-factor--${risk.level}`}
+            >
+              {f.text}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Section: heatmap toggle */}
+      <div className="v4-pcard-section v4-pcard-heat">
+        <button
+          type="button"
+          className="v4-pcard-heat-toggle"
+          onClick={() => setHeatmapOpen((v) => !v)}
+          aria-expanded={heatmapOpen}
+        >
+          <span className={`v4-pcard-heat-arrow ${heatmapOpen ? "is-open" : ""}`}>
+            ▸
+          </span>
+          <span>Коммиты</span>
+          <span className="v4-pcard-heat-meta">
+            {project.commitActivity?.thisWeek ?? 0} за 7д ·{" "}
+            {project.commitActivity?.thisMonth ?? 0} за 30д
+          </span>
+        </button>
+        {heatmapOpen && (
+          <div className="v4-pcard-heat-grid">
+            {heatCells.map(({ d, count }) => (
+              <div
+                key={d}
+                className="v4-cc"
+                data-v={bucket(count)}
+                title={`${d}: ${count} коммит${
+                  count === 1 ? "" : count >= 2 && count <= 4 ? "а" : "ов"
+                }`}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/ProjectsView.tsx
+++ b/src/components/v4/ProjectsView.tsx
@@ -78,9 +78,9 @@ function loadState(): ToolbarState {
 
 function saveState(s: ToolbarState): void {
   try {
-    // do not persist transient query
-    const { query, ...persist } = s;
-    void query;
+    // Strip the transient `query` field — never persist search input.
+    const { query: _query, ...persist } = s;
+    void _query;
     localStorage.setItem(STORAGE_KEY, JSON.stringify(persist));
   } catch {
     /* ignore */
@@ -171,7 +171,9 @@ export function ProjectsView({
     });
   }, [projects, state.phase, state.query]);
 
-  // Sort
+  // Sort. `getMonitor` is included because compareBy reads it for risk-key
+  // sorting; with App.tsx wrapping it in useCallback the reference is stable
+  // until monitors actually change.
   const sorted = useMemo(() => {
     const out = [...filtered];
     out.sort((a, b) => {
@@ -179,8 +181,7 @@ export function ProjectsView({
       return state.asc ? cmp : -cmp;
     });
     return out;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filtered, state.sort, state.asc]);
+  }, [filtered, state.sort, state.asc, getMonitor]);
 
   // Aggregate stats over filtered
   const agg = useMemo(() => {

--- a/src/components/v4/ProjectsView.tsx
+++ b/src/components/v4/ProjectsView.tsx
@@ -1,0 +1,415 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { ProjectData, Monitor, Phase } from "../../types";
+import { ProjectCardV4 } from "./ProjectCardV4";
+import { calcRiskScore } from "../../utils/riskScore";
+
+interface Props {
+  projects: ProjectData[];
+  getMonitor: (repo: string) => Monitor | undefined;
+  onFinanceClick: () => void;
+  onJumpToTab?: (tab: "pipeline" | "audit") => void;
+}
+
+type PhaseFilter = "all" | Phase | "stale";
+
+type SortKey =
+  | "activity"
+  | "open"
+  | "risk"
+  | "progress"
+  | "name";
+
+interface ToolbarState {
+  phase: PhaseFilter;
+  sort: SortKey;
+  asc: boolean;
+  query: string;
+  groupByPhase: boolean;
+}
+
+const STORAGE_KEY = "makeit.projectsView.v1";
+
+const PHASE_LABELS: Record<PhaseFilter, string> = {
+  all: "Все",
+  "pre-dev": "Pre-dev",
+  development: "Dev",
+  support: "Support",
+  stale: "Stale",
+};
+
+const SORT_LABELS: Record<SortKey, string> = {
+  activity: "Активность",
+  open: "Открытые",
+  risk: "Risk score",
+  progress: "Прогресс",
+  name: "Имя",
+};
+
+const PHASE_GROUP_TITLE: Record<Phase, string> = {
+  development: "В разработке",
+  "pre-dev": "Pre-dev",
+  support: "Поддержка",
+};
+
+function loadState(): ToolbarState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<ToolbarState>;
+      return {
+        phase: parsed.phase ?? "all",
+        sort: parsed.sort ?? "activity",
+        asc: parsed.asc ?? false,
+        query: "",
+        groupByPhase: parsed.groupByPhase ?? false,
+      };
+    }
+  } catch {
+    /* ignore */
+  }
+  return {
+    phase: "all",
+    sort: "activity",
+    asc: false,
+    query: "",
+    groupByPhase: false,
+  };
+}
+
+function saveState(s: ToolbarState): void {
+  try {
+    // do not persist transient query
+    const { query, ...persist } = s;
+    void query;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(persist));
+  } catch {
+    /* ignore */
+  }
+}
+
+function isStaleProject(p: ProjectData): boolean {
+  return (
+    p.daysSinceActivity !== null &&
+    p.daysSinceActivity >= 7 &&
+    p.openCount > 0
+  );
+}
+
+function compareBy(
+  a: ProjectData,
+  b: ProjectData,
+  sort: SortKey,
+  getMonitor: (repo: string) => Monitor | undefined
+): number {
+  switch (sort) {
+    case "activity": {
+      // Smaller daysSinceActivity = MORE recent. We want most recent first
+      // when desc=false handled by caller; here return numeric "freshness".
+      const aD = a.daysSinceActivity ?? 9999;
+      const bD = b.daysSinceActivity ?? 9999;
+      return aD - bD;
+    }
+    case "open":
+      return a.openCount - b.openCount;
+    case "risk":
+      return calcRiskScore(a, getMonitor(a.repo)).score -
+        calcRiskScore(b, getMonitor(b.repo)).score;
+    case "progress": {
+      const ap = a.totalCount > 0 ? a.doneCount / a.totalCount : 0;
+      const bp = b.totalCount > 0 ? b.doneCount / b.totalCount : 0;
+      return ap - bp;
+    }
+    case "name":
+      return a.repo.localeCompare(b.repo, "ru");
+  }
+}
+
+export function ProjectsView({
+  projects,
+  getMonitor,
+  onFinanceClick,
+  onJumpToTab,
+}: Props) {
+  const [state, setState] = useState<ToolbarState>(() => loadState());
+  const [sortMenuOpen, setSortMenuOpen] = useState(false);
+  const sortMenuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    saveState(state);
+  }, [state]);
+
+  // Close sort menu on outside click / Escape
+  useEffect(() => {
+    if (!sortMenuOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!sortMenuRef.current?.contains(e.target as Node)) setSortMenuOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setSortMenuOpen(false);
+    };
+    window.addEventListener("mousedown", onDoc);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDoc);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [sortMenuOpen]);
+
+  // Filter
+  const filtered = useMemo(() => {
+    const q = state.query.trim().toLowerCase();
+    return projects.filter((p) => {
+      if (state.phase === "stale") {
+        if (!isStaleProject(p)) return false;
+      } else if (state.phase !== "all") {
+        if (p.phase !== state.phase) return false;
+      }
+      if (q && !p.repo.toLowerCase().includes(q) && !p.client.toLowerCase().includes(q)) {
+        return false;
+      }
+      return true;
+    });
+  }, [projects, state.phase, state.query]);
+
+  // Sort
+  const sorted = useMemo(() => {
+    const out = [...filtered];
+    out.sort((a, b) => {
+      const cmp = compareBy(a, b, state.sort, getMonitor);
+      return state.asc ? cmp : -cmp;
+    });
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filtered, state.sort, state.asc]);
+
+  // Aggregate stats over filtered
+  const agg = useMemo(() => {
+    let open = 0,
+      p1 = 0,
+      stale = 0,
+      doneTotal = 0,
+      total = 0,
+      budget = 0,
+      paid = 0;
+    for (const p of filtered) {
+      open += p.openCount;
+      p1 += p.priorityCounts.P1;
+      if (isStaleProject(p)) stale += 1;
+      doneTotal += p.doneCount;
+      total += p.totalCount;
+      budget += p.budget;
+      paid += p.paid;
+    }
+    return {
+      count: filtered.length,
+      open,
+      p1,
+      stale,
+      doneTotal,
+      total,
+      budget,
+      paid,
+      progress: total > 0 ? Math.round((doneTotal / total) * 100) : 0,
+    };
+  }, [filtered]);
+
+  // Group output (optional)
+  const groups: { title: string; items: ProjectData[] }[] = useMemo(() => {
+    if (!state.groupByPhase) {
+      return [{ title: "", items: sorted }];
+    }
+    const order: Phase[] = ["development", "pre-dev", "support"];
+    return order
+      .map((ph) => ({
+        title: PHASE_GROUP_TITLE[ph],
+        items: sorted.filter((p) => p.phase === ph),
+      }))
+      .filter((g) => g.items.length > 0);
+  }, [sorted, state.groupByPhase]);
+
+  return (
+    <div className="v4-content">
+      {/* Page head */}
+      <div className="v4-ph">
+        <div>
+          <h1>Все проекты</h1>
+          <div className="v4-sub">
+            {projects.length} в портфеле · {agg.count} в выборке
+          </div>
+        </div>
+        <div className="v4-ph-right">
+          <div className="v4-pillgrp">
+            {(Object.keys(PHASE_LABELS) as PhaseFilter[]).map((p) => (
+              <button
+                key={p}
+                type="button"
+                className={state.phase === p ? "is-active" : ""}
+                onClick={() => setState((s) => ({ ...s, phase: p }))}
+              >
+                {PHASE_LABELS[p]}
+              </button>
+            ))}
+          </div>
+          <button type="button" className="v4-btn" onClick={onFinanceClick}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M12 1v22M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6" />
+            </svg>
+            Финансы
+          </button>
+        </div>
+      </div>
+
+      <div style={{ height: 10 }} />
+
+      {/* Aggregate strip + sort/search toolbar */}
+      <div className="v4-projects-toolbar">
+        <div className="v4-projects-agg">
+          <div className="v4-projects-agg-cell">
+            <div className="v4-projects-agg-n num">{agg.count}</div>
+            <div className="v4-projects-agg-l">проектов</div>
+          </div>
+          <div className="v4-projects-agg-cell">
+            <div className="v4-projects-agg-n num">{agg.open}</div>
+            <div className="v4-projects-agg-l">открытых</div>
+          </div>
+          <div className="v4-projects-agg-cell">
+            <div className="v4-projects-agg-n num" style={{ color: agg.p1 > 0 ? "var(--v4-p1)" : undefined }}>
+              {agg.p1}
+            </div>
+            <div className="v4-projects-agg-l">P1</div>
+          </div>
+          <div className="v4-projects-agg-cell">
+            <div className="v4-projects-agg-n num" style={{ color: agg.stale > 0 ? "var(--v4-warn-700)" : undefined }}>
+              {agg.stale}
+            </div>
+            <div className="v4-projects-agg-l">stale</div>
+          </div>
+          <div className="v4-projects-agg-cell">
+            <div className="v4-projects-agg-n num">{agg.progress}%</div>
+            <div className="v4-projects-agg-l">прогресс</div>
+          </div>
+        </div>
+
+        <div className="v4-projects-tools">
+          <div className="v4-search v4-projects-search">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="11" cy="11" r="8" />
+              <path d="M21 21l-4.35-4.35" />
+            </svg>
+            <input
+              value={state.query}
+              onChange={(e) => setState((s) => ({ ...s, query: e.target.value }))}
+              placeholder="Поиск по имени или клиенту…"
+              aria-label="Поиск проектов"
+            />
+            {state.query && (
+              <button
+                type="button"
+                className="v4-projects-search-clear"
+                onClick={() => setState((s) => ({ ...s, query: "" }))}
+                aria-label="Очистить поиск"
+                title="Очистить"
+              >
+                ×
+              </button>
+            )}
+          </div>
+
+          <div className="v4-projects-sort" ref={sortMenuRef}>
+            <button
+              type="button"
+              className="v4-btn"
+              onClick={() => setSortMenuOpen((v) => !v)}
+              aria-haspopup="menu"
+              aria-expanded={sortMenuOpen}
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M3 6h18M6 12h12M10 18h4" />
+              </svg>
+              {SORT_LABELS[state.sort]} {state.asc ? "↑" : "↓"}
+            </button>
+            {sortMenuOpen && (
+              <div className="v4-projects-sort-menu" role="menu">
+                {(Object.keys(SORT_LABELS) as SortKey[]).map((k) => (
+                  <button
+                    key={k}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={state.sort === k}
+                    className={state.sort === k ? "is-active" : ""}
+                    onClick={() => {
+                      setState((s) => ({ ...s, sort: k }));
+                      setSortMenuOpen(false);
+                    }}
+                  >
+                    {SORT_LABELS[k]}
+                  </button>
+                ))}
+                <div className="v4-projects-sort-sep" />
+                <button
+                  type="button"
+                  role="menuitemcheckbox"
+                  aria-checked={state.asc}
+                  className={state.asc ? "is-active" : ""}
+                  onClick={() => setState((s) => ({ ...s, asc: !s.asc }))}
+                >
+                  {state.asc ? "↑ По возрастанию" : "↓ По убыванию"}
+                </button>
+                <div className="v4-projects-sort-sep" />
+                <button
+                  type="button"
+                  role="menuitemcheckbox"
+                  aria-checked={state.groupByPhase}
+                  className={state.groupByPhase ? "is-active" : ""}
+                  onClick={() =>
+                    setState((s) => ({ ...s, groupByPhase: !s.groupByPhase }))
+                  }
+                >
+                  {state.groupByPhase ? "✓" : "□"} Группировать по фазе
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Empty state */}
+      {agg.count === 0 && (
+        <div className="v4-panel">
+          <div className="v4-empty">
+            {state.query
+              ? `По запросу «${state.query}» ничего не найдено`
+              : "Нет проектов в текущем фильтре"}
+          </div>
+        </div>
+      )}
+
+      {/* Cards */}
+      {agg.count > 0 && (
+        <div className="v4-projects-groups">
+          {groups.map((g, i) => (
+            <section key={i} className="v4-projects-group">
+              {g.title && (
+                <h2 className="v4-projects-group-title">
+                  {g.title}{" "}
+                  <span className="v4-projects-group-count">({g.items.length})</span>
+                </h2>
+              )}
+              <div className="v4-projects-grid">
+                {g.items.map((p) => (
+                  <ProjectCardV4
+                    key={p.repo}
+                    project={p}
+                    monitor={getMonitor(p.repo)}
+                    onJumpToTab={onJumpToTab}
+                    onEditFinance={onFinanceClick}
+                  />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -1356,6 +1356,358 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 }
 
 /* ────────────────────────────────────────
+   PROJECTS VIEW (full page, rich cards)
+   ──────────────────────────────────────── */
+
+/* Aggregate strip + tools toolbar */
+.v4-projects-toolbar {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  margin-bottom: 14px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 14px;
+  align-items: center;
+  padding: 8px 14px;
+}
+.v4-projects-agg {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+.v4-projects-agg-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  min-width: 78px;
+  border-right: 1px solid var(--v4-line-soft);
+  text-align: center;
+}
+.v4-projects-agg-cell:last-child { border-right: 0; }
+.v4-projects-agg-n {
+  font-family: var(--v4-mono);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--v4-ink-900);
+  line-height: 1;
+  letter-spacing: -0.01em;
+}
+.v4-projects-agg-l {
+  font-size: 9px;
+  color: var(--v4-ink-500);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-top: 4px;
+}
+.v4-projects-tools {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.v4-projects-search {
+  width: 240px;
+  position: relative;
+}
+.v4-projects-search-clear {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--v4-surface-2);
+  border: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--v4-ink-500);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.v4-projects-search-clear:hover { color: var(--v4-ink-900); background: var(--v4-surface-3); }
+
+.v4-projects-sort {
+  position: relative;
+}
+.v4-projects-sort-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  box-shadow: 0 8px 24px rgba(11, 16, 32, 0.08);
+  padding: 4px;
+  min-width: 220px;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+}
+.v4-projects-sort-menu button,
+.v4-projects-sort-menu a {
+  background: transparent;
+  border: 0;
+  padding: 7px 10px;
+  font-size: 13px;
+  color: var(--v4-ink-700);
+  text-align: left;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: var(--v4-sans);
+  font-weight: 500;
+}
+.v4-projects-sort-menu button:hover,
+.v4-projects-sort-menu a:hover {
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
+}
+.v4-projects-sort-menu .is-active {
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
+}
+.v4-projects-sort-sep {
+  height: 1px;
+  background: var(--v4-line-soft);
+  margin: 4px 0;
+}
+
+/* Group container */
+.v4-projects-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.v4-projects-group-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-700);
+  margin: 0 0 10px;
+  font-family: var(--v4-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.v4-projects-group-count {
+  color: var(--v4-ink-400);
+  font-weight: 500;
+}
+.v4-projects-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+
+/* Full-width project card variant (richer layout) */
+.v4-pcard--full {
+  padding: 0;
+  gap: 0;
+}
+.v4-pcard--full > .v4-pcard-row {
+  padding: 14px 16px 12px 17px;
+}
+.v4-pcard--full .v4-pcard-name-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.v4-pcard--full .v4-pcard-client {
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  font-weight: 500;
+}
+.v4-pcard-section {
+  padding: 11px 16px;
+  border-top: 1px dashed var(--v4-line);
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.v4-pcard--full .v4-pcard-stats {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+.v4-pcard--full .v4-pcard-finance-line {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-family: var(--v4-mono);
+  font-size: 12px;
+  color: var(--v4-ink-700);
+  gap: 8px;
+}
+.v4-pcard--full .v4-pcard-finance-line b { color: var(--v4-ink-900); font-weight: 700; }
+.v4-pcard--full .v4-pcard-finance-sep { color: var(--v4-ink-400); }
+.v4-pcard-finance-bar { height: 5px; }
+
+/* Risk chip (full label) */
+.v4-pcard-risk-chip {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--v4-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 99px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.v4-pcard-risk-chip--low {
+  background: var(--v4-success-50);
+  color: var(--v4-success-700);
+}
+.v4-pcard-risk-chip--medium {
+  background: var(--v4-warn-50);
+  color: var(--v4-warn-700);
+}
+.v4-pcard-risk-chip--high,
+.v4-pcard-risk-chip--critical {
+  background: var(--v4-danger-50);
+  color: var(--v4-danger-700);
+}
+
+/* Unlabeled-priority chip */
+.v4-pcard-pri--unlabeled {
+  color: var(--v4-ink-400);
+  font-style: italic;
+}
+
+/* Velocity trend arrow */
+.v4-trend {
+  font-size: 12px;
+  font-weight: 700;
+  margin-left: 2px;
+}
+.v4-trend--up { color: var(--v4-success-700); }
+.v4-trend--down { color: var(--v4-danger-700); }
+
+/* Risk factors row */
+.v4-pcard-risk-factors {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.v4-risk-factor {
+  display: inline-flex;
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 99px;
+  letter-spacing: 0.01em;
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-600);
+}
+.v4-risk-factor--medium {
+  background: var(--v4-warn-50);
+  color: var(--v4-warn-700);
+}
+.v4-risk-factor--high,
+.v4-risk-factor--critical {
+  background: var(--v4-danger-50);
+  color: var(--v4-danger-700);
+}
+
+/* Heatmap section */
+.v4-pcard-heat { gap: 8px; }
+.v4-pcard-heat-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font-family: var(--v4-sans);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v4-ink-700);
+  cursor: pointer;
+  text-align: left;
+}
+.v4-pcard-heat-toggle:hover { color: var(--v4-ink-900); }
+.v4-pcard-heat-arrow {
+  display: inline-block;
+  transition: transform 120ms;
+  font-size: 10px;
+  color: var(--v4-ink-400);
+}
+.v4-pcard-heat-arrow.is-open { transform: rotate(90deg); }
+.v4-pcard-heat-meta {
+  margin-left: auto;
+  font-family: var(--v4-mono);
+  font-weight: 500;
+  font-size: 11px;
+  color: var(--v4-ink-500);
+}
+.v4-pcard-heat-grid {
+  display: grid;
+  grid-template-columns: repeat(28, 1fr);
+  gap: 2px;
+}
+.v4-pcard-heat-grid .v4-cc { height: 14px; }
+
+/* Quick-actions kebab menu */
+.v4-pcard-menu { position: relative; }
+.v4-pcard-menu-btn {
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  border: 0;
+  background: transparent;
+  color: var(--v4-ink-500);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.v4-pcard-menu-btn:hover {
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
+}
+.v4-pcard-menu-btn svg { width: 14px; height: 14px; }
+.v4-pcard-menu-list {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  box-shadow: 0 8px 24px rgba(11, 16, 32, 0.08);
+  padding: 4px;
+  min-width: 200px;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+}
+.v4-pcard-menu-list a,
+.v4-pcard-menu-list button {
+  background: transparent;
+  border: 0;
+  padding: 7px 10px;
+  font-size: 12.5px;
+  color: var(--v4-ink-700);
+  text-align: left;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: var(--v4-sans);
+  font-weight: 500;
+  text-decoration: none;
+  display: block;
+}
+.v4-pcard-menu-list a:hover,
+.v4-pcard-menu-list button:hover {
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
+}
+
+/* ────────────────────────────────────────
    RESPONSIVE
    ──────────────────────────────────────── */
 @media (max-width: 1100px) {
@@ -1381,8 +1733,12 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   .v4-grid,
   .v4-grid--rev { grid-template-columns: 1fr; }
   .v4-proj-grid { grid-template-columns: 1fr; }
+  .v4-projects-grid { grid-template-columns: 1fr; }
   .v4-ms-grid { grid-template-columns: repeat(2, 1fr); }
   .v4-search { width: 200px; }
+  .v4-projects-toolbar { grid-template-columns: 1fr; }
+  .v4-projects-tools { justify-content: flex-end; flex-wrap: wrap; }
+  .v4-projects-search { width: 100%; }
 }
 .v4-burger { display: none; }
 @media (max-width: 700px) {

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -940,6 +940,8 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 }
 .v4-pcard-stat--danger { color: var(--v4-danger-700); }
 .v4-pcard-stat--danger svg { color: var(--v4-danger-700); }
+.v4-pcard-stat--warn { color: var(--v4-warn-700); }
+.v4-pcard-stat--warn svg { color: var(--v4-warn-700); }
 
 /* ────────────────────────────────────────
    AI INSIGHTS LIST


### PR DESCRIPTION
## Summary

Полный редизайн вкладки **Проекты** в V4 design-system. Сохранена вся функциональность legacy `ProjectCard`, добавлен набор новых фич по запросу.

## Что нового

### Rich-карточка (`ProjectCardV4`)
2-колоночная сетка на desktop, hairline-разделители между секциями. Слева — risk-стрип (3px) для med/high/critical.

| Секция | Содержимое |
|---|---|
| Header | repo + client + monitor-чип + phase-чип + risk-чип + **kebab quick-actions** |
| Issues | open count + P1/P2/P3/P4 dot-счётчик + "?N" безприоритетных + progress bar |
| Finance | paid/budget + remaining + payment bar (если budget>0) |
| Stats | velocity ⚡ **с trend ↗/↘** · cycleTime ⏱ · ETA 🎯 (overdue в красном) · stale-индикатор |
| Risk-factors | бейджи только если risk ≠ low |
| Heatmap | collapsible 28 дней inline с buckets |

### Toolbar
- **Filter pills:** Все · Pre-dev · Dev · Support · **Stale** (≥7д без активности с open)
- **Search:** по имени и клиенту, с очисткой
- **Sort menu:** Активность / Открытые / Risk score / Прогресс / Имя — с asc/desc + **Группировка по фазе**
- **Финансы** кнопка → FinanceEditor

### Aggregate-strip над сеткой
Live-сводка по выборке: количество проектов · открытых · P1 · stale · общий прогресс. Цвета (P1=красный, stale=жёлтый) когда >0.

### Quick-actions kebab-меню
Per-card меню: Открыть в GitHub ↗ / Открыть Pipeline → / Открыть Аудит → / Редактировать финансы…

### Persistence
sort/filter/groupByPhase сохраняются в `localStorage[makeit.projectsView.v1]`. Search — transient (не персистится).

## Технические детали

- A11y: `aria-haspopup`, `aria-expanded`, `role=menu/menuitem`, Escape + outside-click closure для меню
- Адаптив: 2-col → 1-col при <1100px, toolbar вертикальный
- Использует существующие V4-токены и `calcRiskScore` из `utils/riskScore`
- `ProjectCard.tsx` (legacy) удалён из импортов App.tsx, но оставлен в `src/components/` на случай переиспользования

## Verified locally

- ✅ `npx tsc --noEmit` — 0 errors
- ✅ `npm run lint` — 0 errors
- ✅ `npm run build` — clean
- ✅ Preview at 1440×900: рендеринг ОК, kebab-меню (4 пункта), Stale-фильтр (3/8), heatmap раскрытие (28 ячеек), группировка по фазе (В РАЗРАБОТКЕ/PRE-DEV/SUPPORT)

## Test plan

- [ ] Реальные данные — выборка 12 проектов рендерится корректно
- [ ] Sort по каждому из 5 ключей даёт ожидаемый порядок
- [ ] Sort asc/desc toggle переключается
- [ ] Группировка по фазе включается/выключается из sort-меню, sticky после reload
- [ ] Stale-фильтр показывает только проекты ≥7д без активности с open>0
- [ ] Search по «mank» / «Тенгри» — фильтрует корректно, очистка восстанавливает
- [ ] Aggregate-strip пересчитывается при смене фильтра
- [ ] Trend ↗/↘ корректно — для проекта где vel7 << vel14 (например solotax-kg) ↘
- [ ] Kebab-меню: GitHub открывается в новой вкладке; Pipeline/Audit/Финансы — переключают вкладку
- [ ] Heatmap раскрытие/сворачивание — 28 ячеек с правильными bucket-цветами
- [ ] Адаптив на 1100px (1 col) и 700px (без сайдбара)
- [ ] Состояние persists через `localStorage` (refresh страницы)
- [ ] Не сломались дашборд / другие табы

## Дизайн-решения

Я экстраполировал V4 design system самостоятельно (без отдельного Claude Design мокапа) — карточки получили rich-вариант с явно выделенными секциями. Если нужно подровнять под конкретный мокап — скажи и переделаю по handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)