### PR TITLE
feat(milestones): redesign V4 — grouping, search, aggregate strip

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { TokenForm } from "./components/TokenForm";
-import { MilestoneCard } from "./components/MilestoneCard";
 import { ChatPanel } from "./components/ChatPanel";
 import { ChatButton } from "./components/ChatButton";
 import { FinanceEditor } from "./components/FinanceEditor";
@@ -17,6 +16,7 @@ import { Sidebar } from "./components/v4/Sidebar";
 import { Topbar } from "./components/v4/Topbar";
 import { DashboardView } from "./components/v4/DashboardView";
 import { ProjectsView } from "./components/v4/ProjectsView";
+import { MilestonesView } from "./components/v4/milestones/MilestonesView";
 import { useDashboard } from "./hooks/useDashboard";
 import { useMonitors } from "./hooks/useMonitors";
 import { getToken, clearToken, getAuth, clearAuth, clearClaudeKey, MONITOR_MATCH, PROJECTS } from "./utils/config";
@@ -76,19 +76,23 @@ function AppInner() {
     }
   }, [tab]);
 
-  const [msTab, setMsTab] = useState<"open" | "done">("open");
   const [chatOpen, setChatOpen] = useState(false);
   const [financeOpen, setFinanceOpen] = useState(false);
   const [sideOpen, setSideOpen] = useState(false);
 
-  // Track visited tabs so stateful components mount lazily but stay alive
+  // Track visited tabs so stateful components mount lazily but stay alive.
+  // Uses the React-recommended "setState during render" pattern for derived
+  // state — see https://react.dev/reference/react/useState#storing-information-from-previous-renders
+  // (avoids the cascading re-render of doing this in a useEffect).
   const [visitedTabs, setVisitedTabs] = useState<Set<TabId>>(() => new Set(["dashboard", tab]));
-  useEffect(() => {
+  if (!visitedTabs.has(tab)) {
     setVisitedTabs((prev) => {
       if (prev.has(tab)) return prev;
-      return new Set(prev).add(tab);
+      const next = new Set(prev);
+      next.add(tab);
+      return next;
     });
-  }, [tab]);
+  }
 
   useEffect(() => {
     document.body.classList.add("v4");
@@ -120,11 +124,6 @@ function AppInner() {
   const hasToken = !!getToken();
 
   const allMilestones = projects.flatMap((p) => p.milestones);
-  // Milestone считается завершённым если GitHub закрыл его (CLOSED) ИЛИ все issues закрыты
-  const isMilestoneDone = (m: { state: string; openIssues: number; closedIssues: number }) =>
-    m.state === "CLOSED" || (m.openIssues === 0 && m.closedIssues > 0);
-  const openMilestones = allMilestones.filter((m) => !isMilestoneDone(m));
-  const doneMilestones = allMilestones.filter((m) => isMilestoneDone(m));
 
   // Token-form gate: classic experience until token is set
   if (!hasToken) {
@@ -221,62 +220,11 @@ function AppInner() {
           </ErrorBoundary>
         )}
 
-        {projects.length > 0 && tab === "milestones" && (() => {
-          const list = msTab === "open" ? openMilestones : doneMilestones;
-          const sorted = msTab === "open"
-            ? [...list].sort((a, b) => {
-                if (a.dueOn && b.dueOn) return new Date(a.dueOn).getTime() - new Date(b.dueOn).getTime();
-                return a.dueOn ? -1 : b.dueOn ? 1 : 0;
-              })
-            : list;
-          const grouped = Object.entries(
-            sorted.reduce<Record<string, typeof list>>((acc, m) => {
-              (acc[m.repo] ??= []).push(m);
-              return acc;
-            }, {})
-          );
-          return (
-            <div className="v4-legacy-frame">
-              <div className="bento-grid">
-                <div className="bento-panel span-12">
-                  <div className="milestones-sub-tabs">
-                    <button
-                      className={`milestones-sub-tab ${msTab === "open" ? "milestones-sub-tab-active" : ""}`}
-                      onClick={() => setMsTab("open")}
-                    >
-                      Открытые <span className="milestones-sub-tab-count">{openMilestones.length}</span>
-                    </button>
-                    <button
-                      className={`milestones-sub-tab ${msTab === "done" ? "milestones-sub-tab-active" : ""}`}
-                      onClick={() => setMsTab("done")}
-                    >
-                      Завершённые <span className="milestones-sub-tab-count">{doneMilestones.length}</span>
-                    </button>
-                  </div>
-                  {list.length === 0 && (
-                    <div className="empty-state">
-                      {msTab === "open" ? "Нет открытых milestones" : "Пока нет завершённых milestones"}
-                    </div>
-                  )}
-                  <div className="milestones-grouped" style={{ padding: 0 }}>
-                    {grouped.map(([repo, milestones]) => (
-                      <div key={repo} className="milestone-group">
-                        <h3 className="milestone-group-title">
-                          {repo} <span className="milestone-group-count">({milestones.length})</span>
-                        </h3>
-                        <div className="milestones-grid">
-                          {milestones.map((m) => (
-                            <MilestoneCard key={m.url} milestone={m} />
-                          ))}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })()}
+        {projects.length > 0 && tab === "milestones" && (
+          <ErrorBoundary fallback="Ошибка вкладки Milestones">
+            <MilestonesView milestones={allMilestones} lastUpdated={lastUpdated} />
+          </ErrorBoundary>
+        )}
 
         {projects.length > 0 && tab === "uptime" && (
           <div className="v4-legacy-frame">

--- a/src/components/v4/milestones/MilestoneCardV4.tsx
+++ b/src/components/v4/milestones/MilestoneCardV4.tsx
@@ -1,0 +1,198 @@
+import { useState } from "react";
+import type { Milestone } from "../../../types";
+import { daysUntil, formatShortDate } from "../../../utils/date";
+import { classifyMilestone } from "./classifyMilestone";
+
+interface Props {
+  milestone: Milestone;
+}
+
+const PRIORITY_TAG: Record<string, string> = {
+  P1: "v4-ptag--p1",
+  P2: "v4-ptag--p2",
+  P3: "v4-ptag--p3",
+  P4: "v4-ptag--p4",
+};
+
+function inferPriority(m: Milestone): string | null {
+  const labels = (m.issues ?? []).flatMap((i) => i.labels);
+  for (const p of ["P1", "P2", "P3", "P4"]) {
+    if (labels.some((l) => l.startsWith(p))) return p;
+  }
+  return null;
+}
+
+function DeadlineBadge({ dueOn, days }: { dueOn: string | null; days: number | null }) {
+  if (!dueOn) return <span className="v4-ms-badge v4-ms-badge--neutral">без дедлайна</span>;
+  if (days === null) return null;
+  if (days < 0) return <span className="v4-ms-badge v4-ms-badge--overdue">просрочен {Math.abs(days)}д</span>;
+  if (days === 0) return <span className="v4-ms-badge v4-ms-badge--warn">сегодня</span>;
+  if (days <= 3) return <span className="v4-ms-badge v4-ms-badge--warn">{days}д осталось</span>;
+  if (days <= 14) return <span className="v4-ms-badge v4-ms-badge--info">{days}д · {formatShortDate(dueOn)}</span>;
+  return <span className="v4-ms-badge v4-ms-badge--neutral">{formatShortDate(dueOn)}</span>;
+}
+
+const DESC_LIMIT = 160;
+
+export function MilestoneCardV4({ milestone }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [descOpen, setDescOpen] = useState(false);
+
+  const total = milestone.openIssues + milestone.closedIssues;
+  const progress = total > 0 ? Math.round((milestone.closedIssues / total) * 100) : 0;
+  const days = milestone.dueOn ? daysUntil(milestone.dueOn) : null;
+  const cls = classifyMilestone(milestone, days);
+  const isDone = cls === "done";
+
+  const fillColor =
+    isDone
+      ? "var(--v4-success-500)"
+      : progress >= 70
+      ? "var(--v4-success-500)"
+      : progress >= 30
+      ? "var(--v4-accent-500)"
+      : "var(--v4-warn-500)";
+
+  const priority = inferPriority(milestone);
+  const sortedIssues = [...(milestone.issues ?? [])].sort((a, b) => {
+    if (a.state === b.state) return 0;
+    return a.state === "OPEN" ? -1 : 1;
+  });
+
+  const desc = milestone.description ?? "";
+  const descTruncated = desc.length > DESC_LIMIT && !descOpen ? desc.slice(0, DESC_LIMIT).trimEnd() + "…" : desc;
+
+  return (
+    <div className={`v4-mscard-full v4-mscard-full--${cls}`}>
+      {/* Header */}
+      <div
+        className="v4-mscard-full-h"
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        aria-label={`Milestone ${milestone.title}, ${milestone.closedIssues} из ${total} задач закрыто. ${expanded ? "Свернуть" : "Раскрыть"} список.`}
+        onClick={() => setExpanded(!expanded)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setExpanded(!expanded);
+          }
+        }}
+      >
+        <div className="v4-mscard-full-titlerow">
+          <div className="v4-mscard-full-meta">
+            <span className="v4-mscard-full-repo">{milestone.repo}</span>
+            <span className={`v4-mscard-full-arrow ${expanded ? "is-open" : ""}`}>▸</span>
+          </div>
+          <div className="v4-mscard-full-badges">
+            {priority && !isDone && (
+              <span className={`v4-ptag ${PRIORITY_TAG[priority] ?? "v4-ptag--p4"}`}>
+                {priority}
+              </span>
+            )}
+            {isDone ? (
+              <span className="v4-ms-badge v4-ms-badge--done">done ✓</span>
+            ) : (
+              <DeadlineBadge dueOn={milestone.dueOn} days={days} />
+            )}
+          </div>
+        </div>
+        <div className="v4-mscard-full-title">
+          <a
+            href={milestone.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="v4-mscard-full-titlelink"
+          >
+            {isDone && <span className="v4-mscard-full-check">✓ </span>}
+            {milestone.title}
+          </a>
+        </div>
+        {desc && (
+          <div className="v4-mscard-full-desc">
+            {descTruncated}
+            {desc.length > DESC_LIMIT && (
+              <button
+                type="button"
+                className="v4-linkbtn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setDescOpen((v) => !v);
+                }}
+              >
+                {descOpen ? "свернуть" : "ещё"}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Progress */}
+      <div className="v4-mscard-full-progress">
+        <div className="v4-ptrack v4-mscard-full-track">
+          <div
+            className="v4-pfill"
+            style={{ width: `${progress}%`, background: fillColor }}
+          />
+        </div>
+        <span className="v4-mscard-full-pct num">
+          {milestone.closedIssues}/{total} ({progress}%)
+        </span>
+      </div>
+
+      {/* Expanded issue list */}
+      {expanded && sortedIssues.length > 0 && (
+        <div className="v4-mscard-full-issues">
+          {sortedIssues.map((issue) => {
+            const isClosed = issue.state === "CLOSED";
+            return (
+              <div
+                key={issue.number}
+                className={`v4-ms-issue ${isClosed ? "v4-ms-issue--closed" : ""}`}
+              >
+                <span
+                  className={`v4-ms-issue-status ${isClosed ? "v4-ms-issue-status--closed" : "v4-ms-issue-status--open"}`}
+                  aria-hidden="true"
+                >
+                  {isClosed ? "✓" : "○"}
+                </span>
+                <a
+                  href={issue.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="v4-ms-issue-title"
+                >
+                  #{issue.number} {issue.title}
+                </a>
+                <span className="v4-ms-issue-labels">
+                  {issue.labels
+                    .filter((l) => /^P[1-4]/.test(l))
+                    .map((l) => {
+                      const p = l.split("-")[0];
+                      return (
+                        <span
+                          key={l}
+                          className={`v4-ptag ${PRIORITY_TAG[p] ?? "v4-ptag--p4"}`}
+                        >
+                          {p}
+                        </span>
+                      );
+                    })}
+                  {issue.labels.includes("blocked") && (
+                    <span className="v4-ms-issue-blocked">blocked</span>
+                  )}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {expanded && sortedIssues.length === 0 && (
+        <div className="v4-mscard-full-issues v4-mscard-full-issues--empty">
+          Нет привязанных issues
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/milestones/MilestonesView.tsx
+++ b/src/components/v4/milestones/MilestonesView.tsx
@@ -31,16 +31,24 @@ const SORT_LABELS: Record<SortKey, string> = {
   repo: "Репо",
 };
 
+const VALID_SUBS: readonly SubTab[] = ["open", "done"];
+const VALID_GROUPINGS: readonly Grouping[] = ["repo", "deadline"];
+const VALID_SORTS: readonly SortKey[] = ["deadline", "progress", "name", "repo"];
+
 function loadState(): ToolbarState {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
       const p = JSON.parse(raw) as Partial<ToolbarState>;
+      // Validate against allow-lists — protects against stale localStorage
+      // values from older/future schema versions.
       return {
-        sub: p.sub ?? "open",
-        grouping: p.grouping ?? "deadline",
-        sort: p.sort ?? "deadline",
-        asc: p.asc ?? true,
+        sub: VALID_SUBS.includes(p.sub as SubTab) ? (p.sub as SubTab) : "open",
+        grouping: VALID_GROUPINGS.includes(p.grouping as Grouping)
+          ? (p.grouping as Grouping)
+          : "deadline",
+        sort: VALID_SORTS.includes(p.sort as SortKey) ? (p.sort as SortKey) : "deadline",
+        asc: typeof p.asc === "boolean" ? p.asc : true,
         query: "",
       };
     }
@@ -181,6 +189,11 @@ export function MilestonesView({ milestones, lastUpdated }: Props) {
 
   // Group output
   const groups: { key: string; title: string; items: EnrichedMilestone[] }[] = useMemo(() => {
+    // Done sub-tab: deadline-bucketing makes no sense (a closed milestone
+    // can't be "Просрочено"). Always render as a single "Завершённые" group.
+    if (state.sub === "done") {
+      return [{ key: "done", title: "Завершённые", items: sorted }];
+    }
     if (state.grouping === "repo") {
       const map = new Map<string, EnrichedMilestone[]>();
       for (const e of sorted) {
@@ -206,7 +219,7 @@ export function MilestonesView({ milestones, lastUpdated }: Props) {
     return Array.from(map.entries())
       .sort(([, a], [, b]) => a.order - b.order)
       .map(([key, v]) => ({ key, title: v.label, items: v.items }));
-  }, [sorted, state.grouping]);
+  }, [sorted, state.grouping, state.sub]);
 
   return (
     <div className="v4-content">
@@ -374,8 +387,9 @@ export function MilestonesView({ milestones, lastUpdated }: Props) {
         </div>
       </div>
 
-      {/* Empty state */}
-      {agg.count === 0 && (
+      {/* Empty state — keyed off post-search count so search-with-no-results
+          shows the proper feedback message instead of a blank card area. */}
+      {filtered.length === 0 && (
         <div className="v4-panel">
           <div className="v4-empty">
             {state.query
@@ -388,7 +402,7 @@ export function MilestonesView({ milestones, lastUpdated }: Props) {
       )}
 
       {/* Cards */}
-      {agg.count > 0 && (
+      {filtered.length > 0 && (
         <div className="v4-ms-groups">
           {groups.map((g) => (
             <section key={g.key} className="v4-ms-group">

--- a/src/components/v4/milestones/MilestonesView.tsx
+++ b/src/components/v4/milestones/MilestonesView.tsx
@@ -1,0 +1,410 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Milestone } from "../../../types";
+import { daysUntil } from "../../../utils/date";
+import { MilestoneCardV4 } from "./MilestoneCardV4";
+import { classifyMilestone } from "./classifyMilestone";
+
+interface Props {
+  milestones: Milestone[];
+  /** Anchor for daysUntil — recomputed on data refresh */
+  lastUpdated: Date | null;
+}
+
+type SubTab = "open" | "done";
+type Grouping = "repo" | "deadline";
+type SortKey = "deadline" | "progress" | "name" | "repo";
+
+interface ToolbarState {
+  sub: SubTab;
+  grouping: Grouping;
+  sort: SortKey;
+  asc: boolean;
+  query: string;
+}
+
+const STORAGE_KEY = "makeit.milestonesView.v1";
+
+const SORT_LABELS: Record<SortKey, string> = {
+  deadline: "Дедлайн",
+  progress: "Прогресс",
+  name: "Имя",
+  repo: "Репо",
+};
+
+function loadState(): ToolbarState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const p = JSON.parse(raw) as Partial<ToolbarState>;
+      return {
+        sub: p.sub ?? "open",
+        grouping: p.grouping ?? "deadline",
+        sort: p.sort ?? "deadline",
+        asc: p.asc ?? true,
+        query: "",
+      };
+    }
+  } catch {
+    /* ignore */
+  }
+  return { sub: "open", grouping: "deadline", sort: "deadline", asc: true, query: "" };
+}
+
+function saveState(s: ToolbarState) {
+  try {
+    const { query: _q, ...persist } = s;
+    void _q;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(persist));
+  } catch {
+    /* ignore */
+  }
+}
+
+interface EnrichedMilestone {
+  m: Milestone;
+  days: number | null;
+  cls: ReturnType<typeof classifyMilestone>;
+  progressPct: number;
+}
+
+function deadlineBucket(days: number | null): {
+  key: string;
+  label: string;
+  order: number;
+} {
+  if (days === null) return { key: "noeta", label: "Без дедлайна", order: 99 };
+  if (days < 0) return { key: "overdue", label: "Просрочено", order: 0 };
+  if (days <= 7) return { key: "week", label: "Эта неделя", order: 1 };
+  if (days <= 30) return { key: "month", label: "Этот месяц", order: 2 };
+  return { key: "later", label: "Дальше", order: 3 };
+}
+
+export function MilestonesView({ milestones, lastUpdated }: Props) {
+  const [state, setState] = useState<ToolbarState>(() => loadState());
+  const [sortMenuOpen, setSortMenuOpen] = useState(false);
+  const sortMenuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    saveState(state);
+  }, [state]);
+
+  // Close sort menu on outside / Escape
+  useEffect(() => {
+    if (!sortMenuOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!sortMenuRef.current?.contains(e.target as Node)) setSortMenuOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setSortMenuOpen(false);
+    };
+    window.addEventListener("mousedown", onDoc);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDoc);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [sortMenuOpen]);
+
+  // Enrich: precompute days/cls/progress once per refresh
+  const enriched: EnrichedMilestone[] = useMemo(() => {
+    return milestones.map((m) => {
+      const days = m.dueOn ? daysUntil(m.dueOn) : null;
+      const total = m.openIssues + m.closedIssues;
+      const progressPct = total > 0 ? Math.round((m.closedIssues / total) * 100) : 0;
+      return { m, days, cls: classifyMilestone(m, days), progressPct };
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [milestones, lastUpdated?.getTime()]);
+
+  const open = useMemo(() => enriched.filter((e) => e.cls !== "done"), [enriched]);
+  const done = useMemo(() => enriched.filter((e) => e.cls === "done"), [enriched]);
+
+  const baseList = state.sub === "open" ? open : done;
+
+  // Filter by query
+  const filtered = useMemo(() => {
+    const q = state.query.trim().toLowerCase();
+    if (!q) return baseList;
+    return baseList.filter(
+      (e) =>
+        e.m.title.toLowerCase().includes(q) ||
+        e.m.repo.toLowerCase().includes(q) ||
+        (e.m.description?.toLowerCase().includes(q) ?? false)
+    );
+  }, [baseList, state.query]);
+
+  // Sort
+  const sorted = useMemo(() => {
+    const out = [...filtered];
+    out.sort((a, b) => {
+      let cmp = 0;
+      switch (state.sort) {
+        case "deadline":
+          // null deadlines last; otherwise compare days
+          if (a.days === null && b.days === null) cmp = 0;
+          else if (a.days === null) cmp = 1;
+          else if (b.days === null) cmp = -1;
+          else cmp = a.days - b.days;
+          break;
+        case "progress":
+          cmp = a.progressPct - b.progressPct;
+          break;
+        case "name":
+          cmp = a.m.title.localeCompare(b.m.title, "ru");
+          break;
+        case "repo":
+          cmp = a.m.repo.localeCompare(b.m.repo, "ru") || a.m.title.localeCompare(b.m.title, "ru");
+          break;
+      }
+      return state.asc ? cmp : -cmp;
+    });
+    return out;
+  }, [filtered, state.sort, state.asc]);
+
+  // Aggregate stats
+  const agg = useMemo(() => {
+    const totalIssues = baseList.reduce((s, e) => s + e.m.openIssues + e.m.closedIssues, 0);
+    const closedIssues = baseList.reduce((s, e) => s + e.m.closedIssues, 0);
+    const overdue = baseList.filter((e) => e.cls === "overdue").length;
+    const thisWeek = baseList.filter((e) => e.cls === "warn" || (e.days !== null && e.days >= 0 && e.days <= 7)).length;
+    const noEta = baseList.filter((e) => e.cls === "noeta").length;
+    return {
+      count: baseList.length,
+      totalIssues,
+      closedIssues,
+      progress: totalIssues > 0 ? Math.round((closedIssues / totalIssues) * 100) : 0,
+      overdue,
+      thisWeek,
+      noEta,
+    };
+  }, [baseList]);
+
+  // Group output
+  const groups: { key: string; title: string; items: EnrichedMilestone[] }[] = useMemo(() => {
+    if (state.grouping === "repo") {
+      const map = new Map<string, EnrichedMilestone[]>();
+      for (const e of sorted) {
+        const arr = map.get(e.m.repo) ?? [];
+        arr.push(e);
+        map.set(e.m.repo, arr);
+      }
+      return Array.from(map.entries())
+        .sort((a, b) => a[0].localeCompare(b[0], "ru"))
+        .map(([repo, items]) => ({ key: repo, title: repo, items }));
+    }
+    // by deadline
+    const map = new Map<string, { label: string; order: number; items: EnrichedMilestone[] }>();
+    for (const e of sorted) {
+      const b = deadlineBucket(e.days);
+      const cell = map.get(b.key);
+      if (cell) {
+        cell.items.push(e);
+      } else {
+        map.set(b.key, { label: b.label, order: b.order, items: [e] });
+      }
+    }
+    return Array.from(map.entries())
+      .sort(([, a], [, b]) => a.order - b.order)
+      .map(([key, v]) => ({ key, title: v.label, items: v.items }));
+  }, [sorted, state.grouping]);
+
+  return (
+    <div className="v4-content">
+      {/* Page head */}
+      <div className="v4-ph">
+        <div>
+          <h1>Milestones</h1>
+          <div className="v4-sub">
+            {open.length + done.length} в портфеле · {agg.count} в выборке
+          </div>
+        </div>
+        <div className="v4-ph-right">
+          <div className="v4-pillgrp">
+            <button
+              type="button"
+              className={state.sub === "open" ? "is-active" : ""}
+              onClick={() => setState((s) => ({ ...s, sub: "open" }))}
+            >
+              Открытые · {open.length}
+            </button>
+            <button
+              type="button"
+              className={state.sub === "done" ? "is-active" : ""}
+              onClick={() => setState((s) => ({ ...s, sub: "done" }))}
+            >
+              Завершённые · {done.length}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ height: 10 }} />
+
+      {/* Toolbar: aggregate + tools */}
+      <div className="v4-projects-toolbar">
+        <div className="v4-projects-agg">
+          <div className="v4-projects-agg-cell">
+            <div className="v4-projects-agg-n num">{agg.count}</div>
+            <div className="v4-projects-agg-l">milestones</div>
+          </div>
+          <div className="v4-projects-agg-cell" title="Всего issues across milestones">
+            <div className="v4-projects-agg-n num">
+              {agg.closedIssues}/{agg.totalIssues}
+            </div>
+            <div className="v4-projects-agg-l">issues done</div>
+          </div>
+          <div className="v4-projects-agg-cell">
+            <div className="v4-projects-agg-n num">{agg.progress}%</div>
+            <div className="v4-projects-agg-l">прогресс</div>
+          </div>
+          {state.sub === "open" && (
+            <>
+              <div className="v4-projects-agg-cell">
+                <div
+                  className="v4-projects-agg-n num"
+                  style={{ color: agg.overdue > 0 ? "var(--v4-danger-700)" : undefined }}
+                >
+                  {agg.overdue}
+                </div>
+                <div className="v4-projects-agg-l">просрочено</div>
+              </div>
+              <div className="v4-projects-agg-cell">
+                <div
+                  className="v4-projects-agg-n num"
+                  style={{ color: agg.thisWeek > 0 ? "var(--v4-warn-700)" : undefined }}
+                >
+                  {agg.thisWeek}
+                </div>
+                <div className="v4-projects-agg-l">≤ 7д</div>
+              </div>
+              {agg.noEta > 0 && (
+                <div className="v4-projects-agg-cell">
+                  <div className="v4-projects-agg-n num">{agg.noEta}</div>
+                  <div className="v4-projects-agg-l">без даты</div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="v4-projects-tools">
+          <div className="v4-pillgrp">
+            <button
+              type="button"
+              className={state.grouping === "deadline" ? "is-active" : ""}
+              onClick={() => setState((s) => ({ ...s, grouping: "deadline" }))}
+            >
+              По дедлайну
+            </button>
+            <button
+              type="button"
+              className={state.grouping === "repo" ? "is-active" : ""}
+              onClick={() => setState((s) => ({ ...s, grouping: "repo" }))}
+            >
+              По репо
+            </button>
+          </div>
+
+          <div className="v4-search v4-projects-search">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="11" cy="11" r="8" />
+              <path d="M21 21l-4.35-4.35" />
+            </svg>
+            <input
+              value={state.query}
+              onChange={(e) => setState((s) => ({ ...s, query: e.target.value }))}
+              placeholder="Поиск по имени, репо, описанию…"
+              aria-label="Поиск milestones"
+            />
+            {state.query && (
+              <button
+                type="button"
+                className="v4-projects-search-clear"
+                onClick={() => setState((s) => ({ ...s, query: "" }))}
+                aria-label="Очистить поиск"
+              >
+                ×
+              </button>
+            )}
+          </div>
+
+          <div className="v4-projects-sort" ref={sortMenuRef}>
+            <button
+              type="button"
+              className="v4-btn"
+              onClick={() => setSortMenuOpen((v) => !v)}
+              aria-haspopup="menu"
+              aria-expanded={sortMenuOpen}
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M3 6h18M6 12h12M10 18h4" />
+              </svg>
+              {SORT_LABELS[state.sort]} {state.asc ? "↑" : "↓"}
+            </button>
+            {sortMenuOpen && (
+              <div className="v4-projects-sort-menu" role="menu">
+                {(Object.keys(SORT_LABELS) as SortKey[]).map((k) => (
+                  <button
+                    key={k}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={state.sort === k}
+                    className={state.sort === k ? "is-active" : ""}
+                    onClick={() => {
+                      setState((s) => ({ ...s, sort: k }));
+                      setSortMenuOpen(false);
+                    }}
+                  >
+                    {SORT_LABELS[k]}
+                  </button>
+                ))}
+                <div className="v4-projects-sort-sep" />
+                <button
+                  type="button"
+                  role="menuitemcheckbox"
+                  aria-checked={state.asc}
+                  className={state.asc ? "is-active" : ""}
+                  onClick={() => setState((s) => ({ ...s, asc: !s.asc }))}
+                >
+                  {state.asc ? "↑ По возрастанию" : "↓ По убыванию"}
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Empty state */}
+      {agg.count === 0 && (
+        <div className="v4-panel">
+          <div className="v4-empty">
+            {state.query
+              ? `По запросу «${state.query}» ничего не найдено`
+              : state.sub === "open"
+              ? "Нет открытых milestones"
+              : "Пока нет завершённых milestones"}
+          </div>
+        </div>
+      )}
+
+      {/* Cards */}
+      {agg.count > 0 && (
+        <div className="v4-ms-groups">
+          {groups.map((g) => (
+            <section key={g.key} className="v4-ms-group">
+              <h2 className={`v4-ms-group-title v4-ms-group-title--${g.key}`}>
+                {g.title}{" "}
+                <span className="v4-ms-group-count">({g.items.length})</span>
+              </h2>
+              <div className="v4-ms-grid-full">
+                {g.items.map((e) => (
+                  <MilestoneCardV4 key={e.m.url} milestone={e.m} />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/milestones/classifyMilestone.ts
+++ b/src/components/v4/milestones/classifyMilestone.ts
@@ -1,0 +1,18 @@
+import type { Milestone } from "../../../types";
+
+export type MilestoneStatusKind = "done" | "overdue" | "warn" | "soon" | "norm" | "noeta";
+
+/**
+ * Classify a milestone into a visual bucket. Pure — `days` should be
+ * pre-computed from `daysUntil(m.dueOn)` so the caller controls the time
+ * anchor.
+ */
+export function classifyMilestone(m: Milestone, days: number | null): MilestoneStatusKind {
+  const total = m.openIssues + m.closedIssues;
+  if (m.state === "CLOSED" || (total > 0 && m.openIssues === 0)) return "done";
+  if (days === null) return "noeta";
+  if (days < 0) return "overdue";
+  if (days <= 3) return "warn";
+  if (days <= 14) return "soon";
+  return "norm";
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -2436,6 +2436,242 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 }
 
 /* ────────────────────────────────────────
+   MILESTONES VIEW
+   ──────────────────────────────────────── */
+
+.v4-ms-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+.v4-ms-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.v4-ms-group-title {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--v4-ink-700);
+  margin: 0;
+  padding: 4px 6px 6px;
+  border-bottom: 1px dashed var(--v4-line);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.v4-ms-group-count {
+  color: var(--v4-ink-400);
+  font-weight: 500;
+}
+.v4-ms-group-title--overdue { color: var(--v4-danger-700); border-bottom-color: var(--v4-danger-100); }
+.v4-ms-group-title--week { color: var(--v4-warn-700); border-bottom-color: var(--v4-warn-100); }
+.v4-ms-group-title--month { color: var(--v4-accent-700); }
+.v4-ms-group-title--noeta { color: var(--v4-ink-500); }
+.v4-ms-grid-full {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+/* Full-size milestone card */
+.v4-mscard-full {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  padding: 0;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.v4-mscard-full::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: transparent;
+}
+.v4-mscard-full--overdue::before { background: var(--v4-danger-500); }
+.v4-mscard-full--warn::before { background: var(--v4-warn-500); }
+.v4-mscard-full--soon::before { background: var(--v4-accent-500); }
+.v4-mscard-full--done::before { background: var(--v4-success-500); }
+
+.v4-mscard-full-h {
+  padding: 12px 14px 10px 17px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v4-mscard-full-h:hover { background: var(--v4-surface-2); }
+.v4-mscard-full-titlerow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+.v4-mscard-full-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.v4-mscard-full-repo {
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--v4-ink-500);
+}
+.v4-mscard-full-arrow {
+  font-size: 10px;
+  color: var(--v4-ink-400);
+  display: inline-block;
+  transition: transform 120ms;
+  flex-shrink: 0;
+}
+.v4-mscard-full-arrow.is-open { transform: rotate(90deg); }
+.v4-mscard-full-badges {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.v4-mscard-full-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  min-width: 0;
+}
+.v4-mscard-full-titlelink {
+  color: inherit;
+  text-decoration: none;
+}
+.v4-mscard-full-titlelink:hover {
+  color: var(--v4-accent-700);
+}
+.v4-mscard-full-check {
+  color: var(--v4-success-700);
+  font-weight: 700;
+  margin-right: 2px;
+}
+.v4-mscard-full-desc {
+  font-size: 12px;
+  color: var(--v4-ink-600);
+  line-height: 1.45;
+  margin-top: 2px;
+}
+.v4-mscard-full-desc .v4-linkbtn {
+  margin-left: 4px;
+  font-size: 11px;
+}
+
+.v4-mscard-full-progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px 12px 17px;
+  border-top: 1px dashed var(--v4-line);
+}
+.v4-mscard-full-track { flex: 1; }
+.v4-mscard-full-pct {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--v4-ink-700);
+  min-width: 88px;
+  text-align: right;
+}
+
+/* Milestone deadline badge variants */
+.v4-ms-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: 99px;
+  letter-spacing: 0.04em;
+  font-family: var(--v4-mono);
+  white-space: nowrap;
+}
+.v4-ms-badge--overdue { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-ms-badge--warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-ms-badge--info { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.v4-ms-badge--neutral { background: var(--v4-surface-2); color: var(--v4-ink-600); }
+.v4-ms-badge--done { background: var(--v4-success-50); color: var(--v4-success-700); }
+
+/* Issue list inside expanded card */
+.v4-mscard-full-issues {
+  border-top: 1px solid var(--v4-line-soft);
+  background: var(--v4-surface-2);
+  padding: 6px 0;
+  display: flex;
+  flex-direction: column;
+}
+.v4-mscard-full-issues--empty {
+  padding: 14px;
+  text-align: center;
+  color: var(--v4-ink-400);
+  font-size: 12px;
+}
+.v4-ms-issue {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px 6px 17px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--v4-line-soft);
+}
+.v4-ms-issue:last-child { border-bottom: 0; }
+.v4-ms-issue--closed { opacity: 0.62; }
+.v4-ms-issue-status {
+  font-family: var(--v4-mono);
+  font-size: 12px;
+  font-weight: 700;
+  flex-shrink: 0;
+  width: 14px;
+  text-align: center;
+}
+.v4-ms-issue-status--closed { color: var(--v4-success-700); }
+.v4-ms-issue-status--open { color: var(--v4-ink-400); }
+.v4-ms-issue-title {
+  flex: 1;
+  color: var(--v4-ink-800);
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.v4-ms-issue-title:hover { color: var(--v4-accent-700); }
+.v4-ms-issue-labels {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+  flex-shrink: 0;
+}
+.v4-ms-issue-blocked {
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 99px;
+  background: var(--v4-danger-50);
+  color: var(--v4-danger-700);
+}
+
+/* ────────────────────────────────────────
    RESPONSIVE
    ──────────────────────────────────────── */
 @media (max-width: 1100px) {
@@ -2473,6 +2709,7 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   .v4-pl-results-tools { width: 100%; justify-content: stretch; }
   .v4-pl-results-search { width: 100%; }
   .v4-pl-cx-grid { grid-template-columns: repeat(3, 1fr); }
+  .v4-ms-grid-full { grid-template-columns: 1fr; }
 }
 .v4-burger { display: none; }
 @media (max-width: 700px) {


### PR DESCRIPTION
## Summary

Полный редизайн вкладки **Milestones** в V4 design-system. Сохранена вся функциональность legacy `MilestoneCard`, добавлены группировка по дедлайну, aggregate-strip, sort/search.

## Структура

`src/components/v4/milestones/`:
- **MilestonesView** — page с toolbar / agg / grouping
- **MilestoneCardV4** — rich карточка с inline-deadline-badge и expand
- **classifyMilestone** — pure helper (вынесен в отдельный файл для compliance с `react-refresh/only-export-components`)

## Перенесено из legacy

- Sub-tabs Открытые / Завершённые
- Click-to-expand issue list (✓/○, P-priority, blocked-чип)
- Description с truncation + «ещё» toggle (160 chars)
- Progress bar с цветом по % done
- Done-checkmark в title

## Новые фичи

| Фича | Описание |
|---|---|
| **Group toggle** | По дедлайну (default) или По репо. |
| **Deadline bucketing** | Просрочено / Эта неделя / Этот месяц / Дальше / Без дедлайна — каждый bucket с цветным заголовком (red/warn/blue/grey). |
| **Aggregate strip** | milestones · issues done · прогресс · просрочено · ≤7д · без даты (counts окрашиваются в danger/warn когда >0). |
| **Sort menu** | Дедлайн / Прогресс / Имя / Репо + asc/desc. |
| **Search** | По title, repo, description. |
| **Risk-стрип слева** | red=overdue, warn=≤3д, blue=soon, green=done. |
| **Persistence** | sub/grouping/sort/asc в localStorage. |

## Также исправлено

- **App.tsx setState-in-effect** для `visitedTabs` — pre-existing pattern, новое правило `react-hooks/set-state-in-effect` начало срабатывать после обновления плагина. Заменил на React-рекомендованный set-state-during-render.
- Удалены unused legacy imports / state.

## A11y / технические

- Card-header `role=button` + `tabIndex` + `aria-expanded` + Enter/Space
- Sort menu `role=menu/menuitemradio/menuitemcheckbox` + `aria-checked`, Escape + outside-click
- `daysUntil` вычисляется один раз через `useMemo([milestones, lastUpdated])`
- Адаптив: 1100px → 1 col

## Verified locally

- ✅ `npx tsc --noEmit` — 0 errors
- ✅ `npm run lint` — 0 errors
- ✅ `npm run build` — clean
- ✅ Preview at 1440×900 с 10 mock milestones — все 5 deadline-bucket'ов рендерятся, expand работает (8 issues + 1 blocked badge), переключение grouping (Я→Repo даёт 8 групп по 1)

## Test plan

- [ ] Реальные milestones — группировка по дедлайну корректна
- [ ] Sub-tabs Открытые/Завершённые переключаются
- [ ] Sort по каждому из 4 ключей даёт ожидаемый порядок
- [ ] Asc/desc toggle меняет порядок
- [ ] Search по части title или repo фильтрует корректно
- [ ] Click на карточку раскрывает issue list
- [ ] Description «ещё» раскрывает полное описание
- [ ] Aggregate cells пересчитываются при смене подтаба/фильтра
- [ ] Persistence: sub/grouping/sort сохраняются после reload
- [ ] Адаптив 1100px / 700px

🤖 Generated with [Claude Code](https://claude.com/claude-code)