### PR TITLE
feat(transcripts): redesign V4 — aggregate strip, history filters, V4 stepper

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { UptimeBar } from "./components/UptimeBar";
 import { AuditCombinedTab } from "./components/AuditCombinedTab";
 import { PipelineView } from "./components/v4/pipeline/PipelineView";
-import { TranscriptsTab } from "./components/TranscriptsTab";
+import { TranscriptsView } from "./components/v4/transcripts/TranscriptsView";
 import { ResearchTab } from "./components/ResearchTab";
 import { SpecsTab } from "./components/SpecsTab";
 import { QualityTab } from "./components/QualityTab";
@@ -261,13 +261,11 @@ function AppInner() {
             </ErrorBoundary>
           )}
         </div>
-        <div className="v4-legacy-frame" style={{ display: tab === "transcripts" ? undefined : "none" }}>
+        <div style={{ display: tab === "transcripts" ? undefined : "none" }}>
           {visitedTabs.has("transcripts") && (
-            <div className="bento-grid">
-              <ErrorBoundary fallback="Ошибка вкладки Транскрипты">
-                <TranscriptsTab projects={PROJECTS} />
-              </ErrorBoundary>
-            </div>
+            <ErrorBoundary fallback="Ошибка вкладки Транскрипты">
+              <TranscriptsView projects={PROJECTS} />
+            </ErrorBoundary>
           )}
         </div>
         <div className="v4-legacy-frame" style={{ display: tab === "research" ? undefined : "none" }}>

--- a/src/components/v4/transcripts/BatchProgressV4.tsx
+++ b/src/components/v4/transcripts/BatchProgressV4.tsx
@@ -1,0 +1,98 @@
+export type BatchFileStatus = "pending" | "uploading" | "processing" | "done" | "error";
+
+export interface BatchFile {
+  id: string;
+  file: File;
+  status: BatchFileStatus;
+  taskId?: string;
+  error?: string;
+}
+
+interface Props {
+  files: BatchFile[];
+  active: boolean;
+  onCancel: () => void;
+  onClose: () => void;
+}
+
+const STATUS_LABEL: Record<BatchFileStatus, string> = {
+  pending: "Ожидание",
+  uploading: "Загрузка…",
+  processing: "Обработка…",
+  done: "Готово",
+  error: "Ошибка",
+};
+
+const STATUS_ICON: Record<BatchFileStatus, string> = {
+  pending: "○",
+  uploading: "↑",
+  processing: "⟳",
+  done: "✓",
+  error: "✗",
+};
+
+export function BatchProgressV4({ files, active, onCancel, onClose }: Props) {
+  if (files.length === 0) return null;
+
+  const total = files.length;
+  const done = files.filter((f) => f.status === "done").length;
+  const errors = files.filter((f) => f.status === "error").length;
+  const finished = files.every((f) => f.status === "done" || f.status === "error");
+  const pct = ((done + errors) / total) * 100;
+
+  return (
+    <div className="v4-panel v4-tpc-batch-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">
+          Пакетная загрузка <span className="v4-tag">{done}/{total}</span>
+          {errors > 0 && (
+            <span className="v4-tag v4-tag--danger">{errors} ошиб.</span>
+          )}
+        </div>
+        <div className="v4-panel-actions">
+          {active && (
+            <button type="button" className="v4-btn" onClick={onCancel}>
+              Остановить
+            </button>
+          )}
+          {finished && (
+            <button type="button" className="v4-btn v4-btn--pri" onClick={onClose}>
+              Закрыть
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="v4-tpc-batch-bar">
+        <div className="v4-ptrack" style={{ height: 6 }}>
+          <div
+            className="v4-pfill"
+            style={{
+              width: `${pct}%`,
+              background: errors > 0 ? "var(--v4-warn-500)" : "var(--v4-accent-500)",
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="v4-tpc-batch-list">
+        {files.map((bf) => (
+          <div key={bf.id} className={`v4-tpc-batch-row v4-tpc-batch-row--${bf.status}`}>
+            <span
+              className={`v4-tpc-batch-icon v4-tpc-batch-icon--${bf.status}`}
+              aria-hidden="true"
+            >
+              {STATUS_ICON[bf.status]}
+            </span>
+            <span className="v4-tpc-batch-name" title={bf.file.name}>
+              {bf.file.name}
+            </span>
+            <span className={`v4-tpc-batch-status v4-tpc-batch-status--${bf.status}`}>
+              {bf.status === "error" && bf.error ? bf.error : STATUS_LABEL[bf.status]}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/transcripts/TranscriptBriefV4.tsx
+++ b/src/components/v4/transcripts/TranscriptBriefV4.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useMemo, useState } from "react";
+import { renderBriefHtml, renderMarkdownHtml } from "../../../utils/transcript-markdown";
+import type { QualityCheck, TranscriptQuality, TranscriptResult } from "../../../utils/transcript";
+
+interface Props {
+  result: TranscriptResult;
+  onNewUpload: () => void;
+  onEdit: () => void;
+}
+
+const QUALITY_LABEL: Record<TranscriptQuality, string> = {
+  pass: "✓ Качество ОК",
+  warning: "⚠ Замечания",
+  needs_review: "✗ Требуется проверка",
+};
+
+const QUALITY_CLASS: Record<TranscriptQuality, string> = {
+  pass: "v4-tpc-quality--pass",
+  warning: "v4-tpc-quality--warn",
+  needs_review: "v4-tpc-quality--review",
+};
+
+const CHECK_ICON: Record<QualityCheck["status"], string> = {
+  pass: "✓",
+  warning: "⚠",
+  fail: "✗",
+};
+
+function plural(n: number, one: string, few: string, many: string): string {
+  const m10 = n % 10;
+  const m100 = n % 100;
+  if (m10 === 1 && m100 !== 11) return one;
+  if (m10 >= 2 && m10 <= 4 && (m100 < 10 || m100 >= 20)) return few;
+  return many;
+}
+
+function countMarkers(text: string, tag: string): number {
+  const re = new RegExp(`\\[${tag}:[^\\]]*\\]`, "gi");
+  return (text.match(re) || []).length;
+}
+
+export function TranscriptBriefV4({ result, onNewUpload, onEdit }: Props) {
+  const [accordionOpen, setAccordionOpen] = useState(false);
+  const [qualityOpen, setQualityOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const unclearCount = useMemo(() => countMarkers(result.brief, "неразборчиво"), [result.brief]);
+  const conflictCount = useMemo(() => countMarkers(result.brief, "противоречие"), [result.brief]);
+
+  const briefHtml = useMemo(() => renderBriefHtml(result.brief), [result.brief]);
+  const transcriptHtml = useMemo(
+    () => (result.transcript ? renderMarkdownHtml(result.transcript) : ""),
+    [result.transcript]
+  );
+
+  const onDownload = useCallback(() => {
+    const blob = new Blob([result.brief], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `BRIEF-${result.task_id}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [result.brief, result.task_id]);
+
+  const onCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(result.brief);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      const ta = document.createElement("textarea");
+      ta.value = result.brief;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [result.brief]);
+
+  return (
+    <div className="v4-panel v4-tpc-brief-panel">
+      <div className="v4-panel-h v4-tpc-brief-h">
+        <div className="v4-tpc-brief-counters">
+          {result.quality && (
+            result.quality_report ? (
+              <button
+                type="button"
+                className={`v4-tpc-quality-chip ${QUALITY_CLASS[result.quality]}`}
+                aria-expanded={qualityOpen}
+                aria-controls="v4-tpc-quality-report"
+                onClick={() => setQualityOpen((v) => !v)}
+              >
+                {QUALITY_LABEL[result.quality]}
+              </button>
+            ) : (
+              <span className={`v4-tpc-quality-chip ${QUALITY_CLASS[result.quality]} v4-tpc-quality-chip--static`}>
+                {QUALITY_LABEL[result.quality]}
+              </span>
+            )
+          )}
+          {unclearCount > 0 && (
+            <span className="v4-tpc-counter v4-tpc-counter--warn">
+              {unclearCount} {plural(unclearCount, "неразборчивое место", "неразборчивых места", "неразборчивых мест")}
+            </span>
+          )}
+          {conflictCount > 0 && (
+            <span className="v4-tpc-counter v4-tpc-counter--danger">
+              {conflictCount} {plural(conflictCount, "противоречие", "противоречия", "противоречий")}
+            </span>
+          )}
+          {unclearCount === 0 && conflictCount === 0 && (
+            <span className="v4-tpc-counter v4-tpc-counter--ok">Маркеры не найдены</span>
+          )}
+        </div>
+        <div className="v4-tpc-brief-actions">
+          <button type="button" className="v4-btn" onClick={onEdit}>
+            Редактировать
+          </button>
+          <button type="button" className="v4-btn" onClick={onCopy}>
+            {copied ? "Скопировано!" : "Копировать"}
+          </button>
+          <button type="button" className="v4-btn" onClick={onDownload}>
+            Скачать .md
+          </button>
+          <button type="button" className="v4-btn v4-btn--pri" onClick={onNewUpload}>
+            Новый файл
+          </button>
+        </div>
+      </div>
+
+      {result.quality && result.quality_report && (
+        <div
+          id="v4-tpc-quality-report"
+          className="v4-tpc-quality-report"
+          hidden={!qualityOpen}
+        >
+          <div className="v4-tpc-quality-report-h">
+            <span className="v4-tpc-quality-report-t">Отчёт о качестве</span>
+            <span className="v4-pl-mono v4-tpc-quality-report-score">
+              Score: {result.quality_report.score}
+            </span>
+          </div>
+          <ul className="v4-tpc-quality-checks">
+            {result.quality_report.checks.map((check) => (
+              <li
+                key={check.name}
+                className={`v4-tpc-quality-check v4-tpc-quality-check--${check.status}`}
+              >
+                <span className="v4-tpc-quality-check-icon" aria-hidden="true">
+                  {CHECK_ICON[check.status]}
+                </span>
+                <span className="v4-tpc-quality-check-name">{check.name}</span>
+                <span className="v4-tpc-quality-check-msg">{check.message}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div
+        className="v4-tpc-brief-content tpc-brief-content"
+        dangerouslySetInnerHTML={{ __html: briefHtml }}
+      />
+
+      {result.transcript && (
+        <div className="v4-tpc-accordion">
+          <button
+            type="button"
+            className="v4-tpc-accordion-toggle"
+            aria-expanded={accordionOpen}
+            onClick={() => setAccordionOpen((v) => !v)}
+          >
+            <span className={`v4-tpc-accordion-arrow ${accordionOpen ? "is-open" : ""}`}>▸</span>
+            Очищенный транскрипт
+          </button>
+          {accordionOpen && (
+            <div
+              className="v4-tpc-accordion-body tpc-brief-content"
+              dangerouslySetInnerHTML={{ __html: transcriptHtml }}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/transcripts/TranscriptEditorV4.tsx
+++ b/src/components/v4/transcripts/TranscriptEditorV4.tsx
@@ -14,23 +14,37 @@ const draftKey = (taskId: string) => `tpc:draft:${taskId}`;
 type ViewMode = "split" | "edit" | "preview";
 
 export function TranscriptEditorV4({ taskId, initialBrief, onSave, onCancel }: Props) {
-  const [text, setText] = useState<string>(() => {
+  const [text, setText] = useState<string>(initialBrief);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>("split");
+
+  // Draft restore: confirm and apply in an effect (NOT in useState initialiser).
+  // React Strict Mode double-invokes initialisers in dev — calling
+  // window.confirm there fires the dialog twice and violates React's purity
+  // rules for state initialisers. Effects run once per mount even in Strict
+  // Mode (the cleanup-then-rerun pattern doesn't apply here because of the
+  // restoredRef guard).
+  const restoredRef = useRef(false);
+  useEffect(() => {
+    if (restoredRef.current) return;
+    restoredRef.current = true;
     try {
       const stored = localStorage.getItem(draftKey(taskId));
       if (stored && stored !== initialBrief) {
         if (window.confirm("Найден несохранённый черновик. Восстановить?")) {
-          return stored;
+          setText(stored);
+        } else {
+          localStorage.removeItem(draftKey(taskId));
         }
-        localStorage.removeItem(draftKey(taskId));
       }
     } catch {
-      /* ignore */
+      /* localStorage unavailable */
     }
-    return initialBrief;
-  });
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<ViewMode>("split");
+    // Only run once per mount for a given taskId — initialBrief is stable
+    // for the lifetime of this editor instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [taskId]);
 
   const deferredText = useDeferredValue(text);
   const previewHtml = useMemo(() => renderBriefHtml(deferredText), [deferredText]);

--- a/src/components/v4/transcripts/TranscriptEditorV4.tsx
+++ b/src/components/v4/transcripts/TranscriptEditorV4.tsx
@@ -1,0 +1,175 @@
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { saveTranscriptBrief } from "../../../utils/transcript";
+import { renderBriefHtml } from "../../../utils/transcript-markdown";
+
+interface Props {
+  taskId: string;
+  initialBrief: string;
+  onSave: (updatedBrief: string) => void;
+  onCancel: () => void;
+}
+
+const draftKey = (taskId: string) => `tpc:draft:${taskId}`;
+
+type ViewMode = "split" | "edit" | "preview";
+
+export function TranscriptEditorV4({ taskId, initialBrief, onSave, onCancel }: Props) {
+  const [text, setText] = useState<string>(() => {
+    try {
+      const stored = localStorage.getItem(draftKey(taskId));
+      if (stored && stored !== initialBrief) {
+        if (window.confirm("Найден несохранённый черновик. Восстановить?")) {
+          return stored;
+        }
+        localStorage.removeItem(draftKey(taskId));
+      }
+    } catch {
+      /* ignore */
+    }
+    return initialBrief;
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>("split");
+
+  const deferredText = useDeferredValue(text);
+  const previewHtml = useMemo(() => renderBriefHtml(deferredText), [deferredText]);
+
+  const hasChanges = text !== initialBrief;
+  const hasChangesRef = useRef(hasChanges);
+  hasChangesRef.current = hasChanges;
+
+  // Autosave draft
+  useEffect(() => {
+    if (!hasChanges) {
+      try {
+        localStorage.removeItem(draftKey(taskId));
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+    const handle = setTimeout(() => {
+      try {
+        localStorage.setItem(draftKey(taskId), text);
+      } catch {
+        /* ignore quota */
+      }
+    }, 1000);
+    return () => clearTimeout(handle);
+  }, [text, hasChanges, taskId]);
+
+  // beforeunload guard
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (!hasChangesRef.current) return;
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await saveTranscriptBrief(taskId, text);
+      try {
+        localStorage.removeItem(draftKey(taskId));
+      } catch {
+        /* ignore */
+      }
+      onSave(text);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [taskId, text, onSave]);
+
+  // Cmd/Ctrl-S to save (when dirty + not saving)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
+        e.preventDefault();
+        if (hasChangesRef.current && !saving) handleSave();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [handleSave, saving]);
+
+  return (
+    <div className="v4-panel v4-tpc-editor-panel">
+      <div className="v4-panel-h v4-tpc-editor-h">
+        <div className="v4-pillgrp">
+          <button
+            type="button"
+            className={viewMode === "edit" ? "is-active" : ""}
+            onClick={() => setViewMode("edit")}
+          >
+            Редактор
+          </button>
+          <button
+            type="button"
+            className={viewMode === "split" ? "is-active" : ""}
+            onClick={() => setViewMode("split")}
+          >
+            Разделённый
+          </button>
+          <button
+            type="button"
+            className={viewMode === "preview" ? "is-active" : ""}
+            onClick={() => setViewMode("preview")}
+          >
+            Просмотр
+          </button>
+        </div>
+        <div className="v4-tpc-editor-actions">
+          {hasChanges && (
+            <span className="v4-pl-mono v4-tpc-text-muted v4-tpc-editor-dirty">
+              ● несохранённые
+            </span>
+          )}
+          <button type="button" className="v4-btn" onClick={onCancel}>
+            Отмена
+          </button>
+          <button
+            type="button"
+            className="v4-btn v4-btn--pri"
+            disabled={!hasChanges || saving}
+            onClick={handleSave}
+            title="Cmd+S / Ctrl+S"
+          >
+            {saving ? "Сохранение…" : "Сохранить"}
+          </button>
+        </div>
+      </div>
+
+      <div className={`v4-tpc-editor-panes v4-tpc-editor-panes--${viewMode}`}>
+        {viewMode !== "preview" && (
+          <textarea
+            className="v4-tpc-editor-textarea"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            spellCheck={false}
+            aria-label="Markdown редактор"
+          />
+        )}
+        {viewMode !== "edit" && (
+          <div
+            className="v4-tpc-editor-preview tpc-brief-content"
+            dangerouslySetInnerHTML={{ __html: previewHtml }}
+          />
+        )}
+      </div>
+
+      {error && (
+        <div className="v4-error" style={{ margin: "0 18px 14px" }}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/transcripts/TranscriptHistoryV4.tsx
+++ b/src/components/v4/transcripts/TranscriptHistoryV4.tsx
@@ -1,0 +1,514 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  fetchTranscriptList,
+  deleteTranscript,
+  type TranscriptListItem,
+  type TranscriptQuality,
+  type TranscriptionModel,
+} from "../../../utils/transcript";
+
+interface Props {
+  onOpen: (taskId: string) => void;
+  onResume: (taskId: string) => void;
+  onRetry: (taskId: string, transcriptionModel: TranscriptionModel | undefined) => Promise<void>;
+  refreshKey: number;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  done: "Готово",
+  queued: "В очереди",
+  transcribing: "Транскрипция",
+  processing: "Обработка",
+  error: "Ошибка",
+};
+
+const STATUS_CLASS: Record<string, string> = {
+  done: "v4-tpc-status--done",
+  queued: "v4-tpc-status--active",
+  transcribing: "v4-tpc-status--active",
+  processing: "v4-tpc-status--active",
+  error: "v4-tpc-status--err",
+};
+
+const ACTIVE_STATUSES = new Set(["queued", "transcribing", "processing"]);
+
+const STAGE_LABELS: Record<string, string> = {
+  intake: "Приём",
+  stt: "Транскрипция",
+  enrichment: "Обогащение",
+  structuring: "Структуризация",
+  synthesis: "Синтез",
+};
+
+const QUALITY_LABEL: Record<TranscriptQuality, string> = {
+  pass: "ОК",
+  warning: "Замечания",
+  needs_review: "Проверить",
+};
+
+const QUALITY_CLASS: Record<TranscriptQuality, string> = {
+  pass: "v4-tpc-quality--pass",
+  warning: "v4-tpc-quality--warn",
+  needs_review: "v4-tpc-quality--review",
+};
+
+type StatusFilter = "all" | "active" | "done" | "error";
+
+const FILTER_LABELS: Record<StatusFilter, string> = {
+  all: "Все",
+  active: "Активные",
+  done: "Готово",
+  error: "Ошибки",
+};
+
+type SortKey = "date" | "filename" | "project" | "model" | "status";
+
+const SORT_LABELS: Record<SortKey, string> = {
+  date: "Дата",
+  filename: "Файл",
+  project: "Проект",
+  model: "Модель",
+  status: "Статус",
+};
+
+interface ToolbarState {
+  filter: StatusFilter;
+  query: string;
+  project: string;
+  model: TranscriptionModel | "all";
+  sort: SortKey;
+  asc: boolean;
+}
+
+const STORAGE_KEY = "makeit.transcriptsHistory.v1";
+
+const VALID_FILTERS: readonly StatusFilter[] = ["all", "active", "done", "error"];
+const VALID_SORTS: readonly SortKey[] = ["date", "filename", "project", "model", "status"];
+const VALID_MODELS: readonly (TranscriptionModel | "all")[] = ["all", "fast", "quality"];
+
+function loadState(): ToolbarState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const p = JSON.parse(raw) as Partial<ToolbarState>;
+      return {
+        filter: VALID_FILTERS.includes(p.filter as StatusFilter)
+          ? (p.filter as StatusFilter)
+          : "all",
+        query: "",
+        project: typeof p.project === "string" ? p.project : "",
+        model: VALID_MODELS.includes(p.model as TranscriptionModel | "all")
+          ? (p.model as TranscriptionModel | "all")
+          : "all",
+        sort: VALID_SORTS.includes(p.sort as SortKey) ? (p.sort as SortKey) : "date",
+        asc: typeof p.asc === "boolean" ? p.asc : false,
+      };
+    }
+  } catch {
+    /* ignore */
+  }
+  return { filter: "all", query: "", project: "", model: "all", sort: "date", asc: false };
+}
+
+function saveState(s: ToolbarState) {
+  try {
+    const { query: _q, ...persist } = s;
+    void _q;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(persist));
+  } catch {
+    /* ignore */
+  }
+}
+
+function matchesFilter(item: TranscriptListItem, f: StatusFilter): boolean {
+  if (f === "all") return true;
+  if (f === "active") return ACTIVE_STATUSES.has(item.status);
+  if (f === "done") return item.status === "done";
+  if (f === "error") return item.status === "error";
+  return true;
+}
+
+export function TranscriptHistoryV4({ onOpen, onResume, onRetry, refreshKey }: Props) {
+  const [items, setItems] = useState<TranscriptListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [state, setState] = useState<ToolbarState>(() => loadState());
+  const [retryingIds, setRetryingIds] = useState<Set<string>>(new Set());
+  const [sortMenuOpen, setSortMenuOpen] = useState(false);
+  const sortMenuRef = useRef<HTMLDivElement | null>(null);
+  const prevRefreshKey = useRef(refreshKey);
+  const autoRefreshRef = useRef<ReturnType<typeof setInterval>>(null);
+
+  useEffect(() => {
+    saveState(state);
+  }, [state]);
+
+  // Outside click + Escape for sort menu
+  useEffect(() => {
+    if (!sortMenuOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!sortMenuRef.current?.contains(e.target as Node)) setSortMenuOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setSortMenuOpen(false);
+    };
+    window.addEventListener("mousedown", onDoc);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDoc);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [sortMenuOpen]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchTranscriptList();
+      setItems(data);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (refreshKey !== prevRefreshKey.current) {
+      prevRefreshKey.current = refreshKey;
+      load();
+    }
+  }, [refreshKey, load]);
+
+  const hasActive = useMemo(
+    () => items.some((i) => ACTIVE_STATUSES.has(i.status)),
+    [items]
+  );
+
+  useEffect(() => {
+    if (hasActive) {
+      autoRefreshRef.current = setInterval(load, 5000);
+    }
+    return () => {
+      if (autoRefreshRef.current) {
+        clearInterval(autoRefreshRef.current);
+        autoRefreshRef.current = null;
+      }
+    };
+  }, [hasActive, load]);
+
+  const inflightRetriesRef = useRef<Set<string>>(new Set());
+  const handleRetry = useCallback(
+    async (taskId: string, model: TranscriptionModel | undefined) => {
+      if (inflightRetriesRef.current.has(taskId)) return;
+      inflightRetriesRef.current.add(taskId);
+      setRetryingIds(new Set(inflightRetriesRef.current));
+      try {
+        await onRetry(taskId, model);
+      } finally {
+        inflightRetriesRef.current.delete(taskId);
+        setRetryingIds(new Set(inflightRetriesRef.current));
+      }
+    },
+    [onRetry]
+  );
+
+  const handleDelete = useCallback(async (taskId: string, filename: string) => {
+    if (!window.confirm(`Удалить транскрипцию ${filename}?`)) return;
+    try {
+      await deleteTranscript(taskId);
+      setItems((prev) => prev.filter((i) => i.task_id !== taskId));
+    } catch (err) {
+      setError(`Не удалось удалить: ${err}`);
+    }
+  }, []);
+
+  const projects = useMemo(
+    () => [...new Set(items.map((i) => i.project))].sort(),
+    [items]
+  );
+
+  const counts = useMemo(() => {
+    const c = { all: items.length, active: 0, done: 0, error: 0 };
+    for (const i of items) {
+      if (ACTIVE_STATUSES.has(i.status)) c.active++;
+      else if (i.status === "done") c.done++;
+      else if (i.status === "error") c.error++;
+    }
+    return c;
+  }, [items]);
+
+  const filtered = useMemo(() => {
+    const q = state.query.trim().toLowerCase();
+    return items.filter((i) => {
+      if (!matchesFilter(i, state.filter)) return false;
+      if (state.project && i.project !== state.project) return false;
+      if (state.model !== "all" && i.transcription_model !== state.model) return false;
+      if (q && !i.filename.toLowerCase().includes(q) && !i.project.toLowerCase().includes(q)) {
+        return false;
+      }
+      return true;
+    });
+  }, [items, state.filter, state.project, state.model, state.query]);
+
+  const sorted = useMemo(() => {
+    const out = [...filtered];
+    out.sort((a, b) => {
+      // Always keep active rows on top regardless of sort
+      const aActive = ACTIVE_STATUSES.has(a.status) ? 0 : 1;
+      const bActive = ACTIVE_STATUSES.has(b.status) ? 0 : 1;
+      if (aActive !== bActive) return aActive - bActive;
+
+      let cmp = 0;
+      switch (state.sort) {
+        case "date":
+          cmp = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+          break;
+        case "filename":
+          cmp = a.filename.localeCompare(b.filename, "ru");
+          break;
+        case "project":
+          cmp = a.project.localeCompare(b.project, "ru");
+          break;
+        case "model":
+          cmp = (a.transcription_model ?? "").localeCompare(b.transcription_model ?? "");
+          break;
+        case "status":
+          cmp = a.status.localeCompare(b.status);
+          break;
+      }
+      return state.asc ? cmp : -cmp;
+    });
+    return out;
+  }, [filtered, state.sort, state.asc]);
+
+  if (loading && items.length === 0) {
+    return (
+      <div className="v4-panel">
+        <div className="v4-empty">Загрузка истории…</div>
+      </div>
+    );
+  }
+
+  if (error && items.length === 0) {
+    return (
+      <div className="v4-panel">
+        <div className="v4-empty">
+          <p style={{ marginBottom: 12 }}>Не удалось загрузить историю</p>
+          <button type="button" className="v4-btn v4-btn--pri" onClick={load}>
+            Повторить
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="v4-panel v4-tpc-history-panel">
+      <div className="v4-panel-h v4-tpc-history-h">
+        <div className="v4-panel-t">
+          История <span className="v4-tag">{filtered.length}/{items.length}</span>
+        </div>
+        <div className="v4-panel-actions v4-tpc-history-tools">
+          <div className="v4-pillgrp">
+            {(Object.keys(FILTER_LABELS) as StatusFilter[]).map((k) => (
+              <button
+                key={k}
+                type="button"
+                className={state.filter === k ? "is-active" : ""}
+                onClick={() => setState((s) => ({ ...s, filter: k }))}
+              >
+                {FILTER_LABELS[k]} {counts[k] > 0 && <>· {counts[k]}</>}
+              </button>
+            ))}
+          </div>
+          <div className="v4-search v4-tpc-history-search">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="11" cy="11" r="8" />
+              <path d="M21 21l-4.35-4.35" />
+            </svg>
+            <input
+              value={state.query}
+              onChange={(e) => setState((s) => ({ ...s, query: e.target.value }))}
+              placeholder="Поиск по filename / project…"
+              aria-label="Поиск истории"
+            />
+          </div>
+          {projects.length > 1 && (
+            <select
+              className="v4-pl-input v4-tpc-history-select"
+              value={state.project}
+              onChange={(e) => setState((s) => ({ ...s, project: e.target.value }))}
+              aria-label="Фильтр по проекту"
+            >
+              <option value="">Все проекты</option>
+              {projects.map((p) => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </select>
+          )}
+          <select
+            className="v4-pl-input v4-tpc-history-select"
+            value={state.model}
+            onChange={(e) =>
+              setState((s) => ({ ...s, model: e.target.value as TranscriptionModel | "all" }))
+            }
+            aria-label="Фильтр по модели"
+          >
+            <option value="all">Все модели</option>
+            <option value="fast">Быстрая</option>
+            <option value="quality">Качественная</option>
+          </select>
+          <div className="v4-projects-sort" ref={sortMenuRef}>
+            <button
+              type="button"
+              className="v4-btn"
+              onClick={() => setSortMenuOpen((v) => !v)}
+              aria-haspopup="menu"
+              aria-expanded={sortMenuOpen}
+            >
+              {SORT_LABELS[state.sort]} {state.asc ? "↑" : "↓"}
+            </button>
+            {sortMenuOpen && (
+              <div className="v4-projects-sort-menu" role="menu">
+                {(Object.keys(SORT_LABELS) as SortKey[]).map((k) => (
+                  <button
+                    key={k}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={state.sort === k}
+                    className={state.sort === k ? "is-active" : ""}
+                    onClick={() => {
+                      setState((s) => ({ ...s, sort: k }));
+                      setSortMenuOpen(false);
+                    }}
+                  >
+                    {SORT_LABELS[k]}
+                  </button>
+                ))}
+                <div className="v4-projects-sort-sep" />
+                <button
+                  type="button"
+                  role="menuitemcheckbox"
+                  aria-checked={state.asc}
+                  className={state.asc ? "is-active" : ""}
+                  onClick={() => setState((s) => ({ ...s, asc: !s.asc }))}
+                >
+                  {state.asc ? "↑ По возрастанию" : "↓ По убыванию"}
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {sorted.length === 0 ? (
+        <div className="v4-empty">
+          {state.query
+            ? `По запросу «${state.query}» ничего не найдено`
+            : "Нет транскрипций под фильтр"}
+        </div>
+      ) : (
+        <div className="v4-tpc-history-rows">
+          {sorted.map((item) => {
+            const isActive = ACTIVE_STATUSES.has(item.status);
+            const dateStr = new Date(item.created_at).toLocaleString("ru-RU", {
+              day: "2-digit",
+              month: "2-digit",
+              year: "2-digit",
+              hour: "2-digit",
+              minute: "2-digit",
+            });
+            return (
+              <div
+                key={item.task_id}
+                className={`v4-tpc-history-row ${isActive ? "is-active" : ""}`}
+              >
+                <div className="v4-tpc-history-cell v4-tpc-history-date v4-pl-mono">{dateStr}</div>
+                <div className="v4-tpc-history-cell v4-tpc-history-project">
+                  <span className="v4-pl-mono">{item.project}</span>
+                </div>
+                <div className="v4-tpc-history-cell v4-tpc-history-file" title={item.filename}>
+                  {item.filename}
+                </div>
+                <div className="v4-tpc-history-cell v4-tpc-history-model">
+                  {item.transcription_model === "quality" ? (
+                    <span title="Качественная (диаризация)">🎯 quality</span>
+                  ) : item.transcription_model === "fast" ? (
+                    <span title="Быстрая">⚡ fast</span>
+                  ) : (
+                    <span className="v4-tpc-text-muted">—</span>
+                  )}
+                </div>
+                <div className="v4-tpc-history-cell v4-tpc-history-status">
+                  <span className={`v4-tpc-status ${STATUS_CLASS[item.status] ?? ""}`}>
+                    {isActive && <span className="v4-tpc-status-pulse" />}
+                    {STATUS_LABELS[item.status] ?? item.status}
+                    {item.status === "error" && item.current_stage && STAGE_LABELS[item.current_stage] && (
+                      <span className="v4-tpc-text-muted"> ({STAGE_LABELS[item.current_stage]})</span>
+                    )}
+                  </span>
+                </div>
+                <div className="v4-tpc-history-cell v4-tpc-history-quality">
+                  {item.status === "done" && item.quality ? (
+                    <span className={`v4-tpc-quality-chip v4-tpc-quality-chip--static v4-tpc-quality-chip--sm ${QUALITY_CLASS[item.quality]}`}>
+                      {QUALITY_LABEL[item.quality]}
+                    </span>
+                  ) : (
+                    <span className="v4-tpc-text-muted">—</span>
+                  )}
+                </div>
+                <div className="v4-tpc-history-cell v4-tpc-history-actions">
+                  {item.status === "done" && (
+                    <button
+                      type="button"
+                      className="v4-btn v4-btn--pri"
+                      onClick={() => onOpen(item.task_id)}
+                    >
+                      Открыть
+                    </button>
+                  )}
+                  {isActive && (
+                    <button
+                      type="button"
+                      className="v4-btn"
+                      onClick={() => onResume(item.task_id)}
+                    >
+                      Следить
+                    </button>
+                  )}
+                  {item.status === "error" && (
+                    <button
+                      type="button"
+                      className="v4-btn"
+                      onClick={() => handleRetry(item.task_id, item.transcription_model)}
+                      disabled={retryingIds.has(item.task_id)}
+                      title="Повторить с момента сбоя"
+                    >
+                      {retryingIds.has(item.task_id) ? "Запуск…" : "↻ Повторить"}
+                    </button>
+                  )}
+                  {(item.status === "done" || item.status === "error") && (
+                    <button
+                      type="button"
+                      className="v4-btn v4-tpc-btn-icon"
+                      onClick={() => handleDelete(item.task_id, item.filename)}
+                      title="Удалить транскрипцию"
+                      aria-label={`Удалить ${item.filename}`}
+                    >
+                      🗑
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/transcripts/TranscriptHistoryV4.tsx
+++ b/src/components/v4/transcripts/TranscriptHistoryV4.tsx
@@ -132,6 +132,7 @@ export function TranscriptHistoryV4({ onOpen, onResume, onRetry, refreshKey }: P
   const [items, setItems] = useState<TranscriptListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [state, setState] = useState<ToolbarState>(() => loadState());
   const [retryingIds, setRetryingIds] = useState<Set<string>>(new Set());
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
@@ -219,11 +220,15 @@ export function TranscriptHistoryV4({ onOpen, onResume, onRetry, refreshKey }: P
 
   const handleDelete = useCallback(async (taskId: string, filename: string) => {
     if (!window.confirm(`Удалить транскрипцию ${filename}?`)) return;
+    setDeleteError(null);
     try {
       await deleteTranscript(taskId);
       setItems((prev) => prev.filter((i) => i.task_id !== taskId));
     } catch (err) {
-      setError(`Не удалось удалить: ${err}`);
+      // Use a separate state from the load-error so the delete failure is
+      // visible even when items.length > 0 (the load-error panel is
+      // conditional on empty list).
+      setDeleteError(`Не удалось удалить ${filename}: ${err}`);
     }
   }, []);
 
@@ -405,6 +410,20 @@ export function TranscriptHistoryV4({ onOpen, onResume, onRetry, refreshKey }: P
           </div>
         </div>
       </div>
+
+      {deleteError && (
+        <div className="v4-error" style={{ margin: "8px 18px 0" }}>
+          {deleteError}
+          <button
+            type="button"
+            className="v4-linkbtn"
+            style={{ marginLeft: 12 }}
+            onClick={() => setDeleteError(null)}
+          >
+            закрыть
+          </button>
+        </div>
+      )}
 
       {sorted.length === 0 ? (
         <div className="v4-empty">

--- a/src/components/v4/transcripts/TranscriptProgressV4.tsx
+++ b/src/components/v4/transcripts/TranscriptProgressV4.tsx
@@ -50,6 +50,10 @@ export function TranscriptProgressV4({ taskId, onDone, onRetry }: Props) {
   const startedAtRef = useRef<number | null>(null);
   const failCountRef = useRef(0);
   const pollStartedAtRef = useRef<number | null>(null);
+  // Epoch invalidates in-flight polls. Bumped on every effect setup so a
+  // fetch that resolves after taskId changes (e.g. retry from history) can't
+  // setStatus or fire onDone for the previous task.
+  const epochRef = useRef(0);
 
   // React idiomatic state-reset on identity-bearing prop change
   const lastTaskIdRef = useRef(taskId);
@@ -72,6 +76,7 @@ export function TranscriptProgressV4({ taskId, onDone, onRetry }: Props) {
   }, []);
 
   const poll = useCallback(async () => {
+    const myEpoch = epochRef.current;
     const polledMs = pollStartedAtRef.current
       ? Date.now() - pollStartedAtRef.current
       : 0;
@@ -83,6 +88,10 @@ export function TranscriptProgressV4({ taskId, onDone, onRetry }: Props) {
 
     try {
       const s = await fetchTranscriptStatus(taskId);
+      // Drop late responses from a previous taskId — without this, an
+      // in-flight poll resolving after a retry can setStatus / fire onDone
+      // for the wrong task.
+      if (epochRef.current !== myEpoch) return;
       setStatus(s);
       setPollError(null);
       failCountRef.current = 0;
@@ -94,6 +103,7 @@ export function TranscriptProgressV4({ taskId, onDone, onRetry }: Props) {
         if (s.stage === "done") onDone(s.result_url, taskId);
       }
     } catch (err) {
+      if (epochRef.current !== myEpoch) return;
       failCountRef.current += 1;
       setPollError(String(err));
       if (failCountRef.current >= MAX_POLL_FAILURES) {
@@ -104,6 +114,9 @@ export function TranscriptProgressV4({ taskId, onDone, onRetry }: Props) {
   }, [taskId, onDone, stopPolling]);
 
   useEffect(() => {
+    // Bump epoch first so any in-flight poll from the previous taskId
+    // returns early when it eventually resolves.
+    epochRef.current += 1;
     failCountRef.current = 0;
     startedAtRef.current = null;
     pollStartedAtRef.current = Date.now();
@@ -118,6 +131,7 @@ export function TranscriptProgressV4({ taskId, onDone, onRetry }: Props) {
     return () => {
       clearTimeout(initial);
       stopPolling();
+      epochRef.current += 1;
     };
   }, [poll, stopPolling]);
 

--- a/src/components/v4/transcripts/TranscriptProgressV4.tsx
+++ b/src/components/v4/transcripts/TranscriptProgressV4.tsx
@@ -1,0 +1,258 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchTranscriptStatus, type TranscriptStage, type TranscriptStatus } from "../../../utils/transcript";
+
+const POLL_INTERVAL = 2000;
+const MAX_POLL_FAILURES = 5;
+const MAX_POLL_DURATION_MS = 30 * 60 * 1000;
+
+const STAGES: { key: TranscriptStage; label: string }[] = [
+  { key: "intake", label: "Приём" },
+  { key: "stt", label: "Транскрипция" },
+  { key: "enrichment", label: "Обогащение" },
+  { key: "structuring", label: "Структуризация" },
+  { key: "synthesis", label: "Синтез" },
+  { key: "done", label: "Готово" },
+];
+
+function stageIndex(stage: TranscriptStage): number {
+  const idx = STAGES.findIndex((s) => s.key === stage);
+  return idx >= 0 ? idx : 0;
+}
+
+function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  if (m === 0) return `${s} сек`;
+  return `${m} мин ${s} сек`;
+}
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  if (m === 0) return `${s} сек`;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+interface Props {
+  taskId: string;
+  onDone: (resultUrl: string | null, taskId: string) => void;
+  onRetry: () => void;
+}
+
+export function TranscriptProgressV4({ taskId, onDone, onRetry }: Props) {
+  const [status, setStatus] = useState<TranscriptStatus | null>(null);
+  const [pollError, setPollError] = useState<string | null>(null);
+  const [pollExhausted, setPollExhausted] = useState(false);
+  const [stuck, setStuck] = useState(false);
+  const [elapsed, setElapsed] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setInterval>>(null);
+  const elapsedRef = useRef<ReturnType<typeof setInterval>>(null);
+  const startedAtRef = useRef<number | null>(null);
+  const failCountRef = useRef(0);
+  const pollStartedAtRef = useRef<number | null>(null);
+
+  // React idiomatic state-reset on identity-bearing prop change
+  const lastTaskIdRef = useRef(taskId);
+  // eslint-disable-next-line react-hooks/refs
+  if (lastTaskIdRef.current !== taskId) {
+    // eslint-disable-next-line react-hooks/refs
+    lastTaskIdRef.current = taskId;
+    setStuck(false);
+  }
+
+  const stopPolling = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    if (elapsedRef.current) {
+      clearInterval(elapsedRef.current);
+      elapsedRef.current = null;
+    }
+  }, []);
+
+  const poll = useCallback(async () => {
+    const polledMs = pollStartedAtRef.current
+      ? Date.now() - pollStartedAtRef.current
+      : 0;
+    if (polledMs > MAX_POLL_DURATION_MS) {
+      stopPolling();
+      setStuck(true);
+      return;
+    }
+
+    try {
+      const s = await fetchTranscriptStatus(taskId);
+      setStatus(s);
+      setPollError(null);
+      failCountRef.current = 0;
+      if (s.started_at && startedAtRef.current === null) {
+        startedAtRef.current = new Date(s.started_at).getTime();
+      }
+      if (s.stage === "done" || s.error) {
+        stopPolling();
+        if (s.stage === "done") onDone(s.result_url, taskId);
+      }
+    } catch (err) {
+      failCountRef.current += 1;
+      setPollError(String(err));
+      if (failCountRef.current >= MAX_POLL_FAILURES) {
+        stopPolling();
+        setPollExhausted(true);
+      }
+    }
+  }, [taskId, onDone, stopPolling]);
+
+  useEffect(() => {
+    failCountRef.current = 0;
+    startedAtRef.current = null;
+    pollStartedAtRef.current = Date.now();
+    const initial = setTimeout(poll, 0);
+    timerRef.current = setInterval(poll, POLL_INTERVAL);
+    elapsedRef.current = setInterval(() => {
+      const t0 = startedAtRef.current;
+      if (t0 !== null) {
+        setElapsed(Math.max(0, Math.floor((Date.now() - t0) / 1000)));
+      }
+    }, 1000);
+    return () => {
+      clearTimeout(initial);
+      stopPolling();
+    };
+  }, [poll, stopPolling]);
+
+  const currentIdx = status ? stageIndex(status.stage) : 0;
+  const hasError = !!status?.error;
+  const pct = status ? Math.min(100, Math.max(0, status.progress)) : 0;
+  const isDone = status?.stage === "done";
+
+  return (
+    <div className="v4-panel v4-tpc-progress-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">
+          {hasError
+            ? "Ошибка обработки"
+            : isDone
+            ? "Обработка завершена"
+            : status?.file_name
+            ? `Обработка: ${status.file_name}`
+            : "Обработка…"}
+        </div>
+        {!isDone && !hasError && (
+          <div className="v4-panel-meta v4-pl-mono">{formatElapsed(elapsed)}</div>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      {!hasError && (
+        <div className="v4-tpc-progress-bar-row">
+          <div className="v4-ptrack" style={{ height: 8 }}>
+            <div
+              className="v4-pfill"
+              style={{
+                width: `${pct}%`,
+                background: isDone ? "var(--v4-success-500)" : "var(--v4-accent-500)",
+              }}
+            />
+          </div>
+          <span className="v4-pl-mono v4-tpc-progress-pct">{pct}%</span>
+        </div>
+      )}
+
+      {/* Phase stepper */}
+      <div className="v4-tpc-stepper">
+        {STAGES.map((s, i) => {
+          const hasCompletedData = status && status.stages_completed.length > 0;
+          const stepDone = hasCompletedData
+            ? status.stages_completed.includes(s.key) || (s.key === "done" && isDone)
+            : i < currentIdx || (i === currentIdx && isDone);
+          const isActive = i === currentIdx && !hasError && !isDone;
+          const isFailed = i === currentIdx && hasError;
+          const dotCls = stepDone
+            ? "v4-pl-dot--ok"
+            : isFailed
+            ? "v4-pl-dot--fail"
+            : isActive
+            ? "v4-pl-dot--running"
+            : "v4-pl-dot--pending";
+          return (
+            <div key={s.key} className="v4-tpc-step">
+              {i > 0 && (
+                <span className={`v4-pl-phase-link ${stepDone ? "v4-pl-dot--ok" : "v4-pl-dot--pending"}`} />
+              )}
+              <span className={`v4-pl-dot ${dotCls}`} />
+              <span className={`v4-tpc-step-label ${isActive ? "is-active" : ""} ${stepDone ? "is-done" : ""}`}>
+                {s.label}
+              </span>
+              {isActive && status?.stage_detail && (
+                <span className="v4-tpc-step-detail">{status.stage_detail}</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Intermediate stats */}
+      {status && (status.duration_seconds > 0 || status.speaker_count > 0) && (
+        <div className="v4-tpc-progress-stats">
+          {status.duration_seconds > 0 && (
+            <div className="v4-tpc-progress-stat">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+              <span className="v4-tpc-text-muted">Длительность:</span>
+              <b className="v4-pl-mono">{formatDuration(status.duration_seconds)}</b>
+            </div>
+          )}
+          {status.speaker_count > 0 && (
+            <div className="v4-tpc-progress-stat">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
+                <circle cx="9" cy="7" r="4" />
+                <path d="M23 21v-2a4 4 0 00-3-3.87" />
+                <path d="M16 3.13a4 4 0 010 7.75" />
+              </svg>
+              <span className="v4-tpc-text-muted">Спикеров:</span>
+              <b className="v4-pl-mono">{status.speaker_count}</b>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Errors */}
+      {hasError && status && (
+        <div className="v4-tpc-progress-error">
+          <p>{status.error}</p>
+          <p className="v4-tpc-text-muted">
+            Этап: {STAGES[currentIdx]?.label ?? status.stage_detail ?? status.stage}
+            {status.stage_detail && status.stage_detail !== STAGES[currentIdx]?.label && (
+              <> — {status.stage_detail}</>
+            )}
+          </p>
+          <button type="button" className="v4-btn v4-btn--pri" onClick={onRetry}>
+            Повторить
+          </button>
+        </div>
+      )}
+      {pollError && !hasError && (
+        <div className="v4-tpc-progress-error v4-tpc-progress-error--soft">
+          <p>Соединение потеряно: {pollError}</p>
+          {pollExhausted && (
+            <button type="button" className="v4-btn v4-btn--pri" onClick={onRetry}>
+              Повторить
+            </button>
+          )}
+        </div>
+      )}
+      {stuck && !hasError && (
+        <div className="v4-tpc-progress-error v4-tpc-progress-error--soft">
+          <p>Задача висит дольше 30 минут. Возможно, она зависла на бэкенде.</p>
+          <button type="button" className="v4-btn v4-btn--pri" onClick={onRetry}>
+            Считать зависшей и закрыть
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/transcripts/TranscriptsView.tsx
+++ b/src/components/v4/transcripts/TranscriptsView.tsx
@@ -81,7 +81,6 @@ export function TranscriptsView({ projects }: Props) {
   const [batchFiles, setBatchFiles] = useState<BatchFile[]>([]);
   const [batchActive, setBatchActive] = useState(false);
   const abortRef = useRef(false);
-  const retryInProgressRef = useRef(false);
 
   const onSubmitSingle = useCallback(async (file: File) => {
     setUploadError(null);
@@ -144,7 +143,12 @@ export function TranscriptsView({ projects }: Props) {
         }
         const item = queue[idx++];
         activeIds.add(item.id);
-        processOne(item);
+        // Fire-and-forget — surface unexpected throws so they don't
+        // become silent unhandled-rejection warnings.
+        processOne(item).catch((err) => {
+          console.error("[transcripts] batch processOne unexpected error:", err);
+          activeIds.delete(item.id);
+        });
       }
       while (activeIds.size > 0) {
         await new Promise((r) => setTimeout(r, 300));
@@ -216,10 +220,11 @@ export function TranscriptsView({ projects }: Props) {
     setActiveTaskId(taskId);
   }, []);
 
+  // Per-taskId double-click protection lives in TranscriptHistoryV4
+  // (inflightRetriesRef guards each row's button). No view-level guard
+  // needed — and adding one would create dead code that misleads readers.
   const onRetryFromHistory = useCallback(
     async (taskId: string, originalModel: TranscriptionModel | undefined) => {
-      if (retryInProgressRef.current) return;
-      retryInProgressRef.current = true;
       setBriefResult(null);
       setEditing(false);
       setUploadError(null);
@@ -229,8 +234,6 @@ export function TranscriptsView({ projects }: Props) {
         setHistoryRefreshKey((k) => k + 1);
       } catch (err) {
         setUploadError(`Не удалось повторить: ${err}`);
-      } finally {
-        retryInProgressRef.current = false;
       }
     },
     []
@@ -344,8 +347,10 @@ export function TranscriptsView({ projects }: Props) {
         />
       )}
 
-      {/* History — hidden when a brief is being viewed/edited or actively polled */}
-      {!briefResult && !activeTaskId && !loadingBrief && (
+      {/* History — hidden when a brief is being viewed/edited, actively
+          polled, or batch is in flight (its own auto-refresh + the history
+          5s poll would race). */}
+      {!briefResult && !activeTaskId && !loadingBrief && !batchActive && batchFiles.length === 0 && (
         <TranscriptHistoryV4
           onOpen={onOpenFromHistory}
           onResume={onResumeFromHistory}

--- a/src/components/v4/transcripts/TranscriptsView.tsx
+++ b/src/components/v4/transcripts/TranscriptsView.tsx
@@ -1,0 +1,358 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  uploadTranscript,
+  retryTranscript,
+  fetchTranscriptResult,
+  fetchTranscriptList,
+  type TranscriptResult,
+  type TranscriptionModel,
+} from "../../../utils/transcript";
+import type { ProjectConfig } from "../../../types";
+import { UploadZone } from "./UploadZone";
+import { TranscriptProgressV4 } from "./TranscriptProgressV4";
+import { BatchProgressV4, type BatchFile, type BatchFileStatus } from "./BatchProgressV4";
+import { TranscriptBriefV4 } from "./TranscriptBriefV4";
+import { TranscriptEditorV4 } from "./TranscriptEditorV4";
+import { TranscriptHistoryV4 } from "./TranscriptHistoryV4";
+
+interface Props {
+  projects: ProjectConfig[];
+}
+
+const ACTIVE_STATUSES = new Set(["queued", "transcribing", "processing"]);
+const MAX_CONCURRENT = 2;
+
+const STORAGE = {
+  project: "tpc:lastProject",
+  model: "tpc:lastModel",
+};
+
+export function TranscriptsView({ projects }: Props) {
+  const [selectedProject, setSelectedProject] = useState<string>(() => {
+    return localStorage.getItem(STORAGE.project) || projects[0]?.repo || "";
+  });
+  const [selectedModel, setSelectedModel] = useState<TranscriptionModel>(() => {
+    const v = localStorage.getItem(STORAGE.model);
+    return v === "fast" || v === "quality" ? v : "fast";
+  });
+
+  useEffect(() => { localStorage.setItem(STORAGE.project, selectedProject); }, [selectedProject]);
+  useEffect(() => { localStorage.setItem(STORAGE.model, selectedModel); }, [selectedModel]);
+
+  // Active task / batch / brief / editor states (mutually exclusive at the
+  // top of the page).
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+  const [briefResult, setBriefResult] = useState<TranscriptResult | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [loadingBrief, setLoadingBrief] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
+
+  // Aggregate counters from history (updates with refreshKey + initial load)
+  const [agg, setAgg] = useState({ total: 0, active: 0, done: 0, error: 0 });
+
+  const refreshAgg = useCallback(async () => {
+    try {
+      const list = await fetchTranscriptList();
+      const c = { total: list.length, active: 0, done: 0, error: 0 };
+      for (const i of list) {
+        if (ACTIVE_STATUSES.has(i.status)) c.active++;
+        else if (i.status === "done") c.done++;
+        else if (i.status === "error") c.error++;
+      }
+      setAgg(c);
+    } catch {
+      /* silently ignore — history component will surface load errors */
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshAgg();
+  }, [refreshAgg, historyRefreshKey]);
+
+  // Auto-refresh agg every 10s while there are active tasks
+  useEffect(() => {
+    if (agg.active === 0) return;
+    const id = setInterval(refreshAgg, 10_000);
+    return () => clearInterval(id);
+  }, [agg.active, refreshAgg]);
+
+  // Batch upload state
+  const [batchFiles, setBatchFiles] = useState<BatchFile[]>([]);
+  const [batchActive, setBatchActive] = useState(false);
+  const abortRef = useRef(false);
+  const retryInProgressRef = useRef(false);
+
+  const onSubmitSingle = useCallback(async (file: File) => {
+    setUploadError(null);
+    setBriefResult(null);
+    setEditing(false);
+    try {
+      const res = await uploadTranscript(file, selectedProject, selectedModel);
+      setActiveTaskId(res.task_id);
+      setHistoryRefreshKey((k) => k + 1);
+    } catch (err) {
+      setUploadError(String(err));
+    }
+  }, [selectedProject, selectedModel]);
+
+  const onSubmitBatch = useCallback(async (files: File[]) => {
+    abortRef.current = false;
+    setBriefResult(null);
+    setEditing(false);
+    setUploadError(null);
+
+    const batch: BatchFile[] = files.map((f, i) => ({
+      id: `${Date.now()}-${i}`,
+      file: f,
+      status: "pending" as BatchFileStatus,
+    }));
+    setBatchFiles(batch);
+    setBatchActive(true);
+
+    const queue = [...batch];
+    const activeIds = new Set<string>();
+
+    const updateFile = (id: string, patch: Partial<BatchFile>) => {
+      setBatchFiles((prev) =>
+        prev.map((bf) => (bf.id === id ? { ...bf, ...patch } : bf))
+      );
+    };
+
+    const processOne = async (bf: BatchFile) => {
+      if (abortRef.current) {
+        activeIds.delete(bf.id);
+        return;
+      }
+      updateFile(bf.id, { status: "uploading" });
+      try {
+        const res = await uploadTranscript(bf.file, selectedProject, selectedModel);
+        updateFile(bf.id, { status: "done", taskId: res.task_id });
+      } catch (err) {
+        updateFile(bf.id, { status: "error", error: String(err) });
+      } finally {
+        activeIds.delete(bf.id);
+      }
+    };
+
+    let idx = 0;
+    const runNext = async (): Promise<void> => {
+      while (idx < queue.length && !abortRef.current) {
+        if (activeIds.size >= MAX_CONCURRENT) {
+          await new Promise((r) => setTimeout(r, 300));
+          continue;
+        }
+        const item = queue[idx++];
+        activeIds.add(item.id);
+        processOne(item);
+      }
+      while (activeIds.size > 0) {
+        await new Promise((r) => setTimeout(r, 300));
+      }
+    };
+
+    try {
+      await runNext();
+    } finally {
+      setHistoryRefreshKey((k) => k + 1);
+      setBatchActive(false);
+    }
+  }, [selectedProject, selectedModel]);
+
+  const onSubmitFromZone = useCallback((files: File[]) => {
+    if (files.length === 1) return onSubmitSingle(files[0]);
+    if (files.length >= 2) return onSubmitBatch(files);
+  }, [onSubmitSingle, onSubmitBatch]);
+
+  const onCancelBatch = useCallback(() => {
+    abortRef.current = true;
+  }, []);
+  const onCloseBatch = useCallback(() => {
+    setBatchFiles([]);
+    setBatchActive(false);
+  }, []);
+
+  const onProgressDone = useCallback(async (_resultUrl: string | null, taskId: string) => {
+    setActiveTaskId(null);
+    setHistoryRefreshKey((k) => k + 1);
+    try {
+      const data = await fetchTranscriptResult(taskId);
+      setBriefResult(data);
+    } catch (err) {
+      setUploadError(`Обработка завершена, но не удалось загрузить результат: ${err}`);
+    }
+  }, []);
+
+  const onRetry = useCallback(() => {
+    setActiveTaskId(null);
+    setUploadError(null);
+  }, []);
+
+  const onNewUpload = useCallback(() => {
+    setBriefResult(null);
+    setEditing(false);
+    setUploadError(null);
+  }, []);
+
+  const onOpenFromHistory = useCallback(async (taskId: string) => {
+    setBriefResult(null);
+    setEditing(false);
+    setUploadError(null);
+    setLoadingBrief(true);
+    try {
+      const data = await fetchTranscriptResult(taskId);
+      setBriefResult(data);
+    } catch (err) {
+      setUploadError(`Не удалось загрузить результат: ${err}`);
+    } finally {
+      setLoadingBrief(false);
+    }
+  }, []);
+
+  const onResumeFromHistory = useCallback((taskId: string) => {
+    setBriefResult(null);
+    setEditing(false);
+    setUploadError(null);
+    setActiveTaskId(taskId);
+  }, []);
+
+  const onRetryFromHistory = useCallback(
+    async (taskId: string, originalModel: TranscriptionModel | undefined) => {
+      if (retryInProgressRef.current) return;
+      retryInProgressRef.current = true;
+      setBriefResult(null);
+      setEditing(false);
+      setUploadError(null);
+      try {
+        const res = await retryTranscript(taskId, originalModel ?? "fast");
+        setActiveTaskId(res.task_id);
+        setHistoryRefreshKey((k) => k + 1);
+      } catch (err) {
+        setUploadError(`Не удалось повторить: ${err}`);
+      } finally {
+        retryInProgressRef.current = false;
+      }
+    },
+    []
+  );
+
+  const onEditSave = useCallback((updatedBrief: string) => {
+    setBriefResult((prev) => (prev ? { ...prev, brief: updatedBrief } : prev));
+    setEditing(false);
+  }, []);
+
+  const showUploadForm =
+    !activeTaskId && !briefResult && !loadingBrief && !batchActive && batchFiles.length === 0;
+
+  return (
+    <div className="v4-content">
+      <div className="v4-ph">
+        <div>
+          <h1>Транскрипты</h1>
+          <div className="v4-sub">Загрузка и обработка аудио / текстовых файлов</div>
+        </div>
+      </div>
+
+      <div style={{ height: 10 }} />
+
+      {/* Aggregate strip */}
+      <div className="v4-projects-toolbar v4-pl-kpi-strip">
+        <div className="v4-projects-agg">
+          <div className="v4-projects-agg-cell">
+            <div className="v4-projects-agg-n num">{agg.total}</div>
+            <div className="v4-projects-agg-l">в истории</div>
+          </div>
+          <div className="v4-projects-agg-cell">
+            <div
+              className="v4-projects-agg-n num"
+              style={{ color: agg.active > 0 ? "var(--v4-accent-700)" : undefined }}
+            >
+              {agg.active}
+            </div>
+            <div className="v4-projects-agg-l">в работе</div>
+          </div>
+          <div className="v4-projects-agg-cell">
+            <div
+              className="v4-projects-agg-n num"
+              style={{ color: agg.done > 0 ? "var(--v4-success-700)" : undefined }}
+            >
+              {agg.done}
+            </div>
+            <div className="v4-projects-agg-l">готово</div>
+          </div>
+          <div className="v4-projects-agg-cell">
+            <div
+              className="v4-projects-agg-n num"
+              style={{ color: agg.error > 0 ? "var(--v4-danger-700)" : undefined }}
+            >
+              {agg.error}
+            </div>
+            <div className="v4-projects-agg-l">ошибки</div>
+          </div>
+        </div>
+      </div>
+
+      {loadingBrief && (
+        <div className="v4-panel">
+          <div className="v4-empty">Загрузка результата…</div>
+        </div>
+      )}
+
+      {briefResult && editing && (
+        <TranscriptEditorV4
+          taskId={briefResult.task_id}
+          initialBrief={briefResult.brief}
+          onSave={onEditSave}
+          onCancel={() => setEditing(false)}
+        />
+      )}
+
+      {briefResult && !editing && (
+        <TranscriptBriefV4
+          result={briefResult}
+          onNewUpload={onNewUpload}
+          onEdit={() => setEditing(true)}
+        />
+      )}
+
+      {activeTaskId && (
+        <TranscriptProgressV4
+          taskId={activeTaskId}
+          onDone={onProgressDone}
+          onRetry={onRetry}
+        />
+      )}
+
+      {batchFiles.length > 0 && (
+        <BatchProgressV4
+          files={batchFiles}
+          active={batchActive}
+          onCancel={onCancelBatch}
+          onClose={onCloseBatch}
+        />
+      )}
+
+      {showUploadForm && (
+        <UploadZone
+          projects={projects}
+          selectedProject={selectedProject}
+          setSelectedProject={setSelectedProject}
+          selectedModel={selectedModel}
+          setSelectedModel={setSelectedModel}
+          onSubmit={onSubmitFromZone}
+          errorMessage={uploadError}
+        />
+      )}
+
+      {/* History — hidden when a brief is being viewed/edited or actively polled */}
+      {!briefResult && !activeTaskId && !loadingBrief && (
+        <TranscriptHistoryV4
+          onOpen={onOpenFromHistory}
+          onResume={onResumeFromHistory}
+          onRetry={onRetryFromHistory}
+          refreshKey={historyRefreshKey}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/transcripts/UploadZone.tsx
+++ b/src/components/v4/transcripts/UploadZone.tsx
@@ -1,0 +1,264 @@
+import { useCallback, useRef, useState } from "react";
+import type { ProjectConfig } from "../../../types";
+import type { TranscriptionModel } from "../../../utils/transcript";
+
+const VALID_EXTENSIONS = ["mp3", "wav", "m4a", "txt", "md"];
+const AUDIO_EXTENSIONS = ["mp3", "wav", "m4a"];
+const ALL_ACCEPTED = ".mp3,.wav,.m4a,.txt,.md";
+const MAX_FILES = 15;
+
+interface Props {
+  projects: ProjectConfig[];
+  selectedProject: string;
+  setSelectedProject: (v: string) => void;
+  selectedModel: TranscriptionModel;
+  setSelectedModel: (v: TranscriptionModel) => void;
+  onSubmit: (files: File[]) => void;
+  errorMessage?: string | null;
+}
+
+function getFileExt(name: string): string {
+  return name.split(".").pop()?.toLowerCase() ?? "";
+}
+
+function isAudioFile(name: string): boolean {
+  return AUDIO_EXTENSIONS.includes(getFileExt(name));
+}
+
+function ru_plural(n: number, one: string, few: string, many: string): string {
+  const m10 = n % 10;
+  const m100 = n % 100;
+  if (m10 === 1 && m100 !== 11) return one;
+  if (m10 >= 2 && m10 <= 4 && (m100 < 10 || m100 >= 20)) return few;
+  return many;
+}
+
+export function UploadZone({
+  projects,
+  selectedProject,
+  setSelectedProject,
+  selectedModel,
+  setSelectedModel,
+  onSubmit,
+  errorMessage,
+}: Props) {
+  const [files, setFiles] = useState<File[]>([]);
+  const [dragging, setDragging] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const addFiles = useCallback((newFiles: File[]) => {
+    setLocalError(null);
+    const valid: File[] = [];
+    for (const f of newFiles) {
+      const ext = getFileExt(f.name);
+      if (!VALID_EXTENSIONS.includes(ext)) {
+        setLocalError(`Пропущен файл с неподдерживаемым форматом: .${ext}`);
+        continue;
+      }
+      valid.push(f);
+    }
+    setFiles((prev) => {
+      const combined = [...prev, ...valid];
+      if (combined.length > MAX_FILES) {
+        setLocalError(`Максимум ${MAX_FILES} файлов. Лишние не добавлены.`);
+        return combined.slice(0, MAX_FILES);
+      }
+      return combined;
+    });
+  }, []);
+
+  const removeFile = useCallback((index: number) => {
+    setFiles((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const clearFiles = useCallback(() => {
+    setFiles([]);
+    setLocalError(null);
+    if (inputRef.current) inputRef.current.value = "";
+  }, []);
+
+  const onDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragging(true);
+  }, []);
+  const onDragLeave = useCallback(() => setDragging(false), []);
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragging(false);
+      const dropped = Array.from(e.dataTransfer.files);
+      if (dropped.length > 0) addFiles(dropped);
+    },
+    [addFiles]
+  );
+  const onFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const selected = Array.from(e.target.files ?? []);
+      if (selected.length > 0) addFiles(selected);
+      if (inputRef.current) inputRef.current.value = "";
+    },
+    [addFiles]
+  );
+
+  const handleSubmit = useCallback(() => {
+    if (files.length === 0 || !selectedProject) return;
+    onSubmit(files);
+    setFiles([]);
+    if (inputRef.current) inputRef.current.value = "";
+  }, [files, selectedProject, onSubmit]);
+
+  const hasAudio = files.some((f) => isAudioFile(f.name));
+  const hasFiles = files.length > 0;
+
+  return (
+    <div className="v4-tpc-upload">
+      <div
+        className={`v4-tpc-dropzone ${dragging ? "is-active" : ""} ${hasFiles ? "has-files" : ""}`}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        onClick={() => !hasFiles && inputRef.current?.click()}
+        role={!hasFiles ? "button" : undefined}
+        tabIndex={!hasFiles ? 0 : undefined}
+        onKeyDown={(e) => {
+          if (!hasFiles && (e.key === "Enter" || e.key === " ")) {
+            e.preventDefault();
+            inputRef.current?.click();
+          }
+        }}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept={ALL_ACCEPTED}
+          multiple
+          onChange={onFileChange}
+          className="v4-tpc-file-input"
+        />
+        {hasFiles ? (
+          <div className="v4-tpc-file-list">
+            {files.map((f, i) => {
+              const audio = isAudioFile(f.name);
+              return (
+                <div key={`${f.name}-${i}`} className="v4-tpc-file-item">
+                  <span className={`v4-tpc-file-badge v4-tpc-file-badge--${audio ? "audio" : "text"}`}>
+                    {audio ? "🎙" : "📄"}
+                  </span>
+                  <span className="v4-tpc-file-name">{f.name}</span>
+                  <span className="v4-tpc-file-size">
+                    {f.size < 1024 * 1024
+                      ? `${(f.size / 1024).toFixed(1)} KB`
+                      : `${(f.size / 1024 / 1024).toFixed(1)} MB`}
+                  </span>
+                  <button
+                    type="button"
+                    className="v4-tpc-file-remove"
+                    aria-label={`Удалить файл ${f.name}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      removeFile(i);
+                    }}
+                  >
+                    ×
+                  </button>
+                </div>
+              );
+            })}
+            <div className="v4-tpc-file-list-foot">
+              <span className="v4-tpc-text-muted">
+                {files.length} {ru_plural(files.length, "файл", "файла", "файлов")}
+              </span>
+              <button
+                type="button"
+                className="v4-linkbtn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  clearFiles();
+                }}
+              >
+                Очистить все
+              </button>
+              <button
+                type="button"
+                className="v4-linkbtn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  inputRef.current?.click();
+                }}
+              >
+                + Добавить
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="v4-tpc-drop-placeholder">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+              <polyline points="17 8 12 3 7 8" />
+              <line x1="12" y1="3" x2="12" y2="15" />
+            </svg>
+            <p>Перетащите файлы сюда или нажмите для выбора</p>
+            <span className="v4-tpc-drop-hint">mp3, wav, m4a, txt, md (до {MAX_FILES} файлов)</span>
+          </div>
+        )}
+      </div>
+
+      <div className="v4-tpc-controls">
+        <label className="v4-tpc-control-field">
+          <span className="v4-tpc-control-key">Проект</span>
+          <select
+            className="v4-pl-input"
+            value={selectedProject}
+            onChange={(e) => setSelectedProject(e.target.value)}
+          >
+            {projects.map((p) => (
+              <option key={p.repo} value={p.repo}>
+                {p.repo} — {p.client}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {hasAudio && (
+          <fieldset className="v4-tpc-control-field">
+            <span className="v4-tpc-control-key">Модель</span>
+            <div className="v4-pillgrp">
+              <button
+                type="button"
+                className={selectedModel === "fast" ? "is-active" : ""}
+                onClick={() => setSelectedModel("fast")}
+                title="30 секунд, спикеры по контексту"
+              >
+                ⚡ Быстрая
+              </button>
+              <button
+                type="button"
+                className={selectedModel === "quality" ? "is-active" : ""}
+                onClick={() => setSelectedModel("quality")}
+                title="7-15 минут, точная диаризация"
+              >
+                🎯 Качественная
+              </button>
+            </div>
+          </fieldset>
+        )}
+
+        <button
+          type="button"
+          className="v4-btn v4-btn--pri v4-tpc-submit"
+          disabled={!hasFiles || !selectedProject}
+          onClick={handleSubmit}
+        >
+          {files.length > 1 ? `Обработать (${files.length})` : "Обработать"}
+        </button>
+      </div>
+
+      {(localError || errorMessage) && (
+        <div className="v4-error" style={{ marginTop: 12 }}>
+          {localError || errorMessage}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -2987,7 +2987,6 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   border-radius: 99px;
   border: 0;
   cursor: pointer;
-  font-family: var(--v4-mono);
 }
 .v4-tpc-quality-chip--static { cursor: default; }
 .v4-tpc-quality-chip--sm { padding: 2px 7px; font-size: 10px; }

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -2672,6 +2672,540 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 }
 
 /* ────────────────────────────────────────
+   TRANSCRIPTS VIEW
+   ──────────────────────────────────────── */
+
+.v4-tpc-text-muted { color: var(--v4-ink-500); }
+
+/* Upload zone */
+.v4-tpc-upload {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  padding: 18px;
+  margin-bottom: 14px;
+}
+.v4-tpc-dropzone {
+  border: 2px dashed var(--v4-line-strong);
+  border-radius: var(--v4-r-md);
+  padding: 28px 18px;
+  background: var(--v4-surface-2);
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 120ms, background 120ms;
+}
+.v4-tpc-dropzone.is-active {
+  border-color: var(--v4-accent-500);
+  background: var(--v4-accent-50);
+}
+.v4-tpc-dropzone.has-files {
+  text-align: left;
+  padding: 10px 14px;
+  cursor: default;
+}
+.v4-tpc-file-input { display: none; }
+.v4-tpc-drop-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  color: var(--v4-ink-500);
+}
+.v4-tpc-drop-placeholder svg {
+  width: 36px;
+  height: 36px;
+  color: var(--v4-ink-400);
+}
+.v4-tpc-drop-placeholder p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--v4-ink-700);
+  font-weight: 500;
+}
+.v4-tpc-drop-hint {
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
+}
+.v4-tpc-file-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v4-tpc-file-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line-soft);
+  border-radius: var(--v4-r-sm);
+  font-size: 13px;
+}
+.v4-tpc-file-badge {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.v4-tpc-file-badge--audio { background: var(--v4-accent-50); }
+.v4-tpc-file-badge--text { background: var(--v4-surface-3); }
+.v4-tpc-file-name {
+  flex: 1;
+  color: var(--v4-ink-900);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.v4-tpc-file-size {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  flex-shrink: 0;
+}
+.v4-tpc-file-remove {
+  width: 22px;
+  height: 22px;
+  border: 0;
+  background: transparent;
+  color: var(--v4-ink-500);
+  cursor: pointer;
+  font-size: 16px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  line-height: 1;
+}
+.v4-tpc-file-remove:hover {
+  background: var(--v4-danger-50);
+  color: var(--v4-danger-700);
+}
+.v4-tpc-file-list-foot {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 4px 6px;
+  font-size: 12px;
+}
+
+.v4-tpc-controls {
+  display: flex;
+  gap: 14px;
+  align-items: flex-end;
+  margin-top: 14px;
+  flex-wrap: wrap;
+}
+.v4-tpc-control-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 160px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+.v4-tpc-control-key {
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--v4-ink-500);
+}
+.v4-tpc-submit { margin-left: auto; }
+
+/* Progress (single task) */
+.v4-tpc-progress-panel { margin-bottom: 14px; }
+.v4-tpc-progress-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 18px 8px;
+}
+.v4-tpc-progress-pct {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v4-ink-700);
+  min-width: 40px;
+  text-align: right;
+}
+.v4-tpc-stepper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 18px 14px;
+  flex-wrap: wrap;
+}
+.v4-tpc-step {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+.v4-tpc-step-label {
+  color: var(--v4-ink-500);
+  letter-spacing: 0.02em;
+  font-weight: 500;
+}
+.v4-tpc-step-label.is-active { color: var(--v4-accent-700); font-weight: 600; }
+.v4-tpc-step-label.is-done { color: var(--v4-ink-700); }
+.v4-tpc-step-detail {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  margin-left: 4px;
+}
+.v4-tpc-progress-stats {
+  display: flex;
+  gap: 18px;
+  padding: 10px 18px 14px;
+  border-top: 1px dashed var(--v4-line);
+  flex-wrap: wrap;
+}
+.v4-tpc-progress-stat {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--v4-ink-700);
+}
+.v4-tpc-progress-stat svg { width: 14px; height: 14px; color: var(--v4-ink-400); }
+.v4-tpc-progress-stat b { color: var(--v4-ink-900); font-weight: 600; font-family: var(--v4-mono); }
+.v4-tpc-progress-error {
+  margin: 0 18px 14px;
+  padding: 12px 14px;
+  background: var(--v4-danger-50);
+  border: 1px solid var(--v4-danger-100);
+  border-radius: var(--v4-r-md);
+  color: var(--v4-danger-700);
+}
+.v4-tpc-progress-error--soft {
+  background: var(--v4-warn-50);
+  border-color: var(--v4-warn-100);
+  color: var(--v4-warn-700);
+}
+.v4-tpc-progress-error p { margin: 0 0 8px; font-size: 13px; }
+.v4-tpc-progress-error p:last-of-type { margin-bottom: 12px; }
+
+/* Batch progress */
+.v4-tpc-batch-panel { margin-bottom: 14px; }
+.v4-tpc-batch-bar { padding: 0 18px 10px; }
+.v4-tpc-batch-list {
+  padding: 6px 0;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.v4-tpc-batch-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 18px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--v4-line-soft);
+}
+.v4-tpc-batch-row:last-child { border-bottom: 0; }
+.v4-tpc-batch-icon {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-size: 11px;
+  font-weight: 700;
+  flex-shrink: 0;
+  font-family: var(--v4-mono);
+}
+.v4-tpc-batch-icon--pending { background: var(--v4-surface-3); color: var(--v4-ink-500); }
+.v4-tpc-batch-icon--uploading { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.v4-tpc-batch-icon--processing {
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
+  animation: v4-spin 1.5s linear infinite;
+}
+.v4-tpc-batch-icon--done { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-tpc-batch-icon--error { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-tpc-batch-name {
+  flex: 1;
+  color: var(--v4-ink-900);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.v4-tpc-batch-status {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  flex-shrink: 0;
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.v4-tpc-batch-status--done { color: var(--v4-success-700); }
+.v4-tpc-batch-status--error { color: var(--v4-danger-700); }
+
+/* Brief panel */
+.v4-tpc-brief-panel { margin-bottom: 14px; }
+.v4-tpc-brief-h {
+  align-items: center;
+  flex-wrap: wrap;
+  row-gap: 8px;
+}
+.v4-tpc-brief-counters {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.v4-tpc-brief-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.v4-tpc-counter {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 99px;
+}
+.v4-tpc-counter--ok { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-tpc-counter--warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-tpc-counter--danger { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+
+.v4-tpc-quality-chip {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 700;
+  padding: 3px 10px;
+  border-radius: 99px;
+  border: 0;
+  cursor: pointer;
+  font-family: var(--v4-mono);
+}
+.v4-tpc-quality-chip--static { cursor: default; }
+.v4-tpc-quality-chip--sm { padding: 2px 7px; font-size: 10px; }
+.v4-tpc-quality--pass { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-tpc-quality--warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-tpc-quality--review { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+
+.v4-tpc-quality-report {
+  margin: 8px 18px;
+  background: var(--v4-surface-2);
+  border: 1px solid var(--v4-line-soft);
+  border-radius: var(--v4-r-md);
+  padding: 12px;
+}
+.v4-tpc-quality-report-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.v4-tpc-quality-report-t {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+.v4-tpc-quality-report-score {
+  font-size: 11px;
+  color: var(--v4-ink-500);
+}
+.v4-tpc-quality-checks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.v4-tpc-quality-check {
+  display: grid;
+  grid-template-columns: 18px 140px 1fr;
+  gap: 8px;
+  font-size: 12px;
+  align-items: baseline;
+}
+.v4-tpc-quality-check-icon {
+  font-weight: 700;
+  text-align: center;
+}
+.v4-tpc-quality-check--pass .v4-tpc-quality-check-icon { color: var(--v4-success-700); }
+.v4-tpc-quality-check--warning .v4-tpc-quality-check-icon { color: var(--v4-warn-700); }
+.v4-tpc-quality-check--fail .v4-tpc-quality-check-icon { color: var(--v4-danger-700); }
+.v4-tpc-quality-check-name { font-weight: 600; color: var(--v4-ink-700); }
+.v4-tpc-quality-check-msg { color: var(--v4-ink-600); }
+
+.v4-tpc-brief-content {
+  padding: 8px 24px 18px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--v4-ink-800);
+}
+
+.v4-tpc-accordion {
+  border-top: 1px solid var(--v4-line-soft);
+  padding: 0 18px;
+}
+.v4-tpc-accordion-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: 0;
+  padding: 12px 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-700);
+  cursor: pointer;
+  width: 100%;
+  font-family: var(--v4-sans);
+  text-align: left;
+}
+.v4-tpc-accordion-toggle:hover { color: var(--v4-ink-900); }
+.v4-tpc-accordion-arrow {
+  display: inline-block;
+  font-size: 10px;
+  color: var(--v4-ink-400);
+  transition: transform 120ms;
+}
+.v4-tpc-accordion-arrow.is-open { transform: rotate(90deg); }
+.v4-tpc-accordion-body {
+  padding: 4px 6px 18px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--v4-ink-700);
+}
+
+/* Editor */
+.v4-tpc-editor-panel { margin-bottom: 14px; }
+.v4-tpc-editor-h {
+  flex-wrap: wrap;
+  row-gap: 8px;
+}
+.v4-tpc-editor-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.v4-tpc-editor-dirty {
+  font-size: 11px;
+  color: var(--v4-warn-700);
+}
+.v4-tpc-editor-panes {
+  display: grid;
+  height: 540px;
+  gap: 1px;
+  background: var(--v4-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
+}
+.v4-tpc-editor-panes--split { grid-template-columns: 1fr 1fr; }
+.v4-tpc-editor-panes--edit { grid-template-columns: 1fr; }
+.v4-tpc-editor-panes--preview { grid-template-columns: 1fr; }
+.v4-tpc-editor-textarea {
+  border: 0;
+  padding: 14px 18px;
+  font-family: var(--v4-mono);
+  font-size: 13px;
+  line-height: 1.55;
+  background: var(--v4-paper);
+  color: var(--v4-ink-900);
+  resize: none;
+  outline: none;
+  width: 100%;
+  height: 100%;
+}
+.v4-tpc-editor-preview {
+  background: var(--v4-paper);
+  padding: 14px 18px;
+  overflow-y: auto;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--v4-ink-800);
+}
+
+/* History */
+.v4-tpc-history-panel { margin-bottom: 14px; }
+.v4-tpc-history-h {
+  flex-wrap: wrap;
+  row-gap: 10px;
+}
+.v4-tpc-history-tools {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.v4-tpc-history-search { width: 200px; }
+.v4-tpc-history-select {
+  min-width: 0;
+  width: auto;
+  padding: 0 8px;
+  font-size: 12px;
+}
+
+.v4-tpc-history-rows {
+  display: flex;
+  flex-direction: column;
+}
+.v4-tpc-history-row {
+  display: grid;
+  grid-template-columns: 110px 130px 1fr 90px 130px 90px auto;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 18px;
+  border-bottom: 1px solid var(--v4-line-soft);
+  font-size: 12px;
+}
+.v4-tpc-history-row:last-child { border-bottom: 0; }
+.v4-tpc-history-row.is-active { background: var(--v4-accent-50); }
+.v4-tpc-history-cell { min-width: 0; }
+.v4-tpc-history-date { font-size: 11px; color: var(--v4-ink-500); }
+.v4-tpc-history-project { color: var(--v4-ink-700); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v4-tpc-history-file { color: var(--v4-ink-900); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v4-tpc-history-model { font-size: 11px; color: var(--v4-ink-700); }
+.v4-tpc-history-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+.v4-tpc-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 99px;
+  white-space: nowrap;
+}
+.v4-tpc-status--done { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-tpc-status--active { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.v4-tpc-status--err { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-tpc-status-pulse {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--v4-accent-500);
+  animation: v4-pulse 1.5s ease-in-out infinite;
+}
+.v4-tpc-btn-icon {
+  width: 30px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ────────────────────────────────────────
    RESPONSIVE
    ──────────────────────────────────────── */
 @media (max-width: 1100px) {
@@ -2710,6 +3244,17 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   .v4-pl-results-search { width: 100%; }
   .v4-pl-cx-grid { grid-template-columns: repeat(3, 1fr); }
   .v4-ms-grid-full { grid-template-columns: 1fr; }
+  .v4-tpc-history-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+    padding: 12px 16px;
+  }
+  .v4-tpc-history-actions { justify-content: flex-start; flex-wrap: wrap; }
+  .v4-tpc-history-search { width: 100%; }
+  .v4-tpc-history-tools { width: 100%; }
+  .v4-tpc-editor-panes--split { grid-template-columns: 1fr; }
+  .v4-tpc-controls > * { width: 100%; }
+  .v4-tpc-submit { margin-left: 0; }
 }
 .v4-burger { display: none; }
 @media (max-width: 700px) {


### PR DESCRIPTION
## Summary

Полный редизайн вкладки **Транскрипты** в V4 design-system. Заменяет 5 legacy компонентов (~1500 LOC) на модульную V4-структуру, сохраняет 100% функциональности и добавляет UX-улучшения.

## Структура

`src/components/v4/transcripts/`:
- **TranscriptsView** — orchestrator + aggregate strip
- **UploadZone** — drag-drop + project/model selectors
- **TranscriptProgressV4** — phase stepper (V4 dots + pulse) + live timer
- **BatchProgressV4** — V4-styled batch list с прогресс-баром
- **TranscriptBriefV4** — markdown viewer + quality badges + accordion
- **TranscriptEditorV4** — split editor + Cmd/Ctrl-S
- **TranscriptHistoryV4** — фильтруемая история (status/project/model + search/sort)

## Перенесено из legacy (1:1)

- Drag-and-drop multi-file upload (15 max, audio/text валидация)
- Single + batch upload (concurrency=2)
- 5-фазный stepper (intake → stt → enrichment → structuring → synthesis)
- Live elapsed timer + 30-min stuck detection + retry on poll exhaustion
- Quality badges (pass/warning/needs_review) + collapsible quality report
- BRIEF markdown render (DOMPurify+marked) + accordion для transcript
- Split editor (Edit/Split/Preview), useDeferredValue, autosave draft, beforeunload guard, draft restore
- History: open/resume/retry/delete + auto-refresh 5s while active
- localStorage persistence: project, model

## Новые фичи

| Фича | Описание |
|---|---|
| **Aggregate strip** | N в истории · X в работе · Y готово · Z ошибки (color-coded, 10s auto-refresh while active) |
| **History filters** | Status pills (Все/Активные/Готово/Ошибки) с counts + search by filename/project + model dropdown + project dropdown |
| **History sort** | Дата / Файл / Проект / Модель / Статус с asc/desc |
| **Persist filter state** | localStorage `makeit.transcriptsHistory.v1` с allow-list валидацией (Milestones-style), search transient |
| **Cmd/Ctrl-S** | Быстрое сохранение в редакторе |
| **«● несохранённые»** | Live-индикатор в editor toolbar когда dirty |
| **V4 phase dots** | Pulse-animation для running stage (как в Pipeline) |
| **Color-coded quality chips** | Вместо текстовых badges |
| **Mobile-friendly history** | На ≤1100px row становится одной колонкой, actions wrap |

## A11y / технические

- UploadZone dropzone `role=button` + `tabIndex` + Enter/Space
- Sort menu `role=menu/menuitemradio` с `aria-checked`, Escape + outside-click
- Editor textarea `aria-label`
- Quality badge button `aria-expanded` + `aria-controls`
- Reuse V4 tokens
- Reuse `tpc-brief-content` legacy CSS class для markdown rendering (theme-agnostic типографика)

## Verified locally

- ✅ `npx tsc --noEmit` — 0 errors
- ✅ `npm run lint` — 0 errors
- ✅ `npm run build` — clean
- ✅ Preview at 1440×900: header / agg-strip / upload zone / history error-state — все рендерится, console clean

## Test plan

- [ ] Реальный pipeline API — список транскрипций загружается, agg-strip показывает корректные counts
- [ ] Upload одного файла → активный progress с live timer
- [ ] Upload N≥2 файлов → batch panel с concurrency=2
- [ ] Фильтр по статусу (pills) фильтрует строки + counts видимы
- [ ] Search по filename — корректно фильтрует
- [ ] Sort по каждому из 5 ключей + asc/desc
- [ ] Открыть транскрипцию из истории → BRIEF view с markdown
- [ ] Edit BRIEF → Cmd/Ctrl-S сохраняет, dirty indicator появляется/исчезает
- [ ] Retry failed transcription из истории
- [ ] Delete с confirm
- [ ] Persistence: filter/sort сохраняются после reload
- [ ] Адаптив 1100px / 700px (mobile history layout, vertical controls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)