### PR TITLE
feat(quality): redesign Quality dashboard in V4 design system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { PipelineView } from "./components/v4/pipeline/PipelineView";
 import { TranscriptsView } from "./components/v4/transcripts/TranscriptsView";
 import { ResearchTab } from "./components/ResearchTab";
 import { SpecsTab } from "./components/SpecsTab";
-import { QualityTab } from "./components/QualityTab";
+import { QualityView } from "./components/v4/quality/QualityView";
 import { DebateTab } from "./components/DebateTab";
 import { Sidebar } from "./components/v4/Sidebar";
 import { Topbar } from "./components/v4/Topbar";
@@ -286,13 +286,11 @@ function AppInner() {
             </div>
           )}
         </div>
-        <div className="v4-legacy-frame" style={{ display: tab === "quality" ? undefined : "none" }}>
+        <div style={{ display: tab === "quality" ? undefined : "none" }}>
           {visitedTabs.has("quality") && (
-            <div className="bento-grid">
-              <ErrorBoundary fallback="Ошибка вкладки Quality">
-                <QualityTab />
-              </ErrorBoundary>
-            </div>
+            <ErrorBoundary fallback="Ошибка вкладки Quality">
+              <QualityView />
+            </ErrorBoundary>
           )}
         </div>
         <div className="v4-legacy-frame" style={{ display: tab === "debate" ? undefined : "none" }}>

--- a/src/components/v4/quality/AutoTunerConfigCard.tsx
+++ b/src/components/v4/quality/AutoTunerConfigCard.tsx
@@ -1,0 +1,249 @@
+import { useState } from "react";
+import type { QualityConfig, QualityConfigUpdate } from "../../../types";
+
+interface Props {
+  config: QualityConfig | null;
+  onSave: (update: QualityConfigUpdate) => Promise<QualityConfig>;
+}
+
+function fmtHours(h: number): string {
+  if (h <= 0) return "готов";
+  if (h < 1) return `${Math.round(h * 60)} мин`;
+  return `${h.toFixed(1)} ч`;
+}
+
+export function AutoTunerConfigCard({ config, onSave }: Props) {
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [draft, setDraft] = useState<QualityConfigUpdate>({});
+
+  if (config === null) {
+    return (
+      <div className="v4-panel">
+        <div className="v4-panel-h">
+          <div className="v4-panel-t">AutoTuner · Config</div>
+        </div>
+        <div className="v4-empty">Config недоступен (pipeline API offline?)</div>
+      </div>
+    );
+  }
+
+  const merged: QualityConfig = { ...config, ...draft };
+  const hasChanges = Object.keys(draft).length > 0;
+
+  async function save(updatesOverride?: QualityConfigUpdate) {
+    const update: QualityConfigUpdate = updatesOverride ?? draft;
+    if (Object.keys(update).length === 0) return;
+    setSaving(true);
+    setLocalError(null);
+    try {
+      await onSave(update);
+      // Toggle saves leave slider draft intact for explicit review.
+      if (updatesOverride === undefined) setDraft({});
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : "Ошибка сохранения");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function toggleRetroMode() {
+    const next = merged.retro_mode === "auto_apply" ? "reporting" : "auto_apply";
+    await save({ retro_mode: next });
+  }
+
+  async function toggleValidator() {
+    await save({ validate_numeric_claims: !merged.validate_numeric_claims });
+  }
+
+  return (
+    <div className="v4-panel">
+      <div
+        className="v4-panel-h v4-qa-config-h"
+        role="button"
+        tabIndex={0}
+        onClick={() => setOpen((v) => !v)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setOpen((v) => !v);
+          }
+        }}
+        aria-expanded={open}
+      >
+        <div className="v4-panel-t">
+          <span className="v4-qa-arrow" aria-hidden="true">{open ? "▾" : "▸"}</span>{" "}
+          AutoTuner · Config
+        </div>
+        <div className="v4-qa-config-summary">
+          <span className={`v4-tag ${merged.retro_mode === "auto_apply" ? "v4-tag--ok" : ""}`}>
+            {merged.retro_mode === "auto_apply" ? "auto_apply" : "reporting"}
+          </span>
+          <span className="v4-pl-mono v4-qa-text-muted">
+            {(merged.auto_apply_min_confidence * 100).toFixed(0)}% conf · {merged.auto_apply_cooldown_hours}h cd
+          </span>
+          {merged.cooldown_active && (
+            <span className="v4-tag v4-tag--warn">cd · {fmtHours(merged.cooldown_remaining_hours)}</span>
+          )}
+        </div>
+      </div>
+
+      {open && (
+        <div className="v4-qa-config-body">
+          {localError && <div className="v4-error">{localError}</div>}
+
+          <div className="v4-qa-config-grid">
+            <div className="v4-qa-config-cell">
+              <div className="v4-qa-config-label">Retro mode</div>
+              <button
+                type="button"
+                className={`v4-qa-toggle ${merged.retro_mode === "auto_apply" ? "is-on" : ""}`}
+                disabled={saving}
+                onClick={toggleRetroMode}
+              >
+                <span className="v4-qa-toggle-dot" />
+                {merged.retro_mode === "auto_apply" ? "auto_apply" : "reporting"}
+              </button>
+              <div className="v4-qa-config-hint">
+                auto_apply применяет Tier-1 lessons автоматически; reporting — только stage.
+              </div>
+            </div>
+
+            <SliderCell
+              label="Min confidence"
+              value={merged.auto_apply_min_confidence}
+              displayValue={`${(merged.auto_apply_min_confidence * 100).toFixed(0)}%`}
+              min={0.5}
+              max={1.0}
+              step={0.01}
+              disabled={saving}
+              onChange={(v) => setDraft((d) => ({ ...d, auto_apply_min_confidence: v }))}
+            />
+
+            <SliderCell
+              label="Cooldown (часы)"
+              value={merged.auto_apply_cooldown_hours}
+              displayValue={String(merged.auto_apply_cooldown_hours)}
+              min={1}
+              max={168}
+              step={1}
+              disabled={saving}
+              onChange={(v) => setDraft((d) => ({ ...d, auto_apply_cooldown_hours: v }))}
+            />
+
+            <SliderCell
+              label="KPI degradation threshold"
+              value={merged.kpi_degradation_threshold}
+              displayValue={`${(merged.kpi_degradation_threshold * 100).toFixed(0)}%`}
+              min={0.01}
+              max={0.5}
+              step={0.01}
+              disabled={saving}
+              onChange={(v) => setDraft((d) => ({ ...d, kpi_degradation_threshold: v }))}
+            />
+
+            <SliderCell
+              label="Lessons · max lines"
+              value={merged.lessons_max_lines}
+              displayValue={String(merged.lessons_max_lines)}
+              min={10}
+              max={1000}
+              step={10}
+              disabled={saving}
+              onChange={(v) => setDraft((d) => ({ ...d, lessons_max_lines: v }))}
+            />
+
+            <SliderCell
+              label="Lessons TTL (дни)"
+              value={merged.lessons_ttl_days}
+              displayValue={String(merged.lessons_ttl_days)}
+              min={1}
+              max={365}
+              step={1}
+              disabled={saving}
+              onChange={(v) => setDraft((d) => ({ ...d, lessons_ttl_days: v }))}
+            />
+
+            <div className="v4-qa-config-cell">
+              <div className="v4-qa-config-label">Numeric claim validator</div>
+              <button
+                type="button"
+                className={`v4-qa-toggle ${merged.validate_numeric_claims ? "is-on" : ""}`}
+                disabled={saving}
+                onClick={toggleValidator}
+              >
+                <span className="v4-qa-toggle-dot" />
+                {merged.validate_numeric_claims ? "on" : "off"}
+              </button>
+              <div className="v4-qa-config-hint">
+                Сверяет числа в lessons с metrics.jsonl. Tolerance{" "}
+                {(merged.validation_tolerance * 100).toFixed(0)}%.
+              </div>
+            </div>
+          </div>
+
+          <div className="v4-qa-config-actions">
+            {hasChanges && (
+              <>
+                <button
+                  type="button"
+                  className="v4-btn v4-btn--pri"
+                  disabled={saving}
+                  onClick={() => save()}
+                >
+                  {saving ? "Сохранение…" : "Сохранить"}
+                </button>
+                <button
+                  type="button"
+                  className="v4-btn"
+                  disabled={saving}
+                  onClick={() => setDraft({})}
+                >
+                  Отменить
+                </button>
+              </>
+            )}
+            {merged.last_apply_at && (
+              <span className="v4-pl-mono v4-qa-text-muted">
+                last apply: {new Date(merged.last_apply_at).toLocaleString()}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SliderProps {
+  label: string;
+  value: number;
+  displayValue: string;
+  min: number;
+  max: number;
+  step: number;
+  disabled: boolean;
+  onChange: (value: number) => void;
+}
+
+function SliderCell({ label, value, displayValue, min, max, step, disabled, onChange }: SliderProps) {
+  return (
+    <div className="v4-qa-config-cell">
+      <div className="v4-qa-config-label">
+        {label}
+        <span className="v4-pl-mono v4-qa-config-value">{displayValue}</span>
+      </div>
+      <input
+        type="range"
+        className="v4-qa-slider"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+    </div>
+  );
+}

--- a/src/components/v4/quality/LessonsViewer.tsx
+++ b/src/components/v4/quality/LessonsViewer.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import type { LessonsFileResponse } from "../../../types";
+import { fmtAge } from "./utils";
+
+interface Props {
+  projectSlug: string | null;
+  cache: Record<string, LessonsFileResponse>;
+  loadLessons: (slug: string) => Promise<LessonsFileResponse>;
+}
+
+const FILE_LABELS: Record<string, string> = {
+  "lessons-retro.md": "Retro lessons (autotuner)",
+  "lessons-review.md": "Review lessons (per-PR)",
+  "lessons-learned.md": "Legacy",
+};
+
+const FILE_ORDER = ["lessons-retro.md", "lessons-review.md", "lessons-learned.md"] as const;
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
+  const [activeTab, setActiveTab] = useState<string>("lessons-retro.md");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!projectSlug) return;
+    if (cache[projectSlug]) return;
+    let cancelled = false;
+    Promise.resolve().then(() => {
+      if (cancelled) return;
+      setLoading(true);
+      setError(null);
+      loadLessons(projectSlug)
+        .catch((err) => {
+          if (!cancelled) setError(err instanceof Error ? err.message : "Ошибка загрузки");
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    });
+    return () => { cancelled = true; };
+  }, [projectSlug, cache, loadLessons]);
+
+  if (!projectSlug) {
+    return (
+      <div className="v4-panel">
+        <div className="v4-panel-h">
+          <div className="v4-panel-t">Lessons Viewer</div>
+        </div>
+        <div className="v4-empty">
+          Выберите проект в фильтре «Все проекты», чтобы просмотреть lessons-файлы.
+        </div>
+      </div>
+    );
+  }
+
+  const data = cache[projectSlug];
+  const files = data?.files ?? [];
+  const availableNames = files.map((f) => f.filename);
+  const effectiveTab = availableNames.includes(activeTab)
+    ? activeTab
+    : (availableNames[0] ?? activeTab);
+  const activeFile = files.find((f) => f.filename === effectiveTab);
+
+  return (
+    <div className="v4-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">
+          Lessons · <span className="v4-pl-mono">{projectSlug}</span>
+          {loading && <span className="v4-pl-mono v4-qa-text-muted" style={{ marginLeft: 8 }}>загрузка…</span>}
+        </div>
+      </div>
+
+      {error && <div className="v4-error">{error}</div>}
+
+      <div className="v4-qa-lessons-tabs">
+        {FILE_ORDER.map((fname) => {
+          const present = availableNames.includes(fname);
+          const f = files.find((x) => x.filename === fname);
+          return (
+            <button
+              key={fname}
+              type="button"
+              className={`v4-qa-lessons-tab ${effectiveTab === fname ? "is-active" : ""}`}
+              disabled={!present}
+              onClick={() => setActiveTab(fname)}
+              title={present ? FILE_LABELS[fname] : "Файл отсутствует"}
+            >
+              {FILE_LABELS[fname]}
+              {present && <span className="v4-pl-mono v4-qa-lessons-count">{f?.line_count ?? 0}</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      {activeFile ? (
+        <>
+          <div className="v4-qa-lessons-meta">
+            <span className="v4-pl-mono">{activeFile.filename}</span>
+            <span className="v4-pl-mono v4-qa-text-muted">{fmtBytes(activeFile.size_bytes)}</span>
+            <span className="v4-pl-mono v4-qa-text-muted">{activeFile.line_count} строк</span>
+            <span className="v4-pl-mono v4-qa-text-muted">{fmtAge(activeFile.mtime)}</span>
+          </div>
+          <pre className="v4-qa-lessons-pre">{activeFile.content || "(пустой файл)"}</pre>
+        </>
+      ) : !loading ? (
+        <div className="v4-empty">В этом проекте пока нет lessons файлов.</div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/v4/quality/LessonsViewer.tsx
+++ b/src/components/v4/quality/LessonsViewer.tsx
@@ -24,24 +24,31 @@ function fmtBytes(n: number): string {
 
 export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
   const [activeTab, setActiveTab] = useState<string>("lessons-retro.md");
-  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Derive loading state from cache + error so we never paint the
+  // "no files" empty state on the first frame before the fetch starts.
+  // The previous Promise.resolve().then(setLoading(true)) microtask
+  // guarded the `react-hooks/set-state-in-effect` rule but caused a
+  // visible flash where loading=false rendered before flipping to true.
+  const cached = projectSlug ? cache[projectSlug] : undefined;
+  const loading = projectSlug !== null && cached === undefined && error === null;
 
   useEffect(() => {
     if (!projectSlug) return;
     if (cache[projectSlug]) return;
     let cancelled = false;
+    // Microtask defers setError(null) past the effect body so the
+    // react-hooks/set-state-in-effect lint rule (which fires on sync
+    // setState during useEffect) is satisfied. Unlike the previous
+    // setLoading deferral, this no longer causes a visible flash —
+    // `loading` is now derived from cache + error rather than stored.
     Promise.resolve().then(() => {
       if (cancelled) return;
-      setLoading(true);
       setError(null);
-      loadLessons(projectSlug)
-        .catch((err) => {
-          if (!cancelled) setError(err instanceof Error ? err.message : "Ошибка загрузки");
-        })
-        .finally(() => {
-          if (!cancelled) setLoading(false);
-        });
+      loadLessons(projectSlug).catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Ошибка загрузки");
+      });
     });
     return () => { cancelled = true; };
   }, [projectSlug, cache, loadLessons]);
@@ -59,13 +66,13 @@ export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
     );
   }
 
-  const data = cache[projectSlug];
-  const files = data?.files ?? [];
+  const files = cached?.files ?? [];
   const availableNames = files.map((f) => f.filename);
   const effectiveTab = availableNames.includes(activeTab)
     ? activeTab
     : (availableNames[0] ?? activeTab);
   const activeFile = files.find((f) => f.filename === effectiveTab);
+  const tabPanelId = `v4-qa-lessons-panel-${projectSlug}`;
 
   return (
     <div className="v4-panel">
@@ -78,15 +85,20 @@ export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
 
       {error && <div className="v4-error">{error}</div>}
 
-      <div className="v4-qa-lessons-tabs">
+      <div className="v4-qa-lessons-tabs" role="tablist" aria-label="Lessons файлы">
         {FILE_ORDER.map((fname) => {
           const present = availableNames.includes(fname);
           const f = files.find((x) => x.filename === fname);
+          const selected = effectiveTab === fname;
           return (
             <button
               key={fname}
               type="button"
-              className={`v4-qa-lessons-tab ${effectiveTab === fname ? "is-active" : ""}`}
+              role="tab"
+              aria-selected={selected}
+              aria-controls={tabPanelId}
+              tabIndex={selected ? 0 : -1}
+              className={`v4-qa-lessons-tab ${selected ? "is-active" : ""}`}
               disabled={!present}
               onClick={() => setActiveTab(fname)}
               title={present ? FILE_LABELS[fname] : "Файл отсутствует"}
@@ -98,19 +110,23 @@ export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
         })}
       </div>
 
-      {activeFile ? (
-        <>
-          <div className="v4-qa-lessons-meta">
-            <span className="v4-pl-mono">{activeFile.filename}</span>
-            <span className="v4-pl-mono v4-qa-text-muted">{fmtBytes(activeFile.size_bytes)}</span>
-            <span className="v4-pl-mono v4-qa-text-muted">{activeFile.line_count} строк</span>
-            <span className="v4-pl-mono v4-qa-text-muted">{fmtAge(activeFile.mtime)}</span>
-          </div>
-          <pre className="v4-qa-lessons-pre">{activeFile.content || "(пустой файл)"}</pre>
-        </>
-      ) : !loading ? (
-        <div className="v4-empty">В этом проекте пока нет lessons файлов.</div>
-      ) : null}
+      <div id={tabPanelId} role="tabpanel">
+        {activeFile ? (
+          <>
+            <div className="v4-qa-lessons-meta">
+              <span className="v4-pl-mono">{activeFile.filename}</span>
+              <span className="v4-pl-mono v4-qa-text-muted">{fmtBytes(activeFile.size_bytes)}</span>
+              <span className="v4-pl-mono v4-qa-text-muted">{activeFile.line_count} строк</span>
+              <span className="v4-pl-mono v4-qa-text-muted">{fmtAge(activeFile.mtime)}</span>
+            </div>
+            <pre className="v4-qa-lessons-pre">{activeFile.content || "(пустой файл)"}</pre>
+          </>
+        ) : loading ? (
+          <div className="v4-empty">Загрузка lessons-файлов…</div>
+        ) : (
+          <div className="v4-empty">В этом проекте пока нет lessons файлов.</div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/v4/quality/PendingChangePreview.tsx
+++ b/src/components/v4/quality/PendingChangePreview.tsx
@@ -32,6 +32,14 @@ export function PendingChangePreviewV4({ change, loadPreview, onConfirm, onCance
     return () => { cancelled = true; };
   }, [change.id, loadPreview]);
 
+  // Initial focus on mount only — separate from the keydown effect so an
+  // unstable `onCancel` reference (the parent passes an inline arrow) can't
+  // cause the close button to repeatedly steal focus on every parent
+  // re-render (e.g. when actionLoading flips during an approve action).
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+  }, []);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
@@ -40,7 +48,6 @@ export function PendingChangePreviewV4({ change, loadPreview, onConfirm, onCance
       }
     };
     window.addEventListener("keydown", onKey);
-    closeButtonRef.current?.focus();
     return () => window.removeEventListener("keydown", onKey);
   }, [onCancel]);
 

--- a/src/components/v4/quality/PendingChangePreview.tsx
+++ b/src/components/v4/quality/PendingChangePreview.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from "react";
+import type { ApplyPreview, PendingChange } from "../../../types";
+
+interface Props {
+  change: PendingChange;
+  loadPreview: (changeId: string) => Promise<ApplyPreview>;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const TITLE_ID = "v4-qa-pp-title";
+
+export function PendingChangePreviewV4({ change, loadPreview, onConfirm, onCancel }: Props) {
+  const [preview, setPreview] = useState<ApplyPreview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.resolve().then(() => {
+      if (cancelled) return;
+      setLoading(true);
+      setError(null);
+      loadPreview(change.id)
+        .then((p) => { if (!cancelled) setPreview(p); })
+        .catch((err) => {
+          if (!cancelled) setError(err instanceof Error ? err.message : "Ошибка загрузки preview");
+        })
+        .finally(() => { if (!cancelled) setLoading(false); });
+    });
+    return () => { cancelled = true; };
+  }, [change.id, loadPreview]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    closeButtonRef.current?.focus();
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  const validationOk = preview?.validation === null || preview?.validation?.ok !== false;
+  const validationFailed = preview?.validation != null && validationOk === false;
+
+  return (
+    <div className="v4-qa-modal-backdrop" onClick={onCancel}>
+      <div
+        className="v4-qa-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={TITLE_ID}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="v4-qa-modal-h">
+          <div id={TITLE_ID} className="v4-qa-modal-t">Preview · {change.target}</div>
+          <button
+            type="button"
+            ref={closeButtonRef}
+            className="v4-qa-modal-x"
+            aria-label="Закрыть"
+            onClick={onCancel}
+          >×</button>
+        </div>
+
+        <div className="v4-qa-modal-body">
+          <div className="v4-qa-modal-section">
+            <div className="v4-qa-modal-label">Content</div>
+            <div className="v4-qa-modal-content">{change.content}</div>
+          </div>
+
+          <div className="v4-qa-modal-meta">
+            <div><span className="v4-qa-modal-meta-l">Tier</span><span>{change.tier}</span></div>
+            <div><span className="v4-qa-modal-meta-l">Confidence</span><span>{(change.confidence * 100).toFixed(0)}%</span></div>
+            <div><span className="v4-qa-modal-meta-l">Retro</span><span>{change.retro_period}</span></div>
+          </div>
+
+          {loading ? (
+            <div className="v4-empty">Загрузка preview…</div>
+          ) : error ? (
+            <div className="v4-error">{error}</div>
+          ) : preview ? (
+            <>
+              <div className="v4-qa-modal-badges">
+                {preview.dedup_hit ? (
+                  <span className="v4-tag v4-tag--warn">⚠ Duplicate</span>
+                ) : (
+                  <span className="v4-tag v4-tag--ok">✓ Not a duplicate</span>
+                )}
+                {preview.would_rotate && <span className="v4-tag">⟳ Would rotate file</span>}
+                {preview.validation !== null && (
+                  validationOk ? (
+                    <span className="v4-tag v4-tag--ok">✓ Validation OK</span>
+                  ) : (
+                    <span className="v4-tag v4-tag--danger">
+                      ⚠ {String((preview.validation as { reason?: string }).reason ?? "validation failed")}
+                    </span>
+                  )
+                )}
+                {preview.scoped_projects && preview.scoped_projects.length > 0 ? (
+                  <span className="v4-tag">scope: {preview.scoped_projects.join(", ")}</span>
+                ) : (
+                  <span className="v4-tag">scope: all projects</span>
+                )}
+              </div>
+
+              <div className="v4-qa-modal-section">
+                <div className="v4-qa-modal-label">
+                  Targets · {preview.targets.length} {preview.targets.length === 1 ? "файл" : "файлов"}
+                </div>
+                <div className="v4-qa-modal-targets">
+                  {preview.targets.length === 0 ? (
+                    <span className="v4-qa-text-muted">нет resolved targets</span>
+                  ) : (
+                    preview.targets.map((t) => (
+                      <code key={t} className="v4-qa-modal-target">{t}</code>
+                    ))
+                  )}
+                </div>
+              </div>
+
+              <div className="v4-qa-modal-section">
+                <div className="v4-qa-modal-label">
+                  Diff · current lines: {preview.current_line_count}
+                </div>
+                <pre className="v4-qa-modal-diff">
+                  {preview.preview_diff || "(no diff — file would be empty)"}
+                </pre>
+              </div>
+            </>
+          ) : null}
+        </div>
+
+        <div className="v4-qa-modal-foot">
+          <button type="button" className="v4-btn" onClick={onCancel}>Отменить</button>
+          <button
+            type="button"
+            className="v4-btn v4-btn--pri"
+            disabled={loading || !!error || (preview?.dedup_hit ?? false) || validationFailed}
+            onClick={onConfirm}
+            title={
+              preview?.dedup_hit
+                ? "Нельзя применить duplicate"
+                : validationFailed
+                  ? "Validation failed — сверьте цифры в lesson с metrics.jsonl"
+                  : undefined
+            }
+          >
+            Применить
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/quality/PendingChangesPanel.tsx
+++ b/src/components/v4/quality/PendingChangesPanel.tsx
@@ -1,0 +1,281 @@
+import { useEffect, useMemo, useState } from "react";
+import type { ApplyPreview, PendingChange } from "../../../types";
+import { fmtDateTime } from "./utils";
+import { PendingChangePreviewV4 } from "./PendingChangePreview";
+
+interface Props {
+  changes: PendingChange[];
+  actionLoading: string | null;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+  loadPreview?: (changeId: string) => Promise<ApplyPreview>;
+  onBulkReject?: (ids: string[]) => Promise<unknown>;
+  tierFilter: number | null;
+  onTierFilterChange: (tier: number | null) => void;
+}
+
+const TIER_OPTS: Array<[number | null, string]> = [
+  [null, "Все тиры"],
+  [1, "T1 lessons"],
+  [2, "T2 rules"],
+  [3, "T3 config"],
+];
+
+function ageHours(iso: string): number {
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return 0;
+  return Math.max(0, (Date.now() - t) / (1000 * 60 * 60));
+}
+
+function fmtAgeShort(iso: string): string {
+  const h = ageHours(iso);
+  if (h < 1) return `${Math.round(h * 60)} мин`;
+  if (h < 24) return `${h.toFixed(0)} ч`;
+  const d = h / 24;
+  if (d < 7) return `${d.toFixed(0)} дн`;
+  return `${Math.round(d / 7)} нед`;
+}
+
+export function PendingChangesPanel({
+  changes,
+  actionLoading,
+  onApprove,
+  onReject,
+  loadPreview,
+  onBulkReject,
+  tierFilter,
+  onTierFilterChange,
+}: Props) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [previewChange, setPreviewChange] = useState<PendingChange | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [bulkLoading, setBulkLoading] = useState(false);
+
+  // Sort: invalid first, then by confidence × age (urgency).
+  // Memoized: prop array reference is stable across renders only when it
+  // really hasn't changed (parent uses identity), so this is safe.
+  const sortedChanges = useMemo(() => {
+    const arr = [...changes];
+    arr.sort((a, b) => {
+      const aBad = (a.validation as { ok?: boolean } | null)?.ok === false ? 1 : 0;
+      const bBad = (b.validation as { ok?: boolean } | null)?.ok === false ? 1 : 0;
+      if (aBad !== bBad) return bBad - aBad;
+      const scoreA = a.confidence * Math.log(1 + ageHours(a.created_at));
+      const scoreB = b.confidence * Math.log(1 + ageHours(b.created_at));
+      return scoreB - scoreA;
+    });
+    return arr;
+  }, [changes]);
+
+  // Reconcile per-row state when filters drop rows from view.
+  useEffect(() => {
+    const visibleIds = new Set(sortedChanges.map((c) => c.id));
+    setSelectedIds((prev) => {
+      const next = new Set<string>();
+      for (const id of prev) if (visibleIds.has(id)) next.add(id);
+      return next.size === prev.size ? prev : next;
+    });
+    setExpanded((prev) => {
+      const next = new Set<string>();
+      for (const id of prev) if (visibleIds.has(id)) next.add(id);
+      return next.size === prev.size ? prev : next;
+    });
+    setPreviewChange((prev) => (prev && visibleIds.has(prev.id) ? prev : null));
+  }, [sortedChanges]);
+
+  function toggleSelect(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleExpand(id: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function handleBulkReject() {
+    if (!onBulkReject || selectedIds.size === 0) return;
+    setBulkLoading(true);
+    try {
+      await onBulkReject(Array.from(selectedIds));
+      setSelectedIds(new Set());
+    } finally {
+      setBulkLoading(false);
+    }
+  }
+
+  function handleApplyClick(c: PendingChange) {
+    if (loadPreview) setPreviewChange(c);
+    else onApprove(c.id);
+  }
+
+  return (
+    <div className="v4-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">
+          AutoTuner pending
+          {sortedChanges.length > 0 && (
+            <span className="v4-tag v4-tag--warn" style={{ marginLeft: 8 }}>
+              {sortedChanges.length}
+            </span>
+          )}
+        </div>
+        <div className="v4-pillgrp">
+          {TIER_OPTS.map(([value, label]) => (
+            <button
+              key={label}
+              type="button"
+              className={tierFilter === value ? "is-active" : ""}
+              onClick={() => onTierFilterChange(value)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {onBulkReject && selectedIds.size > 0 && (
+        <div className="v4-qa-bulk">
+          <span className="v4-pl-mono">Выбрано: {selectedIds.size}</span>
+          <button
+            type="button"
+            className="v4-btn v4-qa-btn-reject"
+            disabled={bulkLoading}
+            onClick={handleBulkReject}
+          >
+            {bulkLoading ? "…" : `Отклонить ${selectedIds.size}`}
+          </button>
+          <button type="button" className="v4-btn" onClick={() => setSelectedIds(new Set())}>
+            Снять выбор
+          </button>
+        </div>
+      )}
+
+      {sortedChanges.length === 0 ? (
+        <div className="v4-empty">
+          Нет ожидающих изменений. AutoTuner предложит оптимизации после ретроспективы.
+        </div>
+      ) : (
+        <div className="v4-qa-pending-list">
+          {sortedChanges.map((c) => {
+            const busy = actionLoading === c.id;
+            const isExpanded = expanded.has(c.id);
+            const isSelected = selectedIds.has(c.id);
+            const validationFailed = (c.validation as { ok?: boolean } | null)?.ok === false;
+            const confPct = Math.round(c.confidence * 100);
+            return (
+              <div key={c.id} className={`v4-qa-pending ${isSelected ? "is-selected" : ""}`}>
+                <div className="v4-qa-pending-h">
+                  <div className="v4-qa-pending-meta">
+                    {onBulkReject && (
+                      <input
+                        type="checkbox"
+                        className="v4-qa-checkbox"
+                        checked={isSelected}
+                        onChange={() => toggleSelect(c.id)}
+                        aria-label="Выбрать"
+                      />
+                    )}
+                    <span className="v4-qa-pending-target" title={c.target}>{c.target}</span>
+                    <span className="v4-tag v4-pl-mono">{c.change_type}</span>
+                    <span className="v4-tag">T{c.tier}</span>
+                    {c.scoped_projects && c.scoped_projects.length > 0 && (
+                      <span className="v4-tag">scope: {c.scoped_projects.join(", ")}</span>
+                    )}
+                    {validationFailed && (
+                      <span className="v4-tag v4-tag--danger">⚠ validation</span>
+                    )}
+                    <span className="v4-qa-pending-age v4-pl-mono">{fmtAgeShort(c.created_at)}</span>
+                  </div>
+                  <div className="v4-qa-pending-conf" title={`Уверенность: ${confPct}%`}>
+                    <div className="v4-qa-pending-conf-bar">
+                      <div
+                        className="v4-qa-pending-conf-fill"
+                        style={{ width: `${confPct}%`, background: confColor(c.confidence) }}
+                      />
+                    </div>
+                    <span className="v4-pl-mono v4-qa-pending-conf-l" style={{ color: confColor(c.confidence) }}>
+                      {confPct}%
+                    </span>
+                  </div>
+                </div>
+
+                <div className="v4-qa-pending-content">{c.content}</div>
+                <div className="v4-qa-pending-rationale">{c.rationale}</div>
+
+                {isExpanded && (
+                  <div className="v4-qa-pending-details">
+                    <div>
+                      <span className="v4-qa-text-muted">Staged:</span> {fmtDateTime(c.created_at)}
+                    </div>
+                    {c.validation && (
+                      <pre className="v4-qa-pending-json">
+                        {JSON.stringify(c.validation, null, 2)}
+                      </pre>
+                    )}
+                  </div>
+                )}
+
+                <div className="v4-qa-pending-foot">
+                  <button
+                    type="button"
+                    className="v4-linkbtn"
+                    onClick={() => toggleExpand(c.id)}
+                  >
+                    {isExpanded ? "▴ Свернуть" : "▾ Детали"}
+                  </button>
+                  <span className="v4-qa-text-muted v4-pl-mono">{c.retro_period}</span>
+                  <div className="v4-qa-pending-actions">
+                    <button
+                      type="button"
+                      className="v4-btn v4-btn--pri"
+                      disabled={busy}
+                      onClick={() => handleApplyClick(c)}
+                    >
+                      {busy ? "…" : loadPreview ? "Preview + Apply" : "Применить"}
+                    </button>
+                    <button
+                      type="button"
+                      className="v4-btn v4-qa-btn-reject"
+                      disabled={busy}
+                      onClick={() => onReject(c.id)}
+                    >
+                      {busy ? "…" : "Отклонить"}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {previewChange && loadPreview && (
+        <PendingChangePreviewV4
+          change={previewChange}
+          loadPreview={loadPreview}
+          onCancel={() => setPreviewChange(null)}
+          onConfirm={() => {
+            const id = previewChange.id;
+            setPreviewChange(null);
+            onApprove(id);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function confColor(c: number): string {
+  if (c >= 0.85) return "var(--v4-success-700)";
+  if (c >= 0.7) return "var(--v4-warn-700)";
+  return "var(--v4-danger-700)";
+}

--- a/src/components/v4/quality/QualityBarCharts.tsx
+++ b/src/components/v4/quality/QualityBarCharts.tsx
@@ -1,0 +1,48 @@
+import type { QualityFindingsDistribution, QualityErrorsDistribution } from "../../../types";
+
+const PALETTE = [
+  "var(--v4-accent-500)",
+  "var(--v4-purple-500)",
+  "#06B6D4",
+  "var(--v4-success-500)",
+  "var(--v4-warn-500)",
+  "var(--v4-danger-500)",
+];
+
+function sortedEntries(record: Record<string, number>): [string, number][] {
+  return Object.entries(record).sort((a, b) => b[1] - a[1]);
+}
+
+function HBars({ entries }: { entries: [string, number][] }) {
+  if (entries.length === 0) {
+    return <div className="v4-empty">Нет данных</div>;
+  }
+  const maxVal = Math.max(...entries.map(([, v]) => v), 1);
+  return (
+    <div className="v4-qa-bars">
+      {entries.map(([label, value], i) => {
+        const widthPct = Math.max(2, (value / maxVal) * 100);
+        const color = PALETTE[i % PALETTE.length];
+        return (
+          <div key={label} className="v4-qa-bar-row">
+            <span className="v4-qa-bar-label" title={label}>
+              {label}
+            </span>
+            <div className="v4-qa-bar-track">
+              <div className="v4-qa-bar-fill" style={{ width: `${widthPct}%`, background: color }} />
+            </div>
+            <span className="v4-qa-bar-value v4-pl-mono">{value}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function FindingsBarChart({ data }: { data: QualityFindingsDistribution }) {
+  return <HBars entries={sortedEntries(data.categories)} />;
+}
+
+export function ErrorsBarChart({ data }: { data: QualityErrorsDistribution }) {
+  return <HBars entries={sortedEntries(data.classes)} />;
+}

--- a/src/components/v4/quality/QualityHero.tsx
+++ b/src/components/v4/quality/QualityHero.tsx
@@ -1,0 +1,111 @@
+import type { QualitySnapshot } from "../../../types";
+import { healthColor, healthOf, pct, type Health } from "./utils";
+
+interface Props {
+  snapshot: QualitySnapshot | null;
+  pendingCount: number;
+  retroRunning: boolean;
+  onRunRetro: () => void;
+  onRefresh: () => void;
+}
+
+const HEALTH_LABEL: Record<Health, string> = {
+  ok: "Здоровая система",
+  warn: "Есть замечания",
+  danger: "Требуется внимание",
+  unknown: "Нет данных",
+};
+
+const HEALTH_DESC: Record<Health, string> = {
+  ok: "Pipeline работает в зелёной зоне",
+  warn: "Метрики в жёлтой зоне — стоит присмотреться",
+  danger: "Метрики в красной зоне — нужен retro",
+  unknown: "Запустите pipeline для генерации метрик",
+};
+
+export function QualityHero({
+  snapshot,
+  pendingCount,
+  retroRunning,
+  onRunRetro,
+  onRefresh,
+}: Props) {
+  // Aggregate health: worst of FPR, retry, recovery
+  const health: Health = !snapshot
+    ? "unknown"
+    : worstHealth([
+        healthOf(snapshot.first_pass_success_rate, 0.8, 0.6),
+        healthOf(snapshot.retry_rate, 0.1, 0.25, false),
+        healthOf(snapshot.error_recovery_rate, 0.7, 0.4),
+      ]);
+
+  return (
+    <div className={`v4-qa-hero v4-qa-hero--${health}`}>
+      <div className="v4-qa-hero-status">
+        <span className={`v4-qa-hero-dot v4-qa-hero-dot--${health}`} />
+        <div>
+          <div className="v4-qa-hero-title">{HEALTH_LABEL[health]}</div>
+          <div className="v4-qa-hero-sub">
+            {snapshot ? (
+              <>
+                FPR{" "}
+                <b style={{ color: healthColor(healthOf(snapshot.first_pass_success_rate, 0.8, 0.6)) }}>
+                  {pct(snapshot.first_pass_success_rate, 0)}
+                </b>
+                <span className="v4-qa-sep">·</span>
+                Retry{" "}
+                <b style={{ color: healthColor(healthOf(snapshot.retry_rate, 0.1, 0.25, false)) }}>
+                  {pct(snapshot.retry_rate, 0)}
+                </b>
+                <span className="v4-qa-sep">·</span>
+                Recovery{" "}
+                <b style={{ color: healthColor(healthOf(snapshot.error_recovery_rate, 0.7, 0.4)) }}>
+                  {pct(snapshot.error_recovery_rate, 0)}
+                </b>
+                <span className="v4-qa-sep">·</span>
+                <span className="v4-pl-mono">
+                  {snapshot.merged_count}/{snapshot.total_issues}
+                </span>{" "}
+                merged
+                {pendingCount > 0 && (
+                  <>
+                    <span className="v4-qa-sep">·</span>
+                    <b className="v4-qa-text-warn">{pendingCount}</b> pending
+                  </>
+                )}
+              </>
+            ) : (
+              HEALTH_DESC[health]
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="v4-qa-hero-actions">
+        <button type="button" className="v4-btn" onClick={onRefresh}>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M21 12a9 9 0 11-6.22-8.56" />
+            <path d="M21 3v6h-6" />
+          </svg>
+          Обновить
+        </button>
+        <button
+          type="button"
+          className="v4-btn v4-btn--pri"
+          onClick={onRunRetro}
+          disabled={retroRunning}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <polygon points="5 3 19 12 5 21 5 3" />
+          </svg>
+          {retroRunning ? "Запуск…" : "Run Retro"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function worstHealth(items: Health[]): Health {
+  const order: Health[] = ["danger", "warn", "ok", "unknown"];
+  for (const h of order) if (items.includes(h)) return h;
+  return "unknown";
+}

--- a/src/components/v4/quality/QualityKpiGrid.tsx
+++ b/src/components/v4/quality/QualityKpiGrid.tsx
@@ -1,0 +1,138 @@
+import type { QualitySnapshot, QualityTrends } from "../../../types";
+import {
+  deltaVsPrev,
+  duration,
+  healthColor,
+  healthOf,
+  pct,
+  snapshotSeries,
+  sparklinePath,
+  type Health,
+} from "./utils";
+
+interface Props {
+  snapshot: QualitySnapshot;
+  trends: QualityTrends | null;
+}
+
+interface KpiDef {
+  key: keyof QualitySnapshot;
+  label: string;
+  sub?: string;
+  good: number;
+  bad: number;
+  higherIsBetter: boolean;
+  isPercent: boolean;
+}
+
+const KPIS: KpiDef[] = [
+  { key: "first_pass_success_rate", label: "First Pass", sub: "успех с первой попытки", good: 0.8, bad: 0.6, higherIsBetter: true, isPercent: true },
+  { key: "retry_rate", label: "Retry Rate", sub: "повторные попытки", good: 0.1, bad: 0.25, higherIsBetter: false, isPercent: true },
+  { key: "error_recovery_rate", label: "Recovery", sub: "восстановление после ошибок", good: 0.7, bad: 0.4, higherIsBetter: true, isPercent: true },
+  { key: "qa_pass_rate", label: "QA Pass", sub: "прохождение QA", good: 0.9, bad: 0.7, higherIsBetter: true, isPercent: true },
+  { key: "rollback_rate", label: "Rollback", sub: "частота откатов", good: 0.05, bad: 0.15, higherIsBetter: false, isPercent: true },
+  { key: "avg_finding_density", label: "Finding Density", sub: "ср. findings/задачу", good: 1.0, bad: 3.0, higherIsBetter: false, isPercent: false },
+];
+
+const SPARK_W = 88;
+const SPARK_H = 24;
+
+export function QualityKpiGrid({ snapshot, trends }: Props) {
+  return (
+    <div className="v4-qa-kpi-grid">
+      {KPIS.map((def) => {
+        const raw = snapshot[def.key] as number | null;
+        const series = trends ? snapshotSeries(trends.snapshots, def.key) : [];
+        const delta = deltaVsPrev(series);
+        const h: Health = healthOf(raw, def.good, def.bad, def.higherIsBetter);
+        const color = healthColor(h);
+        const display =
+          raw === null
+            ? "—"
+            : def.isPercent
+              ? pct(raw, 0)
+              : raw.toFixed(2);
+        const trend = trends?.trends?.[def.key];
+        const arrow = trend === "up" ? "↑" : trend === "down" ? "↓" : trend === "flat" ? "→" : "";
+        // Trend arrow color: depends on direction × higherIsBetter
+        const trendBetter =
+          trend === "flat" || !trend
+            ? null
+            : (trend === "up") === def.higherIsBetter;
+        const trendColor =
+          trendBetter === null
+            ? "var(--v4-ink-400)"
+            : trendBetter
+              ? "var(--v4-success-700)"
+              : "var(--v4-danger-700)";
+        const sparkD = series.length > 1 ? sparklinePath(series, SPARK_W, SPARK_H) : "";
+
+        return (
+          <div key={String(def.key)} className={`v4-qa-kpi v4-qa-kpi--${h}`}>
+            <div className="v4-qa-kpi-h">
+              <span className="v4-qa-kpi-label">{def.label}</span>
+              {arrow && (
+                <span className="v4-qa-kpi-trend" style={{ color: trendColor }}>
+                  {arrow}
+                </span>
+              )}
+            </div>
+            <div className="v4-qa-kpi-val" style={{ color }}>
+              {display}
+            </div>
+            {def.sub && <div className="v4-qa-kpi-sub">{def.sub}</div>}
+            <div className="v4-qa-kpi-foot">
+              {sparkD ? (
+                <svg viewBox={`0 0 ${SPARK_W} ${SPARK_H}`} className="v4-qa-spark" aria-hidden="true">
+                  <path d={sparkD} fill="none" stroke={color} strokeWidth={1.5} />
+                </svg>
+              ) : (
+                <span className="v4-qa-spark-empty">нет истории</span>
+              )}
+              {delta && def.isPercent && (
+                <span
+                  className="v4-pl-mono v4-qa-kpi-delta"
+                  style={{ color: deltaColor(delta.abs, def.higherIsBetter) }}
+                  title={`vs среднее за прошлые 3 недели`}
+                >
+                  {delta.abs >= 0 ? "+" : ""}
+                  {(delta.abs * 100).toFixed(1)}pp
+                </span>
+              )}
+              {delta && !def.isPercent && (
+                <span
+                  className="v4-pl-mono v4-qa-kpi-delta"
+                  style={{ color: deltaColor(delta.abs, def.higherIsBetter) }}
+                  title={`vs среднее за прошлые 3 недели`}
+                >
+                  {delta.abs >= 0 ? "+" : ""}
+                  {delta.abs.toFixed(2)}
+                </span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+
+      {/* Always-shown 7th tile for avg_duration (purely informational, no health) */}
+      <div className="v4-qa-kpi v4-qa-kpi--neutral">
+        <div className="v4-qa-kpi-h">
+          <span className="v4-qa-kpi-label">Avg Duration</span>
+        </div>
+        <div className="v4-qa-kpi-val">{duration(snapshot.avg_duration_sec)}</div>
+        <div className="v4-qa-kpi-sub">среднее время выполнения</div>
+        <div className="v4-qa-kpi-foot">
+          <span className="v4-pl-mono v4-qa-kpi-delta v4-qa-kpi-delta--mute">
+            {snapshot.merged_count}/{snapshot.total_issues} merged
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function deltaColor(abs: number, higherIsBetter: boolean): string {
+  const better = higherIsBetter ? abs > 0 : abs < 0;
+  if (Math.abs(abs) < 0.005) return "var(--v4-ink-400)";
+  return better ? "var(--v4-success-700)" : "var(--v4-danger-700)";
+}

--- a/src/components/v4/quality/QualityKpiStrip.tsx
+++ b/src/components/v4/quality/QualityKpiStrip.tsx
@@ -1,0 +1,68 @@
+import type { QualitySnapshot, RetroSummary, PendingChange } from "../../../types";
+import { duration, fmtAge } from "./utils";
+
+interface Props {
+  snapshot: QualitySnapshot | null;
+  pendingChanges: PendingChange[];
+  retros: RetroSummary[];
+  // No tuning history needed in strip — it's already displayed in the
+  // history panel itself with full context.
+}
+
+export function QualityKpiStrip({ snapshot, pendingChanges, retros }: Props) {
+  const total = snapshot?.total_issues ?? 0;
+  const pendingCount = pendingChanges.length;
+  const retrosCount = retros.length;
+  const lastRetro = retros.length > 0 ? retros[0] : null;
+  // Retros come in reverse-chronological order from the API; the first item
+  // is the most recent. Period strings like "2026-W17" don't carry a date,
+  // so we just show count + age placeholder.
+
+  return (
+    <div className="v4-projects-toolbar v4-pl-kpi-strip">
+      <div className="v4-projects-agg">
+        <div className="v4-projects-agg-cell" title="Задач за текущий период">
+          <div className="v4-projects-agg-n num">{total}</div>
+          <div className="v4-projects-agg-l">задач за период</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Среднее время выполнения">
+          <div className="v4-projects-agg-n num">
+            {snapshot ? duration(snapshot.avg_duration_sec) : "—"}
+          </div>
+          <div className="v4-projects-agg-l">avg duration</div>
+        </div>
+        <div
+          className="v4-projects-agg-cell"
+          title="Изменения от AutoTuner, ожидающие ревью"
+        >
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: pendingCount > 0 ? "var(--v4-warn-700)" : undefined }}
+          >
+            {pendingCount}
+          </div>
+          <div className="v4-projects-agg-l">pending changes</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Проведённые ретроспективы">
+          <div className="v4-projects-agg-n num">{retrosCount}</div>
+          <div className="v4-projects-agg-l">retros всего</div>
+        </div>
+        <div
+          className="v4-projects-agg-cell"
+          title={lastRetro ? `Последний retro: ${lastRetro.period}` : "Ретроспективы не проводились"}
+        >
+          <div className="v4-projects-agg-n num">
+            {lastRetro?.period ?? "—"}
+          </div>
+          <div className="v4-projects-agg-l">last retro</div>
+        </div>
+        {snapshot?.period_end && (
+          <div className="v4-projects-agg-cell" title={`Период: ${snapshot.period_start} — ${snapshot.period_end}`}>
+            <div className="v4-projects-agg-n num">{fmtAge(snapshot.period_end)}</div>
+            <div className="v4-projects-agg-l">snapshot age</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/quality/QualityTrends.tsx
+++ b/src/components/v4/quality/QualityTrends.tsx
@@ -1,0 +1,215 @@
+import { useMemo, useState } from "react";
+import type { QualitySnapshot, QualityTrends as QualityTrendsT } from "../../../types";
+
+interface MetricDef {
+  key: keyof QualitySnapshot;
+  label: string;
+  color: string;
+  isPercent: boolean;
+  format: (v: number | null) => string;
+}
+
+const METRICS: MetricDef[] = [
+  { key: "first_pass_success_rate", label: "First Pass", color: "#12B76A", isPercent: true, format: pctFmt },
+  { key: "retry_rate", label: "Retry", color: "#F79009", isPercent: true, format: pctFmt },
+  { key: "error_recovery_rate", label: "Recovery", color: "#2563EB", isPercent: true, format: pctFmt },
+  { key: "qa_pass_rate", label: "QA Pass", color: "#7C3AED", isPercent: true, format: pctFmt },
+  { key: "rollback_rate", label: "Rollback", color: "#EF4444", isPercent: true, format: pctFmt },
+  { key: "avg_finding_density", label: "Findings", color: "#06B6D4", isPercent: false, format: (v) => v === null ? "—" : v.toFixed(2) },
+];
+
+const PERIODS = [4, 8, 12] as const;
+
+function pctFmt(v: number | null): string {
+  if (v === null) return "—";
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+const SVG_W = 720;
+const SVG_H = 240;
+const PAD = { top: 16, right: 16, bottom: 36, left: 44 };
+const CHART_W = SVG_W - PAD.left - PAD.right;
+const CHART_H = SVG_H - PAD.top - PAD.bottom;
+
+function shortDate(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return `${d.getDate().toString().padStart(2, "0")}.${(d.getMonth() + 1)
+    .toString()
+    .padStart(2, "0")}`;
+}
+
+interface Props {
+  trends: QualityTrendsT;
+}
+
+export function QualityTrendsV4({ trends }: Props) {
+  const [activeMetrics, setActiveMetrics] = useState<Set<string>>(
+    () => new Set(["first_pass_success_rate", "retry_rate"]),
+  );
+  const [weeks, setWeeks] = useState<number>(12);
+
+  const snapshots = useMemo(() => {
+    const all = trends.snapshots;
+    return all.length > weeks ? all.slice(all.length - weeks) : all;
+  }, [trends.snapshots, weeks]);
+
+  function toggleMetric(key: string) {
+    setActiveMetrics((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        if (next.size > 1) next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }
+
+  if (snapshots.length === 0) {
+    return <div className="v4-empty">Нет данных для графика. Запустите pipeline.</div>;
+  }
+
+  const selectedDefs = METRICS.filter((m) => activeMetrics.has(String(m.key)));
+  const allPercent = selectedDefs.every((m) => m.isPercent);
+
+  let yMin = Infinity;
+  let yMax = -Infinity;
+  for (const snap of snapshots) {
+    for (const m of selectedDefs) {
+      const v = snap[m.key] as number | null;
+      if (v !== null) {
+        if (v < yMin) yMin = v;
+        if (v > yMax) yMax = v;
+      }
+    }
+  }
+  if (!isFinite(yMin)) {
+    yMin = 0;
+    yMax = 1;
+  }
+  const yRange = yMax - yMin || 1;
+  yMin = Math.max(0, yMin - yRange * 0.1);
+  yMax = yMax + yRange * 0.1;
+  if (allPercent) {
+    yMin = Math.max(0, yMin);
+    yMax = Math.min(1, yMax);
+    if (yMax - yMin < 0.1) {
+      yMin = Math.max(0, yMax - 0.5);
+      yMax = Math.min(1, yMin + 0.5);
+    }
+  }
+
+  const xStep = snapshots.length > 1 ? CHART_W / (snapshots.length - 1) : CHART_W;
+  const toX = (i: number) => PAD.left + i * xStep;
+  const toY = (v: number) => PAD.top + CHART_H - ((v - yMin) / (yMax - yMin)) * CHART_H;
+
+  const yTicks: number[] = [];
+  for (let i = 0; i <= 4; i++) {
+    yTicks.push(yMin + ((yMax - yMin) * i) / 4);
+  }
+
+  const formatY = (v: number) => (allPercent ? `${(v * 100).toFixed(0)}%` : v.toFixed(1));
+
+  return (
+    <div className="v4-qa-trends">
+      <div className="v4-qa-trends-controls">
+        <div className="v4-pillgrp">
+          {PERIODS.map((p) => (
+            <button
+              key={p}
+              type="button"
+              className={weeks === p ? "is-active" : ""}
+              onClick={() => setWeeks(p)}
+            >
+              {p}н
+            </button>
+          ))}
+        </div>
+        <div className="v4-qa-metric-toggles">
+          {METRICS.map((m) => {
+            const on = activeMetrics.has(String(m.key));
+            return (
+              <button
+                key={String(m.key)}
+                type="button"
+                className={`v4-qa-metric-btn ${on ? "is-active" : ""}`}
+                style={on ? { borderColor: m.color, color: m.color } : undefined}
+                onClick={() => toggleMetric(String(m.key))}
+                aria-pressed={on}
+              >
+                <span
+                  className="v4-qa-metric-dot"
+                  style={{ background: on ? m.color : "var(--v4-line-strong)" }}
+                />
+                {m.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <svg viewBox={`0 0 ${SVG_W} ${SVG_H}`} className="v4-qa-svg" role="img" aria-label="Quality KPI trends">
+        {yTicks.map((t, i) => (
+          <g key={i}>
+            <line x1={PAD.left} y1={toY(t)} x2={SVG_W - PAD.right} y2={toY(t)} className="v4-qa-grid-line" />
+            <text x={PAD.left - 6} y={toY(t) + 4} className="v4-qa-y-label">
+              {formatY(t)}
+            </text>
+          </g>
+        ))}
+        {snapshots.map((s, i) => {
+          if (snapshots.length > 8 && i % 2 !== 0 && i !== snapshots.length - 1) return null;
+          return (
+            <text key={i} x={toX(i)} y={SVG_H - 8} className="v4-qa-x-label">
+              {shortDate(s.period_start)}
+            </text>
+          );
+        })}
+        {selectedDefs.map((m) => {
+          const points: { x: number; y: number; val: number }[] = [];
+          snapshots.forEach((s, i) => {
+            const v = s[m.key] as number | null;
+            if (v !== null) points.push({ x: toX(i), y: toY(v), val: v });
+          });
+          if (points.length === 0) return null;
+          const pathD = points
+            .map((p, i) => `${i === 0 ? "M" : "L"} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`)
+            .join(" ");
+          return (
+            <g key={String(m.key)}>
+              <path d={pathD} fill="none" stroke={m.color} strokeWidth={2} />
+              {points.map((p, i) => (
+                <g key={i}>
+                  <circle cx={p.x} cy={p.y} r={3} fill={m.color} />
+                  <title>
+                    {m.label}: {m.format(p.val)}
+                  </title>
+                </g>
+              ))}
+            </g>
+          );
+        })}
+      </svg>
+
+      {Object.keys(trends.trends).length > 0 && (
+        <div className="v4-qa-trend-summary">
+          {selectedDefs.map((m) => {
+            const dir = trends.trends[m.key];
+            if (!dir) return null;
+            const arrow = dir === "up" ? "↑" : dir === "down" ? "↓" : "→";
+            return (
+              <span
+                key={String(m.key)}
+                className="v4-qa-trend-tag"
+                style={{ borderColor: m.color, color: m.color }}
+              >
+                {arrow} {m.label}
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/quality/QualityView.tsx
+++ b/src/components/v4/quality/QualityView.tsx
@@ -1,0 +1,279 @@
+import { useState } from "react";
+import { useQuality } from "../../../hooks/useQuality";
+import { QualityHero } from "./QualityHero";
+import { QualityKpiStrip } from "./QualityKpiStrip";
+import { QualityKpiGrid } from "./QualityKpiGrid";
+import { QualityTrendsV4 } from "./QualityTrends";
+import { FindingsBarChart, ErrorsBarChart } from "./QualityBarCharts";
+import { AutoTunerConfigCard } from "./AutoTunerConfigCard";
+import { PendingChangesPanel } from "./PendingChangesPanel";
+import { TuningHistoryPanel } from "./TuningHistoryPanel";
+import { RetroListV4, RetroDetailV4 } from "./RetrosPanel";
+import { LessonsViewer } from "./LessonsViewer";
+
+const PROJECT_OPTIONS = [
+  { value: null, label: "Все проекты" },
+  { value: "moliyakg", label: "moliyakg" },
+  { value: "mankassa-app", label: "mankassa-app" },
+  { value: "Sewing-ERP", label: "Sewing-ERP" },
+  { value: "solotax-kg", label: "solotax-kg" },
+  { value: "makeit-pipeline", label: "makeit-pipeline" },
+] as const;
+
+export function QualityView() {
+  const {
+    available,
+    loading,
+    error,
+    snapshot,
+    trends,
+    findings,
+    errors: errorsData,
+    pendingChanges,
+    tuningHistory,
+    retros,
+    selectedRetro,
+    retroRunning,
+    actionLoading,
+    qualityConfig,
+    lessonsByProject,
+    projectFilter,
+    tierFilter,
+    refresh,
+    approve,
+    reject,
+    rollback,
+    startRetro,
+    loadRetroDetail,
+    clearRetroDetail,
+    saveQualityConfig,
+    loadLessons,
+    previewChange,
+    bulkReject,
+    setProjectFilter,
+    setTierFilter,
+  } = useQuality();
+
+  const [showLessons, setShowLessons] = useState(false);
+
+  if (loading && !snapshot) {
+    return (
+      <div className="v4-content">
+        <div className="v4-ph">
+          <div>
+            <h1>Quality</h1>
+            <div className="v4-sub">Метрики качества pipeline-агента</div>
+          </div>
+        </div>
+        <div className="v4-empty">Загрузка Quality Dashboard…</div>
+      </div>
+    );
+  }
+
+  if (available === false) {
+    return (
+      <div className="v4-content">
+        <div className="v4-ph">
+          <div>
+            <h1>Quality</h1>
+            <div className="v4-sub">Pipeline API офлайн</div>
+          </div>
+          <div className="v4-ph-right">
+            <button type="button" className="v4-btn v4-btn--pri" onClick={() => refresh()}>
+              Повторить
+            </button>
+          </div>
+        </div>
+        <div className="v4-panel">
+          <div className="v4-empty">
+            Не удалось подключиться к Pipeline API. Quality endpoints — часть makeit-pipeline.
+          </div>
+          <pre className="v4-qa-offline-cmd">
+{`# Pipeline Mac:
+launchctl start com.makeit.pipeline-api
+
+# Или туннель:
+launchctl start com.makeit.pipeline-tunnel`}
+          </pre>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="v4-content">
+      <div className="v4-ph">
+        <div>
+          <h1>Quality</h1>
+          <div className="v4-sub">
+            Метрики pipeline-агента
+            {snapshot?.period_start && snapshot?.period_end && (
+              <>
+                {" · "}
+                <span className="v4-pl-mono">
+                  {snapshot.period_start} — {snapshot.period_end}
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+        <div className="v4-ph-right">
+          <select
+            className="v4-pl-input"
+            value={projectFilter ?? ""}
+            onChange={(e) => setProjectFilter(e.target.value || null)}
+            aria-label="Фильтр по проекту"
+          >
+            {PROJECT_OPTIONS.map((opt) => (
+              <option key={opt.label} value={opt.value ?? ""}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div style={{ height: 10 }} />
+
+      <QualityHero
+        snapshot={snapshot}
+        pendingCount={pendingChanges.length}
+        retroRunning={retroRunning}
+        onRunRetro={() => void startRetro()}
+        onRefresh={() => refresh()}
+      />
+
+      {error && <div className="v4-error" style={{ marginTop: 14 }}>{error}</div>}
+
+      <QualityKpiStrip
+        snapshot={snapshot}
+        pendingChanges={pendingChanges}
+        retros={retros}
+      />
+
+      {snapshot ? (
+        <QualityKpiGrid snapshot={snapshot} trends={trends} />
+      ) : (
+        <div className="v4-panel">
+          <div className="v4-empty">
+            Нет snapshot за текущий период. Запустите pipeline для генерации метрик.
+          </div>
+        </div>
+      )}
+
+      {trends && trends.snapshots.length > 0 && (
+        <div className="v4-panel" style={{ marginTop: 14 }}>
+          <div className="v4-panel-h">
+            <div className="v4-panel-t">Тренды KPI</div>
+            <div className="v4-pl-mono v4-qa-text-muted">
+              {trends.snapshots.length} {trends.snapshots.length === 1 ? "неделя" : "недель"}
+            </div>
+          </div>
+          <div className="v4-qa-trends-body">
+            <QualityTrendsV4 trends={trends} />
+          </div>
+        </div>
+      )}
+
+      {(findings || errorsData) && (
+        <div className="v4-grid" style={{ marginTop: 14 }}>
+          <div className="v4-panel">
+            <div className="v4-panel-h">
+              <div className="v4-panel-t">Findings по категориям</div>
+            </div>
+            <div className="v4-qa-bars-body">
+              {findings && Object.keys(findings.categories).length > 0 ? (
+                <FindingsBarChart data={findings} />
+              ) : (
+                <div className="v4-empty">Нет findings за период.</div>
+              )}
+            </div>
+          </div>
+          <div className="v4-panel">
+            <div className="v4-panel-h">
+              <div className="v4-panel-t">Ошибки по классам</div>
+            </div>
+            <div className="v4-qa-bars-body">
+              {errorsData && Object.keys(errorsData.classes).length > 0 ? (
+                <ErrorsBarChart data={errorsData} />
+              ) : (
+                <div className="v4-empty">Нет ошибок за период.</div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div style={{ marginTop: 14 }}>
+        <AutoTunerConfigCard config={qualityConfig} onSave={saveQualityConfig} />
+      </div>
+
+      <div style={{ marginTop: 14 }}>
+        <PendingChangesPanel
+          changes={pendingChanges}
+          actionLoading={actionLoading}
+          onApprove={approve}
+          onReject={reject}
+          loadPreview={previewChange}
+          onBulkReject={bulkReject}
+          tierFilter={tierFilter}
+          onTierFilterChange={setTierFilter}
+        />
+      </div>
+
+      {tuningHistory.length > 0 && (
+        <div style={{ marginTop: 14 }}>
+          <TuningHistoryPanel
+            history={tuningHistory}
+            actionLoading={actionLoading}
+            onRollback={rollback}
+          />
+        </div>
+      )}
+
+      <div className="v4-panel" style={{ marginTop: 14 }}>
+        <div className="v4-panel-h">
+          <div className="v4-panel-t">
+            Ретроспективы
+            {retros.length > 0 && (
+              <span className="v4-tag" style={{ marginLeft: 8 }}>
+                {retros.length}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="v4-qa-retros-body">
+          {selectedRetro ? (
+            <RetroDetailV4 detail={selectedRetro} onBack={clearRetroDetail} />
+          ) : (
+            <RetroListV4
+              retros={retros}
+              retroRunning={retroRunning}
+              onSelect={loadRetroDetail}
+            />
+          )}
+        </div>
+      </div>
+
+      <div style={{ marginTop: 14 }}>
+        <div className="v4-qa-lessons-toggle">
+          <button
+            type="button"
+            className="v4-linkbtn"
+            onClick={() => setShowLessons((v) => !v)}
+            aria-expanded={showLessons}
+          >
+            {showLessons ? "▾" : "▸"} Lessons файлы (read-only)
+          </button>
+        </div>
+        {showLessons && (
+          <LessonsViewer
+            projectSlug={projectFilter}
+            cache={lessonsByProject}
+            loadLessons={loadLessons}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/quality/RetrosPanel.tsx
+++ b/src/components/v4/quality/RetrosPanel.tsx
@@ -1,0 +1,145 @@
+import type { RetroSummary, RetroDetail, RuleChangeAction } from "../../../types";
+import { formatPeriodRange } from "./utils";
+
+const VALID_ACTIONS: RuleChangeAction[] = ["add", "modify", "remove"];
+
+function actionTagClass(action: RuleChangeAction): string {
+  if (!VALID_ACTIONS.includes(action)) return "v4-tag";
+  if (action === "add") return "v4-tag v4-tag--ok";
+  if (action === "remove") return "v4-tag v4-tag--danger";
+  return "v4-tag";
+}
+
+interface ListProps {
+  retros: RetroSummary[];
+  retroRunning: boolean;
+  onSelect: (period: string) => void;
+}
+
+export function RetroListV4({ retros, retroRunning, onSelect }: ListProps) {
+  if (retros.length === 0) {
+    return (
+      <div className="v4-empty">
+        {retroRunning
+          ? "Запуск retro… результаты появятся через несколько секунд."
+          : "Ретроспективы ещё не проводились. Нажмите «Run Retro» в шапке."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="v4-qa-retros">
+      {retros.map((r) => (
+        <button
+          type="button"
+          key={r.period}
+          className="v4-qa-retro-card"
+          onClick={() => onSelect(r.period)}
+        >
+          <div className="v4-qa-retro-period">
+            <span className="v4-pl-mono">{r.period}</span>
+            <span className="v4-qa-text-muted v4-qa-retro-range">
+              {formatPeriodRange(r.period)}
+            </span>
+          </div>
+          <div className="v4-qa-retro-summary" title={r.summary}>
+            {r.summary}
+          </div>
+          <div className="v4-qa-retro-stats">
+            <span className="v4-tag" title="Паттерны">
+              {r.patterns_count} паттернов
+            </span>
+            <span className="v4-tag" title="Рекомендации">
+              {r.recommendations_count} рекомендаций
+            </span>
+            <span className="v4-tag" title="Изменения правил">
+              {r.rule_changes_count} изменений
+            </span>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+interface DetailProps {
+  detail: RetroDetail;
+  onBack: () => void;
+}
+
+export function RetroDetailV4({ detail, onBack }: DetailProps) {
+  return (
+    <div className="v4-qa-retro-detail">
+      <div className="v4-qa-retro-detail-h">
+        <button type="button" className="v4-btn" onClick={onBack}>← Назад</button>
+        <h3 className="v4-qa-retro-detail-t">
+          Ретроспектива{" "}
+          <span className="v4-pl-mono">{detail.period}</span>
+          <span className="v4-qa-text-muted v4-qa-retro-detail-range">
+            {" "}{formatPeriodRange(detail.period)}
+          </span>
+        </h3>
+      </div>
+
+      <div className="v4-qa-retro-section">
+        <div className="v4-qa-retro-label">Итоги</div>
+        <p className="v4-qa-retro-text">{detail.summary}</p>
+      </div>
+
+      {detail.top_patterns.length > 0 && (
+        <div className="v4-qa-retro-section">
+          <div className="v4-qa-retro-label">
+            Основные паттерны ({detail.top_patterns.length})
+          </div>
+          <div className="v4-qa-patterns">
+            {detail.top_patterns.map((p, i) => (
+              <div key={i} className="v4-qa-pattern">
+                <div className="v4-qa-pattern-h">
+                  <span className="v4-qa-pattern-name">{p.pattern}</span>
+                  <span className="v4-tag v4-pl-mono">×{p.count}</span>
+                </div>
+                {p.examples.length > 0 && (
+                  <ul className="v4-qa-pattern-ex">
+                    {p.examples.map((ex, j) => (
+                      <li key={j}>{ex}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {detail.recommendations.length > 0 && (
+        <div className="v4-qa-retro-section">
+          <div className="v4-qa-retro-label">Рекомендации ({detail.recommendations.length})</div>
+          <ul className="v4-qa-recs">
+            {detail.recommendations.map((r, i) => (
+              <li key={i}>{r}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {detail.proposed_rule_changes.length > 0 && (
+        <div className="v4-qa-retro-section">
+          <div className="v4-qa-retro-label">
+            Предложенные изменения правил ({detail.proposed_rule_changes.length})
+          </div>
+          <div className="v4-qa-rules">
+            {detail.proposed_rule_changes.map((rc, i) => (
+              <div key={i} className="v4-qa-rule">
+                <div className="v4-qa-rule-h">
+                  <span className="v4-qa-rule-name">{rc.rule}</span>
+                  <span className={actionTagClass(rc.action)}>{rc.action}</span>
+                </div>
+                <div className="v4-qa-rule-rationale">{rc.rationale}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/quality/TuningHistoryPanel.tsx
+++ b/src/components/v4/quality/TuningHistoryPanel.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import type { PendingChange, PendingChangeStatus } from "../../../types";
+import { fmtDateTime } from "./utils";
+
+interface Props {
+  history: PendingChange[];
+  actionLoading: string | null;
+  onRollback: (id: string) => void;
+}
+
+const STATUS_LABEL: Record<PendingChangeStatus, string> = {
+  pending: "Ожидает",
+  applied: "Применено",
+  rejected: "Отклонено",
+  rolled_back: "Откат",
+};
+
+const STATUS_TAG_CLASS: Record<PendingChangeStatus, string> = {
+  pending: "v4-tag",
+  applied: "v4-tag v4-tag--ok",
+  rejected: "v4-tag v4-tag--warn",
+  rolled_back: "v4-tag v4-tag--danger",
+};
+
+const INITIAL_SHOW = 10;
+
+export function TuningHistoryPanel({ history, actionLoading, onRollback }: Props) {
+  const [showAll, setShowAll] = useState(false);
+
+  if (history.length === 0) return null;
+
+  const visible = showAll ? history : history.slice(0, INITIAL_SHOW);
+
+  return (
+    <div className="v4-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">История изменений</div>
+        <div className="v4-pl-mono v4-qa-text-muted">{history.length} всего</div>
+      </div>
+
+      <div className="v4-qa-history">
+        {visible.map((c) => {
+          const busy = actionLoading === c.id;
+          return (
+            <div key={c.id} className="v4-qa-history-row">
+              <div className="v4-qa-history-main">
+                <span className={STATUS_TAG_CLASS[c.status]}>{STATUS_LABEL[c.status]}</span>
+                <span className="v4-qa-history-target" title={c.target}>{c.target}</span>
+                <span className="v4-tag v4-pl-mono">{c.change_type}</span>
+              </div>
+              <div className="v4-qa-history-meta">
+                <span className="v4-pl-mono v4-qa-text-muted">{fmtDateTime(c.applied_at)}</span>
+                {c.pr_url && (
+                  <a
+                    className="v4-linkbtn"
+                    href={c.pr_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    PR
+                  </a>
+                )}
+                {c.status === "applied" && (
+                  <button
+                    type="button"
+                    className="v4-btn v4-qa-btn-reject"
+                    disabled={busy}
+                    onClick={() => onRollback(c.id)}
+                  >
+                    {busy ? "…" : "Откатить"}
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {history.length > INITIAL_SHOW && (
+        <div className="v4-qa-history-foot">
+          <button type="button" className="v4-btn" onClick={() => setShowAll((v) => !v)}>
+            {showAll ? "Свернуть" : `Показать все (${history.length})`}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/quality/utils.ts
+++ b/src/components/v4/quality/utils.ts
@@ -1,0 +1,170 @@
+import type { QualitySnapshot } from "../../../types";
+
+export type Health = "ok" | "warn" | "danger" | "unknown";
+
+/** Convert ISO week ("2026-W17") or ISO date string into a human-readable
+ * date range. Falls back to the input if it can't be parsed. */
+export function formatPeriodRange(period: string): string {
+  // ISO week format: "YYYY-Www"
+  const wkMatch = period.match(/^(\d{4})-W(\d{1,2})$/);
+  if (wkMatch) {
+    const year = Number(wkMatch[1]);
+    const week = Number(wkMatch[2]);
+    const start = isoWeekStart(year, week);
+    const end = new Date(start);
+    end.setUTCDate(end.getUTCDate() + 6);
+    return `${shortDate(start)}–${shortDate(end)}`;
+  }
+  // Try as date
+  const d = new Date(period);
+  if (!isNaN(d.getTime())) return shortDate(d);
+  return period;
+}
+
+/** ISO 8601 week → Monday of that week (UTC). */
+function isoWeekStart(year: number, week: number): Date {
+  // Jan 4 is always in week 1. The Monday of week 1 is at most 3 days before Jan 4.
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const dayOfWeek = jan4.getUTCDay() || 7; // Sunday → 7
+  const week1Monday = new Date(jan4);
+  week1Monday.setUTCDate(jan4.getUTCDate() - (dayOfWeek - 1));
+  const target = new Date(week1Monday);
+  target.setUTCDate(week1Monday.getUTCDate() + (week - 1) * 7);
+  return target;
+}
+
+const RU_MONTHS_SHORT = [
+  "янв", "фев", "мар", "апр", "май", "июн",
+  "июл", "авг", "сен", "окт", "ноя", "дек",
+];
+
+function shortDate(d: Date): string {
+  return `${d.getUTCDate()} ${RU_MONTHS_SHORT[d.getUTCMonth()]}`;
+}
+
+export function pct(value: number | null, decimals = 1): string {
+  if (value === null || !isFinite(value)) return "—";
+  return `${(value * 100).toFixed(decimals)}%`;
+}
+
+export function duration(seconds: number | null): string {
+  if (seconds === null || !isFinite(seconds)) return "—";
+  if (seconds < 60) return `${Math.round(seconds)}с`;
+  if (seconds < 3600) return `${(seconds / 60).toFixed(1)}м`;
+  return `${(seconds / 3600).toFixed(1)}ч`;
+}
+
+export function fmtAge(iso: string | null): string {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return "—";
+  const days = Math.floor((Date.now() - t) / (1000 * 60 * 60 * 24));
+  if (days < 0) return "—";
+  if (days === 0) return "сегодня";
+  if (days === 1) return "вчера";
+  if (days < 7) return `${days} дн`;
+  if (days < 30) return `${Math.floor(days / 7)} нед`;
+  return `${Math.floor(days / 30)} мес`;
+}
+
+export function fmtDateTime(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "—";
+  return d.toLocaleString("ru-RU", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/** Color rule: higher_is_better=true → ≥good ok, ≥bad warn, else danger. */
+export function healthOf(
+  value: number | null,
+  good: number,
+  bad: number,
+  higherIsBetter = true,
+): Health {
+  if (value === null || !isFinite(value)) return "unknown";
+  if (higherIsBetter) {
+    if (value >= good) return "ok";
+    if (value >= bad) return "warn";
+    return "danger";
+  }
+  if (value <= good) return "ok";
+  if (value <= bad) return "warn";
+  return "danger";
+}
+
+export function healthColor(h: Health): string {
+  if (h === "ok") return "var(--v4-success-700)";
+  if (h === "warn") return "var(--v4-warn-700)";
+  if (h === "danger") return "var(--v4-danger-700)";
+  return "var(--v4-ink-500)";
+}
+
+/** Compose an SVG polyline path scaled to the given viewBox. */
+export function sparklinePath(
+  values: (number | null)[],
+  width: number,
+  height: number,
+): string {
+  const present = values
+    .map((v, i) => (v === null || !isFinite(v) ? null : { i, v }))
+    .filter((p): p is { i: number; v: number } => p !== null);
+  if (present.length === 0) return "";
+  const min = Math.min(...present.map((p) => p.v));
+  const max = Math.max(...present.map((p) => p.v));
+  const range = max - min || 1;
+  const xStep = values.length > 1 ? width / (values.length - 1) : 0;
+  return present
+    .map((p, idx) => {
+      const x = p.i * xStep;
+      const y = height - ((p.v - min) / range) * height;
+      return `${idx === 0 ? "M" : "L"} ${x.toFixed(1)} ${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+/** Series of values across snapshots, ordered chronologically. */
+export function snapshotSeries(
+  snapshots: QualitySnapshot[],
+  key: keyof QualitySnapshot,
+): (number | null)[] {
+  return snapshots.map((s) => {
+    const v = s[key];
+    if (typeof v === "number") return v;
+    return null;
+  });
+}
+
+/** Compare current to mean of previous N snapshots → delta as fraction
+ *  (e.g. -0.05 = 5% worse for higher-is-better, 5% better for lower-is-better).
+ *  Returns null if not enough data. */
+export function deltaVsPrev(
+  series: (number | null)[],
+  prevWindow = 3,
+): { abs: number; cur: number } | null {
+  const present = series.filter((v): v is number => v !== null && isFinite(v));
+  if (present.length < 2) return null;
+  const cur = present[present.length - 1];
+  const prevSlice = present.slice(-1 - prevWindow, -1);
+  if (prevSlice.length === 0) return null;
+  const prev = prevSlice.reduce((s, x) => s + x, 0) / prevSlice.length;
+  return { abs: cur - prev, cur };
+}
+
+export function relativeAgo(ts: string | null): string {
+  if (!ts) return "—";
+  const t = new Date(ts).getTime();
+  if (isNaN(t)) return "—";
+  const diffSec = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  if (diffSec < 60) return `${diffSec}с назад`;
+  const m = Math.floor(diffSec / 60);
+  if (m < 60) return `${m}м назад`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}ч назад`;
+  const d = Math.floor(h / 24);
+  return `${d}д назад`;
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -3205,6 +3205,886 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 }
 
 /* ────────────────────────────────────────
+   QUALITY (Quality Dashboard)
+   ──────────────────────────────────────── */
+.v4-qa-text-muted { color: var(--v4-ink-500); }
+.v4-qa-text-warn { color: var(--v4-warn-700); }
+
+/* — Hero — */
+.v4-qa-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  padding: 18px 22px;
+  margin-bottom: 14px;
+}
+.v4-qa-hero--ok { border-left: 4px solid var(--v4-success-500); }
+.v4-qa-hero--warn { border-left: 4px solid var(--v4-warn-500); }
+.v4-qa-hero--danger { border-left: 4px solid var(--v4-danger-500); }
+.v4-qa-hero--unknown { border-left: 4px solid var(--v4-ink-300); }
+
+.v4-qa-hero-status {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  min-width: 0;
+}
+.v4-qa-hero-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.v4-qa-hero-dot--ok { background: var(--v4-success-500); box-shadow: 0 0 0 4px var(--v4-success-50); }
+.v4-qa-hero-dot--warn { background: var(--v4-warn-500); box-shadow: 0 0 0 4px var(--v4-warn-50); }
+.v4-qa-hero-dot--danger {
+  background: var(--v4-danger-500);
+  box-shadow: 0 0 0 4px var(--v4-danger-50);
+  animation: v4-qa-pulse 1.6s ease-in-out infinite;
+}
+.v4-qa-hero-dot--unknown { background: var(--v4-ink-300); }
+@keyframes v4-qa-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+.v4-qa-hero-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  margin-bottom: 4px;
+}
+.v4-qa-hero-sub {
+  font-size: 13px;
+  color: var(--v4-ink-500);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+.v4-qa-hero-sub b { color: var(--v4-ink-900); font-weight: 600; }
+.v4-qa-sep { color: var(--v4-ink-300); margin: 0 4px; }
+.v4-qa-hero-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* — KPI grid (current snapshot + sparkline + delta) — */
+.v4-qa-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 12px;
+  margin-top: 14px;
+  margin-bottom: 14px;
+}
+.v4-qa-kpi {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+.v4-qa-kpi--ok { border-top: 3px solid var(--v4-success-500); }
+.v4-qa-kpi--warn { border-top: 3px solid var(--v4-warn-500); }
+.v4-qa-kpi--danger { border-top: 3px solid var(--v4-danger-500); }
+.v4-qa-kpi--unknown,
+.v4-qa-kpi--neutral { border-top: 3px solid var(--v4-line); }
+
+.v4-qa-kpi-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.v4-qa-kpi-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--v4-ink-500);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.v4-qa-kpi-trend {
+  font-size: 13px;
+  font-weight: 700;
+}
+.v4-qa-kpi-val {
+  font-family: var(--v4-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--v4-ink-900);
+  line-height: 1;
+}
+.v4-qa-kpi-sub {
+  font-size: 11px;
+  color: var(--v4-ink-400);
+}
+.v4-qa-kpi-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+}
+.v4-qa-spark { width: 88px; height: 24px; flex-shrink: 0; }
+.v4-qa-spark-empty {
+  font-size: 10px;
+  color: var(--v4-ink-300);
+  font-style: italic;
+}
+.v4-qa-kpi-delta {
+  font-size: 11px;
+  font-weight: 600;
+}
+.v4-qa-kpi-delta--mute { color: var(--v4-ink-400); font-weight: 400; }
+
+/* — Trends chart — */
+.v4-qa-trends-body { padding: 16px 18px; }
+.v4-qa-trends {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.v4-qa-trends-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.v4-qa-metric-toggles {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.v4-qa-metric-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid var(--v4-line-strong);
+  background: var(--v4-paper);
+  border-radius: 16px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--v4-ink-500);
+  cursor: pointer;
+  transition: all 100ms;
+}
+.v4-qa-metric-btn:hover { background: var(--v4-surface-2); }
+.v4-qa-metric-btn.is-active { background: var(--v4-paper); }
+.v4-qa-metric-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.v4-qa-svg {
+  width: 100%;
+  height: auto;
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-md);
+  padding: 8px 4px;
+}
+.v4-qa-grid-line { stroke: var(--v4-line); stroke-width: 1; stroke-dasharray: 2 4; }
+.v4-qa-y-label, .v4-qa-x-label {
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  fill: var(--v4-ink-400);
+  text-anchor: end;
+}
+.v4-qa-x-label { text-anchor: middle; }
+.v4-qa-trend-summary {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.v4-qa-trend-tag {
+  display: inline-flex;
+  gap: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 12px;
+  border: 1px solid;
+  background: var(--v4-paper);
+}
+
+/* — Findings/Errors bars — */
+.v4-qa-bars-body { padding: 16px 18px; }
+.v4-qa-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.v4-qa-bar-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 28%) 1fr 50px;
+  align-items: center;
+  gap: 10px;
+}
+.v4-qa-bar-label {
+  font-size: 12px;
+  color: var(--v4-ink-700);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.v4-qa-bar-track {
+  height: 8px;
+  background: var(--v4-surface-3);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.v4-qa-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 200ms ease;
+}
+.v4-qa-bar-value {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  text-align: right;
+}
+
+/* — AutoTuner config card — */
+.v4-qa-config-h {
+  cursor: pointer;
+  user-select: none;
+}
+.v4-qa-config-h:focus-visible {
+  outline: 2px solid var(--v4-accent-500);
+  outline-offset: -2px;
+}
+.v4-qa-arrow {
+  display: inline-block;
+  width: 10px;
+  color: var(--v4-ink-500);
+  font-size: 11px;
+}
+.v4-qa-config-summary {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.v4-qa-config-body {
+  padding: 16px 18px 18px;
+}
+.v4-qa-config-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 14px;
+}
+.v4-qa-config-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v4-qa-config-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--v4-ink-500);
+  font-weight: 600;
+}
+.v4-qa-config-value {
+  color: var(--v4-ink-900);
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.v4-qa-config-hint {
+  font-size: 11px;
+  color: var(--v4-ink-400);
+  line-height: 1.4;
+}
+.v4-qa-slider {
+  width: 100%;
+  cursor: pointer;
+  accent-color: var(--v4-accent-500);
+}
+.v4-qa-slider:disabled { cursor: not-allowed; opacity: 0.6; }
+.v4-qa-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border: 1px solid var(--v4-line-strong);
+  background: var(--v4-paper);
+  border-radius: var(--v4-r-md);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v4-ink-700);
+  cursor: pointer;
+  transition: all 120ms;
+}
+.v4-qa-toggle.is-on {
+  border-color: var(--v4-success-500);
+  color: var(--v4-success-700);
+  background: var(--v4-success-50);
+}
+.v4-qa-toggle:disabled { opacity: 0.6; cursor: not-allowed; }
+.v4-qa-toggle-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--v4-ink-300);
+}
+.v4-qa-toggle.is-on .v4-qa-toggle-dot { background: var(--v4-success-500); }
+.v4-qa-config-actions {
+  margin-top: 14px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* — Pending changes — */
+.v4-qa-bulk {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 10px 18px;
+  background: var(--v4-warn-50);
+  border-bottom: 1px solid var(--v4-warn-100);
+}
+.v4-qa-pending-list {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 0;
+}
+.v4-qa-pending {
+  border-bottom: 1px solid var(--v4-line-soft);
+  padding: 12px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v4-qa-pending:last-child { border-bottom: 0; }
+.v4-qa-pending.is-selected { background: var(--v4-accent-50); }
+.v4-qa-pending-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.v4-qa-pending-meta {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.v4-qa-checkbox {
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+  accent-color: var(--v4-accent-500);
+}
+.v4-qa-pending-target {
+  font-family: var(--v4-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 360px;
+}
+.v4-qa-pending-age {
+  font-size: 11px;
+  color: var(--v4-ink-400);
+  margin-left: 4px;
+}
+.v4-qa-pending-conf {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 130px;
+  flex-shrink: 0;
+}
+.v4-qa-pending-conf-bar {
+  flex: 1;
+  height: 6px;
+  background: var(--v4-surface-3);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.v4-qa-pending-conf-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 200ms ease;
+}
+.v4-qa-pending-conf-l {
+  font-size: 11px;
+  font-weight: 700;
+  min-width: 32px;
+  text-align: right;
+}
+.v4-qa-pending-content {
+  font-size: 13px;
+  color: var(--v4-ink-800);
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.v4-qa-pending-rationale {
+  font-size: 12px;
+  color: var(--v4-ink-500);
+  font-style: italic;
+}
+.v4-qa-pending-details {
+  font-size: 12px;
+  color: var(--v4-ink-700);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v4-qa-pending-json {
+  margin: 0;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-700);
+  white-space: pre-wrap;
+  max-height: 220px;
+  overflow: auto;
+}
+.v4-qa-pending-foot {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.v4-qa-pending-actions {
+  display: flex;
+  gap: 6px;
+  margin-left: auto;
+}
+.v4-qa-btn-reject {
+  border-color: var(--v4-danger-500);
+  color: var(--v4-danger-700);
+}
+.v4-qa-btn-reject:hover {
+  background: var(--v4-danger-50);
+  border-color: var(--v4-danger-500);
+}
+
+/* — Tuning history — */
+.v4-qa-history {
+  display: flex;
+  flex-direction: column;
+}
+.v4-qa-history-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--v4-line-soft);
+  flex-wrap: wrap;
+}
+.v4-qa-history-row:last-child { border-bottom: 0; }
+.v4-qa-history-main {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.v4-qa-history-target {
+  font-family: var(--v4-mono);
+  font-size: 12px;
+  color: var(--v4-ink-800);
+  font-weight: 500;
+  max-width: 320px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.v4-qa-history-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.v4-qa-history-foot {
+  padding: 10px 18px;
+  border-top: 1px solid var(--v4-line-soft);
+}
+
+/* — Retros — */
+.v4-qa-retros-body { padding: 14px 18px; }
+.v4-qa-retros {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+}
+.v4-qa-retro-card {
+  text-align: left;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  padding: 12px 14px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: all 100ms;
+  font: inherit;
+  color: inherit;
+}
+.v4-qa-retro-card:hover {
+  border-color: var(--v4-accent-500);
+  box-shadow: 0 0 0 3px var(--v4-accent-50);
+}
+.v4-qa-retro-period {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.v4-qa-retro-period .v4-pl-mono {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+.v4-qa-retro-range {
+  font-size: 11px;
+}
+.v4-qa-retro-summary {
+  font-size: 12px;
+  color: var(--v4-ink-700);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.v4-qa-retro-stats {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+/* — Retro detail — */
+.v4-qa-retro-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.v4-qa-retro-detail-h {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.v4-qa-retro-detail-t {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+.v4-qa-retro-detail-range {
+  font-size: 13px;
+  font-weight: 400;
+}
+.v4-qa-retro-section { display: flex; flex-direction: column; gap: 8px; }
+.v4-qa-retro-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--v4-ink-500);
+  font-weight: 600;
+}
+.v4-qa-retro-text {
+  margin: 0;
+  font-size: 13px;
+  color: var(--v4-ink-700);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+.v4-qa-patterns,
+.v4-qa-rules {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.v4-qa-pattern,
+.v4-qa-rule {
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
+  padding: 10px 12px;
+}
+.v4-qa-pattern-h,
+.v4-qa-rule-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.v4-qa-pattern-name,
+.v4-qa-rule-name {
+  font-family: var(--v4-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+.v4-qa-pattern-ex {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  font-size: 12px;
+  color: var(--v4-ink-600);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.v4-qa-rule-rationale {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--v4-ink-600);
+  line-height: 1.4;
+}
+.v4-qa-recs {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--v4-ink-700);
+}
+
+/* — Lessons viewer — */
+.v4-qa-lessons-toggle {
+  margin-bottom: 8px;
+}
+.v4-qa-lessons-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 12px 18px 0;
+  border-bottom: 1px solid var(--v4-line-soft);
+  flex-wrap: wrap;
+}
+.v4-qa-lessons-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--v4-ink-500);
+  cursor: pointer;
+  margin-bottom: -1px;
+}
+.v4-qa-lessons-tab:hover:not(:disabled) { color: var(--v4-ink-800); }
+.v4-qa-lessons-tab.is-active {
+  color: var(--v4-accent-700);
+  border-bottom-color: var(--v4-accent-500);
+}
+.v4-qa-lessons-tab:disabled { opacity: 0.4; cursor: not-allowed; }
+.v4-qa-lessons-count {
+  font-size: 10px;
+  color: var(--v4-ink-400);
+  background: var(--v4-surface-3);
+  border-radius: 8px;
+  padding: 1px 6px;
+}
+.v4-qa-lessons-meta {
+  display: flex;
+  gap: 12px;
+  padding: 10px 18px;
+  font-size: 11px;
+  background: var(--v4-surface-2);
+  border-bottom: 1px solid var(--v4-line-soft);
+  flex-wrap: wrap;
+}
+.v4-qa-lessons-pre {
+  margin: 0;
+  padding: 14px 18px;
+  font-family: var(--v4-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--v4-ink-800);
+  background: var(--v4-paper);
+  white-space: pre-wrap;
+  max-height: 480px;
+  overflow: auto;
+}
+
+/* — Modal (preview) — */
+.v4-qa-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 16, 32, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 24px;
+}
+.v4-qa-modal {
+  background: var(--v4-paper);
+  border-radius: var(--v4-r-lg);
+  width: 100%;
+  max-width: 720px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 50px rgba(11, 16, 32, 0.25);
+  overflow: hidden;
+}
+.v4-qa-modal-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--v4-line-soft);
+}
+.v4-qa-modal-t {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+.v4-qa-modal-x {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--v4-r-sm);
+  border: 0;
+  background: transparent;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--v4-ink-500);
+  cursor: pointer;
+}
+.v4-qa-modal-x:hover { background: var(--v4-surface-2); }
+.v4-qa-modal-body {
+  padding: 16px 18px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.v4-qa-modal-section { display: flex; flex-direction: column; gap: 6px; }
+.v4-qa-modal-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--v4-ink-500);
+  font-weight: 600;
+}
+.v4-qa-modal-content {
+  font-size: 13px;
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
+  padding: 10px 12px;
+  white-space: pre-wrap;
+  color: var(--v4-ink-800);
+  line-height: 1.45;
+}
+.v4-qa-modal-meta {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  padding: 10px 12px;
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
+}
+.v4-qa-modal-meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.v4-qa-modal-meta-l {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--v4-ink-400);
+  font-weight: 600;
+}
+.v4-qa-modal-badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.v4-qa-modal-targets {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.v4-qa-modal-target {
+  font-family: var(--v4-mono);
+  font-size: 12px;
+  color: var(--v4-ink-700);
+  background: var(--v4-surface-3);
+  padding: 4px 8px;
+  border-radius: var(--v4-r-sm);
+}
+.v4-qa-modal-diff {
+  margin: 0;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  background: var(--v4-surface-3);
+  padding: 10px 12px;
+  border-radius: var(--v4-r-sm);
+  max-height: 280px;
+  overflow: auto;
+  color: var(--v4-ink-800);
+  line-height: 1.5;
+}
+.v4-qa-modal-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--v4-line-soft);
+}
+
+.v4-qa-offline-cmd {
+  margin: 14px 18px;
+  font-family: var(--v4-mono);
+  font-size: 12px;
+  background: var(--v4-surface-2);
+  padding: 12px 14px;
+  border-radius: var(--v4-r-sm);
+  color: var(--v4-ink-700);
+  white-space: pre;
+  overflow-x: auto;
+}
+
+/* Tag color extras for ok/warn/danger states (used across Quality) */
+.v4-tag--ok { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-tag--warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+
+/* ────────────────────────────────────────
    RESPONSIVE
    ──────────────────────────────────────── */
 @media (max-width: 1100px) {


### PR DESCRIPTION
## Summary
- Migrate Quality tab from legacy bento layout to V4 design tokens (12 new components in `src/components/v4/quality/`)
- Reuse `useQuality` hook unchanged — pure presentation-layer rewrite
- Functional improvements: health-classified hero, KPI sparklines, pending changes sorted by validation × confidence × age, retro period rendered as date range

## UX changes
- **Quality Hero** with at-a-glance health (ok/warn/danger from worst of FPR/Retry/Recovery), promotes Run Retro to the top
- **KPI strip** with portfolio metrics (tasks, avg duration, pending, retros, last retro, snapshot age)
- **KPI grid** — 7 cards with mini-sparklines drawn from trends data + delta vs previous 3-week mean
- **AutoTuner config** collapsible (header summary line: mode + min-conf + cooldown), opens to slider grid
- **Pending changes** auto-sorted: validation-failed first, then `confidence × log(age)`; bulk-reject toolbar; tier filter as `v4-pillgrp`
- **Tuning history** hidden when empty; status as colored `v4-tag`
- **Retros** card grid with human-readable date range derived from ISO week period (`2026-W17` → `21 апр–27 апр`)
- **Lessons viewer** collapsed by default behind toggle so it doesn't bloat the page

## Test plan
- [x] `npx tsc --noEmit` — green
- [x] `npm run lint` — green
- [x] `npm run build` — green
- [ ] Manual smoke: open Quality tab with Pipeline API online — KPIs render, hero classifies health, click Run Retro, expand AutoTuner, approve/reject a pending change

🤖 Generated with [Claude Code](https://claude.com/claude-code)