### PR TITLE
fix(quality): a11y improvements per post-merge review

### DIFF
--- a/src/components/v4/quality/AutoTunerConfigCard.tsx
+++ b/src/components/v4/quality/AutoTunerConfigCard.tsx
@@ -57,6 +57,8 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
     await save({ validate_numeric_claims: !merged.validate_numeric_claims });
   }
 
+  const bodyId = "v4-qa-autotuner-config-body";
+
   return (
     <div className="v4-panel">
       <div
@@ -71,6 +73,7 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
           }
         }}
         aria-expanded={open}
+        aria-controls={bodyId}
       >
         <div className="v4-panel-t">
           <span className="v4-qa-arrow" aria-hidden="true">{open ? "▾" : "▸"}</span>{" "}
@@ -90,7 +93,7 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
       </div>
 
       {open && (
-        <div className="v4-qa-config-body">
+        <div id={bodyId} className="v4-qa-config-body">
           {localError && <div className="v4-error">{localError}</div>}
 
           <div className="v4-qa-config-grid">

--- a/src/components/v4/quality/LessonsViewer.tsx
+++ b/src/components/v4/quality/LessonsViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { LessonsFileResponse } from "../../../types";
 import { fmtAge } from "./utils";
 
@@ -25,6 +25,7 @@ function fmtBytes(n: number): string {
 export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
   const [activeTab, setActiveTab] = useState<string>("lessons-retro.md");
   const [error, setError] = useState<string | null>(null);
+  const tabRefs = useRef<Map<string, HTMLButtonElement | null>>(new Map());
 
   // Derive loading state from cache + error so we never paint the
   // "no files" empty state on the first frame before the fetch starts.
@@ -33,6 +34,38 @@ export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
   // visible flash where loading=false rendered before flipping to true.
   const cached = projectSlug ? cache[projectSlug] : undefined;
   const loading = projectSlug !== null && cached === undefined && error === null;
+
+  const files = cached?.files ?? [];
+  const availableNames = files.map((f) => f.filename);
+  const effectiveTab = availableNames.includes(activeTab)
+    ? activeTab
+    : (availableNames[0] ?? activeTab);
+
+  // ARIA tablist arrow-key navigation per WAI-ARIA APG. Inlined
+  // (no useCallback) because availableNames/effectiveTab are derived
+  // each render and React Compiler handles memoization where needed.
+  const onTabsKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (availableNames.length === 0) return;
+    const key = e.key;
+    if (key !== "ArrowLeft" && key !== "ArrowRight" && key !== "Home" && key !== "End") return;
+    e.preventDefault();
+    const idx = availableNames.indexOf(effectiveTab);
+    let next: string;
+    if (key === "Home") {
+      next = availableNames[0];
+    } else if (key === "End") {
+      next = availableNames[availableNames.length - 1];
+    } else if (key === "ArrowRight") {
+      next = availableNames[(idx + 1) % availableNames.length];
+    } else {
+      next = availableNames[(idx - 1 + availableNames.length) % availableNames.length];
+    }
+    setActiveTab(next);
+    // Defer focus to next paint so the new tab's tabIndex=0 is in the DOM.
+    requestAnimationFrame(() => {
+      tabRefs.current.get(next)?.focus();
+    });
+  };
 
   useEffect(() => {
     if (!projectSlug) return;
@@ -66,11 +99,6 @@ export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
     );
   }
 
-  const files = cached?.files ?? [];
-  const availableNames = files.map((f) => f.filename);
-  const effectiveTab = availableNames.includes(activeTab)
-    ? activeTab
-    : (availableNames[0] ?? activeTab);
   const activeFile = files.find((f) => f.filename === effectiveTab);
   const tabPanelId = `v4-qa-lessons-panel-${projectSlug}`;
 
@@ -85,7 +113,12 @@ export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
 
       {error && <div className="v4-error">{error}</div>}
 
-      <div className="v4-qa-lessons-tabs" role="tablist" aria-label="Lessons файлы">
+      <div
+        className="v4-qa-lessons-tabs"
+        role="tablist"
+        aria-label="Lessons файлы"
+        onKeyDown={onTabsKeyDown}
+      >
         {FILE_ORDER.map((fname) => {
           const present = availableNames.includes(fname);
           const f = files.find((x) => x.filename === fname);
@@ -93,6 +126,9 @@ export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
           return (
             <button
               key={fname}
+              ref={(el) => {
+                tabRefs.current.set(fname, el);
+              }}
               type="button"
               role="tab"
               aria-selected={selected}

--- a/src/components/v4/quality/PendingChangePreview.tsx
+++ b/src/components/v4/quality/PendingChangePreview.tsx
@@ -15,6 +15,7 @@ export function PendingChangePreviewV4({ change, loadPreview, onConfirm, onCance
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const modalRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -40,11 +41,33 @@ export function PendingChangePreviewV4({ change, loadPreview, onConfirm, onCance
     closeButtonRef.current?.focus();
   }, []);
 
+  // Focus trap: Escape closes; Tab/Shift+Tab wrap focus inside the modal
+  // so keyboard users can't fall back into the obscured page content. The
+  // aria-modal="true" attribute promises this to assistive tech, so it
+  // must actually be enforced.
   useEffect(() => {
+    const FOCUSABLE =
+      'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.stopPropagation();
         onCancel();
+        return;
+      }
+      if (e.key !== "Tab" || !modalRef.current) return;
+      const focusables = Array.from(
+        modalRef.current.querySelectorAll<HTMLElement>(FOCUSABLE),
+      ).filter((el) => !el.hasAttribute("aria-hidden"));
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && (active === first || !modalRef.current.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
       }
     };
     window.addEventListener("keydown", onKey);
@@ -57,6 +80,7 @@ export function PendingChangePreviewV4({ change, loadPreview, onConfirm, onCance
   return (
     <div className="v4-qa-modal-backdrop" onClick={onCancel}>
       <div
+        ref={modalRef}
         className="v4-qa-modal"
         role="dialog"
         aria-modal="true"


### PR DESCRIPTION
## Summary
- Fixes three ARIA findings from post-merge review of [#119](https://github.com/Sergio1990-1/makeit-dashboard/pull/119)
- LessonsViewer: arrow-key navigation in tablist (WAI-ARIA APG)
- PendingChangePreview: Tab focus trap inside modal
- AutoTunerConfigCard: aria-controls on collapsible header

## Test plan
- [x] `npx tsc --noEmit` — green
- [x] `npm run lint` — green
- [x] `npm run build` — green
- [ ] Manual: keyboard-navigate Lessons tabs with Arrow keys; Tab inside modal stays inside; screen reader announces "expanded" + region

🤖 Generated with [Claude Code](https://claude.com/claude-code)