### PR TITLE
fix(quality): guard formatPeriodRange against undefined period

### DIFF
--- a/src/components/v4/quality/utils.ts
+++ b/src/components/v4/quality/utils.ts
@@ -3,8 +3,11 @@ import type { QualitySnapshot } from "../../../types";
 export type Health = "ok" | "warn" | "danger" | "unknown";
 
 /** Convert ISO week ("2026-W17") or ISO date string into a human-readable
- * date range. Falls back to the input if it can't be parsed. */
-export function formatPeriodRange(period: string): string {
+ * date range. Falls back to the input if it can't be parsed.
+ * Defensive: server may omit `period` on partial responses; return a dash
+ * rather than crashing the whole retro detail card. */
+export function formatPeriodRange(period: string | null | undefined): string {
+  if (!period) return "—";
   // ISO week format: "YYYY-Www"
   const wkMatch = period.match(/^(\d{4})-W(\d{1,2})$/);
   if (wkMatch) {


### PR DESCRIPTION
## Summary
- Found while visually verifying PR [#119](https://github.com/Sergio1990-1/makeit-dashboard/pull/119) / [#120](https://github.com/Sergio1990-1/makeit-dashboard/pull/120) in browser preview
- Clicking a retro card to open RetroDetailV4 crashed with `TypeError: Cannot read properties of undefined (reading 'match')` from `formatPeriodRange` when the API omitted `period`
- ErrorBoundary caught the crash, but the whole Quality tab became unusable until reload

## Fix
- `formatPeriodRange(period: string | null | undefined)`: return "—" when period is missing instead of calling `.match()` on undefined

## Test plan
- [x] `npx tsc --noEmit` — green
- [x] `npm run lint` — green
- [x] `npm run build` — green
- [x] Verified in preview: retro card click now opens detail without crash; period range renders correctly when present (`20 апр–26 апр` for `2026-W17`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)