### PR TITLE
fix(quality): translate UI labels to Russian

### DIFF
--- a/src/components/v4/quality/AutoTunerConfigCard.tsx
+++ b/src/components/v4/quality/AutoTunerConfigCard.tsx
@@ -109,7 +109,7 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
                 {merged.retro_mode === "auto_apply" ? "автоприменение" : "только отчёт"}
               </button>
               <div className="v4-qa-config-hint">
-                Автоприменение раскатывает Tier-1 уроки сразу; «только отчёт» — лишь складывает в stage.
+                Автоприменение раскатывает уроки уровня 1 сразу; «только отчёт» — лишь кладёт в буфер ожидания.
               </div>
             </div>
 

--- a/src/components/v4/quality/AutoTunerConfigCard.tsx
+++ b/src/components/v4/quality/AutoTunerConfigCard.tsx
@@ -22,9 +22,9 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
     return (
       <div className="v4-panel">
         <div className="v4-panel-h">
-          <div className="v4-panel-t">AutoTuner · Config</div>
+          <div className="v4-panel-t">AutoTuner · параметры</div>
         </div>
-        <div className="v4-empty">Config недоступен (pipeline API offline?)</div>
+        <div className="v4-empty">Параметры недоступны (Pipeline API офлайн?)</div>
       </div>
     );
   }
@@ -77,17 +77,17 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
       >
         <div className="v4-panel-t">
           <span className="v4-qa-arrow" aria-hidden="true">{open ? "▾" : "▸"}</span>{" "}
-          AutoTuner · Config
+          AutoTuner · параметры
         </div>
         <div className="v4-qa-config-summary">
           <span className={`v4-tag ${merged.retro_mode === "auto_apply" ? "v4-tag--ok" : ""}`}>
-            {merged.retro_mode === "auto_apply" ? "auto_apply" : "reporting"}
+            {merged.retro_mode === "auto_apply" ? "автоприменение" : "только отчёт"}
           </span>
           <span className="v4-pl-mono v4-qa-text-muted">
-            {(merged.auto_apply_min_confidence * 100).toFixed(0)}% conf · {merged.auto_apply_cooldown_hours}h cd
+            мин. уверенность {(merged.auto_apply_min_confidence * 100).toFixed(0)}% · задержка {merged.auto_apply_cooldown_hours}ч
           </span>
           {merged.cooldown_active && (
-            <span className="v4-tag v4-tag--warn">cd · {fmtHours(merged.cooldown_remaining_hours)}</span>
+            <span className="v4-tag v4-tag--warn">задержка · {fmtHours(merged.cooldown_remaining_hours)}</span>
           )}
         </div>
       </div>
@@ -98,7 +98,7 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
 
           <div className="v4-qa-config-grid">
             <div className="v4-qa-config-cell">
-              <div className="v4-qa-config-label">Retro mode</div>
+              <div className="v4-qa-config-label">Режим ретроспективы</div>
               <button
                 type="button"
                 className={`v4-qa-toggle ${merged.retro_mode === "auto_apply" ? "is-on" : ""}`}
@@ -106,15 +106,15 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
                 onClick={toggleRetroMode}
               >
                 <span className="v4-qa-toggle-dot" />
-                {merged.retro_mode === "auto_apply" ? "auto_apply" : "reporting"}
+                {merged.retro_mode === "auto_apply" ? "автоприменение" : "только отчёт"}
               </button>
               <div className="v4-qa-config-hint">
-                auto_apply применяет Tier-1 lessons автоматически; reporting — только stage.
+                Автоприменение раскатывает Tier-1 уроки сразу; «только отчёт» — лишь складывает в stage.
               </div>
             </div>
 
             <SliderCell
-              label="Min confidence"
+              label="Мин. уверенность"
               value={merged.auto_apply_min_confidence}
               displayValue={`${(merged.auto_apply_min_confidence * 100).toFixed(0)}%`}
               min={0.5}
@@ -125,7 +125,7 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
             />
 
             <SliderCell
-              label="Cooldown (часы)"
+              label="Задержка (часы)"
               value={merged.auto_apply_cooldown_hours}
               displayValue={String(merged.auto_apply_cooldown_hours)}
               min={1}
@@ -136,7 +136,7 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
             />
 
             <SliderCell
-              label="KPI degradation threshold"
+              label="Порог деградации KPI"
               value={merged.kpi_degradation_threshold}
               displayValue={`${(merged.kpi_degradation_threshold * 100).toFixed(0)}%`}
               min={0.01}
@@ -147,7 +147,7 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
             />
 
             <SliderCell
-              label="Lessons · max lines"
+              label="Уроки · макс. строк"
               value={merged.lessons_max_lines}
               displayValue={String(merged.lessons_max_lines)}
               min={10}
@@ -158,7 +158,7 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
             />
 
             <SliderCell
-              label="Lessons TTL (дни)"
+              label="Уроки · срок жизни (дни)"
               value={merged.lessons_ttl_days}
               displayValue={String(merged.lessons_ttl_days)}
               min={1}
@@ -169,7 +169,7 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
             />
 
             <div className="v4-qa-config-cell">
-              <div className="v4-qa-config-label">Numeric claim validator</div>
+              <div className="v4-qa-config-label">Проверка чисел</div>
               <button
                 type="button"
                 className={`v4-qa-toggle ${merged.validate_numeric_claims ? "is-on" : ""}`}
@@ -177,10 +177,10 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
                 onClick={toggleValidator}
               >
                 <span className="v4-qa-toggle-dot" />
-                {merged.validate_numeric_claims ? "on" : "off"}
+                {merged.validate_numeric_claims ? "включена" : "выключена"}
               </button>
               <div className="v4-qa-config-hint">
-                Сверяет числа в lessons с metrics.jsonl. Tolerance{" "}
+                Сверяет числа в уроках с metrics.jsonl. Допуск{" "}
                 {(merged.validation_tolerance * 100).toFixed(0)}%.
               </div>
             </div>
@@ -209,7 +209,7 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
             )}
             {merged.last_apply_at && (
               <span className="v4-pl-mono v4-qa-text-muted">
-                last apply: {new Date(merged.last_apply_at).toLocaleString()}
+                последнее применение: {new Date(merged.last_apply_at).toLocaleString()}
               </span>
             )}
           </div>

--- a/src/components/v4/quality/LessonsViewer.tsx
+++ b/src/components/v4/quality/LessonsViewer.tsx
@@ -9,9 +9,9 @@ interface Props {
 }
 
 const FILE_LABELS: Record<string, string> = {
-  "lessons-retro.md": "Retro lessons (autotuner)",
-  "lessons-review.md": "Review lessons (per-PR)",
-  "lessons-learned.md": "Legacy",
+  "lessons-retro.md": "Уроки от ретроспектив (AutoTuner)",
+  "lessons-review.md": "Уроки от ревью (по PR)",
+  "lessons-learned.md": "Старый формат (legacy)",
 };
 
 const FILE_ORDER = ["lessons-retro.md", "lessons-review.md", "lessons-learned.md"] as const;
@@ -90,10 +90,10 @@ export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
     return (
       <div className="v4-panel">
         <div className="v4-panel-h">
-          <div className="v4-panel-t">Lessons Viewer</div>
+          <div className="v4-panel-t">Файлы уроков</div>
         </div>
         <div className="v4-empty">
-          Выберите проект в фильтре «Все проекты», чтобы просмотреть lessons-файлы.
+          Выберите проект в фильтре «Все проекты», чтобы просмотреть файлы уроков.
         </div>
       </div>
     );
@@ -106,7 +106,7 @@ export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
     <div className="v4-panel">
       <div className="v4-panel-h">
         <div className="v4-panel-t">
-          Lessons · <span className="v4-pl-mono">{projectSlug}</span>
+          Уроки · <span className="v4-pl-mono">{projectSlug}</span>
           {loading && <span className="v4-pl-mono v4-qa-text-muted" style={{ marginLeft: 8 }}>загрузка…</span>}
         </div>
       </div>
@@ -116,7 +116,7 @@ export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
       <div
         className="v4-qa-lessons-tabs"
         role="tablist"
-        aria-label="Lessons файлы"
+        aria-label="Файлы уроков"
         onKeyDown={onTabsKeyDown}
       >
         {FILE_ORDER.map((fname) => {
@@ -158,9 +158,9 @@ export function LessonsViewer({ projectSlug, cache, loadLessons }: Props) {
             <pre className="v4-qa-lessons-pre">{activeFile.content || "(пустой файл)"}</pre>
           </>
         ) : loading ? (
-          <div className="v4-empty">Загрузка lessons-файлов…</div>
+          <div className="v4-empty">Загрузка файлов уроков…</div>
         ) : (
-          <div className="v4-empty">В этом проекте пока нет lessons файлов.</div>
+          <div className="v4-empty">В этом проекте пока нет файлов уроков.</div>
         )}
       </div>
     </div>

--- a/src/components/v4/quality/PendingChangePreview.tsx
+++ b/src/components/v4/quality/PendingChangePreview.tsx
@@ -88,7 +88,7 @@ export function PendingChangePreviewV4({ change, loadPreview, onConfirm, onCance
         onClick={(e) => e.stopPropagation()}
       >
         <div className="v4-qa-modal-h">
-          <div id={TITLE_ID} className="v4-qa-modal-t">Preview · {change.target}</div>
+          <div id={TITLE_ID} className="v4-qa-modal-t">Просмотр · {change.target}</div>
           <button
             type="button"
             ref={closeButtonRef}
@@ -100,52 +100,52 @@ export function PendingChangePreviewV4({ change, loadPreview, onConfirm, onCance
 
         <div className="v4-qa-modal-body">
           <div className="v4-qa-modal-section">
-            <div className="v4-qa-modal-label">Content</div>
+            <div className="v4-qa-modal-label">Содержимое</div>
             <div className="v4-qa-modal-content">{change.content}</div>
           </div>
 
           <div className="v4-qa-modal-meta">
-            <div><span className="v4-qa-modal-meta-l">Tier</span><span>{change.tier}</span></div>
-            <div><span className="v4-qa-modal-meta-l">Confidence</span><span>{(change.confidence * 100).toFixed(0)}%</span></div>
-            <div><span className="v4-qa-modal-meta-l">Retro</span><span>{change.retro_period}</span></div>
+            <div><span className="v4-qa-modal-meta-l">Уровень</span><span>{change.tier}</span></div>
+            <div><span className="v4-qa-modal-meta-l">Уверенность</span><span>{(change.confidence * 100).toFixed(0)}%</span></div>
+            <div><span className="v4-qa-modal-meta-l">Ретроспектива</span><span>{change.retro_period}</span></div>
           </div>
 
           {loading ? (
-            <div className="v4-empty">Загрузка preview…</div>
+            <div className="v4-empty">Загрузка предпросмотра…</div>
           ) : error ? (
             <div className="v4-error">{error}</div>
           ) : preview ? (
             <>
               <div className="v4-qa-modal-badges">
                 {preview.dedup_hit ? (
-                  <span className="v4-tag v4-tag--warn">⚠ Duplicate</span>
+                  <span className="v4-tag v4-tag--warn">⚠ Дубликат</span>
                 ) : (
-                  <span className="v4-tag v4-tag--ok">✓ Not a duplicate</span>
+                  <span className="v4-tag v4-tag--ok">✓ Не дубликат</span>
                 )}
-                {preview.would_rotate && <span className="v4-tag">⟳ Would rotate file</span>}
+                {preview.would_rotate && <span className="v4-tag">⟳ Файл будет ротирован</span>}
                 {preview.validation !== null && (
                   validationOk ? (
-                    <span className="v4-tag v4-tag--ok">✓ Validation OK</span>
+                    <span className="v4-tag v4-tag--ok">✓ Проверка пройдена</span>
                   ) : (
                     <span className="v4-tag v4-tag--danger">
-                      ⚠ {String((preview.validation as { reason?: string }).reason ?? "validation failed")}
+                      ⚠ {String((preview.validation as { reason?: string }).reason ?? "проверка не пройдена")}
                     </span>
                   )
                 )}
                 {preview.scoped_projects && preview.scoped_projects.length > 0 ? (
-                  <span className="v4-tag">scope: {preview.scoped_projects.join(", ")}</span>
+                  <span className="v4-tag">проекты: {preview.scoped_projects.join(", ")}</span>
                 ) : (
-                  <span className="v4-tag">scope: all projects</span>
+                  <span className="v4-tag">все проекты</span>
                 )}
               </div>
 
               <div className="v4-qa-modal-section">
                 <div className="v4-qa-modal-label">
-                  Targets · {preview.targets.length} {preview.targets.length === 1 ? "файл" : "файлов"}
+                  Целевые файлы · {preview.targets.length} {preview.targets.length === 1 ? "файл" : "файлов"}
                 </div>
                 <div className="v4-qa-modal-targets">
                   {preview.targets.length === 0 ? (
-                    <span className="v4-qa-text-muted">нет resolved targets</span>
+                    <span className="v4-qa-text-muted">не найдены</span>
                   ) : (
                     preview.targets.map((t) => (
                       <code key={t} className="v4-qa-modal-target">{t}</code>
@@ -156,10 +156,10 @@ export function PendingChangePreviewV4({ change, loadPreview, onConfirm, onCance
 
               <div className="v4-qa-modal-section">
                 <div className="v4-qa-modal-label">
-                  Diff · current lines: {preview.current_line_count}
+                  Diff · текущих строк: {preview.current_line_count}
                 </div>
                 <pre className="v4-qa-modal-diff">
-                  {preview.preview_diff || "(no diff — file would be empty)"}
+                  {preview.preview_diff || "(diff пустой — файл будет создан)"}
                 </pre>
               </div>
             </>
@@ -175,9 +175,9 @@ export function PendingChangePreviewV4({ change, loadPreview, onConfirm, onCance
             onClick={onConfirm}
             title={
               preview?.dedup_hit
-                ? "Нельзя применить duplicate"
+                ? "Нельзя применить дубликат"
                 : validationFailed
-                  ? "Validation failed — сверьте цифры в lesson с metrics.jsonl"
+                  ? "Проверка не пройдена — сверьте цифры в уроке с metrics.jsonl"
                   : undefined
             }
           >

--- a/src/components/v4/quality/PendingChangesPanel.tsx
+++ b/src/components/v4/quality/PendingChangesPanel.tsx
@@ -15,10 +15,10 @@ interface Props {
 }
 
 const TIER_OPTS: Array<[number | null, string]> = [
-  [null, "Все тиры"],
-  [1, "T1 lessons"],
-  [2, "T2 rules"],
-  [3, "T3 config"],
+  [null, "Все уровни"],
+  [1, "Уроки"],
+  [2, "Правила"],
+  [3, "Параметры"],
 ];
 
 function ageHours(iso: string): number {
@@ -121,7 +121,7 @@ export function PendingChangesPanel({
     <div className="v4-panel">
       <div className="v4-panel-h">
         <div className="v4-panel-t">
-          AutoTuner pending
+          AutoTuner · в очереди
           {sortedChanges.length > 0 && (
             <span className="v4-tag v4-tag--warn" style={{ marginLeft: 8 }}>
               {sortedChanges.length}
@@ -186,12 +186,12 @@ export function PendingChangesPanel({
                     )}
                     <span className="v4-qa-pending-target" title={c.target}>{c.target}</span>
                     <span className="v4-tag v4-pl-mono">{c.change_type}</span>
-                    <span className="v4-tag">T{c.tier}</span>
+                    <span className="v4-tag" title={`Уровень ${c.tier}`}>Т{c.tier}</span>
                     {c.scoped_projects && c.scoped_projects.length > 0 && (
-                      <span className="v4-tag">scope: {c.scoped_projects.join(", ")}</span>
+                      <span className="v4-tag">проекты: {c.scoped_projects.join(", ")}</span>
                     )}
                     {validationFailed && (
-                      <span className="v4-tag v4-tag--danger">⚠ validation</span>
+                      <span className="v4-tag v4-tag--danger">⚠ проверка</span>
                     )}
                     <span className="v4-qa-pending-age v4-pl-mono">{fmtAgeShort(c.created_at)}</span>
                   </div>
@@ -214,7 +214,7 @@ export function PendingChangesPanel({
                 {isExpanded && (
                   <div className="v4-qa-pending-details">
                     <div>
-                      <span className="v4-qa-text-muted">Staged:</span> {fmtDateTime(c.created_at)}
+                      <span className="v4-qa-text-muted">Поставлено в очередь:</span> {fmtDateTime(c.created_at)}
                     </div>
                     {c.validation && (
                       <pre className="v4-qa-pending-json">
@@ -240,7 +240,7 @@ export function PendingChangesPanel({
                       disabled={busy}
                       onClick={() => handleApplyClick(c)}
                     >
-                      {busy ? "…" : loadPreview ? "Preview + Apply" : "Применить"}
+                      {busy ? "…" : loadPreview ? "Просмотр и применить" : "Применить"}
                     </button>
                     <button
                       type="button"

--- a/src/components/v4/quality/PendingChangesPanel.tsx
+++ b/src/components/v4/quality/PendingChangesPanel.tsx
@@ -16,9 +16,9 @@ interface Props {
 
 const TIER_OPTS: Array<[number | null, string]> = [
   [null, "Все уровни"],
-  [1, "Уроки"],
-  [2, "Правила"],
-  [3, "Параметры"],
+  [1, "Т1 · Уроки"],
+  [2, "Т2 · Правила"],
+  [3, "Т3 · Параметры"],
 ];
 
 function ageHours(iso: string): number {

--- a/src/components/v4/quality/QualityHero.tsx
+++ b/src/components/v4/quality/QualityHero.tsx
@@ -48,17 +48,17 @@ export function QualityHero({
           <div className="v4-qa-hero-sub">
             {snapshot ? (
               <>
-                FPR{" "}
+                С первой попытки{" "}
                 <b style={{ color: healthColor(healthOf(snapshot.first_pass_success_rate, 0.8, 0.6)) }}>
                   {pct(snapshot.first_pass_success_rate, 0)}
                 </b>
                 <span className="v4-qa-sep">·</span>
-                Retry{" "}
+                Повторы{" "}
                 <b style={{ color: healthColor(healthOf(snapshot.retry_rate, 0.1, 0.25, false)) }}>
                   {pct(snapshot.retry_rate, 0)}
                 </b>
                 <span className="v4-qa-sep">·</span>
-                Recovery{" "}
+                Восстановление{" "}
                 <b style={{ color: healthColor(healthOf(snapshot.error_recovery_rate, 0.7, 0.4)) }}>
                   {pct(snapshot.error_recovery_rate, 0)}
                 </b>
@@ -66,11 +66,11 @@ export function QualityHero({
                 <span className="v4-pl-mono">
                   {snapshot.merged_count}/{snapshot.total_issues}
                 </span>{" "}
-                merged
+                замержено
                 {pendingCount > 0 && (
                   <>
                     <span className="v4-qa-sep">·</span>
-                    <b className="v4-qa-text-warn">{pendingCount}</b> pending
+                    <b className="v4-qa-text-warn">{pendingCount}</b> в очереди
                   </>
                 )}
               </>
@@ -97,7 +97,7 @@ export function QualityHero({
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <polygon points="5 3 19 12 5 21 5 3" />
           </svg>
-          {retroRunning ? "Запуск…" : "Run Retro"}
+          {retroRunning ? "Запуск…" : "Провести ретро"}
         </button>
       </div>
     </div>

--- a/src/components/v4/quality/QualityKpiGrid.tsx
+++ b/src/components/v4/quality/QualityKpiGrid.tsx
@@ -26,12 +26,12 @@ interface KpiDef {
 }
 
 const KPIS: KpiDef[] = [
-  { key: "first_pass_success_rate", label: "First Pass", sub: "успех с первой попытки", good: 0.8, bad: 0.6, higherIsBetter: true, isPercent: true },
-  { key: "retry_rate", label: "Retry Rate", sub: "повторные попытки", good: 0.1, bad: 0.25, higherIsBetter: false, isPercent: true },
-  { key: "error_recovery_rate", label: "Recovery", sub: "восстановление после ошибок", good: 0.7, bad: 0.4, higherIsBetter: true, isPercent: true },
-  { key: "qa_pass_rate", label: "QA Pass", sub: "прохождение QA", good: 0.9, bad: 0.7, higherIsBetter: true, isPercent: true },
-  { key: "rollback_rate", label: "Rollback", sub: "частота откатов", good: 0.05, bad: 0.15, higherIsBetter: false, isPercent: true },
-  { key: "avg_finding_density", label: "Finding Density", sub: "ср. findings/задачу", good: 1.0, bad: 3.0, higherIsBetter: false, isPercent: false },
+  { key: "first_pass_success_rate", label: "С первой попытки", sub: "успех без повторов", good: 0.8, bad: 0.6, higherIsBetter: true, isPercent: true },
+  { key: "retry_rate", label: "Частота повторов", sub: "повторные попытки", good: 0.1, bad: 0.25, higherIsBetter: false, isPercent: true },
+  { key: "error_recovery_rate", label: "Восстановление", sub: "успех после ошибок", good: 0.7, bad: 0.4, higherIsBetter: true, isPercent: true },
+  { key: "qa_pass_rate", label: "Прохождение QA", sub: "пройдено проверок QA", good: 0.9, bad: 0.7, higherIsBetter: true, isPercent: true },
+  { key: "rollback_rate", label: "Откаты", sub: "частота откатов", good: 0.05, bad: 0.15, higherIsBetter: false, isPercent: true },
+  { key: "avg_finding_density", label: "Плотность находок", sub: "ср. находок на задачу", good: 1.0, bad: 3.0, higherIsBetter: false, isPercent: false },
 ];
 
 const SPARK_W = 88;
@@ -117,13 +117,13 @@ export function QualityKpiGrid({ snapshot, trends }: Props) {
       {/* Always-shown 7th tile for avg_duration (purely informational, no health) */}
       <div className="v4-qa-kpi v4-qa-kpi--neutral">
         <div className="v4-qa-kpi-h">
-          <span className="v4-qa-kpi-label">Avg Duration</span>
+          <span className="v4-qa-kpi-label">Среднее время</span>
         </div>
         <div className="v4-qa-kpi-val">{duration(snapshot.avg_duration_sec)}</div>
-        <div className="v4-qa-kpi-sub">среднее время выполнения</div>
+        <div className="v4-qa-kpi-sub">время выполнения задачи</div>
         <div className="v4-qa-kpi-foot">
           <span className="v4-pl-mono v4-qa-kpi-delta v4-qa-kpi-delta--mute">
-            {snapshot.merged_count}/{snapshot.total_issues} merged
+            {snapshot.merged_count}/{snapshot.total_issues} замержено
           </span>
         </div>
       </div>

--- a/src/components/v4/quality/QualityKpiGrid.tsx
+++ b/src/components/v4/quality/QualityKpiGrid.tsx
@@ -26,12 +26,12 @@ interface KpiDef {
 }
 
 const KPIS: KpiDef[] = [
-  { key: "first_pass_success_rate", label: "С первой попытки", sub: "успех без повторов", good: 0.8, bad: 0.6, higherIsBetter: true, isPercent: true },
-  { key: "retry_rate", label: "Частота повторов", sub: "повторные попытки", good: 0.1, bad: 0.25, higherIsBetter: false, isPercent: true },
+  { key: "first_pass_success_rate", label: "С первой попытки", sub: "успех с первой попытки", good: 0.8, bad: 0.6, higherIsBetter: true, isPercent: true },
+  { key: "retry_rate", label: "Повторы", sub: "повторные попытки", good: 0.1, bad: 0.25, higherIsBetter: false, isPercent: true },
   { key: "error_recovery_rate", label: "Восстановление", sub: "успех после ошибок", good: 0.7, bad: 0.4, higherIsBetter: true, isPercent: true },
   { key: "qa_pass_rate", label: "Прохождение QA", sub: "пройдено проверок QA", good: 0.9, bad: 0.7, higherIsBetter: true, isPercent: true },
   { key: "rollback_rate", label: "Откаты", sub: "частота откатов", good: 0.05, bad: 0.15, higherIsBetter: false, isPercent: true },
-  { key: "avg_finding_density", label: "Плотность находок", sub: "ср. находок на задачу", good: 1.0, bad: 3.0, higherIsBetter: false, isPercent: false },
+  { key: "avg_finding_density", label: "Находки", sub: "ср. находок на задачу", good: 1.0, bad: 3.0, higherIsBetter: false, isPercent: false },
 ];
 
 const SPARK_W = 88;

--- a/src/components/v4/quality/QualityKpiStrip.tsx
+++ b/src/components/v4/quality/QualityKpiStrip.tsx
@@ -29,7 +29,7 @@ export function QualityKpiStrip({ snapshot, pendingChanges, retros }: Props) {
           <div className="v4-projects-agg-n num">
             {snapshot ? duration(snapshot.avg_duration_sec) : "—"}
           </div>
-          <div className="v4-projects-agg-l">avg duration</div>
+          <div className="v4-projects-agg-l">ср. время</div>
         </div>
         <div
           className="v4-projects-agg-cell"
@@ -41,25 +41,25 @@ export function QualityKpiStrip({ snapshot, pendingChanges, retros }: Props) {
           >
             {pendingCount}
           </div>
-          <div className="v4-projects-agg-l">pending changes</div>
+          <div className="v4-projects-agg-l">в очереди</div>
         </div>
         <div className="v4-projects-agg-cell" title="Проведённые ретроспективы">
           <div className="v4-projects-agg-n num">{retrosCount}</div>
-          <div className="v4-projects-agg-l">retros всего</div>
+          <div className="v4-projects-agg-l">ретроспектив</div>
         </div>
         <div
           className="v4-projects-agg-cell"
-          title={lastRetro ? `Последний retro: ${lastRetro.period}` : "Ретроспективы не проводились"}
+          title={lastRetro ? `Последняя ретроспектива: ${lastRetro.period}` : "Ретроспективы не проводились"}
         >
           <div className="v4-projects-agg-n num">
             {lastRetro?.period ?? "—"}
           </div>
-          <div className="v4-projects-agg-l">last retro</div>
+          <div className="v4-projects-agg-l">последняя</div>
         </div>
         {snapshot?.period_end && (
           <div className="v4-projects-agg-cell" title={`Период: ${snapshot.period_start} — ${snapshot.period_end}`}>
             <div className="v4-projects-agg-n num">{fmtAge(snapshot.period_end)}</div>
-            <div className="v4-projects-agg-l">snapshot age</div>
+            <div className="v4-projects-agg-l">возраст данных</div>
           </div>
         )}
       </div>

--- a/src/components/v4/quality/QualityTrends.tsx
+++ b/src/components/v4/quality/QualityTrends.tsx
@@ -10,12 +10,12 @@ interface MetricDef {
 }
 
 const METRICS: MetricDef[] = [
-  { key: "first_pass_success_rate", label: "First Pass", color: "#12B76A", isPercent: true, format: pctFmt },
-  { key: "retry_rate", label: "Retry", color: "#F79009", isPercent: true, format: pctFmt },
-  { key: "error_recovery_rate", label: "Recovery", color: "#2563EB", isPercent: true, format: pctFmt },
-  { key: "qa_pass_rate", label: "QA Pass", color: "#7C3AED", isPercent: true, format: pctFmt },
-  { key: "rollback_rate", label: "Rollback", color: "#EF4444", isPercent: true, format: pctFmt },
-  { key: "avg_finding_density", label: "Findings", color: "#06B6D4", isPercent: false, format: (v) => v === null ? "—" : v.toFixed(2) },
+  { key: "first_pass_success_rate", label: "С первой попытки", color: "#12B76A", isPercent: true, format: pctFmt },
+  { key: "retry_rate", label: "Повторы", color: "#F79009", isPercent: true, format: pctFmt },
+  { key: "error_recovery_rate", label: "Восстановление", color: "#2563EB", isPercent: true, format: pctFmt },
+  { key: "qa_pass_rate", label: "Прохождение QA", color: "#7C3AED", isPercent: true, format: pctFmt },
+  { key: "rollback_rate", label: "Откаты", color: "#EF4444", isPercent: true, format: pctFmt },
+  { key: "avg_finding_density", label: "Находки", color: "#06B6D4", isPercent: false, format: (v) => v === null ? "—" : v.toFixed(2) },
 ];
 
 const PERIODS = [4, 8, 12] as const;

--- a/src/components/v4/quality/QualityView.tsx
+++ b/src/components/v4/quality/QualityView.tsx
@@ -65,7 +65,7 @@ export function QualityView() {
             <div className="v4-sub">Метрики качества pipeline-агента</div>
           </div>
         </div>
-        <div className="v4-empty">Загрузка Quality Dashboard…</div>
+        <div className="v4-empty">Загрузка метрик качества…</div>
       </div>
     );
   }
@@ -86,7 +86,7 @@ export function QualityView() {
         </div>
         <div className="v4-panel">
           <div className="v4-empty">
-            Не удалось подключиться к Pipeline API. Quality endpoints — часть makeit-pipeline.
+            Не удалось подключиться к Pipeline API. Эндпоинты качества — часть makeit-pipeline.
           </div>
           <pre className="v4-qa-offline-cmd">
 {`# Pipeline Mac:
@@ -179,13 +179,13 @@ launchctl start com.makeit.pipeline-tunnel`}
         <div className="v4-grid" style={{ marginTop: 14 }}>
           <div className="v4-panel">
             <div className="v4-panel-h">
-              <div className="v4-panel-t">Findings по категориям</div>
+              <div className="v4-panel-t">Находки по категориям</div>
             </div>
             <div className="v4-qa-bars-body">
               {findings && Object.keys(findings.categories).length > 0 ? (
                 <FindingsBarChart data={findings} />
               ) : (
-                <div className="v4-empty">Нет findings за период.</div>
+                <div className="v4-empty">Нет находок за период.</div>
               )}
             </div>
           </div>
@@ -263,7 +263,7 @@ launchctl start com.makeit.pipeline-tunnel`}
             onClick={() => setShowLessons((v) => !v)}
             aria-expanded={showLessons}
           >
-            {showLessons ? "▾" : "▸"} Lessons файлы (read-only)
+            {showLessons ? "▾" : "▸"} Файлы уроков (только чтение)
           </button>
         </div>
         {showLessons && (


### PR DESCRIPTION
## Summary
- Replace English labels (Retry Rate, First Pass, Recovery, Rollback, Finding Density, Run Retro, etc.) with Russian equivalents across all V4 Quality components
- Product names (AutoTuner, Pipeline) and acronyms (KPI, QA, PR) kept English per Russian tech-writing convention
- Verified visually in preview: hero, KPI strip, KPI cards (7), trends chart toggles, AutoTuner config sliders, pending changes panel + tier filters, preview modal, lessons viewer

## Coverage
- KPI grid: First Pass → С первой попытки, Retry Rate → Частота повторов, Recovery → Восстановление, etc.
- KPI strip: avg duration / pending / retros всего / last retro / snapshot age
- Hero metrics inline + Run Retro button
- Trends chart metric toggles
- AutoTuner config card (header summary + 7 slider/toggle labels + hint texts)
- Pending changes panel (title, tier filter pills, tags, action buttons, expanded details)
- Preview modal (title, badges, sections, tooltip)
- Lessons viewer (panel title, file tab labels, empty state)
- Tier code: `T1/T2/T3` → `Т1/Т2/Т3` (Cyrillic to match RU labels)

## Test plan
- [x] `npx tsc --noEmit` — green
- [x] `npm run lint` — green
- [x] `npm run build` — green
- [x] Verified in preview: all 9 panels render with RU labels (DOM inspection confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)