### PR TITLE
feat(monitoring): redesign Monitoring tab in V4 design system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { ChatPanel } from "./components/ChatPanel";
 import { ChatButton } from "./components/ChatButton";
 import { FinanceEditor } from "./components/FinanceEditor";
 import { ErrorBoundary } from "./components/ErrorBoundary";
-import { UptimeBar } from "./components/UptimeBar";
+import { MonitoringView } from "./components/v4/monitoring/MonitoringView";
 import { AuditCombinedTab } from "./components/AuditCombinedTab";
 import { PipelineView } from "./components/v4/pipeline/PipelineView";
 import { TranscriptsView } from "./components/v4/transcripts/TranscriptsView";
@@ -185,13 +185,13 @@ function AppInner() {
         {error && <div className="v4-error">{error}</div>}
 
         {/* Loading / empty state — only for tabs that depend on GitHub project data.
-            Tabs like Pipeline, Audit, Quality, Debate, Specs, Research, Transcripts
-            have their own state and shouldn't be obscured by this banner. */}
-        {projects.length === 0 && (tab === "dashboard" || tab === "projects" || tab === "milestones" || tab === "uptime") && loading && (
+            Tabs like Pipeline, Audit, Quality, Debate, Specs, Research, Transcripts,
+            Monitoring have their own state and shouldn't be obscured by this banner. */}
+        {projects.length === 0 && (tab === "dashboard" || tab === "projects" || tab === "milestones") && loading && (
           <div className="v4-loading">Загрузка данных…</div>
         )}
 
-        {projects.length === 0 && (tab === "dashboard" || tab === "projects" || tab === "milestones" || tab === "uptime") && !loading && !error && (
+        {projects.length === 0 && (tab === "dashboard" || tab === "projects" || tab === "milestones") && !loading && !error && (
           <div className="v4-loading">Нажмите «Обновить» для загрузки данных</div>
         )}
 
@@ -226,22 +226,15 @@ function AppInner() {
           </ErrorBoundary>
         )}
 
-        {projects.length > 0 && tab === "uptime" && (
-          <div className="v4-legacy-frame">
-            <div className="bento-grid">
-              <div className="bento-panel span-12">
-                <div className="bento-panel-title">Мониторинг</div>
-                <ErrorBoundary fallback="Ошибка в мониторинге">
-                  <UptimeBar
-                    monitors={monitors}
-                    loading={monitorsLoading}
-                    error={monitorsError}
-                    onRefresh={refreshMonitors}
-                  />
-                </ErrorBoundary>
-              </div>
-            </div>
-          </div>
+        {tab === "uptime" && (
+          <ErrorBoundary fallback="Ошибка вкладки Мониторинг">
+            <MonitoringView
+              monitors={monitors}
+              loading={monitorsLoading}
+              error={monitorsError}
+              onRefresh={refreshMonitors}
+            />
+          </ErrorBoundary>
         )}
 
         {/* Stateful tabs — mount lazily on first visit, keep alive via display:none */}

--- a/src/components/v4/monitoring/MonitorCard.tsx
+++ b/src/components/v4/monitoring/MonitorCard.tsx
@@ -1,0 +1,84 @@
+import type { Monitor } from "../../../types";
+import {
+  fmtAge,
+  getProjectName,
+  isStale,
+  monitorHealth,
+  STATUS_LABEL,
+  uptimeColor,
+} from "./utils";
+
+interface Props {
+  monitor: Monitor;
+  /** Render-once timestamp, frozen via parent useState. */
+  nowMs: number;
+}
+
+export function MonitorCard({ monitor, nowMs }: Props) {
+  const project = getProjectName(monitor);
+  const health = monitorHealth(monitor);
+  const stale = isStale(monitor.lastCheckedAt, nowMs);
+  const uptime = monitor.uptimePct;
+  const upBarPct = uptime !== null ? Math.max(0, Math.min(100, uptime)) : 0;
+  const uColor = uptimeColor(uptime);
+
+  // Strip protocol for display brevity, keep full URL on the link itself.
+  const displayUrl = monitor.url.replace(/^https?:\/\//, "");
+
+  return (
+    <div className={`v4-mon-card v4-mon-card--${health}`}>
+      <div className="v4-mon-card-h">
+        <div className="v4-mon-card-name">
+          <span className={`v4-mon-card-dot v4-mon-card-dot--${health}`} aria-hidden="true" />
+          <span className="v4-mon-card-title" title={monitor.name}>
+            {monitor.name}
+          </span>
+        </div>
+        <span className={`v4-tag v4-mon-status v4-mon-status--${monitor.status}`}>
+          {STATUS_LABEL[monitor.status]}
+        </span>
+      </div>
+
+      <a
+        className="v4-mon-card-url v4-pl-mono"
+        href={monitor.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={monitor.url}
+      >
+        {displayUrl}
+      </a>
+
+      <div className="v4-mon-card-uptime">
+        <div className="v4-mon-card-uptime-row">
+          <span className="v4-mon-text-muted">Uptime</span>
+          <span className="v4-pl-mono v4-mon-card-uptime-val" style={{ color: uColor }}>
+            {uptime !== null ? `${uptime.toFixed(2)}%` : "—"}
+          </span>
+        </div>
+        {uptime !== null && (
+          <div className="v4-mon-card-uptime-bar">
+            <div
+              className="v4-mon-card-uptime-fill"
+              style={{ width: `${upBarPct}%`, background: uColor }}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="v4-mon-card-foot">
+        {project && (
+          <span className="v4-tag v4-mon-card-project" title={`Проект: ${project}`}>
+            {project}
+          </span>
+        )}
+        <span
+          className={`v4-pl-mono v4-mon-card-checked${stale ? " is-stale" : ""}`}
+          title={monitor.lastCheckedAt ?? "Никогда не проверялся"}
+        >
+          {stale && "⚠ "}{fmtAge(monitor.lastCheckedAt, nowMs)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/monitoring/MonitorCard.tsx
+++ b/src/components/v4/monitoring/MonitorCard.tsx
@@ -76,7 +76,13 @@ export function MonitorCard({ monitor, nowMs }: Props) {
           className={`v4-pl-mono v4-mon-card-checked${stale ? " is-stale" : ""}`}
           title={monitor.lastCheckedAt ?? "Никогда не проверялся"}
         >
-          {stale && "⚠ "}{fmtAge(monitor.lastCheckedAt, nowMs)}
+          {stale && (
+            <>
+              <span className="v4-sr-only">Устаревшие данные: </span>
+              <span aria-hidden="true">⚠ </span>
+            </>
+          )}
+          {fmtAge(monitor.lastCheckedAt, nowMs)}
         </span>
       </div>
     </div>

--- a/src/components/v4/monitoring/MonitoringHero.tsx
+++ b/src/components/v4/monitoring/MonitoringHero.tsx
@@ -1,0 +1,86 @@
+import type { Monitor } from "../../../types";
+import { fmtAge, poolHealth, type MonitorHealth } from "./utils";
+
+interface Props {
+  monitors: Monitor[];
+  loading: boolean;
+  onRefresh: () => void;
+  /** Render-once timestamp (frozen via useState in parent) so we don't tick on every render. */
+  nowMs: number;
+}
+
+const HEALTH_TITLE: Record<MonitorHealth, string> = {
+  ok: "Все сервисы онлайн",
+  warn: "Есть замечания",
+  danger: "Сервисы недоступны",
+  unknown: "Нет данных",
+};
+
+const HEALTH_DESC: Record<MonitorHealth, string> = {
+  ok: "Все мониторы возвращают 2xx",
+  warn: "Один или несколько uptime ниже 99% или ждут проверки",
+  danger: "Один или несколько сервисов не отвечают — нужен incident-response",
+  unknown: "Подключите Cloudflare Worker для получения данных",
+};
+
+export function MonitoringHero({ monitors, loading, onRefresh, nowMs }: Props) {
+  const health = poolHealth(monitors);
+  const downCount = monitors.filter((m) => m.status === "down").length;
+  const upCount = monitors.filter((m) => m.status === "up").length;
+  const pausedCount = monitors.filter((m) => m.status === "paused").length;
+  const lastChecked = monitors.reduce<number | null>((acc, m) => {
+    if (!m.lastCheckedAt) return acc;
+    const t = new Date(m.lastCheckedAt).getTime();
+    if (isNaN(t)) return acc;
+    return acc === null || t > acc ? t : acc;
+  }, null);
+
+  return (
+    <div className={`v4-mon-hero v4-mon-hero--${health}`}>
+      <div className="v4-mon-hero-status">
+        <span className={`v4-mon-hero-dot v4-mon-hero-dot--${health}`} />
+        <div>
+          <div className="v4-mon-hero-title">{HEALTH_TITLE[health]}</div>
+          <div className="v4-mon-hero-sub">
+            {monitors.length > 0 ? (
+              <>
+                {downCount > 0 && (
+                  <>
+                    <b className="v4-mon-text-danger">{downCount}</b> не отвечает
+                    <span className="v4-mon-sep">·</span>
+                  </>
+                )}
+                <b className="v4-mon-text-success">{upCount}</b> онлайн
+                {pausedCount > 0 && (
+                  <>
+                    <span className="v4-mon-sep">·</span>
+                    <b className="v4-mon-text-muted">{pausedCount}</b> на паузе
+                  </>
+                )}
+                <span className="v4-mon-sep">·</span>
+                всего <b>{monitors.length}</b>
+                {lastChecked !== null && (
+                  <>
+                    <span className="v4-mon-sep">·</span>
+                    обновлено <span className="v4-pl-mono v4-mon-text-muted">{fmtAge(new Date(lastChecked).toISOString(), nowMs)}</span>
+                  </>
+                )}
+              </>
+            ) : (
+              HEALTH_DESC[health]
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="v4-mon-hero-actions">
+        <button type="button" className="v4-btn v4-btn--pri" onClick={onRefresh} disabled={loading}>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M21 12a9 9 0 11-6.22-8.56" />
+            <path d="M21 3v6h-6" />
+          </svg>
+          {loading ? "Загрузка…" : "Обновить"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/monitoring/MonitoringHero.tsx
+++ b/src/components/v4/monitoring/MonitoringHero.tsx
@@ -38,7 +38,7 @@ export function MonitoringHero({ monitors, loading, onRefresh, nowMs }: Props) {
   return (
     <div className={`v4-mon-hero v4-mon-hero--${health}`}>
       <div className="v4-mon-hero-status">
-        <span className={`v4-mon-hero-dot v4-mon-hero-dot--${health}`} />
+        <span className={`v4-mon-hero-dot v4-mon-hero-dot--${health}`} aria-hidden="true" />
         <div>
           <div className="v4-mon-hero-title">{HEALTH_TITLE[health]}</div>
           <div className="v4-mon-hero-sub">

--- a/src/components/v4/monitoring/MonitoringKpiStrip.tsx
+++ b/src/components/v4/monitoring/MonitoringKpiStrip.tsx
@@ -1,0 +1,78 @@
+import type { Monitor } from "../../../types";
+
+interface Props {
+  monitors: Monitor[];
+}
+
+export function MonitoringKpiStrip({ monitors }: Props) {
+  const total = monitors.length;
+  const up = monitors.filter((m) => m.status === "up").length;
+  const down = monitors.filter((m) => m.status === "down").length;
+  const paused = monitors.filter((m) => m.status === "paused").length;
+  const pending = monitors.filter((m) => m.status === "pending").length;
+
+  const uptimes = monitors
+    .map((m) => m.uptimePct)
+    .filter((u): u is number => u !== null && isFinite(u));
+  const avgUptime = uptimes.length > 0
+    ? uptimes.reduce((s, u) => s + u, 0) / uptimes.length
+    : null;
+
+  return (
+    <div className="v4-projects-toolbar v4-pl-kpi-strip">
+      <div className="v4-projects-agg">
+        <div className="v4-projects-agg-cell" title="Всего мониторов">
+          <div className="v4-projects-agg-n num">{total}</div>
+          <div className="v4-projects-agg-l">всего</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Сервисы со статусом up">
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: up > 0 ? "var(--v4-success-700)" : undefined }}
+          >
+            {up}
+          </div>
+          <div className="v4-projects-agg-l">онлайн</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Сервисы со статусом down">
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: down > 0 ? "var(--v4-danger-700)" : undefined }}
+          >
+            {down}
+          </div>
+          <div className="v4-projects-agg-l">не отвечает</div>
+        </div>
+        {paused > 0 && (
+          <div className="v4-projects-agg-cell" title="Мониторы на паузе">
+            <div className="v4-projects-agg-n num">{paused}</div>
+            <div className="v4-projects-agg-l">на паузе</div>
+          </div>
+        )}
+        {pending > 0 && (
+          <div className="v4-projects-agg-cell" title="Мониторы в статусе pending">
+            <div className="v4-projects-agg-n num">{pending}</div>
+            <div className="v4-projects-agg-l">проверяется</div>
+          </div>
+        )}
+        <div className="v4-projects-agg-cell" title="Средний uptime по всем мониторам">
+          <div
+            className="v4-projects-agg-n num"
+            style={{
+              color: avgUptime === null
+                ? undefined
+                : avgUptime >= 99.9
+                  ? "var(--v4-success-700)"
+                  : avgUptime >= 99
+                    ? undefined
+                    : "var(--v4-warn-700)",
+            }}
+          >
+            {avgUptime !== null ? `${avgUptime.toFixed(2)}%` : "—"}
+          </div>
+          <div className="v4-projects-agg-l">средний uptime</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/monitoring/MonitoringSetup.tsx
+++ b/src/components/v4/monitoring/MonitoringSetup.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { setWorkerUrl } from "../../../utils/config";
+
+interface Props {
+  onSaved: () => void;
+}
+
+export function MonitoringSetup({ onSaved }: Props) {
+  const [urlInput, setUrlInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  function handleSave() {
+    const trimmed = urlInput.trim();
+    if (!trimmed) {
+      setError("Введите URL воркера");
+      return;
+    }
+    try {
+      const u = new URL(trimmed);
+      if (u.protocol !== "https:" && u.protocol !== "http:") {
+        setError("URL должен быть http(s)");
+        return;
+      }
+    } catch {
+      setError("Невалидный URL");
+      return;
+    }
+    setError(null);
+    setWorkerUrl(trimmed);
+    onSaved();
+  }
+
+  return (
+    <div className="v4-panel v4-mon-setup">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">Подключение Better Stack</div>
+      </div>
+      <div className="v4-mon-setup-body">
+        <p className="v4-mon-setup-desc">
+          Для работы нужен Cloudflare Worker, который проксирует запросы к Better Stack API
+          (чтобы не светить токен в браузере).
+        </p>
+        <a
+          className="v4-mon-setup-doc"
+          href="https://github.com/Sergio1990-1/makeit-dashboard/blob/main/cloudflare-worker/betterstack-proxy.js"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          📖 Инструкция по настройке воркера →
+        </a>
+
+        <label className="v4-mon-setup-field">
+          <span className="v4-tpc-control-key">URL воркера</span>
+          <input
+            type="url"
+            className="v4-pl-input"
+            placeholder="https://betterstack-proxy.YOUR-NAME.workers.dev"
+            value={urlInput}
+            onChange={(e) => setUrlInput(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleSave()}
+            autoFocus
+          />
+        </label>
+
+        {error && <div className="v4-error">{error}</div>}
+
+        <div className="v4-mon-setup-actions">
+          <button type="button" className="v4-btn v4-btn--pri" onClick={handleSave}>
+            Сохранить
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/monitoring/MonitoringView.tsx
+++ b/src/components/v4/monitoring/MonitoringView.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useMemo, useState } from "react";
+import type { Monitor, MonitorStatus } from "../../../types";
+import { getWorkerUrl } from "../../../utils/config";
+import { MonitoringHero } from "./MonitoringHero";
+import { MonitoringKpiStrip } from "./MonitoringKpiStrip";
+import { MonitorCard } from "./MonitorCard";
+import { MonitoringSetup } from "./MonitoringSetup";
+import { getProjectName, STATUS_LABEL, STATUS_RANK } from "./utils";
+
+interface Props {
+  monitors: Monitor[];
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}
+
+type StatusFilter = "all" | MonitorStatus;
+type GroupBy = "none" | "project";
+
+const STATUS_FILTERS: Array<{ key: StatusFilter; label: string }> = [
+  { key: "all", label: "Все" },
+  { key: "down", label: STATUS_LABEL.down },
+  { key: "up", label: STATUS_LABEL.up },
+  { key: "paused", label: STATUS_LABEL.paused },
+];
+
+const STORAGE = {
+  status: "v4mon:status",
+  group: "v4mon:group",
+};
+
+function readStatus(): StatusFilter {
+  try {
+    const v = localStorage.getItem(STORAGE.status);
+    if (v === "all" || v === "up" || v === "down" || v === "paused" || v === "pending") {
+      return v;
+    }
+  } catch {
+    /* ignore */
+  }
+  return "all";
+}
+
+function readGroup(): GroupBy {
+  try {
+    const v = localStorage.getItem(STORAGE.group);
+    if (v === "none" || v === "project") return v;
+  } catch {
+    /* ignore */
+  }
+  return "none";
+}
+
+export function MonitoringView({ monitors, loading, error, onRefresh }: Props) {
+  // Re-render gate for the worker-URL setup screen. Toggling this triggers a
+  // refresh in the parent's useMonitors effect via getWorkerUrl() change.
+  const [hasWorker, setHasWorker] = useState(() => !!getWorkerUrl());
+
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>(() => readStatus());
+  const [group, setGroup] = useState<GroupBy>(() => readGroup());
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE.status, statusFilter);
+    } catch {
+      /* ignore */
+    }
+  }, [statusFilter]);
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE.group, group);
+    } catch {
+      /* ignore */
+    }
+  }, [group]);
+
+  // Frozen "now" — refreshed every 30s and snapped to the current time
+  // whenever the monitors array identity changes (i.e. after a refresh).
+  // Microtask defer satisfies react-hooks/set-state-in-effect, which fires
+  // on synchronous setState in useEffect bodies.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+  useEffect(() => {
+    let cancelled = false;
+    Promise.resolve().then(() => {
+      if (!cancelled) setNowMs(Date.now());
+    });
+    return () => { cancelled = true; };
+  }, [monitors]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return monitors.filter((m) => {
+      if (statusFilter !== "all" && m.status !== statusFilter) return false;
+      if (q) {
+        const inName = m.name.toLowerCase().includes(q);
+        const inUrl = m.url.toLowerCase().includes(q);
+        const project = (getProjectName(m) ?? "").toLowerCase();
+        const inProject = project.includes(q);
+        if (!inName && !inUrl && !inProject) return false;
+      }
+      return true;
+    });
+  }, [monitors, statusFilter, search]);
+
+  const sorted = useMemo(() => {
+    const arr = [...filtered];
+    arr.sort((a, b) => {
+      const ra = STATUS_RANK[a.status];
+      const rb = STATUS_RANK[b.status];
+      if (ra !== rb) return ra - rb;
+      return a.name.localeCompare(b.name, "ru");
+    });
+    return arr;
+  }, [filtered]);
+
+  const grouped = useMemo(() => {
+    if (group !== "project") return null;
+    const map = new Map<string, Monitor[]>();
+    for (const m of sorted) {
+      const p = getProjectName(m) ?? "Прочее";
+      const arr = map.get(p) ?? [];
+      arr.push(m);
+      map.set(p, arr);
+    }
+    return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b, "ru"));
+  }, [sorted, group]);
+
+  if (!hasWorker) {
+    return (
+      <div className="v4-content">
+        <div className="v4-ph">
+          <div>
+            <h1>Мониторинг</h1>
+            <div className="v4-sub">Better Stack uptime · подключение не настроено</div>
+          </div>
+        </div>
+        <div style={{ height: 10 }} />
+        <MonitoringSetup
+          onSaved={() => {
+            setHasWorker(true);
+            onRefresh();
+          }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="v4-content">
+      <div className="v4-ph">
+        <div>
+          <h1>Мониторинг</h1>
+          <div className="v4-sub">
+            Better Stack uptime ·{" "}
+            <span className="v4-pl-mono">{monitors.length}</span> {monitors.length === 1 ? "монитор" : "мониторов"}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ height: 10 }} />
+
+      <MonitoringHero
+        monitors={monitors}
+        loading={loading}
+        onRefresh={onRefresh}
+        nowMs={nowMs}
+      />
+
+      {error && <div className="v4-error" style={{ marginTop: 14 }}>{error}</div>}
+
+      <MonitoringKpiStrip monitors={monitors} />
+
+      <div className="v4-mon-toolbar">
+        <div className="v4-mon-search">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            type="search"
+            placeholder="Поиск по имени, url, проекту…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="v4-pillgrp">
+          {STATUS_FILTERS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              className={statusFilter === key ? "is-active" : ""}
+              onClick={() => setStatusFilter(key)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <div className="v4-pillgrp">
+          <button
+            type="button"
+            className={group === "none" ? "is-active" : ""}
+            onClick={() => setGroup("none")}
+          >
+            Список
+          </button>
+          <button
+            type="button"
+            className={group === "project" ? "is-active" : ""}
+            onClick={() => setGroup("project")}
+          >
+            По проектам
+          </button>
+        </div>
+      </div>
+
+      {monitors.length === 0 && !loading && !error ? (
+        <div className="v4-panel">
+          <div className="v4-empty">Мониторы не найдены. Проверьте настройку воркера.</div>
+        </div>
+      ) : sorted.length === 0 ? (
+        <div className="v4-panel">
+          <div className="v4-empty">
+            По текущим фильтрам ничего не найдено
+            {search && (
+              <>
+                {" "}для запроса <span className="v4-pl-mono">«{search}»</span>
+              </>
+            )}
+            .
+          </div>
+        </div>
+      ) : grouped ? (
+        <div className="v4-mon-groups">
+          {grouped.map(([project, items]) => (
+            <div key={project} className="v4-mon-group">
+              <div className="v4-mon-group-h">
+                <span className="v4-mon-group-name">{project}</span>
+                <span className="v4-pl-mono v4-mon-text-muted">
+                  {items.length} {items.length === 1 ? "монитор" : "мониторов"}
+                </span>
+              </div>
+              <div className="v4-mon-grid">
+                {items.map((m) => (
+                  <MonitorCard key={m.id} monitor={m} nowMs={nowMs} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="v4-mon-grid">
+          {sorted.map((m) => (
+            <MonitorCard key={m.id} monitor={m} nowMs={nowMs} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/monitoring/MonitoringView.tsx
+++ b/src/components/v4/monitoring/MonitoringView.tsx
@@ -32,7 +32,10 @@ const STORAGE = {
 function readStatus(): StatusFilter {
   try {
     const v = localStorage.getItem(STORAGE.status);
-    if (v === "all" || v === "up" || v === "down" || v === "paused" || v === "pending") {
+    // Allow only values that have a corresponding pill in STATUS_FILTERS —
+    // otherwise the user could end up in a "pending" filtered view with no
+    // active pill and no obvious way to clear it.
+    if (v === "all" || v === "up" || v === "down" || v === "paused") {
       return v;
     }
   } catch {
@@ -52,9 +55,10 @@ function readGroup(): GroupBy {
 }
 
 export function MonitoringView({ monitors, loading, error, onRefresh }: Props) {
-  // Re-render gate for the worker-URL setup screen. Toggling this triggers a
-  // refresh in the parent's useMonitors effect via getWorkerUrl() change.
-  const [hasWorker, setHasWorker] = useState(() => !!getWorkerUrl());
+  // Snapshot at mount: shows the setup screen if no worker URL is configured.
+  // Setup completion calls window.location.reload() so this stays a one-shot
+  // — no setter needed.
+  const [hasWorker] = useState(() => !!getWorkerUrl());
 
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>(() => readStatus());
@@ -142,8 +146,12 @@ export function MonitoringView({ monitors, loading, error, onRefresh }: Props) {
         <div style={{ height: 10 }} />
         <MonitoringSetup
           onSaved={() => {
-            setHasWorker(true);
-            onRefresh();
+            // Reload so useMonitors' mount-time effect re-arms the 2-min
+            // polling interval. Without a reload, the hook only ever
+            // started its setInterval at mount when getWorkerUrl() was
+            // null and returned early; toggling setHasWorker just shows
+            // the data UI but auto-refresh stays inert.
+            window.location.reload();
           }}
         />
       </div>
@@ -183,6 +191,7 @@ export function MonitoringView({ monitors, loading, error, onRefresh }: Props) {
           </svg>
           <input
             type="search"
+            aria-label="Поиск по мониторам"
             placeholder="Поиск по имени, url, проекту…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}

--- a/src/components/v4/monitoring/utils.ts
+++ b/src/components/v4/monitoring/utils.ts
@@ -1,0 +1,79 @@
+import type { Monitor, MonitorStatus } from "../../../types";
+import { MONITOR_MATCH } from "../../../utils/config";
+
+export type MonitorHealth = "ok" | "warn" | "danger" | "unknown";
+
+export const STATUS_LABEL: Record<MonitorStatus, string> = {
+  up: "Онлайн",
+  down: "Не отвечает",
+  paused: "На паузе",
+  pending: "Проверяется",
+};
+
+export const STATUS_RANK: Record<MonitorStatus, number> = {
+  // Lower rank = appears first in sort. Down first for incident triage.
+  down: 0,
+  pending: 1,
+  paused: 2,
+  up: 3,
+};
+
+/** Health classification of a monitor for color treatment. */
+export function monitorHealth(m: Monitor): MonitorHealth {
+  if (m.status === "down") return "danger";
+  if (m.status === "pending") return "warn";
+  if (m.status === "paused") return "unknown";
+  if (m.uptimePct !== null && m.uptimePct < 99) return "warn";
+  return "ok";
+}
+
+/** Aggregate health across the monitor pool. */
+export function poolHealth(monitors: Monitor[]): MonitorHealth {
+  if (monitors.length === 0) return "unknown";
+  if (monitors.some((m) => m.status === "down")) return "danger";
+  if (monitors.some((m) => m.status === "pending")) return "warn";
+  if (monitors.some((m) => m.uptimePct !== null && m.uptimePct < 99)) return "warn";
+  return "ok";
+}
+
+export function uptimeColor(pct: number | null): string {
+  if (pct === null) return "var(--v4-ink-400)";
+  if (pct >= 99.9) return "var(--v4-success-700)";
+  if (pct >= 99) return "var(--v4-success-500)";
+  if (pct >= 95) return "var(--v4-warn-700)";
+  return "var(--v4-danger-700)";
+}
+
+/** Reverse-lookup project repo for a monitor via MONITOR_MATCH keywords. */
+export function getProjectName(monitor: Monitor): string | null {
+  const name = monitor.name.toLowerCase();
+  const url = monitor.url.toLowerCase();
+  for (const [project, keywords] of Object.entries(MONITOR_MATCH)) {
+    if (keywords.some((kw) => name.includes(kw.toLowerCase()) || url.includes(kw.toLowerCase()))) {
+      return project;
+    }
+  }
+  return null;
+}
+
+export function fmtAge(iso: string | null, nowMs: number): string {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return "—";
+  const diffSec = Math.max(0, Math.floor((nowMs - t) / 1000));
+  if (diffSec < 60) return `${diffSec}с назад`;
+  const m = Math.floor(diffSec / 60);
+  if (m < 60) return `${m}м назад`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}ч назад`;
+  const d = Math.floor(h / 24);
+  return `${d}д назад`;
+}
+
+/** A monitor is "stale" when its last check is suspiciously old (>5 min). */
+export function isStale(iso: string | null, nowMs: number): boolean {
+  if (!iso) return false;
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return false;
+  return nowMs - t > 5 * 60 * 1000;
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -4085,6 +4085,293 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 .v4-tag--warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
 
 /* ────────────────────────────────────────
+   MONITORING (Better Stack uptime)
+   ──────────────────────────────────────── */
+.v4-mon-text-muted { color: var(--v4-ink-500); }
+.v4-mon-text-success { color: var(--v4-success-700); }
+.v4-mon-text-danger { color: var(--v4-danger-700); }
+
+.v4-mon-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  padding: 18px 22px;
+  margin-bottom: 14px;
+}
+.v4-mon-hero--ok { border-left: 4px solid var(--v4-success-500); }
+.v4-mon-hero--warn { border-left: 4px solid var(--v4-warn-500); }
+.v4-mon-hero--danger { border-left: 4px solid var(--v4-danger-500); }
+.v4-mon-hero--unknown { border-left: 4px solid var(--v4-ink-300); }
+.v4-mon-hero-status {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  min-width: 0;
+}
+.v4-mon-hero-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.v4-mon-hero-dot--ok { background: var(--v4-success-500); box-shadow: 0 0 0 4px var(--v4-success-50); }
+.v4-mon-hero-dot--warn { background: var(--v4-warn-500); box-shadow: 0 0 0 4px var(--v4-warn-50); }
+.v4-mon-hero-dot--danger {
+  background: var(--v4-danger-500);
+  box-shadow: 0 0 0 4px var(--v4-danger-50);
+  animation: v4-mon-pulse 1.6s ease-in-out infinite;
+}
+.v4-mon-hero-dot--unknown { background: var(--v4-ink-300); }
+@keyframes v4-mon-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+.v4-mon-hero-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  margin-bottom: 4px;
+}
+.v4-mon-hero-sub {
+  font-size: 13px;
+  color: var(--v4-ink-500);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+.v4-mon-hero-sub b { color: var(--v4-ink-900); font-weight: 600; }
+.v4-mon-sep { color: var(--v4-ink-300); margin: 0 4px; }
+.v4-mon-hero-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* — Toolbar (search + filters) — */
+.v4-mon-toolbar {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 14px 0;
+}
+.v4-mon-search {
+  position: relative;
+  flex: 1 1 280px;
+  min-width: 220px;
+}
+.v4-mon-search svg {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
+  color: var(--v4-ink-400);
+  pointer-events: none;
+}
+.v4-mon-search input {
+  width: 100%;
+  height: 36px;
+  padding: 0 14px 0 36px;
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  background: var(--v4-paper);
+  font-size: 13px;
+  color: var(--v4-ink-900);
+}
+.v4-mon-search input:focus {
+  outline: none;
+  border-color: var(--v4-accent-500);
+  box-shadow: 0 0 0 3px var(--v4-accent-50);
+}
+.v4-mon-search input::placeholder { color: var(--v4-ink-400); }
+
+/* — Card grid + groups — */
+.v4-mon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 12px;
+}
+.v4-mon-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.v4-mon-group { display: flex; flex-direction: column; gap: 10px; }
+.v4-mon-group-h {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 0 4px;
+}
+.v4-mon-group-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  font-family: var(--v4-mono);
+}
+
+/* — Monitor card — */
+.v4-mon-card {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+  transition: border-color 120ms;
+}
+.v4-mon-card--ok { border-top: 3px solid var(--v4-success-500); }
+.v4-mon-card--warn { border-top: 3px solid var(--v4-warn-500); }
+.v4-mon-card--danger { border-top: 3px solid var(--v4-danger-500); }
+.v4-mon-card--unknown { border-top: 3px solid var(--v4-line); }
+
+.v4-mon-card-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.v4-mon-card-name {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+}
+.v4-mon-card-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.v4-mon-card-dot--ok { background: var(--v4-success-500); }
+.v4-mon-card-dot--warn { background: var(--v4-warn-500); }
+.v4-mon-card-dot--danger {
+  background: var(--v4-danger-500);
+  animation: v4-mon-pulse 1.6s ease-in-out infinite;
+}
+.v4-mon-card-dot--unknown { background: var(--v4-ink-300); }
+.v4-mon-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.v4-mon-status {
+  flex-shrink: 0;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.v4-mon-status--up { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-mon-status--down { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-mon-status--paused { background: var(--v4-surface-3); color: var(--v4-ink-500); }
+.v4-mon-status--pending { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+
+.v4-mon-card-url {
+  font-size: 12px;
+  color: var(--v4-accent-700);
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+.v4-mon-card-url:hover { text-decoration: underline; }
+
+.v4-mon-card-uptime {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.v4-mon-card-uptime-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+.v4-mon-card-uptime-val {
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.v4-mon-card-uptime-bar {
+  height: 6px;
+  background: var(--v4-surface-3);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.v4-mon-card-uptime-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 200ms ease;
+}
+
+.v4-mon-card-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.v4-mon-card-project {
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
+  font-family: var(--v4-mono);
+  font-size: 11px;
+}
+.v4-mon-card-checked {
+  font-size: 11px;
+  color: var(--v4-ink-400);
+}
+.v4-mon-card-checked.is-stale {
+  color: var(--v4-warn-700);
+  font-weight: 600;
+}
+
+/* — Setup card — */
+.v4-mon-setup-body {
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.v4-mon-setup-desc {
+  margin: 0;
+  font-size: 13px;
+  color: var(--v4-ink-700);
+  line-height: 1.5;
+}
+.v4-mon-setup-doc {
+  font-size: 13px;
+  color: var(--v4-accent-700);
+  text-decoration: none;
+}
+.v4-mon-setup-doc:hover { text-decoration: underline; }
+.v4-mon-setup-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v4-mon-setup-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+/* ────────────────────────────────────────
    RESPONSIVE
    ──────────────────────────────────────── */
 @media (max-width: 1100px) {

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -4091,6 +4091,19 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 .v4-mon-text-success { color: var(--v4-success-700); }
 .v4-mon-text-danger { color: var(--v4-danger-700); }
 
+/* Visually-hidden helper for screen-reader-only labels next to icons. */
+.v4-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .v4-mon-hero {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- Migrate Monitoring (uptime) tab from a single-bento table to V4 design system
- 6 new components (~660 LOC) in `src/components/v4/monitoring/` + ~290 lines of CSS
- `useMonitors` hook unchanged — pure presentation rewrite

## UX changes vs legacy
- **Hero with pool-health classification** — danger if any monitor down, warn for pending or uptime <99%, ok otherwise. Pulsing red dot for danger so outages are impossible to miss.
- **KPI strip** — total / онлайн / не отвечает / на паузе / проверяется / средний uptime. Coloured digits when bad.
- **Card grid instead of table** — each card has status badge (colored), clickable URL, uptime bar, project tag (resolved via `MONITOR_MATCH`), last-checked age.
- **Stale flag** — last-checked >5 min ago shows ⚠ in warn-orange. The previous UI silently displayed any age.
- **Search** — by name / url / project.
- **Status filter pills** — Все / Не отвечает / Онлайн / На паузе.
- **Group toggle** — Список / По проектам (uses `MONITOR_MATCH` for grouping).
- **Down-first sort** — incidents at top, then pending → paused → online (alphabetical within bucket). Triage-friendly default.
- **Setup screen in V4** — Cloudflare Worker URL prompt with link to docs.
- **localStorage preferences** — status filter and group toggle persist across sessions.
- **Removed uptime from the GitHub-loading banner gate** — Monitoring no longer obscured by "Загрузка данных…" when GitHub data is empty (it doesn't depend on GitHub).

## Test plan
- [x] `npx tsc --noEmit` — green
- [x] `npm run lint` — green
- [x] `npm run build` — green
- [x] Verified in preview with mocked Better Stack worker (8 monitors: 1 down, 1 pending, 1 paused, 5 up):
  - Hero classifies as danger, sub: "1 не отвечает · 5 онлайн · 1 на паузе · всего 8 · обновлено 1м назад"
  - 8 cards render in correct sort order (Mankassa down → MyMoney pending → Beer Bot paused → 5 up alphabetically)
  - Project tags resolved (`MANKASSA-APP`, `MYMONEY`, `BEER_BOT`, etc.)
  - Stale flag visible on monitors >5 min old (Beer Bot 4h, MyMoney 8m)
  - KPI strip shows correct counts + 98.92% avg uptime in warn-orange
  - Status filter / search / group toggle interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)