### PR TITLE
feat(audit): redesign Audit tab in V4 design system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { ChatButton } from "./components/ChatButton";
 import { FinanceEditor } from "./components/FinanceEditor";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { MonitoringView } from "./components/v4/monitoring/MonitoringView";
-import { AuditCombinedTab } from "./components/AuditCombinedTab";
+import { AuditView } from "./components/v4/audit/AuditView";
 import { PipelineView } from "./components/v4/pipeline/PipelineView";
 import { TranscriptsView } from "./components/v4/transcripts/TranscriptsView";
 import { ResearchTab } from "./components/ResearchTab";
@@ -238,13 +238,11 @@ function AppInner() {
         )}
 
         {/* Stateful tabs — mount lazily on first visit, keep alive via display:none */}
-        <div className="v4-legacy-frame" style={{ display: tab === "audit" ? undefined : "none" }}>
+        <div style={{ display: tab === "audit" ? undefined : "none" }}>
           {visitedTabs.has("audit") && (
-            <div className="bento-grid">
-              <ErrorBoundary fallback="Ошибка вкладки Аудит">
-                <AuditCombinedTab dashboardProjects={projects} />
-              </ErrorBoundary>
-            </div>
+            <ErrorBoundary fallback="Ошибка вкладки Аудит">
+              <AuditView dashboardProjects={projects} />
+            </ErrorBoundary>
           )}
         </div>
         <div style={{ display: tab === "pipeline" ? undefined : "none" }}>

--- a/src/components/v4/audit/AuditHero.tsx
+++ b/src/components/v4/audit/AuditHero.tsx
@@ -1,0 +1,81 @@
+import type { AuditProjectStatus } from "../../../types";
+import {
+  poolHealth,
+  totalFindingsBySeverity,
+  type AuditHealth,
+} from "./utils";
+
+interface Props {
+  projects: AuditProjectStatus[];
+  loading: boolean;
+  onRefresh: () => void;
+  /** Optional title override — defaults to "Аудит кода" / "UX аудит" set by parent. */
+  title?: string;
+}
+
+const HEALTH_TITLE: Record<AuditHealth, string> = {
+  ok: "Критических находок нет",
+  warn: "Есть высокоприоритетные находки",
+  danger: "Есть критические находки",
+  unknown: "Аудит не проводился",
+};
+
+export function AuditHero({ projects, loading, onRefresh }: Props) {
+  const health = poolHealth(projects);
+  const totals = totalFindingsBySeverity(projects);
+  const audited = projects.filter((p) => p.last_run).length;
+  const needsVerify = projects.filter((p) => p.last_run && !p.last_run.verification).length;
+
+  return (
+    <div className={`v4-au-hero v4-au-hero--${health}`}>
+      <div className="v4-au-hero-status">
+        <span className={`v4-au-hero-dot v4-au-hero-dot--${health}`} aria-hidden="true" />
+        <div>
+          <div className="v4-au-hero-title">{HEALTH_TITLE[health]}</div>
+          <div className="v4-au-hero-sub">
+            {audited > 0 ? (
+              <>
+                {totals.critical > 0 && (
+                  <>
+                    <b className="v4-au-text-danger">{totals.critical}</b> критических
+                    <span className="v4-au-sep">·</span>
+                  </>
+                )}
+                {totals.high > 0 && (
+                  <>
+                    <b className="v4-au-text-warn">{totals.high}</b> высоких
+                    <span className="v4-au-sep">·</span>
+                  </>
+                )}
+                {totals.medium > 0 && (
+                  <>
+                    <b>{totals.medium}</b> средних
+                    <span className="v4-au-sep">·</span>
+                  </>
+                )}
+                <span>проаудированы <b>{audited}</b> из <b>{projects.length}</b></span>
+                {needsVerify > 0 && (
+                  <>
+                    <span className="v4-au-sep">·</span>
+                    <b className="v4-au-text-warn">{needsVerify}</b> ждут верификации
+                  </>
+                )}
+              </>
+            ) : (
+              <>Аудит не запускался ни для одного проекта. Выберите проект и нажмите «Аудит».</>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="v4-au-hero-actions">
+        <button type="button" className="v4-btn" onClick={onRefresh} disabled={loading}>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M21 12a9 9 0 11-6.22-8.56" />
+            <path d="M21 3v6h-6" />
+          </svg>
+          {loading ? "Загрузка…" : "Обновить"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/audit/AuditKpiStrip.tsx
+++ b/src/components/v4/audit/AuditKpiStrip.tsx
@@ -1,0 +1,61 @@
+import type { AuditProjectStatus } from "../../../types";
+import {
+  avgDurationSec,
+  fmtCost,
+  fmtDuration,
+  totalCost,
+  totalFindingsBySeverity,
+} from "./utils";
+
+interface Props {
+  projects: AuditProjectStatus[];
+}
+
+export function AuditKpiStrip({ projects }: Props) {
+  const total = projects.length;
+  const audited = projects.filter((p) => p.last_run).length;
+  const totals = totalFindingsBySeverity(projects);
+  const cost = totalCost(projects);
+  const avgDur = avgDurationSec(projects);
+
+  return (
+    <div className="v4-projects-toolbar v4-pl-kpi-strip">
+      <div className="v4-projects-agg">
+        <div className="v4-projects-agg-cell" title="Всего проектов в конфиге">
+          <div className="v4-projects-agg-n num">{total}</div>
+          <div className="v4-projects-agg-l">проектов</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Проекты с last_run">
+          <div className="v4-projects-agg-n num">{audited}</div>
+          <div className="v4-projects-agg-l">проаудированы</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Сумма critical-находок по портфелю">
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: totals.critical > 0 ? "var(--v4-danger-700)" : undefined }}
+          >
+            {totals.critical}
+          </div>
+          <div className="v4-projects-agg-l">критических</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Сумма high-находок по портфелю">
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: totals.high > 0 ? "var(--v4-warn-700)" : undefined }}
+          >
+            {totals.high}
+          </div>
+          <div className="v4-projects-agg-l">высоких</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Сумма GPU-стоимости всех last_run">
+          <div className="v4-projects-agg-n num">{fmtCost(cost)}</div>
+          <div className="v4-projects-agg-l">потрачено</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Средняя длительность одного аудита">
+          <div className="v4-projects-agg-n num">{fmtDuration(avgDur)}</div>
+          <div className="v4-projects-agg-l">ср. время</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/audit/AuditOfflinePanel.tsx
+++ b/src/components/v4/audit/AuditOfflinePanel.tsx
@@ -1,0 +1,33 @@
+interface Props {
+  onRetry: () => void;
+}
+
+/** Shared offline banner shown by both Code and UX sub-views when the
+ * makeit-auditor server is unreachable. */
+export function AuditOfflinePanel({ onRetry }: Props) {
+  return (
+    <div className="v4-panel">
+      <div className="v4-empty">
+        Сервер аудита недоступен. Проверьте, что makeit-auditor запущен локально или на VPS.
+      </div>
+      <pre className="v4-au-offline-cmd">
+{`# Локально:
+cd ~/Desktop/makeit-auditor
+source .venv/bin/activate
+makeit-audit serve
+
+# На VPS:
+ssh root@89.167.17.79 "docker ps | grep makeit_auditor"`}
+      </pre>
+      <div className="v4-au-offline-actions">
+        <button type="button" className="v4-btn v4-btn--pri" onClick={onRetry}>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M21 12a9 9 0 11-6.22-8.56" />
+            <path d="M21 3v6h-6" />
+          </svg>
+          Подключиться
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/audit/AuditProjectCardV4.tsx
+++ b/src/components/v4/audit/AuditProjectCardV4.tsx
@@ -1,0 +1,254 @@
+import type { AuditProjectStatus, AuditRunStatus } from "../../../types";
+import {
+  fmtAge,
+  fmtCost,
+  fmtDuration,
+  isAuditStale,
+  projectHealth,
+  SEVERITY_COLOR,
+  SEVERITY_LABEL,
+  STALE_DAYS,
+  type Severity,
+} from "./utils";
+
+interface Props {
+  project: AuditProjectStatus;
+  status: AuditRunStatus | undefined;
+  /** GitHub issue progress for issues created in the current audit run. */
+  auditIssueProgress?: { total: number; closed: number };
+  nowMs: number;
+  onRun: () => void;
+  onCancel: () => void;
+  onVerify: () => void;
+  onCreateIssues: () => void;
+}
+
+const SEV_ORDER: Severity[] = ["critical", "high", "medium", "low"];
+
+export function AuditProjectCardV4({
+  project,
+  status,
+  auditIssueProgress,
+  nowMs,
+  onRun,
+  onCancel,
+  onVerify,
+  onCreateIssues,
+}: Props) {
+  const isRunning = status?.state === "running";
+  const isFailed = status?.state === "failed";
+  const lr = project.last_run;
+  const hasRun = !!lr;
+  const isVerified = !!lr?.verification;
+  const repoName = project.repo.split("/")[1] || project.name;
+  const repoOwner = project.repo.split("/")[0] || "";
+  const health = projectHealth(project);
+  const stale = lr ? isAuditStale(lr.timestamp, nowMs) : false;
+
+  const totalSeg = lr
+    ? SEV_ORDER.reduce((s, k) => s + lr.severity_counts[k], 0)
+    : 0;
+
+  return (
+    <div className={`v4-au-card v4-au-card--${health}${isRunning ? " is-running" : ""}`}>
+      {/* Header */}
+      <div className="v4-au-card-h">
+        <div className="v4-au-card-name">
+          <span className="v4-au-card-title" title={repoName}>{repoName}</span>
+          {repoOwner && <span className="v4-tag v4-au-card-owner">{repoOwner}</span>}
+        </div>
+        <div className="v4-au-card-badges">
+          {isRunning && (
+            <span className="v4-tag v4-tag--warn v4-au-status v4-au-status--running">
+              <span className="v4-au-running-dot" aria-hidden="true" /> running
+            </span>
+          )}
+          {isFailed && !isRunning && (
+            <span className="v4-tag v4-tag--danger v4-au-status">error</span>
+          )}
+          {!isRunning && !isFailed && hasRun && isVerified && (
+            <span className="v4-tag v4-tag--ok v4-au-status">верифицировано</span>
+          )}
+          {!isRunning && !isFailed && hasRun && !isVerified && (
+            <span className="v4-tag v4-tag--warn v4-au-status">ждёт верификации</span>
+          )}
+          {!isRunning && !hasRun && (
+            <span className="v4-tag v4-au-status">не аудирован</span>
+          )}
+        </div>
+      </div>
+
+      {/* Body */}
+      {isRunning && status ? (
+        <div className="v4-au-card-progress">
+          <div className="v4-au-progress-h">
+            <span className="v4-au-progress-stage">{status.stage || "Запуск…"}</span>
+            <span className="v4-pl-mono v4-au-progress-pct">{status.progress}%</span>
+          </div>
+          <div className="v4-au-progress-track">
+            <div
+              className="v4-au-progress-fill"
+              style={{ width: `${Math.max(2, status.progress)}%` }}
+            />
+          </div>
+          {status.message && (
+            <div className="v4-au-progress-msg">{status.message}</div>
+          )}
+        </div>
+      ) : isFailed && status ? (
+        <div className="v4-au-card-error">
+          <div className="v4-au-card-error-t">Ошибка аудита</div>
+          <div className="v4-au-card-error-b">{status.error || "Unknown error"}</div>
+        </div>
+      ) : !hasRun ? (
+        <div className="v4-au-card-empty">Прогонов аудита не было</div>
+      ) : (
+        <>
+          {/* Findings + severity bar */}
+          <div className="v4-au-card-findings">
+            <div className="v4-au-findings-h">
+              <span className="v4-pl-mono v4-au-findings-total">{lr.total_findings}</span>
+              <span className="v4-au-text-muted">находок</span>
+              <div className="v4-au-findings-pris">
+                {SEV_ORDER.map((sev) => {
+                  const n = lr.severity_counts[sev];
+                  if (n === 0) return null;
+                  return (
+                    <span key={sev} className="v4-au-pri" title={SEVERITY_LABEL[sev]}>
+                      <span className="v4-au-pri-dot" style={{ background: SEVERITY_COLOR[sev] }} />
+                      <span className="v4-pl-mono">{n}</span>
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+            {totalSeg > 0 && (
+              <div className="v4-au-sev-bar">
+                {SEV_ORDER.map((sev) => {
+                  const n = lr.severity_counts[sev];
+                  if (n === 0) return null;
+                  return (
+                    <div
+                      key={sev}
+                      className="v4-au-sev-seg"
+                      style={{ flex: n, background: SEVERITY_COLOR[sev] }}
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* Issue progress (when issues were created from this run) */}
+          {auditIssueProgress && (
+            <div className="v4-au-card-fixed">
+              <div className="v4-au-fixed-h">
+                <span className="v4-au-text-muted">Закрыто</span>
+                <span
+                  className={`v4-pl-mono v4-au-fixed-cnt${auditIssueProgress.closed === auditIssueProgress.total ? " is-done" : ""}`}
+                >
+                  {auditIssueProgress.closed} / {auditIssueProgress.total}
+                </span>
+              </div>
+              <div className="v4-au-fixed-track">
+                <div
+                  className="v4-au-fixed-fill"
+                  style={{
+                    width: auditIssueProgress.total > 0
+                      ? `${(auditIssueProgress.closed / auditIssueProgress.total) * 100}%`
+                      : "0%",
+                  }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Verification stats (only when verified) */}
+          {isVerified && lr.verification && (
+            <div className="v4-au-card-verify">
+              <span className="v4-au-text-muted">Верификация</span>
+              <span className="v4-pl-mono" style={{ color: "var(--v4-danger-700)" }} title="Подтверждено">
+                ✓ {lr.verification.confirmed}
+              </span>
+              <span className="v4-pl-mono" style={{ color: "var(--v4-success-700)" }} title="Ложное срабатывание">
+                ✗ {lr.verification.false_positive}
+              </span>
+              <span className="v4-pl-mono" style={{ color: "var(--v4-warn-700)" }} title="Неуверенно">
+                ? {lr.verification.uncertain}
+              </span>
+            </div>
+          )}
+
+          {/* Meta footer */}
+          <div className="v4-au-card-meta">
+            <div className="v4-au-meta-cell">
+              <span className="v4-au-text-muted">GPU</span>
+              <span className="v4-pl-mono v4-au-meta-val">
+                {fmtCost(lr.cost_usd ?? 0)}
+              </span>
+            </div>
+            <div className="v4-au-meta-cell">
+              <span className="v4-au-text-muted">Время</span>
+              <span className="v4-pl-mono v4-au-meta-val">
+                {fmtDuration(lr.duration_seconds)}
+              </span>
+            </div>
+            <div className="v4-au-meta-cell v4-au-meta-cell--age">
+              <span className={`v4-pl-mono${stale ? " v4-au-text-warn" : " v4-au-text-muted"}`}
+                title={stale ? `Аудит старше ${STALE_DAYS} дней` : lr.timestamp}
+              >
+                {stale && (
+                  <>
+                    <span className="v4-sr-only">Устаревшие данные: </span>
+                    <span aria-hidden="true">⚠ </span>
+                  </>
+                )}
+                {fmtAge(lr.timestamp, nowMs)}
+              </span>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Actions */}
+      <div className="v4-au-card-actions">
+        {isRunning ? (
+          <button type="button" className="v4-btn v4-au-btn-cancel" onClick={onCancel}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <rect x="6" y="6" width="12" height="12" rx="2" />
+            </svg>
+            Отменить
+          </button>
+        ) : (
+          <button type="button" className="v4-btn" onClick={onRun}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polygon points="5 3 19 12 5 21 5 3" />
+            </svg>
+            {hasRun || isFailed ? "Перезапуск" : "Аудит"}
+          </button>
+        )}
+        {!isRunning && hasRun && (
+          <button
+            type="button"
+            className={`v4-btn${isVerified ? " v4-au-btn-ok" : ""}`}
+            onClick={onVerify}
+            title={isVerified ? "Повторить верификацию" : "Верифицировать findings"}
+          >
+            {isVerified ? "✓ Верифицировано" : "Верифицировать"}
+          </button>
+        )}
+        {!isRunning && hasRun && (
+          <button
+            type="button"
+            className="v4-btn v4-btn--pri"
+            onClick={onCreateIssues}
+            disabled={!isVerified}
+            title={!isVerified ? "Сначала выполните верификацию" : "Создать GitHub Issues"}
+          >
+            Создать Issues
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/audit/AuditView.tsx
+++ b/src/components/v4/audit/AuditView.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import type { ProjectData } from "../../../types";
+import { CodeAuditView } from "./CodeAuditView";
+import { UXAuditView } from "./UXAuditView";
+
+interface Props {
+  dashboardProjects?: ProjectData[];
+}
+
+type SubTab = "code" | "ux";
+
+const STORAGE_SUB = "v4au:subtab";
+
+function readSub(): SubTab {
+  try {
+    const v = localStorage.getItem(STORAGE_SUB);
+    if (v === "code" || v === "ux") return v;
+  } catch { /* ignore */ }
+  return "code";
+}
+
+export function AuditView({ dashboardProjects = [] }: Props) {
+  const [subTab, setSubTab] = useState<SubTab>(() => readSub());
+
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_SUB, subTab); } catch { /* ignore */ }
+  }, [subTab]);
+
+  return (
+    <div className="v4-content">
+      <div className="v4-ph">
+        <div>
+          <h1>Аудит</h1>
+          <div className="v4-sub">
+            {subTab === "code"
+              ? "Code audit · LLM + детерминистические анализаторы"
+              : "UX audit · Lighthouse + axe-core + Vision LLM"}
+          </div>
+        </div>
+        <div className="v4-ph-right">
+          <div className="v4-pillgrp">
+            <button
+              type="button"
+              className={subTab === "code" ? "is-active" : ""}
+              onClick={() => setSubTab("code")}
+            >
+              Код
+            </button>
+            <button
+              type="button"
+              className={subTab === "ux" ? "is-active" : ""}
+              onClick={() => setSubTab("ux")}
+            >
+              UX
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ height: 10 }} />
+
+      {subTab === "code"
+        ? <CodeAuditView dashboardProjects={dashboardProjects} />
+        : <UXAuditView />}
+    </div>
+  );
+}

--- a/src/components/v4/audit/CodeAuditView.tsx
+++ b/src/components/v4/audit/CodeAuditView.tsx
@@ -37,9 +37,12 @@ function readFilter(): AuditFilter {
 
 export function CodeAuditView({ dashboardProjects = [] }: Props) {
   const { projects, runStatuses, auditorAvailable, loading, refresh, startRun, cancelRun } = useAudit();
+  // Store the full project object for each open dialog so a background
+  // refresh() that drops/replaces a project can't silently close the
+  // dialog mid-render via a failed lookup.
   const [confirmingProject, setConfirmingProject] = useState<AuditProjectStatus | null>(null);
-  const [issuesDialogProject, setIssuesDialogProject] = useState<string | null>(null);
-  const [verifyDialogProject, setVerifyDialogProject] = useState<string | null>(null);
+  const [issuesDialogProject, setIssuesDialogProject] = useState<AuditProjectStatus | null>(null);
+  const [verifyDialogProject, setVerifyDialogProject] = useState<AuditProjectStatus | null>(null);
 
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<AuditFilter>(() => readFilter());
@@ -130,8 +133,13 @@ export function CodeAuditView({ dashboardProjects = [] }: Props) {
       ) : (
         <div className="v4-au-grid">
           {visible.map((p) => {
+            // dashboardProjects[].repo is "owner/name"; auditor's p.repo is
+            // also "owner/name" but legacy callers used to compare against
+            // just the name segment. Compare slug-to-slug on both sides so
+            // the lookup actually matches.
+            const auditRepoName = (p.repo.split("/")[1] ?? p.repo).toLowerCase();
             const dashProject = dashboardProjects.find(
-              (dp) => dp.repo.toLowerCase() === (p.repo.split("/")[1] || p.repo).toLowerCase(),
+              (dp) => (dp.repo.split("/")[1] ?? dp.repo).toLowerCase() === auditRepoName,
             );
             const currentIssueUrls = p.last_run?.issue_urls ?? [];
             const auditIssues = currentIssueUrls.length > 0
@@ -153,8 +161,8 @@ export function CodeAuditView({ dashboardProjects = [] }: Props) {
                 nowMs={nowMs}
                 onRun={() => setConfirmingProject(p)}
                 onCancel={() => cancelRun(p.name)}
-                onVerify={() => setVerifyDialogProject(p.name)}
-                onCreateIssues={() => setIssuesDialogProject(p.name)}
+                onVerify={() => setVerifyDialogProject(p)}
+                onCreateIssues={() => setIssuesDialogProject(p)}
               />
             );
           })}
@@ -180,40 +188,33 @@ export function CodeAuditView({ dashboardProjects = [] }: Props) {
         />
       )}
 
-      {verifyDialogProject && (() => {
-        const dialogProject = projects.find((p) => p.name === verifyDialogProject);
-        if (!dialogProject) return null;
-        return (
-          <AuditVerifyDialog
-            project={dialogProject}
-            onClose={() => setVerifyDialogProject(null)}
-            onComplete={() => {
-              setVerifyDialogProject(null);
-              refresh();
-            }}
-          />
-        );
-      })()}
+      {verifyDialogProject && (
+        <AuditVerifyDialog
+          project={verifyDialogProject}
+          onClose={() => setVerifyDialogProject(null)}
+          onComplete={() => {
+            setVerifyDialogProject(null);
+            refresh();
+          }}
+        />
+      )}
 
-      {issuesDialogProject && (() => {
-        const dialogProject = projects.find((p) => p.name === issuesDialogProject);
-        if (!dialogProject) return null;
-        return (
-          <AuditIssuesDialog
-            project={dialogProject}
-            onClose={() => setIssuesDialogProject(null)}
-            onComplete={async (issuesCreated, issueUrls) => {
-              try {
-                await postAuditMeta(issuesDialogProject, issuesCreated, issueUrls);
-              } catch (e) {
-                console.error("Failed to save audit meta (issues still exist in GitHub):", e);
-              }
-              setIssuesDialogProject(null);
-              refresh();
-            }}
-          />
-        );
-      })()}
+      {issuesDialogProject && (
+        <AuditIssuesDialog
+          project={issuesDialogProject}
+          onClose={() => setIssuesDialogProject(null)}
+          onComplete={async (issuesCreated, issueUrls) => {
+            const projectName = issuesDialogProject.name;
+            try {
+              await postAuditMeta(projectName, issuesCreated, issueUrls);
+            } catch (e) {
+              console.error("Failed to save audit meta (issues still exist in GitHub):", e);
+            }
+            setIssuesDialogProject(null);
+            refresh();
+          }}
+        />
+      )}
     </>
   );
 }

--- a/src/components/v4/audit/CodeAuditView.tsx
+++ b/src/components/v4/audit/CodeAuditView.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useState } from "react";
+import { useAudit } from "../../../hooks/useAudit";
+import { postAuditMeta } from "../../../utils/auditor";
+import type { AuditProjectStatus, ProjectData } from "../../../types";
+import { AuditConfirmDialog } from "../../AuditConfirmDialog";
+import { AuditIssuesDialog } from "../../AuditIssuesDialog";
+import { AuditVerifyDialog } from "../../AuditVerifyDialog";
+import { AuditHero } from "./AuditHero";
+import { AuditKpiStrip } from "./AuditKpiStrip";
+import { AuditOfflinePanel } from "./AuditOfflinePanel";
+import { AuditProjectCardV4 } from "./AuditProjectCardV4";
+import {
+  applyFilter,
+  applySearch,
+  AUDIT_FILTERS,
+  sortProjects,
+  type AuditFilter,
+} from "./utils";
+
+interface Props {
+  dashboardProjects?: ProjectData[];
+}
+
+const STORAGE_FILTER = "v4au:filter";
+
+function readFilter(): AuditFilter {
+  try {
+    const v = localStorage.getItem(STORAGE_FILTER);
+    if (v === "all" || v === "critical" || v === "needsVerify" || v === "verified" || v === "notAudited" || v === "stale") {
+      return v;
+    }
+  } catch {
+    /* ignore */
+  }
+  return "all";
+}
+
+export function CodeAuditView({ dashboardProjects = [] }: Props) {
+  const { projects, runStatuses, auditorAvailable, loading, refresh, startRun, cancelRun } = useAudit();
+  const [confirmingProject, setConfirmingProject] = useState<AuditProjectStatus | null>(null);
+  const [issuesDialogProject, setIssuesDialogProject] = useState<string | null>(null);
+  const [verifyDialogProject, setVerifyDialogProject] = useState<string | null>(null);
+
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<AuditFilter>(() => readFilter());
+
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_FILTER, filter); } catch { /* ignore */ }
+  }, [filter]);
+
+  // Frozen "now" — refreshed on data change + every 30s — for stable
+  // relative timestamps. Microtask defer satisfies react-hooks/set-state-in-effect.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+  useEffect(() => {
+    let cancelled = false;
+    Promise.resolve().then(() => {
+      if (!cancelled) setNowMs(Date.now());
+    });
+    return () => { cancelled = true; };
+  }, [projects]);
+
+  const visible = useMemo(() => {
+    return sortProjects(applySearch(applyFilter(projects, filter, nowMs), search));
+  }, [projects, filter, search, nowMs]);
+
+  if (loading && projects.length === 0) {
+    return (
+      <div className="v4-empty" style={{ marginTop: 14 }}>Подключаемся к серверу аудита…</div>
+    );
+  }
+
+  if (auditorAvailable === false) {
+    return (
+      <div style={{ marginTop: 14 }}>
+        <AuditOfflinePanel onRetry={refresh} />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <AuditHero projects={projects} loading={loading} onRefresh={refresh} />
+
+      <AuditKpiStrip projects={projects} />
+
+      <div className="v4-au-toolbar">
+        <div className="v4-mon-search">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            type="search"
+            aria-label="Поиск по проектам"
+            placeholder="Поиск по имени проекта…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="v4-pillgrp">
+          {AUDIT_FILTERS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              className={filter === key ? "is-active" : ""}
+              onClick={() => setFilter(key)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {visible.length === 0 ? (
+        <div className="v4-panel">
+          <div className="v4-empty">
+            По текущим фильтрам ничего не найдено
+            {search && (
+              <>
+                {" "}для запроса <span className="v4-pl-mono">«{search}»</span>
+              </>
+            )}
+            .
+          </div>
+        </div>
+      ) : (
+        <div className="v4-au-grid">
+          {visible.map((p) => {
+            const dashProject = dashboardProjects.find(
+              (dp) => dp.repo.toLowerCase() === (p.repo.split("/")[1] || p.repo).toLowerCase(),
+            );
+            const currentIssueUrls = p.last_run?.issue_urls ?? [];
+            const auditIssues = currentIssueUrls.length > 0
+              ? (dashProject?.issues.filter((i) => currentIssueUrls.includes(i.url)) ?? [])
+              : [];
+            const auditIssueProgress = auditIssues.length > 0
+              ? {
+                  total: auditIssues.length,
+                  closed: auditIssues.filter((i) => i.closedAt !== null).length,
+                }
+              : undefined;
+
+            return (
+              <AuditProjectCardV4
+                key={p.name}
+                project={p}
+                status={runStatuses[p.name]}
+                auditIssueProgress={auditIssueProgress}
+                nowMs={nowMs}
+                onRun={() => setConfirmingProject(p)}
+                onCancel={() => cancelRun(p.name)}
+                onVerify={() => setVerifyDialogProject(p.name)}
+                onCreateIssues={() => setIssuesDialogProject(p.name)}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {/* Dialogs reused from legacy — they own their own modal styling and
+          implement complex multi-state flows that aren't worth reskinning
+          for this PR. */}
+      {confirmingProject && (
+        <AuditConfirmDialog
+          projectName={confirmingProject.name}
+          maxPrice={confirmingProject.gpu_config.max_price_per_hour}
+          lastRunCost={confirmingProject.last_run?.cost_usd ?? null}
+          lastRunDuration={confirmingProject.last_run?.duration_seconds ?? null}
+          timeoutHours={confirmingProject.gpu_config.timeout_hours}
+          onCancel={() => setConfirmingProject(null)}
+          onConfirm={async () => {
+            const name = confirmingProject.name;
+            setConfirmingProject(null);
+            await startRun(name);
+          }}
+        />
+      )}
+
+      {verifyDialogProject && (() => {
+        const dialogProject = projects.find((p) => p.name === verifyDialogProject);
+        if (!dialogProject) return null;
+        return (
+          <AuditVerifyDialog
+            project={dialogProject}
+            onClose={() => setVerifyDialogProject(null)}
+            onComplete={() => {
+              setVerifyDialogProject(null);
+              refresh();
+            }}
+          />
+        );
+      })()}
+
+      {issuesDialogProject && (() => {
+        const dialogProject = projects.find((p) => p.name === issuesDialogProject);
+        if (!dialogProject) return null;
+        return (
+          <AuditIssuesDialog
+            project={dialogProject}
+            onClose={() => setIssuesDialogProject(null)}
+            onComplete={async (issuesCreated, issueUrls) => {
+              try {
+                await postAuditMeta(issuesDialogProject, issuesCreated, issueUrls);
+              } catch (e) {
+                console.error("Failed to save audit meta (issues still exist in GitHub):", e);
+              }
+              setIssuesDialogProject(null);
+              refresh();
+            }}
+          />
+        );
+      })()}
+    </>
+  );
+}

--- a/src/components/v4/audit/UXAuditView.tsx
+++ b/src/components/v4/audit/UXAuditView.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useMemo, useState } from "react";
+import { useUXAudit } from "../../../hooks/useUXAudit";
+import type { AuditProjectStatus } from "../../../types";
+import { AuditOfflinePanel } from "./AuditOfflinePanel";
+import { UXProjectCardV4 } from "./UXProjectCardV4";
+
+const STORAGE_FILTER = "v4ux:filter";
+
+type UXFilter = "all" | "completed" | "running" | "notRun";
+
+const FILTERS: Array<{ key: UXFilter; label: string }> = [
+  { key: "all", label: "Все" },
+  { key: "completed", label: "Завершены" },
+  { key: "running", label: "Запущены" },
+  { key: "notRun", label: "Не запускались" },
+];
+
+function readFilter(): UXFilter {
+  try {
+    const v = localStorage.getItem(STORAGE_FILTER);
+    if (v === "all" || v === "completed" || v === "running" || v === "notRun") return v;
+  } catch { /* ignore */ }
+  return "all";
+}
+
+export function UXAuditView() {
+  const { projects, statuses, results, auditorAvailable, loading, error, refresh, startRun, cancelRun } = useUXAudit();
+  const [expandedProject, setExpandedProject] = useState<string | null>(null);
+  const [findingFilter, setFindingFilter] = useState<string>("all");
+  const [pageFilter, setPageFilter] = useState<string>("all");
+  const [runError, setRunError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<UXFilter>(() => readFilter());
+
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_FILTER, filter); } catch { /* ignore */ }
+  }, [filter]);
+
+  const filtered = useMemo<AuditProjectStatus[]>(() => {
+    const q = search.trim().toLowerCase();
+    return projects.filter((p) => {
+      if (q && !p.name.toLowerCase().includes(q) && !p.repo.toLowerCase().includes(q)) return false;
+      const s = statuses[p.name]?.state;
+      if (filter === "completed" && s !== "completed") return false;
+      if (filter === "running" && s !== "running") return false;
+      if (filter === "notRun" && (s === "completed" || s === "running" || s === "failed")) return false;
+      return true;
+    });
+  }, [projects, statuses, filter, search]);
+
+  if (loading && projects.length === 0) {
+    return (
+      <div className="v4-empty" style={{ marginTop: 14 }}>Загрузка UX-конфигурации…</div>
+    );
+  }
+
+  if (auditorAvailable === false) {
+    return (
+      <div style={{ marginTop: 14 }}>
+        <AuditOfflinePanel onRetry={refresh} />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {(error || runError) && (
+        <div className="v4-error" style={{ marginTop: 14 }}>{runError || error}</div>
+      )}
+
+      <div className="v4-au-toolbar">
+        <div className="v4-mon-search">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            type="search"
+            aria-label="Поиск по проектам"
+            placeholder="Поиск по имени проекта…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="v4-pillgrp">
+          {FILTERS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              className={filter === key ? "is-active" : ""}
+              onClick={() => setFilter(key)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <button type="button" className="v4-btn" onClick={refresh} disabled={loading}>
+          {loading ? "Загрузка…" : "↻ Обновить"}
+        </button>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="v4-panel">
+          <div className="v4-empty">
+            По текущим фильтрам ничего не найдено
+            {search && (
+              <>
+                {" "}для запроса <span className="v4-pl-mono">«{search}»</span>
+              </>
+            )}
+            .
+          </div>
+        </div>
+      ) : (
+        <div className="v4-au-grid">
+          {filtered.map((p) => (
+            <UXProjectCardV4
+              key={p.name}
+              project={p}
+              status={statuses[p.name]}
+              result={results[p.name]}
+              isExpanded={expandedProject === p.name}
+              findingFilter={findingFilter}
+              pageFilter={pageFilter}
+              onRun={async () => {
+                setRunError(null);
+                try { await startRun(p.name); } catch (e) {
+                  setRunError(e instanceof Error ? e.message : String(e));
+                }
+              }}
+              onCancel={() => cancelRun(p.name)}
+              onToggleExpand={() => {
+                const willExpand = expandedProject !== p.name;
+                setExpandedProject(willExpand ? p.name : null);
+                if (willExpand) { setFindingFilter("all"); setPageFilter("all"); }
+              }}
+              onSeverityChange={setFindingFilter}
+              onPageChange={setPageFilter}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/v4/audit/UXAuditView.tsx
+++ b/src/components/v4/audit/UXAuditView.tsx
@@ -132,7 +132,11 @@ export function UXAuditView() {
               onToggleExpand={() => {
                 const willExpand = expandedProject !== p.name;
                 setExpandedProject(willExpand ? p.name : null);
-                if (willExpand) { setFindingFilter("all"); setPageFilter("all"); }
+                // Reset filters on every toggle (expand AND collapse) so the
+                // next card opens with a clean slate, regardless of what the
+                // previously expanded card's filters were.
+                setFindingFilter("all");
+                setPageFilter("all");
               }}
               onSeverityChange={setFindingFilter}
               onPageChange={setPageFilter}

--- a/src/components/v4/audit/UXProjectCardV4.tsx
+++ b/src/components/v4/audit/UXProjectCardV4.tsx
@@ -1,0 +1,300 @@
+import type {
+  AuditProjectStatus,
+  UXAuditResults,
+  UXAuditRunStatus,
+  UXFinding,
+  UXScreenshot,
+} from "../../../types";
+import { SEVERITY_COLOR, SEVERITY_LABEL, type Severity } from "./utils";
+
+interface Props {
+  project: AuditProjectStatus;
+  status: UXAuditRunStatus | undefined;
+  result: UXAuditResults | undefined;
+  isExpanded: boolean;
+  findingFilter: string;
+  pageFilter: string;
+  onRun: () => void;
+  onCancel: () => void;
+  onToggleExpand: () => void;
+  onSeverityChange: (v: string) => void;
+  onPageChange: (v: string) => void;
+}
+
+const SEV_ORDER: Severity[] = ["critical", "high", "medium", "low"];
+
+export function UXProjectCardV4({
+  project,
+  status,
+  result,
+  isExpanded,
+  findingFilter,
+  pageFilter,
+  onRun,
+  onCancel,
+  onToggleExpand,
+  onSeverityChange,
+  onPageChange,
+}: Props) {
+  const isRunning = status?.state === "running";
+  const isCompleted = status?.state === "completed";
+  const isFailed = status?.state === "failed";
+  const repoName = project.repo.split("/")[1] || project.name;
+  const repoOwner = project.repo.split("/")[0] || "";
+
+  const totalSeg = result
+    ? SEV_ORDER.reduce((s, k) => s + result.severity_counts[k], 0)
+    : 0;
+
+  const health: "ok" | "warn" | "danger" | "unknown" =
+    !result ? "unknown"
+    : result.severity_counts.critical > 0 ? "danger"
+    : result.severity_counts.high > 0 ? "warn"
+    : "ok";
+
+  return (
+    <div className={`v4-au-card v4-au-card--${health}${isRunning ? " is-running" : ""}`}>
+      <div className="v4-au-card-h">
+        <div className="v4-au-card-name">
+          <span className="v4-au-card-title" title={repoName}>{repoName}</span>
+          {repoOwner && <span className="v4-tag v4-au-card-owner">{repoOwner}</span>}
+        </div>
+        <div className="v4-au-card-badges">
+          {isRunning && (
+            <span className="v4-tag v4-tag--warn v4-au-status v4-au-status--running">
+              <span className="v4-au-running-dot" aria-hidden="true" /> running
+            </span>
+          )}
+          {isFailed && !isRunning && (
+            <span className="v4-tag v4-tag--danger v4-au-status">error</span>
+          )}
+          {!isRunning && !isFailed && isCompleted && (
+            <span className="v4-tag v4-tag--ok v4-au-status">готово</span>
+          )}
+          {!isRunning && !isFailed && !isCompleted && (
+            <span className="v4-tag v4-au-status">нет результатов</span>
+          )}
+        </div>
+      </div>
+
+      {isRunning && status ? (
+        <div className="v4-au-card-progress">
+          <div className="v4-au-progress-h">
+            <span className="v4-au-progress-stage">{status.stage || "Запуск…"}</span>
+            <span className="v4-pl-mono v4-au-progress-pct">{status.progress}%</span>
+          </div>
+          <div className="v4-au-progress-track">
+            <div
+              className="v4-au-progress-fill"
+              style={{ width: `${Math.max(2, status.progress)}%` }}
+            />
+          </div>
+          {status.message && (
+            <div className="v4-au-progress-msg">{status.message}</div>
+          )}
+        </div>
+      ) : isFailed && status ? (
+        <div className="v4-au-card-error">
+          <div className="v4-au-card-error-t">Ошибка UX аудита</div>
+          <div className="v4-au-card-error-b">{status.error || "Unknown error"}</div>
+        </div>
+      ) : isCompleted && result ? (
+        <>
+          <div className="v4-au-card-findings">
+            <div className="v4-au-findings-h">
+              <span className="v4-pl-mono v4-au-findings-total">{result.total_findings}</span>
+              <span className="v4-au-text-muted">находок</span>
+              <div className="v4-au-findings-pris">
+                {SEV_ORDER.map((sev) => {
+                  const n = result.severity_counts[sev];
+                  if (n === 0) return null;
+                  return (
+                    <span key={sev} className="v4-au-pri" title={SEVERITY_LABEL[sev]}>
+                      <span className="v4-au-pri-dot" style={{ background: SEVERITY_COLOR[sev] }} />
+                      <span className="v4-pl-mono">{n}</span>
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+            {totalSeg > 0 && (
+              <div className="v4-au-sev-bar">
+                {SEV_ORDER.map((sev) => {
+                  const n = result.severity_counts[sev];
+                  if (n === 0) return null;
+                  return (
+                    <div
+                      key={sev}
+                      className="v4-au-sev-seg"
+                      style={{ flex: n, background: SEVERITY_COLOR[sev] }}
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* Stats: L1 / Vision / Screenshots */}
+          <div className="v4-au-card-meta">
+            <div className="v4-au-meta-cell">
+              <span className="v4-au-text-muted">L1</span>
+              <span className="v4-pl-mono v4-au-meta-val">{result.l1_findings}</span>
+            </div>
+            <div className="v4-au-meta-cell">
+              <span className="v4-au-text-muted">Vision</span>
+              <span className="v4-pl-mono v4-au-meta-val">{result.vision_findings}</span>
+            </div>
+            <div className="v4-au-meta-cell">
+              <span className="v4-au-text-muted">Скриншоты</span>
+              <span className="v4-pl-mono v4-au-meta-val">{result.screenshots.length}</span>
+            </div>
+          </div>
+        </>
+      ) : (
+        <div className="v4-au-card-empty">Нет результатов UX аудита</div>
+      )}
+
+      <div className="v4-au-card-actions">
+        {isRunning ? (
+          <button type="button" className="v4-btn v4-au-btn-cancel" onClick={onCancel}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <rect x="6" y="6" width="12" height="12" rx="2" />
+            </svg>
+            Отменить
+          </button>
+        ) : (
+          <button type="button" className="v4-btn" onClick={onRun}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polygon points="5 3 19 12 5 21 5 3" />
+            </svg>
+            {isCompleted || isFailed ? "Перезапуск" : "UX аудит"}
+          </button>
+        )}
+        {isCompleted && result && (
+          <button type="button" className="v4-btn" onClick={onToggleExpand}>
+            {isExpanded ? "▴ Свернуть" : "▾ Подробнее"}
+          </button>
+        )}
+      </div>
+
+      {isExpanded && result && (
+        <div className="v4-au-ux-expanded">
+          <UXScreenshotGallery screenshots={result.screenshots} />
+          <UXFindingsList
+            findings={result.findings}
+            screenshots={result.screenshots}
+            severityFilter={findingFilter}
+            pageFilter={pageFilter}
+            onSeverityChange={onSeverityChange}
+            onPageChange={onPageChange}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UXScreenshotGallery({ screenshots }: { screenshots: UXScreenshot[] }) {
+  const byPage: Record<string, UXScreenshot[]> = {};
+  for (const s of screenshots) {
+    (byPage[s.page_name] ??= []).push(s);
+  }
+
+  return (
+    <div className="v4-au-ux-shots">
+      <h4 className="v4-au-ux-h">Скриншоты</h4>
+      {Object.entries(byPage).map(([pageName, shots]) => (
+        <div key={pageName} className="v4-au-ux-page">
+          <div className="v4-au-ux-page-name">{pageName}</div>
+          <div className="v4-au-ux-shots-row">
+            {shots.map((s) => (
+              <div key={`${s.page_name}-${s.viewport}`} className="v4-au-ux-shot">
+                <div className="v4-au-ux-shot-vp">{s.viewport} ({s.width}×{s.height})</div>
+                <div className="v4-au-ux-shot-url">{s.url}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface FListProps {
+  findings: UXFinding[];
+  screenshots: UXScreenshot[];
+  severityFilter: string;
+  pageFilter: string;
+  onSeverityChange: (v: string) => void;
+  onPageChange: (v: string) => void;
+}
+
+function UXFindingsList({
+  findings,
+  screenshots,
+  severityFilter,
+  pageFilter,
+  onSeverityChange,
+  onPageChange,
+}: FListProps) {
+  const pages = Array.from(new Set(screenshots.map((s) => s.page_name)));
+  const filtered = findings.filter((f) => {
+    if (severityFilter !== "all" && f.severity !== severityFilter) return false;
+    if (pageFilter !== "all" && !f.file.includes(pageFilter) && !f.description.includes(pageFilter)) return false;
+    return true;
+  });
+
+  return (
+    <div className="v4-au-ux-findings">
+      <h4 className="v4-au-ux-h">Findings ({filtered.length}/{findings.length})</h4>
+      <div className="v4-au-ux-filters">
+        <select
+          aria-label="Фильтр по severity"
+          className="v4-pl-input"
+          value={severityFilter}
+          onChange={(e) => onSeverityChange(e.target.value)}
+        >
+          <option value="all">Все severity</option>
+          <option value="critical">Critical</option>
+          <option value="high">High</option>
+          <option value="medium">Medium</option>
+          <option value="low">Low</option>
+        </select>
+        <select
+          aria-label="Фильтр по странице"
+          className="v4-pl-input"
+          value={pageFilter}
+          onChange={(e) => onPageChange(e.target.value)}
+        >
+          <option value="all">Все страницы</option>
+          {pages.map((p) => <option key={p} value={p}>{p}</option>)}
+        </select>
+      </div>
+      <div className="v4-au-ux-findings-list">
+        {filtered.length === 0 && (
+          <div className="v4-empty">Нет findings по выбранным фильтрам</div>
+        )}
+        {filtered.map((f, i) => (
+          <div key={i} className="v4-au-ux-finding">
+            <div className="v4-au-ux-finding-h">
+              <span
+                className="v4-au-ux-finding-sev"
+                style={{ color: SEVERITY_COLOR[f.severity as Severity] ?? "var(--v4-ink-500)" }}
+              >
+                {f.severity.toUpperCase()}
+              </span>
+              <span className="v4-pl-mono v4-au-text-muted">[{f.tool}]</span>
+              {f.confidence != null && (
+                <span className="v4-pl-mono v4-au-text-muted">{Math.round(f.confidence * 100)}%</span>
+              )}
+            </div>
+            <div className="v4-au-ux-finding-desc">{f.description}</div>
+            {f.recommendation && (
+              <div className="v4-au-ux-finding-rec">{f.recommendation}</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/audit/UXProjectCardV4.tsx
+++ b/src/components/v4/audit/UXProjectCardV4.tsx
@@ -274,8 +274,11 @@ function UXFindingsList({
         {filtered.length === 0 && (
           <div className="v4-empty">Нет findings по выбранным фильтрам</div>
         )}
-        {filtered.map((f, i) => (
-          <div key={i} className="v4-au-ux-finding">
+        {filtered.map((f) => (
+          <div
+            key={`${f.file}::${f.tool}::${f.description.slice(0, 80)}`}
+            className="v4-au-ux-finding"
+          >
             <div className="v4-au-ux-finding-h">
               <span
                 className="v4-au-ux-finding-sev"

--- a/src/components/v4/audit/utils.ts
+++ b/src/components/v4/audit/utils.ts
@@ -1,0 +1,170 @@
+import type {
+  AuditProjectStatus,
+  AuditRunStatus,
+  AuditVerificationSummary,
+} from "../../../types";
+
+export type Severity = "critical" | "high" | "medium" | "low";
+export type AuditHealth = "ok" | "warn" | "danger" | "unknown";
+
+export const SEVERITY_COLOR: Record<Severity, string> = {
+  critical: "var(--v4-danger-500)",
+  high: "var(--v4-warn-500)",
+  medium: "var(--v4-accent-500)",
+  low: "var(--v4-ink-400)",
+};
+
+export const SEVERITY_LABEL: Record<Severity, string> = {
+  critical: "Критические",
+  high: "Высокие",
+  medium: "Средние",
+  low: "Низкие",
+};
+
+/** True if the audit hasn't been run for >14 days. */
+export const STALE_DAYS = 14;
+export function isAuditStale(timestamp: string | null | undefined, nowMs: number): boolean {
+  if (!timestamp) return false;
+  const t = new Date(timestamp).getTime();
+  if (isNaN(t)) return false;
+  return nowMs - t > STALE_DAYS * 24 * 60 * 60 * 1000;
+}
+
+/** Verification verdict counts derived from a verification summary. */
+export function verifiedConfirmed(v: AuditVerificationSummary | null): number {
+  if (!v) return 0;
+  return v.confirmed;
+}
+
+/** Project-level health: critical → danger, high → warn, else ok. */
+export function projectHealth(p: AuditProjectStatus): AuditHealth {
+  const lr = p.last_run;
+  if (!lr) return "unknown";
+  if (lr.severity_counts.critical > 0) return "danger";
+  if (lr.severity_counts.high > 0) return "warn";
+  return "ok";
+}
+
+/** Worst-of-all health across the portfolio. */
+export function poolHealth(projects: AuditProjectStatus[]): AuditHealth {
+  if (projects.length === 0) return "unknown";
+  const audited = projects.filter((p) => p.last_run);
+  if (audited.length === 0) return "unknown";
+  if (audited.some((p) => (p.last_run?.severity_counts.critical ?? 0) > 0)) return "danger";
+  if (audited.some((p) => (p.last_run?.severity_counts.high ?? 0) > 0)) return "warn";
+  return "ok";
+}
+
+export function totalFindingsBySeverity(
+  projects: AuditProjectStatus[],
+): Record<Severity, number> {
+  const acc: Record<Severity, number> = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const p of projects) {
+    if (!p.last_run) continue;
+    acc.critical += p.last_run.severity_counts.critical;
+    acc.high += p.last_run.severity_counts.high;
+    acc.medium += p.last_run.severity_counts.medium;
+    acc.low += p.last_run.severity_counts.low;
+  }
+  return acc;
+}
+
+export function totalCost(projects: AuditProjectStatus[]): number {
+  return projects.reduce((s, p) => s + (p.last_run?.cost_usd ?? 0), 0);
+}
+
+export function avgDurationSec(projects: AuditProjectStatus[]): number | null {
+  const audited = projects.filter((p) => p.last_run);
+  if (audited.length === 0) return null;
+  const sum = audited.reduce((s, p) => s + (p.last_run?.duration_seconds ?? 0), 0);
+  return sum / audited.length;
+}
+
+export function fmtCost(usd: number): string {
+  if (usd === 0) return "$0";
+  if (usd < 1) return `$${usd.toFixed(2)}`;
+  if (usd < 100) return `$${usd.toFixed(2)}`;
+  return `$${usd.toFixed(0)}`;
+}
+
+export function fmtDuration(seconds: number | null): string {
+  if (seconds === null || !isFinite(seconds)) return "—";
+  if (seconds < 60) return `${Math.round(seconds)}с`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}м`;
+  return `${(seconds / 3600).toFixed(1)}ч`;
+}
+
+export function fmtAge(iso: string | null | undefined, nowMs: number): string {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return "—";
+  const diffSec = Math.max(0, Math.floor((nowMs - t) / 1000));
+  if (diffSec < 60) return `${diffSec}с назад`;
+  const m = Math.floor(diffSec / 60);
+  if (m < 60) return `${m}м назад`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}ч назад`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}д назад`;
+  if (d < 30) return `${Math.floor(d / 7)} нед назад`;
+  return `${Math.floor(d / 30)} мес назад`;
+}
+
+export type RunningState = AuditRunStatus["state"];
+
+export function isRunningState(s: RunningState | undefined): boolean {
+  return s === "running";
+}
+
+/** Filter set used by the project filter pills. */
+export type AuditFilter = "all" | "critical" | "needsVerify" | "verified" | "notAudited" | "stale";
+
+export const AUDIT_FILTERS: Array<{ key: AuditFilter; label: string }> = [
+  { key: "all", label: "Все" },
+  { key: "critical", label: "Критические" },
+  { key: "needsVerify", label: "Нужна верификация" },
+  { key: "stale", label: "Устаревшие" },
+  { key: "notAudited", label: "Без аудита" },
+  { key: "verified", label: "Верифицированы" },
+];
+
+export function applyFilter(
+  projects: AuditProjectStatus[],
+  filter: AuditFilter,
+  nowMs: number,
+): AuditProjectStatus[] {
+  if (filter === "all") return projects;
+  if (filter === "critical") return projects.filter((p) => (p.last_run?.severity_counts.critical ?? 0) > 0);
+  if (filter === "needsVerify") return projects.filter((p) => p.last_run && !p.last_run.verification);
+  if (filter === "verified") return projects.filter((p) => p.last_run?.verification);
+  if (filter === "notAudited") return projects.filter((p) => !p.last_run);
+  if (filter === "stale") return projects.filter((p) => isAuditStale(p.last_run?.timestamp, nowMs));
+  return projects;
+}
+
+/** Sort: critical-first, then high count, then alphabetical. */
+export function sortProjects(projects: AuditProjectStatus[]): AuditProjectStatus[] {
+  const arr = [...projects];
+  arr.sort((a, b) => {
+    const ac = a.last_run?.severity_counts.critical ?? 0;
+    const bc = b.last_run?.severity_counts.critical ?? 0;
+    if (ac !== bc) return bc - ac;
+    const ah = a.last_run?.severity_counts.high ?? 0;
+    const bh = b.last_run?.severity_counts.high ?? 0;
+    if (ah !== bh) return bh - ah;
+    return a.name.localeCompare(b.name, "ru");
+  });
+  return arr;
+}
+
+export function applySearch(
+  projects: AuditProjectStatus[],
+  q: string,
+): AuditProjectStatus[] {
+  const needle = q.trim().toLowerCase();
+  if (!needle) return projects;
+  return projects.filter((p) =>
+    p.name.toLowerCase().includes(needle) ||
+    p.repo.toLowerCase().includes(needle),
+  );
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -4385,6 +4385,474 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 }
 
 /* ────────────────────────────────────────
+   AUDIT (code + UX)
+   ──────────────────────────────────────── */
+.v4-au-text-muted { color: var(--v4-ink-500); }
+.v4-au-text-warn { color: var(--v4-warn-700); }
+.v4-au-text-danger { color: var(--v4-danger-700); }
+
+/* — Hero — */
+.v4-au-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  padding: 18px 22px;
+  margin-bottom: 14px;
+}
+.v4-au-hero--ok { border-left: 4px solid var(--v4-success-500); }
+.v4-au-hero--warn { border-left: 4px solid var(--v4-warn-500); }
+.v4-au-hero--danger { border-left: 4px solid var(--v4-danger-500); }
+.v4-au-hero--unknown { border-left: 4px solid var(--v4-ink-300); }
+.v4-au-hero-status {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  min-width: 0;
+}
+.v4-au-hero-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.v4-au-hero-dot--ok { background: var(--v4-success-500); box-shadow: 0 0 0 4px var(--v4-success-50); }
+.v4-au-hero-dot--warn { background: var(--v4-warn-500); box-shadow: 0 0 0 4px var(--v4-warn-50); }
+.v4-au-hero-dot--danger {
+  background: var(--v4-danger-500);
+  box-shadow: 0 0 0 4px var(--v4-danger-50);
+  animation: v4-au-pulse 1.6s ease-in-out infinite;
+}
+.v4-au-hero-dot--unknown { background: var(--v4-ink-300); }
+@keyframes v4-au-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+.v4-au-hero-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  margin-bottom: 4px;
+}
+.v4-au-hero-sub {
+  font-size: 13px;
+  color: var(--v4-ink-500);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+.v4-au-hero-sub b { color: var(--v4-ink-900); font-weight: 600; }
+.v4-au-sep { color: var(--v4-ink-300); margin: 0 4px; }
+.v4-au-hero-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* — Toolbar (search + filter pills) — */
+.v4-au-toolbar {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 14px 0;
+}
+
+/* — Card grid — */
+.v4-au-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 14px;
+}
+
+/* — Project card — */
+.v4-au-card {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  transition: border-color 120ms;
+}
+.v4-au-card--ok { border-top: 3px solid var(--v4-success-500); }
+.v4-au-card--warn { border-top: 3px solid var(--v4-warn-500); }
+.v4-au-card--danger { border-top: 3px solid var(--v4-danger-500); }
+.v4-au-card--unknown { border-top: 3px solid var(--v4-line); }
+.v4-au-card.is-running {
+  background: var(--v4-accent-50);
+  border-color: var(--v4-accent-500);
+}
+.v4-au-card-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.v4-au-card-name {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.v4-au-card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
+}
+.v4-au-card-owner {
+  background: var(--v4-surface-3);
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
+  font-size: 11px;
+}
+.v4-au-card-badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.v4-au-status {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+.v4-au-status--running {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.v4-au-running-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--v4-warn-500);
+  animation: v4-au-pulse 1s ease-in-out infinite;
+}
+
+.v4-au-card-empty {
+  font-size: 13px;
+  color: var(--v4-ink-400);
+  padding: 8px 0;
+  text-align: center;
+  font-style: italic;
+}
+
+/* — Findings + severity bar — */
+.v4-au-card-findings {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.v4-au-findings-h {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.v4-au-findings-total {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--v4-ink-900);
+}
+.v4-au-findings-pris {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+.v4-au-pri {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+}
+.v4-au-pri-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.v4-au-sev-bar {
+  height: 8px;
+  display: flex;
+  background: var(--v4-surface-3);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.v4-au-sev-seg {
+  height: 100%;
+  transition: flex 200ms ease;
+}
+
+/* — Issue progress (closed/total) — */
+.v4-au-card-fixed {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
+}
+.v4-au-fixed-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.v4-au-fixed-cnt {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v4-ink-700);
+}
+.v4-au-fixed-cnt.is-done { color: var(--v4-success-700); }
+.v4-au-fixed-track {
+  height: 6px;
+  background: var(--v4-surface-3);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.v4-au-fixed-fill {
+  height: 100%;
+  background: var(--v4-success-500);
+  border-radius: 3px;
+  transition: width 200ms ease;
+}
+
+/* — Verification stats strip — */
+.v4-au-card-verify {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 12px;
+  padding: 8px 12px;
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
+}
+
+/* — Meta footer (cost / time / age) — */
+.v4-au-card-meta {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 12px;
+  border-top: 1px dashed var(--v4-line-soft);
+  padding-top: 10px;
+}
+.v4-au-meta-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.v4-au-meta-cell--age {
+  margin-left: auto;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+}
+.v4-au-meta-val {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+
+/* — Progress (running) — */
+.v4-au-card-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-accent-100);
+  border-radius: var(--v4-r-sm);
+}
+.v4-au-progress-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.v4-au-progress-stage {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-accent-700);
+}
+.v4-au-progress-pct {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--v4-accent-700);
+}
+.v4-au-progress-track {
+  height: 8px;
+  background: var(--v4-surface-3);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.v4-au-progress-fill {
+  height: 100%;
+  background: var(--v4-accent-500);
+  border-radius: 4px;
+  transition: width 500ms ease-out;
+}
+.v4-au-progress-msg {
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  font-style: italic;
+}
+
+/* — Error block — */
+.v4-au-card-error {
+  padding: 10px 12px;
+  background: var(--v4-danger-50);
+  border-radius: var(--v4-r-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.v4-au-card-error-t {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v4-danger-700);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.v4-au-card-error-b {
+  font-size: 12px;
+  color: var(--v4-ink-700);
+  word-break: break-word;
+}
+
+/* — Card actions — */
+.v4-au-card-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: auto;
+}
+.v4-au-card-actions .v4-btn { flex: 1 1 auto; min-width: 0; justify-content: center; }
+.v4-au-btn-cancel {
+  border-color: var(--v4-danger-500);
+  color: var(--v4-danger-700);
+}
+.v4-au-btn-cancel:hover { background: var(--v4-danger-50); }
+.v4-au-btn-ok {
+  border-color: var(--v4-success-500);
+  color: var(--v4-success-700);
+  background: var(--v4-success-50);
+}
+
+/* — Offline panel CLI hint — */
+.v4-au-offline-cmd {
+  margin: 14px 18px;
+  font-family: var(--v4-mono);
+  font-size: 12px;
+  background: var(--v4-surface-2);
+  padding: 12px 14px;
+  border-radius: var(--v4-r-sm);
+  color: var(--v4-ink-700);
+  white-space: pre;
+  overflow-x: auto;
+}
+.v4-au-offline-actions {
+  display: flex;
+  gap: 8px;
+  padding: 0 18px 18px;
+}
+
+/* — UX expanded panel inside card — */
+.v4-au-ux-expanded {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--v4-line-soft);
+  margin-top: 4px;
+}
+.v4-au-ux-h {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.v4-au-ux-shots {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.v4-au-ux-page-name {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v4-ink-700);
+  margin-bottom: 4px;
+}
+.v4-au-ux-shots-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.v4-au-ux-shot {
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
+  padding: 8px 10px;
+  font-size: 11px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 140px;
+}
+.v4-au-ux-shot-vp { color: var(--v4-ink-700); font-weight: 600; }
+.v4-au-ux-shot-url {
+  color: var(--v4-ink-400);
+  font-family: var(--v4-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+}
+.v4-au-ux-findings { display: flex; flex-direction: column; gap: 8px; }
+.v4-au-ux-filters { display: flex; gap: 8px; flex-wrap: wrap; }
+.v4-au-ux-findings-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+.v4-au-ux-finding {
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.v4-au-ux-finding-h {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 11px;
+}
+.v4-au-ux-finding-sev { font-weight: 700; }
+.v4-au-ux-finding-desc { font-size: 13px; color: var(--v4-ink-800); line-height: 1.4; }
+.v4-au-ux-finding-rec {
+  font-size: 12px;
+  color: var(--v4-ink-600);
+  font-style: italic;
+  border-left: 3px solid var(--v4-accent-500);
+  padding-left: 8px;
+}
+
+/* ────────────────────────────────────────
    RESPONSIVE
    ──────────────────────────────────────── */
 @media (max-width: 1100px) {


### PR DESCRIPTION
## Summary
- Migrate Audit tab (Code + UX sub-tabs) from bento layout to V4 design system
- 9 new components (~1500 LOC) in `src/components/v4/audit/` + ~470 lines of CSS
- Reuse `useAudit` / `useUXAudit` hooks unchanged
- Reuse 3 existing dialogs (AuditConfirmDialog, AuditVerifyDialog, AuditIssuesDialog) — complex multi-state flows kept as-is

## UX improvements vs legacy
- **AuditView** with v4-pillgrp Код/UX sub-tabs (localStorage-persisted) replacing plain text buttons
- **AuditHero** with portfolio-level pool-health: danger if any critical, warn if any high, ok otherwise. Pulsing red dot for danger so outages stand out.
- **AuditKpiStrip** — total / audited / critical / high / cost / avg time across all projects (was per-card only before)
- **AuditProjectCardV4** with V4 tokens — colored top border by health, status badge (running pulse / error / verified / needs-verify / not-audited), severity bar, issue progress, verification stats inline, GPU cost / time / age
- **Stale flag (⚠)** on audits older than 14 days — was silently displayed before
- **Filter pills**: Все / Критические / Нужна верификация / Устаревшие / Без аудита / Верифицированы (localStorage-persisted)
- **Search** by repo name
- **Critical-first sort** for incident triage (was no sort)
- **UXProjectCardV4** with same shell + UX-specific stats (L1 / Vision / Скриншоты) and expandable details (screenshots gallery + findings filters)
- **Removed audit from GitHub-data-loading banner gate** (was already correct, no change needed)

## Test plan
- [x] `npx tsc --noEmit` — green
- [x] `npm run lint` — green
- [x] `npm run build` — green
- [x] Verified in preview with mocked auditor (5 projects: 1 critical+high, 1 verified-mankassa with stale flag for 30-day-old audit, 1 running with progress bar, 1 failed with error, 1 not-audited):
  - Hero classifies as danger ("Есть критические находки"), sub: "3 критических · 12 высоких · 15 средних · проаудированы 3 из 5 · 2 ждут верификации"
  - KPI strip: 5 / 3 / 3 / 12 / \$1.72 / 13м
  - Card states render correctly: danger (red border-top), warn (orange), ok (green), unknown (gray), is-running (blue background)
  - ⚠ stale flag visible for 1-month-old audit
  - Sub-tab switch to UX renders properly with separate filter pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)