### PR TITLE
feat(debate): redesign Debate tab in V4 design system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { TranscriptsView } from "./components/v4/transcripts/TranscriptsView";
 import { ResearchTab } from "./components/ResearchTab";
 import { SpecsTab } from "./components/SpecsTab";
 import { QualityView } from "./components/v4/quality/QualityView";
-import { DebateTab } from "./components/DebateTab";
+import { DebateView } from "./components/v4/debate/DebateView";
 import { Sidebar } from "./components/v4/Sidebar";
 import { Topbar } from "./components/v4/Topbar";
 import { DashboardView } from "./components/v4/DashboardView";
@@ -284,13 +284,11 @@ function AppInner() {
             </ErrorBoundary>
           )}
         </div>
-        <div className="v4-legacy-frame" style={{ display: tab === "debate" ? undefined : "none" }}>
+        <div style={{ display: tab === "debate" ? undefined : "none" }}>
           {visitedTabs.has("debate") && (
-            <div className="bento-grid">
-              <ErrorBoundary fallback="Ошибка вкладки Debate">
-                <DebateTab />
-              </ErrorBoundary>
-            </div>
+            <ErrorBoundary fallback="Ошибка вкладки Debate">
+              <DebateView />
+            </ErrorBoundary>
           )}
         </div>
       </main>

--- a/src/components/v4/debate/DebateCard.tsx
+++ b/src/components/v4/debate/DebateCard.tsx
@@ -1,0 +1,62 @@
+import type { DebateListItem } from "../../../types/debate";
+import {
+  consensusTagClass,
+  CONSENSUS_LABEL,
+  fmtAge,
+  fmtCost,
+  statusTagClass,
+  STATUS_LABEL,
+} from "./utils";
+
+interface Props {
+  debate: DebateListItem;
+  nowMs: number;
+  onOpen: () => void;
+}
+
+export function DebateCard({ debate: d, nowMs, onOpen }: Props) {
+  const isRunning = d.status === "running" || d.status === "queued";
+  const isError = d.status === "error";
+  const isDone = d.status === "done";
+  const project = d.project ? d.project.split("/").pop() : null;
+  const health: "ok" | "warn" | "danger" | "neutral" =
+    isError ? "danger"
+    : isRunning ? "warn"
+    : isDone ? "ok"
+    : "neutral";
+
+  return (
+    <button
+      type="button"
+      className={`v4-db-card v4-db-card--${health}`}
+      onClick={onOpen}
+      aria-label={`Открыть дебат: ${d.topic}`}
+    >
+      <div className="v4-db-card-h">
+        <span className={statusTagClass(d.status)}>{STATUS_LABEL[d.status]}</span>
+        {isDone && (
+          <span className={consensusTagClass(d.consensus_level)}>
+            {CONSENSUS_LABEL[d.consensus_level]}
+          </span>
+        )}
+        {isRunning && (
+          <span className="v4-db-card-running-dot" aria-hidden="true" />
+        )}
+      </div>
+
+      <div className="v4-db-card-topic">{d.topic}</div>
+
+      <div className="v4-db-card-meta">
+        {project && (
+          <span className="v4-tag v4-db-card-project" title={d.project}>
+            {project}
+          </span>
+        )}
+        <span className="v4-pl-mono v4-db-card-cost" title="Стоимость API-вызовов">
+          {fmtCost(d.total_cost ?? 0)}
+        </span>
+        <span className="v4-pl-mono v4-db-card-age">{fmtAge(d.created_at, nowMs)}</span>
+      </div>
+    </button>
+  );
+}

--- a/src/components/v4/debate/DebateCard.tsx
+++ b/src/components/v4/debate/DebateCard.tsx
@@ -33,10 +33,12 @@ export function DebateCard({ debate: d, nowMs, onOpen }: Props) {
       aria-label={`Открыть дебат: ${d.topic}`}
     >
       <div className="v4-db-card-h">
-        <span className={statusTagClass(d.status)}>{STATUS_LABEL[d.status]}</span>
+        <span className={statusTagClass(d.status)}>
+          {STATUS_LABEL[d.status] ?? d.status}
+        </span>
         {isDone && (
           <span className={consensusTagClass(d.consensus_level)}>
-            {CONSENSUS_LABEL[d.consensus_level]}
+            {CONSENSUS_LABEL[d.consensus_level] ?? d.consensus_level}
           </span>
         )}
         {isRunning && (

--- a/src/components/v4/debate/DebateHero.tsx
+++ b/src/components/v4/debate/DebateHero.tsx
@@ -1,0 +1,88 @@
+import type { DebateListItem } from "../../../types/debate";
+
+interface Props {
+  debates: DebateListItem[];
+  loading: boolean;
+  onRefresh: () => void;
+  onStart: () => void;
+  /** Open the active debate's chat view. */
+  onOpenActive: (id: string) => void;
+}
+
+export function DebateHero({ debates, loading, onRefresh, onStart, onOpenActive }: Props) {
+  const active = debates.find((d) => d.status === "running");
+  const queued = debates.filter((d) => d.status === "queued").length;
+  const total = debates.length;
+
+  const health: "ok" | "warn" | "danger" | "unknown" = active
+    ? "warn"
+    : total === 0
+      ? "unknown"
+      : "ok";
+
+  const title = active
+    ? "Идёт дебат"
+    : queued > 0
+      ? `${queued} в очереди`
+      : total === 0
+        ? "Дебатов ещё не было"
+        : "Все дебаты завершены";
+
+  return (
+    <div className={`v4-db-hero v4-db-hero--${health}`}>
+      <div className="v4-db-hero-status">
+        <span className={`v4-db-hero-dot v4-db-hero-dot--${health}`} aria-hidden="true" />
+        <div>
+          <div className="v4-db-hero-title">{title}</div>
+          <div className="v4-db-hero-sub">
+            {active ? (
+              <>
+                <span className="v4-db-hero-topic" title={active.topic}>{active.topic}</span>
+                {active.project && (
+                  <>
+                    <span className="v4-db-sep">·</span>
+                    <span className="v4-pl-mono v4-db-text-muted">
+                      {active.project.split("/").pop()}
+                    </span>
+                  </>
+                )}
+              </>
+            ) : total === 0 ? (
+              <>Multi-agent technical consilium для архитектурных решений</>
+            ) : (
+              <>Запустите новый дебат или откройте историю</>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="v4-db-hero-actions">
+        {active && (
+          <button
+            type="button"
+            className="v4-btn"
+            onClick={() => onOpenActive(active.id)}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M5 12h14" />
+              <path d="m12 5 7 7-7 7" />
+            </svg>
+            Открыть
+          </button>
+        )}
+        <button type="button" className="v4-btn" onClick={onRefresh} disabled={loading}>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M21 12a9 9 0 11-6.22-8.56" />
+            <path d="M21 3v6h-6" />
+          </svg>
+          {loading ? "Загрузка…" : "Обновить"}
+        </button>
+        <button type="button" className="v4-btn v4-btn--pri" onClick={onStart}>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <polygon points="5 3 19 12 5 21 5 3" />
+          </svg>
+          Запустить дебат
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/debate/DebateKpiStrip.tsx
+++ b/src/components/v4/debate/DebateKpiStrip.tsx
@@ -1,0 +1,60 @@
+import type { DebateListItem } from "../../../types/debate";
+import { fmtCost, totalCost } from "./utils";
+
+interface Props {
+  debates: DebateListItem[];
+}
+
+export function DebateKpiStrip({ debates }: Props) {
+  const total = debates.length;
+  const running = debates.filter((d) => d.status === "running" || d.status === "queued").length;
+  const done = debates.filter((d) => d.status === "done").length;
+  const error = debates.filter((d) => d.status === "error").length;
+  const cost = totalCost(debates);
+  const unanimous = debates.filter((d) => d.status === "done" && d.consensus_level === "unanimous").length;
+
+  return (
+    <div className="v4-projects-toolbar v4-pl-kpi-strip">
+      <div className="v4-projects-agg">
+        <div className="v4-projects-agg-cell" title="Всего дебатов в истории">
+          <div className="v4-projects-agg-n num">{total}</div>
+          <div className="v4-projects-agg-l">всего</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="В работе или в очереди">
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: running > 0 ? "var(--v4-warn-700)" : undefined }}
+          >
+            {running}
+          </div>
+          <div className="v4-projects-agg-l">в работе</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Успешно завершены">
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: done > 0 ? "var(--v4-success-700)" : undefined }}
+          >
+            {done}
+          </div>
+          <div className="v4-projects-agg-l">завершены</div>
+        </div>
+        {error > 0 && (
+          <div className="v4-projects-agg-cell" title="Завершились с ошибкой">
+            <div className="v4-projects-agg-n num" style={{ color: "var(--v4-danger-700)" }}>
+              {error}
+            </div>
+            <div className="v4-projects-agg-l">ошибки</div>
+          </div>
+        )}
+        <div className="v4-projects-agg-cell" title="Дебаты с единогласным консенсусом">
+          <div className="v4-projects-agg-n num">{unanimous}</div>
+          <div className="v4-projects-agg-l">единогласно</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Сумма потраченных API-токенов">
+          <div className="v4-projects-agg-n num">{fmtCost(cost)}</div>
+          <div className="v4-projects-agg-l">потрачено</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/debate/DebateView.tsx
+++ b/src/components/v4/debate/DebateView.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useState } from "react";
+import { useDebate } from "../../../hooks/useDebate";
+import { DebateChat } from "../../DebateChat";
+import { StartDebateModal } from "../../StartDebateModal";
+import { DebateCard } from "./DebateCard";
+import { DebateHero } from "./DebateHero";
+import { DebateKpiStrip } from "./DebateKpiStrip";
+import {
+  applyFilter,
+  applySearch,
+  applySort,
+  DEBATE_FILTERS,
+  type DebateFilter,
+  type DebateSort,
+} from "./utils";
+
+const STORAGE_FILTER = "v4db:filter";
+const STORAGE_SORT = "v4db:sort";
+
+function readFilter(): DebateFilter {
+  try {
+    const v = localStorage.getItem(STORAGE_FILTER);
+    if (v === "all" || v === "running" || v === "done" || v === "error") return v;
+  } catch { /* ignore */ }
+  return "all";
+}
+
+function readSort(): DebateSort {
+  try {
+    const v = localStorage.getItem(STORAGE_SORT);
+    if (v === "date" || v === "cost") return v;
+  } catch { /* ignore */ }
+  return "date";
+}
+
+export function DebateView() {
+  const { debates, loading, error, refresh } = useDebate();
+  const [showModal, setShowModal] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [manualBack, setManualBack] = useState(false);
+
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<DebateFilter>(() => readFilter());
+  const [sort, setSort] = useState<DebateSort>(() => readSort());
+
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_FILTER, filter); } catch { /* ignore */ }
+  }, [filter]);
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_SORT, sort); } catch { /* ignore */ }
+  }, [sort]);
+
+  // Frozen "now" — refreshed every 30s and on data change.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+  useEffect(() => {
+    let cancelled = false;
+    Promise.resolve().then(() => {
+      if (!cancelled) setNowMs(Date.now());
+    });
+    return () => { cancelled = true; };
+  }, [debates]);
+
+  // Auto-resume: if no debate explicitly selected, pick the running one
+  // unless the user explicitly clicked "back" out of it.
+  const effectiveId = selectedId
+    ?? (manualBack ? null : debates.find((d) => d.status === "running")?.id ?? null);
+
+  const visible = useMemo(() => {
+    return applySort(applySearch(applyFilter(debates, filter), search), sort);
+  }, [debates, filter, search, sort]);
+
+  const handleStarted = (id: string) => {
+    setShowModal(false);
+    setManualBack(false);
+    refresh();
+    setSelectedId(id);
+  };
+
+  /* ── Chat view ── */
+  if (effectiveId) {
+    return (
+      <div className="v4-content">
+        <DebateChat
+          debateId={effectiveId}
+          onBack={() => { setManualBack(true); setSelectedId(null); }}
+        />
+      </div>
+    );
+  }
+
+  /* ── List view ── */
+  return (
+    <div className="v4-content">
+      <div className="v4-ph">
+        <div>
+          <h1>Debate</h1>
+          <div className="v4-sub">
+            Multi-agent technical consilium ·{" "}
+            <span className="v4-pl-mono">{debates.length}</span> {debates.length === 1 ? "дебат" : "дебатов"}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ height: 10 }} />
+
+      <DebateHero
+        debates={debates}
+        loading={loading}
+        onRefresh={refresh}
+        onStart={() => setShowModal(true)}
+        onOpenActive={(id) => { setManualBack(false); setSelectedId(id); }}
+      />
+
+      {error && <div className="v4-error" style={{ marginTop: 14 }}>{error}</div>}
+
+      <DebateKpiStrip debates={debates} />
+
+      <div className="v4-au-toolbar">
+        <div className="v4-mon-search">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            type="search"
+            aria-label="Поиск по теме или проекту"
+            placeholder="Поиск по теме, проекту…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="v4-pillgrp">
+          {DEBATE_FILTERS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              className={filter === key ? "is-active" : ""}
+              onClick={() => setFilter(key)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <div className="v4-pillgrp">
+          <button
+            type="button"
+            className={sort === "date" ? "is-active" : ""}
+            onClick={() => setSort("date")}
+          >
+            По дате
+          </button>
+          <button
+            type="button"
+            className={sort === "cost" ? "is-active" : ""}
+            onClick={() => setSort("cost")}
+          >
+            По стоимости
+          </button>
+        </div>
+      </div>
+
+      {loading && debates.length === 0 ? (
+        <div className="v4-empty" style={{ marginTop: 14 }}>Загрузка…</div>
+      ) : visible.length === 0 && debates.length === 0 ? (
+        <div className="v4-panel">
+          <div className="v4-db-empty">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+              <path d="M8 9h8" />
+              <path d="M8 13h6" />
+            </svg>
+            <h3>Дебатов ещё не было</h3>
+            <p>
+              Мультиагентная дискуссия для архитектурных решений: несколько AI-экспертов
+              обсуждают тему с разных позиций и формируют ADR (Architecture Decision Record).
+            </p>
+            <button type="button" className="v4-btn v4-btn--pri" onClick={() => setShowModal(true)}>
+              Запустить первый дебат
+            </button>
+          </div>
+        </div>
+      ) : visible.length === 0 ? (
+        <div className="v4-panel">
+          <div className="v4-empty">
+            По текущим фильтрам ничего не найдено
+            {search && (
+              <>
+                {" "}для запроса <span className="v4-pl-mono">«{search}»</span>
+              </>
+            )}
+            .
+          </div>
+        </div>
+      ) : (
+        <div className="v4-db-grid">
+          {visible.map((d) => (
+            <DebateCard
+              key={d.id}
+              debate={d}
+              nowMs={nowMs}
+              onOpen={() => { setManualBack(false); setSelectedId(d.id); }}
+            />
+          ))}
+        </div>
+      )}
+
+      {showModal && (
+        <StartDebateModal
+          onClose={() => setShowModal(false)}
+          onStarted={handleStarted}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/debate/utils.ts
+++ b/src/components/v4/debate/utils.ts
@@ -1,0 +1,89 @@
+import type { DebateListItem } from "../../../types/debate";
+
+export const STATUS_LABEL: Record<DebateListItem["status"], string> = {
+  queued: "В очереди",
+  running: "В работе",
+  done: "Завершён",
+  error: "Ошибка",
+};
+
+export const CONSENSUS_LABEL: Record<DebateListItem["consensus_level"], string> = {
+  unanimous: "Единогласно",
+  majority: "Большинство",
+  contested: "Спорно",
+};
+
+export type DebateFilter = "all" | "running" | "done" | "error";
+
+export const DEBATE_FILTERS: Array<{ key: DebateFilter; label: string }> = [
+  { key: "all", label: "Все" },
+  { key: "running", label: "В работе" },
+  { key: "done", label: "Завершены" },
+  { key: "error", label: "Ошибки" },
+];
+
+export function applyFilter(items: DebateListItem[], f: DebateFilter): DebateListItem[] {
+  if (f === "all") return items;
+  if (f === "running") return items.filter((d) => d.status === "running" || d.status === "queued");
+  return items.filter((d) => d.status === f);
+}
+
+export function applySearch(items: DebateListItem[], q: string): DebateListItem[] {
+  const needle = q.trim().toLowerCase();
+  if (!needle) return items;
+  return items.filter((d) =>
+    d.topic.toLowerCase().includes(needle) ||
+    (d.project ?? "").toLowerCase().includes(needle),
+  );
+}
+
+export type DebateSort = "date" | "cost";
+
+export function applySort(items: DebateListItem[], by: DebateSort): DebateListItem[] {
+  const arr = [...items];
+  if (by === "cost") {
+    arr.sort((a, b) => (b.total_cost ?? 0) - (a.total_cost ?? 0));
+  } else {
+    arr.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+  }
+  return arr;
+}
+
+export function totalCost(items: DebateListItem[]): number {
+  return items.reduce((s, d) => s + (d.total_cost ?? 0), 0);
+}
+
+export function fmtCost(usd: number): string {
+  if (usd === 0) return "$0";
+  if (usd < 1) return `$${usd.toFixed(3)}`;
+  if (usd < 100) return `$${usd.toFixed(2)}`;
+  return `$${usd.toFixed(0)}`;
+}
+
+export function fmtAge(iso: string, nowMs: number): string {
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return "—";
+  const diffSec = Math.max(0, Math.floor((nowMs - t) / 1000));
+  if (diffSec < 60) return "только что";
+  const m = Math.floor(diffSec / 60);
+  if (m < 60) return `${m}м назад`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}ч назад`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}д назад`;
+  if (d < 30) return `${Math.floor(d / 7)} нед назад`;
+  return `${Math.floor(d / 30)} мес назад`;
+}
+
+export function statusTagClass(s: DebateListItem["status"]): string {
+  if (s === "done") return "v4-tag v4-tag--ok";
+  if (s === "running") return "v4-tag v4-tag--warn";
+  if (s === "error") return "v4-tag v4-tag--danger";
+  return "v4-tag";
+}
+
+export function consensusTagClass(c: DebateListItem["consensus_level"]): string {
+  if (c === "unanimous") return "v4-tag v4-tag--ok";
+  if (c === "contested") return "v4-tag v4-tag--danger";
+  return "v4-tag";
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -4943,7 +4943,7 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   cursor: pointer;
   font: inherit;
   color: inherit;
-  transition: border-color 120ms, box-shadow 120ms, transform 120ms;
+  transition: border-color 120ms, box-shadow 120ms;
   min-width: 0;
 }
 .v4-db-card:hover {
@@ -4959,6 +4959,9 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   border-top: 3px solid var(--v4-warn-500);
   background: var(--v4-warn-50);
 }
+/* Reset background on focus so the blue accent outline has enough
+ * contrast against the warn-yellow tint. */
+.v4-db-card--warn:focus-visible { background: var(--v4-paper); }
 .v4-db-card--danger { border-top: 3px solid var(--v4-danger-500); }
 .v4-db-card--neutral { border-top: 3px solid var(--v4-line); }
 

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -4853,6 +4853,197 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 }
 
 /* ────────────────────────────────────────
+   DEBATE
+   ──────────────────────────────────────── */
+.v4-db-text-muted { color: var(--v4-ink-500); }
+.v4-db-sep { color: var(--v4-ink-300); margin: 0 4px; }
+
+/* — Hero — */
+.v4-db-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  padding: 18px 22px;
+  margin-bottom: 14px;
+}
+.v4-db-hero--ok { border-left: 4px solid var(--v4-success-500); }
+.v4-db-hero--warn { border-left: 4px solid var(--v4-warn-500); }
+.v4-db-hero--danger { border-left: 4px solid var(--v4-danger-500); }
+.v4-db-hero--unknown { border-left: 4px solid var(--v4-ink-300); }
+.v4-db-hero-status {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  min-width: 0;
+}
+.v4-db-hero-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.v4-db-hero-dot--ok { background: var(--v4-success-500); box-shadow: 0 0 0 4px var(--v4-success-50); }
+.v4-db-hero-dot--warn {
+  background: var(--v4-warn-500);
+  box-shadow: 0 0 0 4px var(--v4-warn-50);
+  animation: v4-db-pulse 1.6s ease-in-out infinite;
+}
+.v4-db-hero-dot--danger { background: var(--v4-danger-500); box-shadow: 0 0 0 4px var(--v4-danger-50); }
+.v4-db-hero-dot--unknown { background: var(--v4-ink-300); }
+@keyframes v4-db-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+.v4-db-hero-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  margin-bottom: 4px;
+}
+.v4-db-hero-sub {
+  font-size: 13px;
+  color: var(--v4-ink-500);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+.v4-db-hero-topic {
+  color: var(--v4-ink-900);
+  font-weight: 600;
+  max-width: 480px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.v4-db-hero-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* — Card grid — */
+.v4-db-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 14px;
+}
+
+/* — Card — */
+.v4-db-card {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: border-color 120ms, box-shadow 120ms, transform 120ms;
+  min-width: 0;
+}
+.v4-db-card:hover {
+  border-color: var(--v4-accent-500);
+  box-shadow: 0 0 0 3px var(--v4-accent-50);
+}
+.v4-db-card:focus-visible {
+  outline: 2px solid var(--v4-accent-500);
+  outline-offset: 2px;
+}
+.v4-db-card--ok { border-top: 3px solid var(--v4-success-500); }
+.v4-db-card--warn {
+  border-top: 3px solid var(--v4-warn-500);
+  background: var(--v4-warn-50);
+}
+.v4-db-card--danger { border-top: 3px solid var(--v4-danger-500); }
+.v4-db-card--neutral { border-top: 3px solid var(--v4-line); }
+
+.v4-db-card-h {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.v4-db-card-running-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--v4-warn-500);
+  margin-left: auto;
+  animation: v4-db-pulse 1s ease-in-out infinite;
+}
+.v4-db-card-topic {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.v4-db-card-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: auto;
+  font-size: 12px;
+}
+.v4-db-card-project {
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  max-width: 160px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.v4-db-card-cost {
+  font-weight: 600;
+  color: var(--v4-ink-700);
+}
+.v4-db-card-age {
+  margin-left: auto;
+  color: var(--v4-ink-400);
+  font-size: 11px;
+}
+
+/* — Empty state (first-time) — */
+.v4-db-empty {
+  text-align: center;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+.v4-db-empty svg {
+  width: 48px;
+  height: 48px;
+  color: var(--v4-ink-300);
+}
+.v4-db-empty h3 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--v4-ink-900);
+}
+.v4-db-empty p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--v4-ink-500);
+  max-width: 480px;
+  line-height: 1.5;
+}
+.v4-db-empty .v4-btn { margin-top: 8px; }
+
+/* ────────────────────────────────────────
    RESPONSIVE
    ──────────────────────────────────────── */
 @media (max-width: 1100px) {


### PR DESCRIPTION
## Summary
- Migrate Debate Engine from bento-panel + table layout to V4 design system
- 5 new components (~520 LOC) in `src/components/v4/debate/` + ~190 lines of CSS
- Reuse `useDebate` / `useDebateStatus` hooks unchanged
- Reuse `DebateChat` (~520 LOC) and `StartDebateModal` (~280 LOC) as-is — complex multi-state flows kept untouched

## UX changes vs legacy
- **Hero card** with active-debate visibility — pulsing orange dot + topic + project + "Открыть" quick action when a debate is running. Was only a small badge in the table.
- **KPI strip**: всего / в работе / завершены / ошибки / единогласно / потрачено
- **Russian status badges**: Queued/Running/Done/Error → В очереди/В работе/Завершён/Ошибка
- **Russian consensus badges**: Unanimous/Majority/Contested → Единогласно/Большинство/Спорно
- **Search** by topic or project (was none)
- **Filter pills**: Все / В работе / Завершены / Ошибки (localStorage-persisted)
- **Sort toggle**: По дате / По стоимости (was only date desc, hardcoded)
- **Card grid** instead of separate desktop table + mobile cards — single responsive layout
- **Running cards** get warn-orange tinted background so they're impossible to miss
- **First-time empty state** in V4 style with CTA

## Test plan
- [x] `npx tsc --noEmit` — green
- [x] `npm run lint` — green
- [x] `npm run build` — green
- [x] Verified in preview with mocked debate list (7 debates: 1 running, 1 queued, 4 done with mixed consensus, 1 error):
  - Hero classifies as warn ("Идёт дебат") with topic + project + Открыть button
  - KPI strip: 7 / 2 / 4 / 1 / 2 / \$3.64
  - Sort: queued → running → done by date desc
  - Card states: warn (running, orange bg), warn (queued), ok (done), danger (error)
  - Status/consensus badges render in Russian

🤖 Generated with [Claude Code](https://claude.com/claude-code)