### PR TITLE
feat(research): redesign Research/Discovery tab in V4 design system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { MonitoringView } from "./components/v4/monitoring/MonitoringView";
 import { AuditView } from "./components/v4/audit/AuditView";
 import { PipelineView } from "./components/v4/pipeline/PipelineView";
 import { TranscriptsView } from "./components/v4/transcripts/TranscriptsView";
-import { ResearchTab } from "./components/ResearchTab";
+import { ResearchView } from "./components/v4/research/ResearchView";
 import { SpecsTab } from "./components/SpecsTab";
 import { QualityView } from "./components/v4/quality/QualityView";
 import { DebateView } from "./components/v4/debate/DebateView";
@@ -259,13 +259,11 @@ function AppInner() {
             </ErrorBoundary>
           )}
         </div>
-        <div className="v4-legacy-frame" style={{ display: tab === "research" ? undefined : "none" }}>
+        <div style={{ display: tab === "research" ? undefined : "none" }}>
           {visitedTabs.has("research") && (
-            <div className="bento-grid">
-              <ErrorBoundary fallback="Ошибка вкладки Research">
-                <ResearchTab repos={projects.map((p) => p.repo)} />
-              </ErrorBoundary>
-            </div>
+            <ErrorBoundary fallback="Ошибка вкладки Research">
+              <ResearchView repos={projects.map((p) => p.repo)} />
+            </ErrorBoundary>
           )}
         </div>
         <div className="v4-legacy-frame" style={{ display: tab === "specs" ? undefined : "none" }}>

--- a/src/components/v4/research/ResearchAgentBanner.tsx
+++ b/src/components/v4/research/ResearchAgentBanner.tsx
@@ -1,0 +1,55 @@
+import type { ResearchAgentStatus } from "../../../utils/pipeline";
+
+interface Props {
+  status: ResearchAgentStatus;
+  onDismiss: () => void;
+}
+
+export function ResearchAgentBanner({ status, onDismiss }: Props) {
+  const isDone = status.status === "done";
+  const isError = status.status === "error";
+  const isActive = !isDone && !isError;
+  const label = status.agent === "research" ? "Research" : "Discovery";
+  const health = isError ? "danger" : isDone ? "ok" : "warn";
+
+  return (
+    <div className={`v4-rsh-agent v4-rsh-agent--${health}`} role="status">
+      <div className="v4-rsh-agent-h">
+        <div className="v4-rsh-agent-label">
+          <span className={`v4-rsh-agent-dot v4-rsh-agent-dot--${health}`} aria-hidden="true" />
+          <b>{label} агент</b>
+          {status.project && (
+            <span className="v4-pl-mono v4-rsh-text-muted">{status.project.split("/").pop()}</span>
+          )}
+        </div>
+        <div className="v4-rsh-agent-stage">
+          {isError ? (status.error ?? "Ошибка") : isDone ? "Завершён" : status.stage}
+        </div>
+        {(isDone || isError) && (
+          <button
+            type="button"
+            className="v4-btn v4-rsh-agent-dismiss"
+            onClick={onDismiss}
+            aria-label="Скрыть"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+      {isActive && (
+        <div
+          className="v4-rsh-agent-track"
+          role="progressbar"
+          aria-valuenow={status.progress}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div
+            className="v4-rsh-agent-fill"
+            style={{ width: `${Math.max(2, status.progress)}%` }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/research/ResearchHero.tsx
+++ b/src/components/v4/research/ResearchHero.tsx
@@ -1,0 +1,82 @@
+import type { ProjectResearch } from "../../../types";
+import { totals } from "./utils";
+
+interface Props {
+  projects: ProjectResearch[];
+  loading: boolean;
+  pipelineAvailable: boolean | null;
+  onRefresh: () => void;
+  onStart: () => void;
+}
+
+export function ResearchHero({ projects, loading, pipelineAvailable, onRefresh, onStart }: Props) {
+  const t = totals(projects);
+  const offline = pipelineAvailable === false;
+
+  const health: "ok" | "warn" | "danger" | "unknown" =
+    offline ? "danger"
+    : t.projects === 0 ? "unknown"
+    : t.withResearch === 0 ? "warn"
+    : "ok";
+
+  const title = offline
+    ? "Pipeline API офлайн"
+    : t.projects === 0
+      ? "Research / Discovery"
+      : t.withResearch === 0
+        ? "Анализ ещё не проводился"
+        : `Проанализировано ${t.withResearch} из ${t.projects} проектов`;
+
+  return (
+    <div className={`v4-rsh-hero v4-rsh-hero--${health}`}>
+      <div className="v4-rsh-hero-status">
+        <span className={`v4-rsh-hero-dot v4-rsh-hero-dot--${health}`} aria-hidden="true" />
+        <div>
+          <div className="v4-rsh-hero-title">{title}</div>
+          <div className="v4-rsh-hero-sub">
+            {offline ? (
+              <>Запуск research/discovery агентов невозможен. Проверьте makeit-pipeline.</>
+            ) : t.projects === 0 ? (
+              <>Анализ рынка, конкурентов и болевых точек. Research → RESEARCH.md, Discovery → DISCOVERY.md.</>
+            ) : (
+              <>
+                <b>{t.competitors}</b> конкурентов
+                <span className="v4-rsh-sep">·</span>
+                <b>{t.painPoints}</b> болевых точек
+                <span className="v4-rsh-sep">·</span>
+                <b>{t.suggestions}</b> идей
+                {t.quickWins > 0 && (
+                  <>
+                    <span className="v4-rsh-sep">·</span>
+                    <b className="v4-rsh-text-success">{t.quickWins}</b> quick wins
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="v4-rsh-hero-actions">
+        <button type="button" className="v4-btn" onClick={onRefresh} disabled={loading}>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M21 12a9 9 0 11-6.22-8.56" />
+            <path d="M21 3v6h-6" />
+          </svg>
+          {loading ? "Загрузка…" : "Обновить"}
+        </button>
+        <button
+          type="button"
+          className="v4-btn v4-btn--pri"
+          onClick={onStart}
+          disabled={offline}
+          title={offline ? "Pipeline API недоступен" : "Запустить Research агента"}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <polygon points="5 3 19 12 5 21 5 3" />
+          </svg>
+          Запустить Research
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/research/ResearchKpiStrip.tsx
+++ b/src/components/v4/research/ResearchKpiStrip.tsx
@@ -1,0 +1,56 @@
+import type { ProjectResearch } from "../../../types";
+import { totals } from "./utils";
+
+interface Props {
+  projects: ProjectResearch[];
+}
+
+export function ResearchKpiStrip({ projects }: Props) {
+  const t = totals(projects);
+
+  return (
+    <div className="v4-projects-toolbar v4-pl-kpi-strip">
+      <div className="v4-projects-agg">
+        <div className="v4-projects-agg-cell" title="Всего проектов в портфеле">
+          <div className="v4-projects-agg-n num">{t.projects}</div>
+          <div className="v4-projects-agg-l">проектов</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Проекты с RESEARCH.md">
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: t.withResearch > 0 ? "var(--v4-success-700)" : undefined }}
+          >
+            {t.withResearch}
+          </div>
+          <div className="v4-projects-agg-l">с research</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Проекты с DISCOVERY.md">
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: t.withDiscovery > 0 ? "var(--v4-success-700)" : undefined }}
+          >
+            {t.withDiscovery}
+          </div>
+          <div className="v4-projects-agg-l">с discovery</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Сумма competitor-карточек по портфелю">
+          <div className="v4-projects-agg-n num">{t.competitors}</div>
+          <div className="v4-projects-agg-l">конкурентов</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Сумма идей в DISCOVERY.md">
+          <div className="v4-projects-agg-n num">{t.suggestions}</div>
+          <div className="v4-projects-agg-l">идей</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Quick Wins — быстрые победы из DISCOVERY.md">
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: t.quickWins > 0 ? "var(--v4-success-700)" : undefined }}
+          >
+            {t.quickWins}
+          </div>
+          <div className="v4-projects-agg-l">quick wins</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/research/ResearchProjectCardV4.tsx
+++ b/src/components/v4/research/ResearchProjectCardV4.tsx
@@ -18,7 +18,11 @@ export function ResearchProjectCardV4({
   onLaunchDiscovery,
 }: Props) {
   const [expanded, setExpanded] = useState(false);
-  const [openSection, setOpenSection] = useState<Section | null>(null);
+  // Pre-open the Discovery section by default — it's the most useful view
+  // for an actively-investigated project. Initialising openSection here
+  // (rather than passing defaultOpen down) keeps the parent state in sync
+  // with what's visually open, so the first toggle click closes correctly.
+  const [openSection, setOpenSection] = useState<Section | null>("discovery");
 
   const hasResearch = !!pr.research;
   const hasDiscovery = !!pr.discovery;
@@ -45,19 +49,12 @@ export function ResearchProjectCardV4({
 
   return (
     <div className={`v4-rsh-card v4-rsh-card--${health}${expanded ? " is-expanded" : ""}`}>
-      <div
-        className={`v4-rsh-card-h${hasData ? " is-clickable" : ""}`}
-        onClick={toggleExpand}
-        onKeyDown={(e) => {
-          if (hasData && (e.key === "Enter" || e.key === " ")) {
-            e.preventDefault();
-            toggleExpand();
-          }
-        }}
-        role={hasData ? "button" : undefined}
-        tabIndex={hasData ? 0 : undefined}
-        aria-expanded={hasData ? expanded : undefined}
-      >
+      {/* Header is a row of plain spans + nested buttons + an explicit
+          expand <button> at the end. We deliberately do NOT make the
+          whole row a role="button" — that would nest interactive elements
+          (the action buttons) inside another interactive element, which
+          violates WCAG 4.1.1 and breaks screen-reader navigation. */}
+      <div className="v4-rsh-card-h">
         <div className="v4-rsh-card-name">
           <span className="v4-rsh-card-title">{pr.repo}</span>
           {pr.loading && <span className="v4-rsh-card-loading" aria-label="Загрузка" />}
@@ -91,7 +88,7 @@ export function ResearchProjectCardV4({
           )}
         </div>
 
-        <div className="v4-rsh-card-actions" onClick={(e) => e.stopPropagation()}>
+        <div className="v4-rsh-card-actions">
           <button
             type="button"
             className="v4-btn"
@@ -115,9 +112,16 @@ export function ResearchProjectCardV4({
         </div>
 
         {hasData && (
-          <span className="v4-rsh-card-chevron" aria-hidden="true">
+          <button
+            type="button"
+            className="v4-rsh-card-chevron"
+            onClick={toggleExpand}
+            disabled={!hasData}
+            aria-expanded={hasData ? expanded : undefined}
+            aria-label={expanded ? `Свернуть ${pr.repo}` : `Развернуть ${pr.repo}`}
+          >
             {expanded ? "▾" : "▸"}
-          </span>
+          </button>
         )}
       </div>
 
@@ -134,8 +138,8 @@ export function ResearchProjectCardV4({
               tone="warn"
             >
               <ul className="v4-rsh-list">
-                {pr.research.painPoints.map((p, i) => (
-                  <li key={i}>{p.theme}</li>
+                {pr.research.painPoints.map((p) => (
+                  <li key={p.theme}>{p.theme}</li>
                 ))}
               </ul>
             </CollapsibleSection>
@@ -148,8 +152,8 @@ export function ResearchProjectCardV4({
               tone="ok"
             >
               <ul className="v4-rsh-list">
-                {pr.research.opportunities.map((o, i) => (
-                  <li key={i}>{o}</li>
+                {pr.research.opportunities.map((o) => (
+                  <li key={o}>{o}</li>
                 ))}
               </ul>
             </CollapsibleSection>
@@ -160,7 +164,6 @@ export function ResearchProjectCardV4({
               isOpen={openSection === "discovery"}
               onToggle={() => toggleSection("discovery")}
               tone="ok"
-              defaultOpen
             >
               <DiscoverySection discovery={pr.discovery} />
             </CollapsibleSection>
@@ -176,30 +179,22 @@ interface SectionProps {
   isOpen: boolean;
   onToggle: () => void;
   tone: "ok" | "warn";
-  defaultOpen?: boolean;
   children: React.ReactNode;
 }
 
-function CollapsibleSection({ title, isOpen, onToggle, tone, defaultOpen, children }: SectionProps) {
-  // defaultOpen pre-expands on first render via local state hint, but
-  // user toggle takes precedence afterwards.
-  const [hasInteracted, setHasInteracted] = useState(false);
-  const open = hasInteracted ? isOpen : defaultOpen ?? isOpen;
+function CollapsibleSection({ title, isOpen, onToggle, tone, children }: SectionProps) {
   return (
     <div className={`v4-rsh-section v4-rsh-section--${tone}`}>
       <button
         type="button"
         className="v4-rsh-section-h"
-        onClick={() => {
-          setHasInteracted(true);
-          onToggle();
-        }}
-        aria-expanded={open}
+        onClick={onToggle}
+        aria-expanded={isOpen}
       >
-        <span className="v4-rsh-section-arrow" aria-hidden="true">{open ? "▾" : "▸"}</span>
+        <span className="v4-rsh-section-arrow" aria-hidden="true">{isOpen ? "▾" : "▸"}</span>
         <span className="v4-rsh-section-title">{title}</span>
       </button>
-      {open && <div className="v4-rsh-section-body">{children}</div>}
+      {isOpen && <div className="v4-rsh-section-body">{children}</div>}
     </div>
   );
 }
@@ -274,7 +269,7 @@ function CompetitorMatrix({ research }: { research: ResearchData }) {
               {c.audience && <div className="v4-rsh-comp-meta">Аудитория: {c.audience}</div>}
               {c.features.length > 0 && (
                 <ul className="v4-rsh-comp-features">
-                  {c.features.map((f, i) => <li key={i}>{f}</li>)}
+                  {c.features.map((f) => <li key={f}>{f}</li>)}
                 </ul>
               )}
             </div>
@@ -319,8 +314,11 @@ function DiscoveryGroup({
       </div>
       <div className="v4-rsh-disc-list">
         {suggestions.map((s, i) => (
+          // Composite key to handle near-duplicates: name should be unique
+          // most of the time; the description prefix breaks ties; index is
+          // a last-resort fallback if both name+description collide.
           <div
-            key={`${s.name}-${i}`}
+            key={`${s.name}::${(s.description ?? "").slice(0, 40)}::${i}`}
             className="v4-rsh-disc-item"
           >
             <div className="v4-rsh-disc-h">

--- a/src/components/v4/research/ResearchProjectCardV4.tsx
+++ b/src/components/v4/research/ResearchProjectCardV4.tsx
@@ -1,0 +1,342 @@
+import { useState } from "react";
+import type { DiscoveryData, DiscoverySuggestion, ProjectResearch, ResearchData } from "../../../types";
+import { effortTagClass, impactTagClass } from "./utils";
+
+interface Props {
+  pr: ProjectResearch;
+  agentStarting: boolean;
+  onLaunchResearch: (repo: string) => void;
+  onLaunchDiscovery: (repo: string) => void;
+}
+
+type Section = "competitors" | "pains" | "opportunities" | "discovery";
+
+export function ResearchProjectCardV4({
+  pr,
+  agentStarting,
+  onLaunchResearch,
+  onLaunchDiscovery,
+}: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [openSection, setOpenSection] = useState<Section | null>(null);
+
+  const hasResearch = !!pr.research;
+  const hasDiscovery = !!pr.discovery;
+  const hasData = hasResearch || hasDiscovery;
+  const totalIdeas = pr.discovery?.suggestions.length ?? 0;
+  const quickWins = pr.discovery?.quickWins.length ?? 0;
+  const competitors = pr.research?.competitors.length ?? 0;
+  const pains = pr.research?.painPoints.length ?? 0;
+  const opportunities = pr.research?.opportunities.length ?? 0;
+
+  const health: "ok" | "warn" | "unknown" =
+    hasResearch && hasDiscovery ? "ok"
+    : hasData ? "warn"
+    : "unknown";
+
+  function toggleExpand() {
+    if (!hasData) return;
+    setExpanded((v) => !v);
+  }
+
+  function toggleSection(s: Section) {
+    setOpenSection((cur) => (cur === s ? null : s));
+  }
+
+  return (
+    <div className={`v4-rsh-card v4-rsh-card--${health}${expanded ? " is-expanded" : ""}`}>
+      <div
+        className={`v4-rsh-card-h${hasData ? " is-clickable" : ""}`}
+        onClick={toggleExpand}
+        onKeyDown={(e) => {
+          if (hasData && (e.key === "Enter" || e.key === " ")) {
+            e.preventDefault();
+            toggleExpand();
+          }
+        }}
+        role={hasData ? "button" : undefined}
+        tabIndex={hasData ? 0 : undefined}
+        aria-expanded={hasData ? expanded : undefined}
+      >
+        <div className="v4-rsh-card-name">
+          <span className="v4-rsh-card-title">{pr.repo}</span>
+          {pr.loading && <span className="v4-rsh-card-loading" aria-label="Загрузка" />}
+          {hasResearch && <span className="v4-tag v4-tag--ok">research</span>}
+          {hasDiscovery && <span className="v4-tag v4-tag--ok">discovery</span>}
+          {!hasData && !pr.loading && (
+            <span className="v4-tag v4-rsh-text-muted">{pr.error ?? "нет данных"}</span>
+          )}
+        </div>
+
+        <div className="v4-rsh-card-stats">
+          {competitors > 0 && (
+            <span className="v4-rsh-card-stat" title="Конкуренты">
+              <b>{competitors}</b> конк.
+            </span>
+          )}
+          {pains > 0 && (
+            <span className="v4-rsh-card-stat" title="Болевые точки">
+              <b>{pains}</b> болей
+            </span>
+          )}
+          {totalIdeas > 0 && (
+            <span className="v4-rsh-card-stat" title="Идеи из discovery">
+              <b>{totalIdeas}</b> идей
+            </span>
+          )}
+          {quickWins > 0 && (
+            <span className="v4-rsh-card-stat v4-rsh-text-success" title="Quick wins">
+              <b>{quickWins}</b> QW
+            </span>
+          )}
+        </div>
+
+        <div className="v4-rsh-card-actions" onClick={(e) => e.stopPropagation()}>
+          <button
+            type="button"
+            className="v4-btn"
+            onClick={() => onLaunchResearch(pr.repo)}
+            disabled={agentStarting}
+            title="Запустить Research агента"
+          >
+            Research
+          </button>
+          {hasResearch && (
+            <button
+              type="button"
+              className="v4-btn"
+              onClick={() => onLaunchDiscovery(pr.repo)}
+              disabled={agentStarting}
+              title="Запустить Discovery агента (требует RESEARCH.md)"
+            >
+              Discovery
+            </button>
+          )}
+        </div>
+
+        {hasData && (
+          <span className="v4-rsh-card-chevron" aria-hidden="true">
+            {expanded ? "▾" : "▸"}
+          </span>
+        )}
+      </div>
+
+      {expanded && hasData && (
+        <div className="v4-rsh-card-body">
+          {hasResearch && pr.research && (
+            <CompetitorMatrix research={pr.research} />
+          )}
+          {hasResearch && pr.research && pr.research.painPoints.length > 0 && (
+            <CollapsibleSection
+              title={`Болевые точки (${pains})`}
+              isOpen={openSection === "pains"}
+              onToggle={() => toggleSection("pains")}
+              tone="warn"
+            >
+              <ul className="v4-rsh-list">
+                {pr.research.painPoints.map((p, i) => (
+                  <li key={i}>{p.theme}</li>
+                ))}
+              </ul>
+            </CollapsibleSection>
+          )}
+          {hasResearch && pr.research && pr.research.opportunities.length > 0 && (
+            <CollapsibleSection
+              title={`Возможности (${opportunities})`}
+              isOpen={openSection === "opportunities"}
+              onToggle={() => toggleSection("opportunities")}
+              tone="ok"
+            >
+              <ul className="v4-rsh-list">
+                {pr.research.opportunities.map((o, i) => (
+                  <li key={i}>{o}</li>
+                ))}
+              </ul>
+            </CollapsibleSection>
+          )}
+          {hasDiscovery && pr.discovery && (
+            <CollapsibleSection
+              title={`Discovery идеи (${totalIdeas})`}
+              isOpen={openSection === "discovery"}
+              onToggle={() => toggleSection("discovery")}
+              tone="ok"
+              defaultOpen
+            >
+              <DiscoverySection discovery={pr.discovery} />
+            </CollapsibleSection>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  isOpen: boolean;
+  onToggle: () => void;
+  tone: "ok" | "warn";
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}
+
+function CollapsibleSection({ title, isOpen, onToggle, tone, defaultOpen, children }: SectionProps) {
+  // defaultOpen pre-expands on first render via local state hint, but
+  // user toggle takes precedence afterwards.
+  const [hasInteracted, setHasInteracted] = useState(false);
+  const open = hasInteracted ? isOpen : defaultOpen ?? isOpen;
+  return (
+    <div className={`v4-rsh-section v4-rsh-section--${tone}`}>
+      <button
+        type="button"
+        className="v4-rsh-section-h"
+        onClick={() => {
+          setHasInteracted(true);
+          onToggle();
+        }}
+        aria-expanded={open}
+      >
+        <span className="v4-rsh-section-arrow" aria-hidden="true">{open ? "▾" : "▸"}</span>
+        <span className="v4-rsh-section-title">{title}</span>
+      </button>
+      {open && <div className="v4-rsh-section-body">{children}</div>}
+    </div>
+  );
+}
+
+function CompetitorMatrix({ research }: { research: ResearchData }) {
+  const { featureMatrix, competitors } = research;
+  const features = Object.keys(featureMatrix);
+
+  if (features.length === 0 && competitors.length === 0) return null;
+
+  // Matrix view
+  if (features.length > 0) {
+    const compNames = new Set<string>();
+    for (const row of Object.values(featureMatrix)) {
+      for (const key of Object.keys(row)) compNames.add(key);
+    }
+    const headers = Array.from(compNames);
+    return (
+      <div className="v4-rsh-section v4-rsh-section--neutral">
+        <div className="v4-rsh-section-h-static">
+          <span className="v4-rsh-section-title">Матрица функций</span>
+        </div>
+        <div className="v4-rsh-section-body">
+          <div className="v4-rsh-matrix-wrap">
+            <table className="v4-rsh-matrix">
+              <thead>
+                <tr>
+                  <th>Функция</th>
+                  {headers.map((h) => <th key={h}>{h}</th>)}
+                </tr>
+              </thead>
+              <tbody>
+                {features.map((f) => (
+                  <tr key={f}>
+                    <td className="v4-rsh-matrix-feature">{f}</td>
+                    {headers.map((h) => {
+                      const val = featureMatrix[f]?.[h] ?? "—";
+                      const isYes = /✅|\byes\b|\bда\b|\+/i.test(val);
+                      const isNo = /❌|\bno\b|\bнет\b|^−$|^-$/i.test(val);
+                      return (
+                        <td
+                          key={h}
+                          className={isYes ? "v4-rsh-cell-yes" : isNo ? "v4-rsh-cell-no" : ""}
+                        >
+                          {val}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Fallback: cards
+  return (
+    <div className="v4-rsh-section v4-rsh-section--neutral">
+      <div className="v4-rsh-section-h-static">
+        <span className="v4-rsh-section-title">Конкуренты ({competitors.length})</span>
+      </div>
+      <div className="v4-rsh-section-body">
+        <div className="v4-rsh-comp-grid">
+          {competitors.map((c) => (
+            <div key={c.name} className="v4-rsh-comp">
+              <div className="v4-rsh-comp-name">{c.name}</div>
+              {c.url && <div className="v4-rsh-comp-url v4-pl-mono">{c.url}</div>}
+              {c.pricing && <div className="v4-rsh-comp-meta">Цена: {c.pricing}</div>}
+              {c.audience && <div className="v4-rsh-comp-meta">Аудитория: {c.audience}</div>}
+              {c.features.length > 0 && (
+                <ul className="v4-rsh-comp-features">
+                  {c.features.map((f, i) => <li key={i}>{f}</li>)}
+                </ul>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DiscoverySection({ discovery }: { discovery: DiscoveryData }) {
+  const { quickWins, strategicBets, niceToHaves } = discovery;
+  return (
+    <div className="v4-rsh-disc">
+      {quickWins.length > 0 && (
+        <DiscoveryGroup title="Quick Wins" suggestions={quickWins} accent="ok" />
+      )}
+      {strategicBets.length > 0 && (
+        <DiscoveryGroup title="Strategic Bets" suggestions={strategicBets} accent="warn" />
+      )}
+      {niceToHaves.length > 0 && (
+        <DiscoveryGroup title="Nice to Have" suggestions={niceToHaves} accent="neutral" />
+      )}
+    </div>
+  );
+}
+
+function DiscoveryGroup({
+  title,
+  suggestions,
+  accent,
+}: {
+  title: string;
+  suggestions: DiscoverySuggestion[];
+  accent: "ok" | "warn" | "neutral";
+}) {
+  return (
+    <div className={`v4-rsh-disc-group v4-rsh-disc-group--${accent}`}>
+      <div className="v4-rsh-disc-group-h">
+        <span className="v4-rsh-disc-group-t">{title}</span>
+        <span className="v4-pl-mono v4-rsh-text-muted">{suggestions.length}</span>
+      </div>
+      <div className="v4-rsh-disc-list">
+        {suggestions.map((s, i) => (
+          <div
+            key={`${s.name}-${i}`}
+            className="v4-rsh-disc-item"
+          >
+            <div className="v4-rsh-disc-h">
+              <span className="v4-rsh-disc-name">{s.name}</span>
+              <div className="v4-rsh-disc-badges">
+                {s.effort && <span className={effortTagClass(s.effort)}>{s.effort}</span>}
+                {s.impact && <span className={impactTagClass(s.impact)}>{s.impact}</span>}
+              </div>
+            </div>
+            {s.description && <div className="v4-rsh-disc-desc">{s.description}</div>}
+            {s.evidence && (
+              <div className="v4-rsh-disc-evidence">Источник: {s.evidence}</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/research/ResearchView.tsx
+++ b/src/components/v4/research/ResearchView.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useResearch } from "../../../hooks/useResearch";
+import { useResearchAgent } from "../../../hooks/useResearchAgent";
+import { StartResearchModal } from "../../StartResearchModal";
+import { GITHUB_OWNER } from "../../../utils/config";
+import { ResearchAgentBanner } from "./ResearchAgentBanner";
+import { ResearchHero } from "./ResearchHero";
+import { ResearchKpiStrip } from "./ResearchKpiStrip";
+import { ResearchProjectCardV4 } from "./ResearchProjectCardV4";
+import {
+  applyFilter,
+  applySearch,
+  RESEARCH_FILTERS,
+  type ResearchFilter,
+} from "./utils";
+
+interface Props {
+  repos: string[];
+}
+
+const STORAGE_FILTER = "v4rsh:filter";
+
+function readFilter(): ResearchFilter {
+  try {
+    const v = localStorage.getItem(STORAGE_FILTER);
+    if (v === "all" || v === "withResearch" || v === "withDiscovery" || v === "noData" || v === "hasQuickWins") {
+      return v;
+    }
+  } catch { /* ignore */ }
+  return "all";
+}
+
+export function ResearchView({ repos }: Props) {
+  const { projects, loading, refresh } = useResearch();
+  const agent = useResearchAgent();
+  const loadedRef = useRef(false);
+
+  const [showModal, setShowModal] = useState(false);
+  const [modalRepo, setModalRepo] = useState<string | undefined>();
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<ResearchFilter>(() => readFilter());
+
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_FILTER, filter); } catch { /* ignore */ }
+  }, [filter]);
+
+  const { checkPipeline } = agent;
+  useEffect(() => {
+    if (!loadedRef.current && repos.length > 0) {
+      loadedRef.current = true;
+      refresh(repos);
+      checkPipeline();
+    }
+  }, [repos, refresh, checkPipeline]);
+
+  const visible = useMemo(() => {
+    return applySearch(applyFilter(projects, filter), search);
+  }, [projects, filter, search]);
+
+  function handleOpenModal(repo?: string) {
+    setModalRepo(repo);
+    setShowModal(true);
+  }
+
+  function handleStartResearch(project: string, description: string, region: string) {
+    setShowModal(false);
+    agent.launchResearch({
+      project,
+      product_description: description || undefined,
+      region: region || undefined,
+    });
+  }
+
+  function handleStartDiscovery(repo: string) {
+    agent.launchDiscovery(`${GITHUB_OWNER}/${repo}`);
+  }
+
+  return (
+    <div className="v4-content">
+      <div className="v4-ph">
+        <div>
+          <h1>Research</h1>
+          <div className="v4-sub">
+            RESEARCH.md + DISCOVERY.md из репозиториев ·{" "}
+            <span className="v4-pl-mono">{projects.length}</span> {projects.length === 1 ? "проект" : "проектов"}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ height: 10 }} />
+
+      <ResearchHero
+        projects={projects}
+        loading={loading}
+        pipelineAvailable={agent.pipelineAvailable}
+        onRefresh={() => refresh(repos)}
+        onStart={() => handleOpenModal()}
+      />
+
+      {agent.error && (
+        <div className="v4-error" style={{ marginTop: 14 }} role="alert">
+          {agent.error}
+        </div>
+      )}
+
+      {agent.activeRun && (
+        <ResearchAgentBanner
+          status={agent.activeRun}
+          onDismiss={agent.clearActiveRun}
+        />
+      )}
+
+      <ResearchKpiStrip projects={projects} />
+
+      <div className="v4-au-toolbar">
+        <div className="v4-mon-search">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            type="search"
+            aria-label="Поиск по имени проекта"
+            placeholder="Поиск по проекту…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="v4-pillgrp">
+          {RESEARCH_FILTERS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              className={filter === key ? "is-active" : ""}
+              onClick={() => setFilter(key)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading && projects.length === 0 ? (
+        <div className="v4-empty" style={{ marginTop: 14 }}>Загрузка данных из репозиториев…</div>
+      ) : visible.length === 0 && projects.length === 0 ? (
+        <div className="v4-panel">
+          <div className="v4-rsh-empty">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="11" cy="11" r="8" />
+              <path d="M21 21l-4.35-4.35" />
+              <path d="M11 8v6" />
+              <path d="M8 11h6" />
+            </svg>
+            <h3>Research & Discovery</h3>
+            <p>
+              Анализ рынка, конкурентов и болевых точек пользователей.
+              Research агент собирает данные и формирует RESEARCH.md,
+              Discovery агент на их основе генерирует рекомендации в DISCOVERY.md.
+            </p>
+            <button
+              type="button"
+              className="v4-btn v4-btn--pri"
+              onClick={() => handleOpenModal()}
+              disabled={agent.pipelineAvailable === false}
+            >
+              Запустить Research
+            </button>
+          </div>
+        </div>
+      ) : visible.length === 0 ? (
+        <div className="v4-panel">
+          <div className="v4-empty">
+            По текущим фильтрам ничего не найдено
+            {search && (
+              <>
+                {" "}для запроса <span className="v4-pl-mono">«{search}»</span>
+              </>
+            )}
+            .
+          </div>
+        </div>
+      ) : (
+        <div className="v4-rsh-list">
+          {visible.map((pr) => (
+            <ResearchProjectCardV4
+              key={pr.repo}
+              pr={pr}
+              agentStarting={agent.starting}
+              onLaunchResearch={(repo) => handleOpenModal(repo)}
+              onLaunchDiscovery={handleStartDiscovery}
+            />
+          ))}
+        </div>
+      )}
+
+      {showModal && (
+        <StartResearchModal
+          defaultRepo={modalRepo}
+          onClose={() => setShowModal(false)}
+          onStart={handleStartResearch}
+          starting={agent.starting}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/research/ResearchView.tsx
+++ b/src/components/v4/research/ResearchView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useResearch } from "../../../hooks/useResearch";
 import { useResearchAgent } from "../../../hooks/useResearchAgent";
 import { StartResearchModal } from "../../StartResearchModal";
@@ -57,23 +57,38 @@ export function ResearchView({ repos }: Props) {
     return applySearch(applyFilter(projects, filter), search);
   }, [projects, filter, search]);
 
-  function handleOpenModal(repo?: string) {
+  // useCallback so memoised cards don't re-render whenever the parent
+  // ticks for unrelated state (agent status flips, search input).
+  const handleOpenModal = useCallback((repo?: string) => {
     setModalRepo(repo);
     setShowModal(true);
-  }
+  }, []);
 
-  function handleStartResearch(project: string, description: string, region: string) {
-    setShowModal(false);
-    agent.launchResearch({
-      project,
-      product_description: description || undefined,
-      region: region || undefined,
-    });
-  }
+  const handleStartResearch = useCallback(
+    (project: string, description: string, region: string) => {
+      setShowModal(false);
+      agent.launchResearch({
+        project,
+        product_description: description || undefined,
+        region: region || undefined,
+      });
+    },
+    [agent],
+  );
 
-  function handleStartDiscovery(repo: string) {
-    agent.launchDiscovery(`${GITHUB_OWNER}/${repo}`);
-  }
+  const handleStartDiscovery = useCallback(
+    (repo: string) => {
+      agent.launchDiscovery(`${GITHUB_OWNER}/${repo}`);
+    },
+    [agent],
+  );
+
+  const handleLaunchResearchFromCard = useCallback(
+    (repo: string) => {
+      handleOpenModal(repo);
+    },
+    [handleOpenModal],
+  );
 
   return (
     <div className="v4-content">
@@ -180,17 +195,27 @@ export function ResearchView({ repos }: Props) {
           </div>
         </div>
       ) : (
-        <div className="v4-rsh-list">
-          {visible.map((pr) => (
-            <ResearchProjectCardV4
-              key={pr.repo}
-              pr={pr}
-              agentStarting={agent.starting}
-              onLaunchResearch={(repo) => handleOpenModal(repo)}
-              onLaunchDiscovery={handleStartDiscovery}
-            />
-          ))}
-        </div>
+        <>
+          {/* Subtle inline indicator while a background refresh is running
+              and we already have data to show. Keeps the list visible
+              instead of swapping to a spinner. */}
+          {loading && projects.length > 0 && (
+            <div className="v4-rsh-refresh-hint v4-pl-mono v4-rsh-text-muted" role="status">
+              Обновление…
+            </div>
+          )}
+          <div className="v4-rsh-list">
+            {visible.map((pr) => (
+              <ResearchProjectCardV4
+                key={pr.repo}
+                pr={pr}
+                agentStarting={agent.starting}
+                onLaunchResearch={handleLaunchResearchFromCard}
+                onLaunchDiscovery={handleStartDiscovery}
+              />
+            ))}
+          </div>
+        </>
       )}
 
       {showModal && (

--- a/src/components/v4/research/utils.ts
+++ b/src/components/v4/research/utils.ts
@@ -1,0 +1,110 @@
+import type { ProjectResearch } from "../../../types";
+
+export type Effort = "S" | "M" | "L" | "XL";
+export type Impact = "critical" | "high" | "medium" | "low";
+
+export const EFFORT_LABEL: Record<string, string> = {
+  S: "S",
+  M: "M",
+  L: "L",
+  XL: "XL",
+};
+
+export const IMPACT_COLOR: Record<string, string> = {
+  critical: "var(--v4-danger-500)",
+  high: "var(--v4-warn-500)",
+  medium: "var(--v4-accent-500)",
+  low: "var(--v4-ink-400)",
+};
+
+export const IMPACT_LABEL: Record<string, string> = {
+  critical: "Критический",
+  high: "Высокий",
+  medium: "Средний",
+  low: "Низкий",
+};
+
+export type ResearchFilter = "all" | "withResearch" | "withDiscovery" | "noData" | "hasQuickWins";
+
+export const RESEARCH_FILTERS: Array<{ key: ResearchFilter; label: string }> = [
+  { key: "all", label: "Все" },
+  { key: "withResearch", label: "С research" },
+  { key: "withDiscovery", label: "С discovery" },
+  { key: "hasQuickWins", label: "Quick wins" },
+  { key: "noData", label: "Без данных" },
+];
+
+export function applyFilter(items: ProjectResearch[], f: ResearchFilter): ProjectResearch[] {
+  if (f === "all") return items;
+  if (f === "withResearch") return items.filter((p) => !!p.research);
+  if (f === "withDiscovery") return items.filter((p) => !!p.discovery);
+  if (f === "noData") return items.filter((p) => !p.research && !p.discovery);
+  if (f === "hasQuickWins") return items.filter((p) => (p.discovery?.quickWins.length ?? 0) > 0);
+  return items;
+}
+
+export function applySearch(items: ProjectResearch[], q: string): ProjectResearch[] {
+  const needle = q.trim().toLowerCase();
+  if (!needle) return items;
+  return items.filter((p) => p.repo.toLowerCase().includes(needle));
+}
+
+export interface PortfolioTotals {
+  projects: number;
+  withResearch: number;
+  withDiscovery: number;
+  competitors: number;
+  painPoints: number;
+  opportunities: number;
+  suggestions: number;
+  quickWins: number;
+  strategicBets: number;
+  niceToHaves: number;
+}
+
+export function totals(items: ProjectResearch[]): PortfolioTotals {
+  const t: PortfolioTotals = {
+    projects: items.length,
+    withResearch: 0,
+    withDiscovery: 0,
+    competitors: 0,
+    painPoints: 0,
+    opportunities: 0,
+    suggestions: 0,
+    quickWins: 0,
+    strategicBets: 0,
+    niceToHaves: 0,
+  };
+  for (const p of items) {
+    if (p.research) t.withResearch++;
+    if (p.discovery) t.withDiscovery++;
+    if (p.research) {
+      t.competitors += p.research.competitors.length;
+      t.painPoints += p.research.painPoints.length;
+      t.opportunities += p.research.opportunities.length;
+    }
+    if (p.discovery) {
+      t.suggestions += p.discovery.suggestions.length;
+      t.quickWins += p.discovery.quickWins.length;
+      t.strategicBets += p.discovery.strategicBets.length;
+      t.niceToHaves += p.discovery.niceToHaves.length;
+    }
+  }
+  return t;
+}
+
+export function effortTagClass(e: string): string {
+  if (e === "S") return "v4-tag v4-tag--ok";
+  if (e === "M") return "v4-tag";
+  if (e === "L") return "v4-tag v4-tag--warn";
+  if (e === "XL") return "v4-tag v4-tag--danger";
+  return "v4-tag";
+}
+
+export function impactTagClass(i: string): string {
+  if (i === "critical") return "v4-tag v4-tag--danger";
+  if (i === "high") return "v4-tag v4-tag--warn";
+  if (i === "medium") return "v4-tag";
+  if (i === "low") return "v4-tag";
+  return "v4-tag";
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -5218,9 +5218,32 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 }
 .v4-rsh-card-chevron {
   color: var(--v4-ink-400);
+  font-size: 14px;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-sm);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 120ms, border-color 120ms;
+}
+.v4-rsh-card-chevron:hover:not(:disabled) {
+  background: var(--v4-surface-2);
+  border-color: var(--v4-accent-500);
+  color: var(--v4-accent-700);
+}
+.v4-rsh-card-chevron:focus-visible {
+  outline: 2px solid var(--v4-accent-500);
+  outline-offset: 1px;
+}
+.v4-rsh-card-chevron:disabled { opacity: 0.4; cursor: not-allowed; }
+.v4-rsh-refresh-hint {
   font-size: 12px;
-  width: 14px;
-  text-align: center;
+  padding: 0 4px 8px;
 }
 
 .v4-rsh-card-body {

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -5047,6 +5047,396 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 .v4-db-empty .v4-btn { margin-top: 8px; }
 
 /* ────────────────────────────────────────
+   RESEARCH / DISCOVERY
+   ──────────────────────────────────────── */
+.v4-rsh-text-muted { color: var(--v4-ink-500); }
+.v4-rsh-text-success { color: var(--v4-success-700); }
+.v4-rsh-sep { color: var(--v4-ink-300); margin: 0 4px; }
+
+/* — Hero — */
+.v4-rsh-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  padding: 18px 22px;
+  margin-bottom: 14px;
+}
+.v4-rsh-hero--ok { border-left: 4px solid var(--v4-success-500); }
+.v4-rsh-hero--warn { border-left: 4px solid var(--v4-warn-500); }
+.v4-rsh-hero--danger { border-left: 4px solid var(--v4-danger-500); }
+.v4-rsh-hero--unknown { border-left: 4px solid var(--v4-ink-300); }
+.v4-rsh-hero-status { display: flex; gap: 14px; align-items: center; min-width: 0; }
+.v4-rsh-hero-dot { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; }
+.v4-rsh-hero-dot--ok { background: var(--v4-success-500); box-shadow: 0 0 0 4px var(--v4-success-50); }
+.v4-rsh-hero-dot--warn { background: var(--v4-warn-500); box-shadow: 0 0 0 4px var(--v4-warn-50); }
+.v4-rsh-hero-dot--danger { background: var(--v4-danger-500); box-shadow: 0 0 0 4px var(--v4-danger-50); }
+.v4-rsh-hero-dot--unknown { background: var(--v4-ink-300); }
+.v4-rsh-hero-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  margin-bottom: 4px;
+}
+.v4-rsh-hero-sub {
+  font-size: 13px;
+  color: var(--v4-ink-500);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+.v4-rsh-hero-sub b { color: var(--v4-ink-900); font-weight: 600; }
+.v4-rsh-hero-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* — Agent banner — */
+.v4-rsh-agent {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  padding: 12px 16px;
+  margin: 14px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.v4-rsh-agent--ok { border-left: 4px solid var(--v4-success-500); }
+.v4-rsh-agent--warn { border-left: 4px solid var(--v4-warn-500); background: var(--v4-warn-50); }
+.v4-rsh-agent--danger { border-left: 4px solid var(--v4-danger-500); background: var(--v4-danger-50); }
+.v4-rsh-agent-h {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.v4-rsh-agent-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--v4-ink-900);
+}
+.v4-rsh-agent-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.v4-rsh-agent-dot--ok { background: var(--v4-success-500); }
+.v4-rsh-agent-dot--warn {
+  background: var(--v4-warn-500);
+  animation: v4-rsh-pulse 1s ease-in-out infinite;
+}
+.v4-rsh-agent-dot--danger { background: var(--v4-danger-500); }
+@keyframes v4-rsh-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+.v4-rsh-agent-stage {
+  font-size: 12px;
+  color: var(--v4-ink-700);
+  flex: 1;
+  min-width: 0;
+}
+.v4-rsh-agent-dismiss { padding: 2px 10px; }
+.v4-rsh-agent-track {
+  height: 6px;
+  background: var(--v4-surface-3);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.v4-rsh-agent-fill {
+  height: 100%;
+  background: var(--v4-accent-500);
+  border-radius: 3px;
+  transition: width 400ms ease-out;
+}
+
+/* — Project card list — */
+.v4-rsh-list { display: flex; flex-direction: column; gap: 10px; }
+
+.v4-rsh-card {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition: border-color 120ms;
+}
+.v4-rsh-card--ok { border-left: 3px solid var(--v4-success-500); }
+.v4-rsh-card--warn { border-left: 3px solid var(--v4-warn-500); }
+.v4-rsh-card--unknown { border-left: 3px solid var(--v4-line); }
+.v4-rsh-card.is-expanded { border-color: var(--v4-accent-500); }
+
+.v4-rsh-card-h {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 14px 18px;
+  flex-wrap: wrap;
+}
+.v4-rsh-card-h.is-clickable { cursor: pointer; }
+.v4-rsh-card-h.is-clickable:hover { background: var(--v4-surface-2); }
+.v4-rsh-card-h:focus-visible {
+  outline: 2px solid var(--v4-accent-500);
+  outline-offset: -2px;
+}
+.v4-rsh-card-name {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  flex: 1 1 auto;
+  min-width: 200px;
+}
+.v4-rsh-card-title {
+  font-family: var(--v4-mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+.v4-rsh-card-loading {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--v4-warn-500);
+  animation: v4-rsh-pulse 1s ease-in-out infinite;
+}
+.v4-rsh-card-stats {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--v4-ink-500);
+}
+.v4-rsh-card-stat b { color: var(--v4-ink-900); font-weight: 600; }
+.v4-rsh-card-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.v4-rsh-card-chevron {
+  color: var(--v4-ink-400);
+  font-size: 12px;
+  width: 14px;
+  text-align: center;
+}
+
+.v4-rsh-card-body {
+  padding: 4px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-top: 1px solid var(--v4-line-soft);
+}
+
+/* — Collapsible sections inside card — */
+.v4-rsh-section {
+  border: 1px solid var(--v4-line-soft);
+  border-radius: var(--v4-r-sm);
+  overflow: hidden;
+}
+.v4-rsh-section--ok { border-left: 3px solid var(--v4-success-500); }
+.v4-rsh-section--warn { border-left: 3px solid var(--v4-warn-500); }
+.v4-rsh-section--neutral { border-left: 3px solid var(--v4-accent-500); }
+.v4-rsh-section-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: transparent;
+  border: 0;
+  padding: 8px 12px;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+}
+.v4-rsh-section-h:hover { background: var(--v4-surface-2); }
+.v4-rsh-section-h-static {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--v4-surface-2);
+}
+.v4-rsh-section-arrow { color: var(--v4-ink-500); font-size: 11px; width: 12px; }
+.v4-rsh-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+.v4-rsh-section-body {
+  padding: 10px 12px 12px;
+  border-top: 1px solid var(--v4-line-soft);
+}
+
+.v4-rsh-list ul.v4-rsh-list,
+ul.v4-rsh-list {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--v4-ink-700);
+}
+
+/* — Competitor matrix — */
+.v4-rsh-matrix-wrap {
+  overflow-x: auto;
+}
+.v4-rsh-matrix {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.v4-rsh-matrix th,
+.v4-rsh-matrix td {
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--v4-line-soft);
+}
+.v4-rsh-matrix th {
+  background: var(--v4-surface-2);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--v4-ink-500);
+  font-weight: 600;
+}
+.v4-rsh-matrix-feature {
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+.v4-rsh-cell-yes { color: var(--v4-success-700); font-weight: 600; }
+.v4-rsh-cell-no { color: var(--v4-danger-700); }
+
+/* — Competitor cards (fallback when no matrix) — */
+.v4-rsh-comp-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 10px;
+}
+.v4-rsh-comp {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-sm);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+.v4-rsh-comp-name { font-weight: 600; color: var(--v4-ink-900); font-size: 13px; }
+.v4-rsh-comp-url { color: var(--v4-accent-700); font-size: 11px; }
+.v4-rsh-comp-meta { color: var(--v4-ink-500); }
+.v4-rsh-comp-features {
+  margin: 4px 0 0;
+  padding-left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: var(--v4-ink-700);
+}
+
+/* — Discovery section — */
+.v4-rsh-disc { display: flex; flex-direction: column; gap: 12px; }
+.v4-rsh-disc-group {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line-soft);
+  border-radius: var(--v4-r-sm);
+  overflow: hidden;
+}
+.v4-rsh-disc-group--ok { border-left: 3px solid var(--v4-success-500); }
+.v4-rsh-disc-group--warn { border-left: 3px solid var(--v4-warn-500); }
+.v4-rsh-disc-group--neutral { border-left: 3px solid var(--v4-line); }
+.v4-rsh-disc-group-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: var(--v4-surface-2);
+  font-size: 12px;
+}
+.v4-rsh-disc-group-t {
+  font-weight: 700;
+  color: var(--v4-ink-900);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.v4-rsh-disc-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+}
+.v4-rsh-disc-item {
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.v4-rsh-disc-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.v4-rsh-disc-name {
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  font-size: 13px;
+}
+.v4-rsh-disc-badges {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.v4-rsh-disc-desc {
+  font-size: 12px;
+  color: var(--v4-ink-700);
+  line-height: 1.4;
+}
+.v4-rsh-disc-evidence {
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  font-style: italic;
+}
+
+/* — Empty state — */
+.v4-rsh-empty {
+  text-align: center;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+.v4-rsh-empty svg {
+  width: 48px;
+  height: 48px;
+  color: var(--v4-ink-300);
+}
+.v4-rsh-empty h3 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--v4-ink-900);
+}
+.v4-rsh-empty p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--v4-ink-500);
+  max-width: 480px;
+  line-height: 1.5;
+}
+.v4-rsh-empty .v4-btn { margin-top: 8px; }
+
+/* ────────────────────────────────────────
    RESPONSIVE
    ──────────────────────────────────────── */
 @media (max-width: 1100px) {


### PR DESCRIPTION
## Summary
- Migrate Research/Discovery tab from bento-panel + inline accordion to V4 design system
- 6 new components (~850 LOC) in `src/components/v4/research/` + ~390 lines of CSS
- `useResearch` and `useResearchAgent` hooks reused unchanged
- `StartResearchModal` (~100 LOC) reused as-is

## UX changes vs legacy
- **Hero card** with pool-health: danger if pipeline offline, warn if no project has research yet, ok otherwise. Shows portfolio totals (competitors / pain points / ideas / quick wins) inline.
- **KPI strip**: total / с research / с discovery / конкуренты / идей / quick wins
- **Search** by repo name (was none)
- **Filter pills**: Все / С research / С discovery / Quick wins / Без данных (localStorage-persisted)
- **Agent banner** now V4-styled with pulsing warn dot during run; ok/danger end states
- **Project cards** reorganised — header shows research/discovery presence as colored tags + inline action buttons; expanded body splits into collapsible sections (competitor matrix, pain points, opportunities, discovery groups with effort+impact tags)
- **Empty state** redesigned with proper CTA and V4 styling

## Test plan
- [x] `npx tsc --noEmit` — green
- [x] `npm run lint` — green
- [x] `npm run build` — green
- [x] Verified empty state in preview (hero + KPI strip + filter pills + empty CTA all render correctly when no GitHub data is loaded)
- [ ] Manual: connect GitHub token, expand a project with RESEARCH.md/DISCOVERY.md, verify competitor matrix + sections render

🤖 Generated with [Claude Code](https://claude.com/claude-code)