### PR TITLE
feat(specs): redesign Specs tab in V4 design system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { AuditView } from "./components/v4/audit/AuditView";
 import { PipelineView } from "./components/v4/pipeline/PipelineView";
 import { TranscriptsView } from "./components/v4/transcripts/TranscriptsView";
 import { ResearchView } from "./components/v4/research/ResearchView";
-import { SpecsTab } from "./components/SpecsTab";
+import { SpecsView } from "./components/v4/specs/SpecsView";
 import { QualityView } from "./components/v4/quality/QualityView";
 import { DebateView } from "./components/v4/debate/DebateView";
 import { Sidebar } from "./components/v4/Sidebar";
@@ -266,13 +266,11 @@ function AppInner() {
             </ErrorBoundary>
           )}
         </div>
-        <div className="v4-legacy-frame" style={{ display: tab === "specs" ? undefined : "none" }}>
+        <div style={{ display: tab === "specs" ? undefined : "none" }}>
           {visitedTabs.has("specs") && (
-            <div className="bento-grid">
-              <ErrorBoundary fallback="Ошибка вкладки Specs">
-                <SpecsTab />
-              </ErrorBoundary>
-            </div>
+            <ErrorBoundary fallback="Ошибка вкладки Specs">
+              <SpecsView />
+            </ErrorBoundary>
           )}
         </div>
         <div style={{ display: tab === "quality" ? undefined : "none" }}>

--- a/src/components/v4/specs/EpicPanel.tsx
+++ b/src/components/v4/specs/EpicPanel.tsx
@@ -1,6 +1,12 @@
 import { useState } from "react";
 import type { EpicData } from "../../../types";
-import { priorityTagClass, sizeTagClass, stripEpicPrefix } from "./utils";
+import {
+  pluralRu,
+  priorityTagClass,
+  sizeTagClass,
+  stripEpicPrefix,
+  TASK_FORMS,
+} from "./utils";
 
 interface Props {
   epic: EpicData;
@@ -25,7 +31,7 @@ export function EpicPanel({ epic }: Props) {
         <span className="v4-spc-epic-meta">
           {taskCount > 0 && (
             <span className="v4-spc-epic-stat">
-              {taskCount} {taskCount === 1 ? "задача" : "задач"}
+              {taskCount} {pluralRu(taskCount, TASK_FORMS)}
             </span>
           )}
           {epic.deadline && (

--- a/src/components/v4/specs/EpicPanel.tsx
+++ b/src/components/v4/specs/EpicPanel.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import type { EpicData } from "../../../types";
+import { priorityTagClass, sizeTagClass, stripEpicPrefix } from "./utils";
+
+interface Props {
+  epic: EpicData;
+}
+
+/** Single epic with collapsible task table. */
+export function EpicPanel({ epic }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const cleanTitle = stripEpicPrefix(epic.title);
+  const taskCount = epic.tasks.length;
+
+  return (
+    <div className={`v4-spc-epic ${expanded ? "is-expanded" : ""}`}>
+      <button
+        type="button"
+        className="v4-spc-epic-header"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        <span className="v4-spc-epic-id v4-pl-mono">{epic.id}</span>
+        <span className="v4-spc-epic-title">{cleanTitle}</span>
+        <span className="v4-spc-epic-meta">
+          {taskCount > 0 && (
+            <span className="v4-spc-epic-stat">
+              {taskCount} {taskCount === 1 ? "задача" : "задач"}
+            </span>
+          )}
+          {epic.deadline && (
+            <span className="v4-spc-epic-stat" title="Дедлайн">
+              {epic.deadline}
+            </span>
+          )}
+          {epic.priority && (
+            <span className={priorityTagClass(epic.priority)}>{epic.priority}</span>
+          )}
+        </span>
+        <span className="v4-spc-chevron" aria-hidden="true">
+          {expanded ? "▾" : "▸"}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="v4-spc-epic-body">
+          {epic.overview && <p className="v4-spc-epic-overview">{epic.overview}</p>}
+
+          {taskCount > 0 ? (
+            <div className="v4-spc-table-wrap">
+              <table className="v4-spc-table">
+                <thead>
+                  <tr>
+                    <th className="v4-spc-th-num">#</th>
+                    <th>Задача</th>
+                    <th className="v4-spc-th-size">Размер</th>
+                    <th>Зависимости</th>
+                    <th>Repo</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {epic.tasks.map((task) => (
+                    <tr key={task.number}>
+                      <td className="v4-spc-td-num v4-pl-mono">#{task.number}</td>
+                      <td className="v4-spc-td-title">{task.title}</td>
+                      <td>
+                        {task.size ? (
+                          <span className={sizeTagClass(task.size)}>{task.size}</span>
+                        ) : (
+                          <span className="v4-spc-text-muted">—</span>
+                        )}
+                      </td>
+                      <td className="v4-spc-td-deps">
+                        {task.dependencies ? (
+                          <span className="v4-pl-mono">{task.dependencies}</span>
+                        ) : (
+                          <span className="v4-spc-text-muted">—</span>
+                        )}
+                      </td>
+                      <td className="v4-spc-td-repo">
+                        {task.repo ? (
+                          <span className="v4-pl-mono">{task.repo}</span>
+                        ) : (
+                          <span className="v4-spc-text-muted">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="v4-spc-empty-inline">Задачи ещё не описаны</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/specs/PipelineFlow.tsx
+++ b/src/components/v4/specs/PipelineFlow.tsx
@@ -1,0 +1,32 @@
+import type { SpecsProject } from "../../../types";
+
+interface Props {
+  project: SpecsProject;
+}
+
+/** Visual PRD → Epic → Tasks → Dev → Done flow inside a project card. */
+export function PipelineFlow({ project }: Props) {
+  const { epics, totalTasks, computedStatus } = project;
+
+  const stages = [
+    { key: "prd", label: "PRD", active: true },
+    { key: "epic", label: "Epic", active: epics.length > 0 },
+    { key: "tasks", label: `Tasks (${totalTasks})`, active: totalTasks > 0 },
+    { key: "dev", label: "Dev", active: computedStatus === "in_development" || computedStatus === "completed" },
+    { key: "done", label: "Done", active: computedStatus === "completed" },
+  ];
+
+  return (
+    <div className="v4-spc-flow" role="list" aria-label="Этапы пайплайна">
+      {stages.map((s, i) => (
+        <div key={s.key} className="v4-spc-flow-step" role="listitem">
+          <div className={`v4-spc-flow-dot ${s.active ? "is-active" : ""}`} aria-hidden="true" />
+          <span className={`v4-spc-flow-label ${s.active ? "" : "is-inactive"}`}>{s.label}</span>
+          {i < stages.length - 1 && (
+            <div className={`v4-spc-flow-line ${s.active ? "is-active" : ""}`} aria-hidden="true" />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/v4/specs/SpecCardV4.tsx
+++ b/src/components/v4/specs/SpecCardV4.tsx
@@ -3,11 +3,13 @@ import type { SpecsProject } from "../../../types";
 import { EpicPanel } from "./EpicPanel";
 import { PipelineFlow } from "./PipelineFlow";
 import {
+  pluralRu,
   priorityTagClass,
   STATUS_HEALTH,
   STATUS_LABEL,
   statusTagClass,
   stripPrdPrefix,
+  TASK_FORMS,
 } from "./utils";
 
 interface Props {
@@ -46,7 +48,7 @@ function SpecCardV4Inner({ project, initialExpanded = false }: Props) {
             {epics.length} {epics.length === 1 ? "epic" : "epics"}
           </span>
           <span className="v4-spc-card-stat">
-            {totalTasks} {totalTasks === 1 ? "задача" : "задач"}
+            {totalTasks} {pluralRu(totalTasks, TASK_FORMS)}
           </span>
           <button
             type="button"

--- a/src/components/v4/specs/SpecCardV4.tsx
+++ b/src/components/v4/specs/SpecCardV4.tsx
@@ -1,0 +1,103 @@
+import { memo, useState } from "react";
+import type { SpecsProject } from "../../../types";
+import { EpicPanel } from "./EpicPanel";
+import { PipelineFlow } from "./PipelineFlow";
+import {
+  priorityTagClass,
+  STATUS_HEALTH,
+  STATUS_LABEL,
+  statusTagClass,
+  stripPrdPrefix,
+} from "./utils";
+
+interface Props {
+  project: SpecsProject;
+  /** Optional initial expanded state — used by parent to expand the first card. */
+  initialExpanded?: boolean;
+}
+
+/**
+ * V4 PRD card. Header is always visible (id, title, status, priority, counts).
+ * Body (PipelineFlow + epics) collapsed by default; chevron toggles open.
+ *
+ * Accessibility: chevron is the only interactive element in the header so
+ * we never nest a button inside a clickable parent (WCAG 4.1.1).
+ */
+function SpecCardV4Inner({ project, initialExpanded = false }: Props) {
+  const [expanded, setExpanded] = useState(initialExpanded);
+
+  const { prd, epics, computedStatus, totalTasks } = project;
+  const cleanTitle = stripPrdPrefix(prd.title);
+  const health = STATUS_HEALTH[computedStatus];
+
+  return (
+    <article className={`v4-spc-card v4-spc-card--${health} ${expanded ? "is-expanded" : ""}`}>
+      <div className="v4-spc-card-head">
+        <div className="v4-spc-card-id-block">
+          <span className="v4-spc-card-id v4-pl-mono">{prd.id}</span>
+          <h3 className="v4-spc-card-title">{cleanTitle}</h3>
+        </div>
+        <div className="v4-spc-card-meta">
+          <span className={statusTagClass(computedStatus)}>{STATUS_LABEL[computedStatus]}</span>
+          {prd.priority && (
+            <span className={priorityTagClass(prd.priority)}>{prd.priority}</span>
+          )}
+          <span className="v4-spc-card-stat">
+            {epics.length} {epics.length === 1 ? "epic" : "epics"}
+          </span>
+          <span className="v4-spc-card-stat">
+            {totalTasks} {totalTasks === 1 ? "задача" : "задач"}
+          </span>
+          <button
+            type="button"
+            className="v4-spc-card-toggle"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+            aria-label={expanded ? "Свернуть детали PRD" : "Развернуть детали PRD"}
+          >
+            <span aria-hidden="true">{expanded ? "▾" : "▸"}</span>
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="v4-spc-card-body">
+          <PipelineFlow project={project} />
+
+          {(prd.author || prd.date || prd.status) && (
+            <div className="v4-spc-prd-meta">
+              {prd.author && (
+                <span>
+                  <span className="v4-spc-text-muted">Автор:</span> {prd.author}
+                </span>
+              )}
+              {prd.date && (
+                <span>
+                  <span className="v4-spc-text-muted">Дата:</span> {prd.date}
+                </span>
+              )}
+              {prd.status && (
+                <span>
+                  <span className="v4-spc-text-muted">PRD статус:</span>{" "}
+                  <span className="v4-pl-mono">{prd.status}</span>
+                </span>
+              )}
+            </div>
+          )}
+
+          {epics.length > 0 ? (
+            <div className="v4-spc-epics">
+              {epics.map((e) => (
+                <EpicPanel key={e.id} epic={e} />
+              ))}
+            </div>
+          ) : (
+            <div className="v4-spc-empty-inline">Нет связанных эпиков</div>
+          )}
+        </div>
+      )}
+    </article>
+  );
+}
+
+export const SpecCardV4 = memo(SpecCardV4Inner);

--- a/src/components/v4/specs/SpecsHero.tsx
+++ b/src/components/v4/specs/SpecsHero.tsx
@@ -1,5 +1,5 @@
 import type { SpecsProject } from "../../../types";
-import { totals } from "./utils";
+import { pluralRu, SPEC_FORMS, SPEC_READY_FORMS, TASK_FORMS, totals } from "./utils";
 
 interface Props {
   projects: SpecsProject[];
@@ -23,10 +23,10 @@ export function SpecsHero({ projects, loading, error, onRefresh }: Props) {
     : t.prds === 0
       ? "Specs Tracking"
       : t.inDevelopment > 0
-        ? `${t.inDevelopment} ${t.inDevelopment === 1 ? "PRD" : "PRD"} в разработке`
+        ? `${t.inDevelopment} PRD в разработке`
         : t.specReady > 0
-          ? `${t.specReady} ${t.specReady === 1 ? "спека готова" : "спек готовы"} к запуску`
-          : `${t.prds} ${t.prds === 1 ? "спецификация" : "спецификаций"}`;
+          ? `${t.specReady} ${pluralRu(t.specReady, SPEC_READY_FORMS)} к запуску`
+          : `${t.prds} ${pluralRu(t.prds, SPEC_FORMS)}`;
 
   return (
     <div className={`v4-rsh-hero v4-rsh-hero--${health}`}>
@@ -45,7 +45,7 @@ export function SpecsHero({ projects, loading, error, onRefresh }: Props) {
                 <span className="v4-rsh-sep">·</span>
                 <b>{t.epics}</b> {t.epics === 1 ? "epic" : "epics"}
                 <span className="v4-rsh-sep">·</span>
-                <b>{t.tasks}</b> {t.tasks === 1 ? "задача" : "задач"}
+                <b>{t.tasks}</b> {pluralRu(t.tasks, TASK_FORMS)}
                 {t.completed > 0 && (
                   <>
                     <span className="v4-rsh-sep">·</span>

--- a/src/components/v4/specs/SpecsHero.tsx
+++ b/src/components/v4/specs/SpecsHero.tsx
@@ -1,0 +1,71 @@
+import type { SpecsProject } from "../../../types";
+import { totals } from "./utils";
+
+interface Props {
+  projects: SpecsProject[];
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}
+
+export function SpecsHero({ projects, loading, error, onRefresh }: Props) {
+  const t = totals(projects);
+
+  const health: "ok" | "warn" | "danger" | "unknown" =
+    error ? "danger"
+    : t.prds === 0 ? "unknown"
+    : t.inDevelopment > 0 ? "ok"
+    : t.specReady > 0 ? "warn"
+    : "unknown";
+
+  const title = error
+    ? "Ошибка загрузки спецификаций"
+    : t.prds === 0
+      ? "Specs Tracking"
+      : t.inDevelopment > 0
+        ? `${t.inDevelopment} ${t.inDevelopment === 1 ? "PRD" : "PRD"} в разработке`
+        : t.specReady > 0
+          ? `${t.specReady} ${t.specReady === 1 ? "спека готова" : "спек готовы"} к запуску`
+          : `${t.prds} ${t.prds === 1 ? "спецификация" : "спецификаций"}`;
+
+  return (
+    <div className={`v4-rsh-hero v4-rsh-hero--${health}`}>
+      <div className="v4-rsh-hero-status">
+        <span className={`v4-rsh-hero-dot v4-rsh-hero-dot--${health}`} aria-hidden="true" />
+        <div>
+          <div className="v4-rsh-hero-title">{title}</div>
+          <div className="v4-rsh-hero-sub">
+            {error ? (
+              <>{error}</>
+            ) : t.prds === 0 ? (
+              <>PRD → Epic → Tasks из <span className="v4-pl-mono">makeit-pipeline</span>. Запустите <span className="v4-pl-mono">makeit-plan</span> для генерации спецификаций.</>
+            ) : (
+              <>
+                <b>{t.prds}</b> PRD
+                <span className="v4-rsh-sep">·</span>
+                <b>{t.epics}</b> {t.epics === 1 ? "epic" : "epics"}
+                <span className="v4-rsh-sep">·</span>
+                <b>{t.tasks}</b> {t.tasks === 1 ? "задача" : "задач"}
+                {t.completed > 0 && (
+                  <>
+                    <span className="v4-rsh-sep">·</span>
+                    <b className="v4-rsh-text-success">{t.completed}</b> завершено
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="v4-rsh-hero-actions">
+        <button type="button" className="v4-btn" onClick={onRefresh} disabled={loading}>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M21 12a9 9 0 11-6.22-8.56" />
+            <path d="M21 3v6h-6" />
+          </svg>
+          {loading ? "Загрузка…" : "Обновить"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/specs/SpecsKpiStrip.tsx
+++ b/src/components/v4/specs/SpecsKpiStrip.tsx
@@ -1,0 +1,60 @@
+import type { SpecsProject } from "../../../types";
+import { totals } from "./utils";
+
+interface Props {
+  projects: SpecsProject[];
+}
+
+export function SpecsKpiStrip({ projects }: Props) {
+  const t = totals(projects);
+
+  return (
+    <div className="v4-projects-toolbar v4-pl-kpi-strip">
+      <div className="v4-projects-agg">
+        <div className="v4-projects-agg-cell" title="Всего PRD в портфеле">
+          <div className="v4-projects-agg-n num">{t.prds}</div>
+          <div className="v4-projects-agg-l">PRD</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="PRD в активной разработке">
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: t.inDevelopment > 0 ? "var(--v4-success-700)" : undefined }}
+          >
+            {t.inDevelopment}
+          </div>
+          <div className="v4-projects-agg-l">в разработке</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Спека готова, можно запускать">
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: t.specReady > 0 ? "var(--v4-warn-600)" : undefined }}
+          >
+            {t.specReady}
+          </div>
+          <div className="v4-projects-agg-l">готовы</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Черновики PRD без эпиков">
+          <div className="v4-projects-agg-n num">{t.draft}</div>
+          <div className="v4-projects-agg-l">черновики</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Завершённые проекты">
+          <div
+            className="v4-projects-agg-n num"
+            style={{ color: t.completed > 0 ? "var(--v4-success-700)" : undefined }}
+          >
+            {t.completed}
+          </div>
+          <div className="v4-projects-agg-l">завершено</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Всего epic'ов">
+          <div className="v4-projects-agg-n num">{t.epics}</div>
+          <div className="v4-projects-agg-l">epics</div>
+        </div>
+        <div className="v4-projects-agg-cell" title="Всего задач во всех эпиках">
+          <div className="v4-projects-agg-n num">{t.tasks}</div>
+          <div className="v4-projects-agg-l">задач</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/specs/SpecsView.tsx
+++ b/src/components/v4/specs/SpecsView.tsx
@@ -64,8 +64,7 @@ export function SpecsView() {
           <h1>Specs</h1>
           <div className="v4-sub">
             PRD → Epic → Tasks из <span className="v4-pl-mono">makeit-pipeline</span> ·{" "}
-            <span className="v4-pl-mono">{projects.length}</span>{" "}
-            {projects.length === 1 ? "PRD" : "PRD"}
+            <span className="v4-pl-mono">{projects.length}</span> PRD
           </div>
         </div>
       </div>

--- a/src/components/v4/specs/SpecsView.tsx
+++ b/src/components/v4/specs/SpecsView.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useSpecs } from "../../../hooks/useSpecs";
+import { SpecsHero } from "./SpecsHero";
+import { SpecsKpiStrip } from "./SpecsKpiStrip";
+import { SpecCardV4 } from "./SpecCardV4";
+import {
+  applyFilter,
+  applySearch,
+  SPEC_FILTERS,
+  type SpecFilter,
+} from "./utils";
+
+const STORAGE_FILTER = "v4spc:filter";
+
+function readFilter(): SpecFilter {
+  try {
+    const v = localStorage.getItem(STORAGE_FILTER);
+    if (
+      v === "all" ||
+      v === "in_development" ||
+      v === "spec_ready" ||
+      v === "draft" ||
+      v === "completed"
+    ) {
+      return v;
+    }
+  } catch {
+    /* ignore */
+  }
+  return "all";
+}
+
+export function SpecsView() {
+  const { projects, loading, error, refresh } = useSpecs();
+  const loadedRef = useRef(false);
+
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<SpecFilter>(() => readFilter());
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_FILTER, filter);
+    } catch {
+      /* ignore */
+    }
+  }, [filter]);
+
+  useEffect(() => {
+    if (!loadedRef.current) {
+      loadedRef.current = true;
+      refresh();
+    }
+  }, [refresh]);
+
+  const visible = useMemo(
+    () => applySearch(applyFilter(projects, filter), search),
+    [projects, filter, search],
+  );
+
+  return (
+    <div className="v4-content">
+      <div className="v4-ph">
+        <div>
+          <h1>Specs</h1>
+          <div className="v4-sub">
+            PRD → Epic → Tasks из <span className="v4-pl-mono">makeit-pipeline</span> ·{" "}
+            <span className="v4-pl-mono">{projects.length}</span>{" "}
+            {projects.length === 1 ? "PRD" : "PRD"}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ height: 10 }} />
+
+      <SpecsHero
+        projects={projects}
+        loading={loading}
+        error={error}
+        onRefresh={refresh}
+      />
+
+      <SpecsKpiStrip projects={projects} />
+
+      <div className="v4-au-toolbar">
+        <div className="v4-mon-search">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            type="search"
+            aria-label="Поиск по PRD или эпику"
+            placeholder="Поиск по PRD или эпику…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="v4-pillgrp">
+          {SPEC_FILTERS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              className={filter === key ? "is-active" : ""}
+              onClick={() => setFilter(key)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading && projects.length === 0 ? (
+        <div className="v4-empty" style={{ marginTop: 14 }}>
+          Загрузка спецификаций…
+        </div>
+      ) : visible.length === 0 && projects.length === 0 ? (
+        <div className="v4-panel">
+          <div className="v4-spc-empty">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+              <polyline points="14 2 14 8 20 8" />
+              <line x1="16" y1="13" x2="8" y2="13" />
+              <line x1="16" y1="17" x2="8" y2="17" />
+              <polyline points="10 9 9 9 8 9" />
+            </svg>
+            <h3>Specs Tracking</h3>
+            <p>
+              Отслеживание спецификаций от PRD до задач. Используйте{" "}
+              <span className="v4-pl-mono">makeit-plan</span> в{" "}
+              <span className="v4-pl-mono">makeit-pipeline</span>, чтобы сгенерировать PRD,
+              Epic и Tasks из описания фичи.
+            </p>
+            <div className="v4-spc-empty-cmd">
+              <code>makeit-plan "описание фичи"</code>
+            </div>
+            <button type="button" className="v4-btn v4-btn--pri" onClick={refresh} disabled={loading}>
+              {loading ? "Загрузка…" : "Загрузить спецификации"}
+            </button>
+          </div>
+        </div>
+      ) : visible.length === 0 ? (
+        <div className="v4-panel">
+          <div className="v4-empty">
+            По текущим фильтрам ничего не найдено
+            {search && (
+              <>
+                {" "}для запроса <span className="v4-pl-mono">«{search}»</span>
+              </>
+            )}
+            .
+          </div>
+        </div>
+      ) : (
+        <>
+          {loading && projects.length > 0 && (
+            <div className="v4-rsh-refresh-hint v4-pl-mono v4-rsh-text-muted" role="status">
+              Обновление…
+            </div>
+          )}
+          <div className="v4-spc-list">
+            {visible.map((p, i) => (
+              <SpecCardV4
+                key={p.prd.id}
+                project={p}
+                initialExpanded={i === 0 && p.computedStatus === "in_development"}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/specs/utils.ts
+++ b/src/components/v4/specs/utils.ts
@@ -1,0 +1,112 @@
+import type { SpecsProject, SpecStatus } from "../../../types";
+
+export const STATUS_LABEL: Record<SpecStatus, string> = {
+  draft: "Черновик",
+  spec_ready: "Спека готова",
+  in_development: "В разработке",
+  completed: "Завершено",
+};
+
+/** Health/colour bucket for a single PRD status. */
+export const STATUS_HEALTH: Record<SpecStatus, "ok" | "warn" | "danger" | "unknown"> = {
+  draft: "warn",
+  spec_ready: "unknown",
+  in_development: "ok",
+  completed: "ok",
+};
+
+/** v4-tag class for status badge. */
+export function statusTagClass(s: SpecStatus): string {
+  if (s === "in_development") return "v4-tag v4-tag--ok";
+  if (s === "completed") return "v4-tag v4-tag--ok";
+  if (s === "spec_ready") return "v4-tag";
+  return "v4-tag v4-tag--warn"; // draft
+}
+
+/** v4-tag class for priority badge. Recognises P1-critical / P2-high / P3-medium. */
+export function priorityTagClass(priority: string): string {
+  const p = priority.toLowerCase();
+  if (p.includes("p1") || p.includes("critical")) return "v4-tag v4-tag--danger";
+  if (p.includes("p2") || p.includes("high")) return "v4-tag v4-tag--warn";
+  if (p.includes("p3") || p.includes("medium")) return "v4-tag";
+  return "v4-tag";
+}
+
+/** v4-tag class for task size (S / M / L / XL). */
+export function sizeTagClass(size: string): string {
+  if (size === "S") return "v4-tag v4-tag--ok";
+  if (size === "M") return "v4-tag";
+  if (size === "L") return "v4-tag v4-tag--warn";
+  if (size === "XL") return "v4-tag v4-tag--danger";
+  return "v4-tag";
+}
+
+export type SpecFilter = "all" | "in_development" | "spec_ready" | "draft" | "completed";
+
+export const SPEC_FILTERS: Array<{ key: SpecFilter; label: string }> = [
+  { key: "all", label: "Все" },
+  { key: "in_development", label: "В разработке" },
+  { key: "spec_ready", label: "Спека готова" },
+  { key: "draft", label: "Черновики" },
+  { key: "completed", label: "Завершено" },
+];
+
+export function applyFilter(items: SpecsProject[], f: SpecFilter): SpecsProject[] {
+  if (f === "all") return items;
+  return items.filter((p) => p.computedStatus === f);
+}
+
+export function applySearch(items: SpecsProject[], q: string): SpecsProject[] {
+  const needle = q.trim().toLowerCase();
+  if (!needle) return items;
+  return items.filter((p) => {
+    const title = p.prd.title.toLowerCase();
+    const id = p.prd.id.toLowerCase();
+    if (title.includes(needle) || id.includes(needle)) return true;
+    // Search in epic titles too
+    return p.epics.some(
+      (e) => e.title.toLowerCase().includes(needle) || e.id.toLowerCase().includes(needle),
+    );
+  });
+}
+
+export interface SpecsTotals {
+  prds: number;
+  inDevelopment: number;
+  specReady: number;
+  draft: number;
+  completed: number;
+  epics: number;
+  tasks: number;
+}
+
+export function totals(items: SpecsProject[]): SpecsTotals {
+  const t: SpecsTotals = {
+    prds: items.length,
+    inDevelopment: 0,
+    specReady: 0,
+    draft: 0,
+    completed: 0,
+    epics: 0,
+    tasks: 0,
+  };
+  for (const p of items) {
+    if (p.computedStatus === "in_development") t.inDevelopment++;
+    else if (p.computedStatus === "spec_ready") t.specReady++;
+    else if (p.computedStatus === "draft") t.draft++;
+    else if (p.computedStatus === "completed") t.completed++;
+    t.epics += p.epics.length;
+    t.tasks += p.totalTasks;
+  }
+  return t;
+}
+
+/** Strip "PRD-NNN: " prefix from title. */
+export function stripPrdPrefix(title: string): string {
+  return title.replace(/^PRD-\d+:\s*/i, "");
+}
+
+/** Strip "Epic-NNN: " prefix from title. */
+export function stripEpicPrefix(title: string): string {
+  return title.replace(/^Epic-\d+:\s*/i, "");
+}

--- a/src/components/v4/specs/utils.ts
+++ b/src/components/v4/specs/utils.ts
@@ -110,3 +110,36 @@ export function stripPrdPrefix(title: string): string {
 export function stripEpicPrefix(title: string): string {
   return title.replace(/^Epic-\d+:\s*/i, "");
 }
+
+/**
+ * Russian noun pluralization.
+ *   forms = [one, few (2-4), many (0, 5+, 11-14)]
+ *
+ * Examples:
+ *   pluralRu(1,  ["задача", "задачи", "задач"]) → "задача"
+ *   pluralRu(3,  ["задача", "задачи", "задач"]) → "задачи"
+ *   pluralRu(5,  ["задача", "задачи", "задач"]) → "задач"
+ *   pluralRu(11, ["задача", "задачи", "задач"]) → "задач"   // 11-14 are "many"
+ *   pluralRu(21, ["задача", "задачи", "задач"]) → "задача"  // ends in 1, not 11
+ */
+export function pluralRu(n: number, forms: [string, string, string]): string {
+  const abs = Math.abs(n);
+  const mod100 = abs % 100;
+  if (mod100 >= 11 && mod100 <= 14) return forms[2];
+  const mod10 = abs % 10;
+  if (mod10 === 1) return forms[0];
+  if (mod10 >= 2 && mod10 <= 4) return forms[1];
+  return forms[2];
+}
+
+export const TASK_FORMS: [string, string, string] = ["задача", "задачи", "задач"];
+export const SPEC_FORMS: [string, string, string] = [
+  "спецификация",
+  "спецификации",
+  "спецификаций",
+];
+export const SPEC_READY_FORMS: [string, string, string] = [
+  "спека готова",
+  "спеки готовы",
+  "спек готово",
+];

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -5460,6 +5460,343 @@ ul.v4-rsh-list {
 .v4-rsh-empty .v4-btn { margin-top: 8px; }
 
 /* ────────────────────────────────────────
+   SPECS — PRD → Epic → Tasks
+   ──────────────────────────────────────── */
+.v4-spc-text-muted { color: var(--v4-ink-500); }
+
+.v4-spc-list { display: flex; flex-direction: column; gap: 10px; }
+
+/* — PRD card — */
+.v4-spc-card {
+  background: var(--v4-card);
+  border: 1px solid var(--v4-line);
+  border-radius: 14px;
+  padding: 14px 18px;
+  transition: border-color 150ms, box-shadow 150ms;
+}
+.v4-spc-card--ok { border-left: 3px solid var(--v4-success-500); }
+.v4-spc-card--warn { border-left: 3px solid var(--v4-warn-500); }
+.v4-spc-card--unknown { border-left: 3px solid var(--v4-line); }
+.v4-spc-card--danger { border-left: 3px solid var(--v4-danger-500); }
+.v4-spc-card.is-expanded {
+  border-color: var(--v4-accent-500);
+  box-shadow: 0 2px 6px rgba(11, 16, 32, 0.05);
+}
+
+.v4-spc-card-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+}
+.v4-spc-card-id-block {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.v4-spc-card-id {
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.v4-spc-card-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.v4-spc-card-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.v4-spc-card-stat {
+  font-size: 12px;
+  color: var(--v4-ink-600);
+  white-space: nowrap;
+}
+.v4-spc-card-toggle {
+  background: transparent;
+  border: 1px solid var(--v4-line);
+  border-radius: 8px;
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--v4-ink-700);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 120ms, border-color 120ms;
+}
+.v4-spc-card-toggle:hover {
+  background: var(--v4-soft);
+  border-color: var(--v4-accent-500);
+  color: var(--v4-accent-500);
+}
+.v4-spc-card-toggle:focus-visible {
+  outline: 2px solid var(--v4-accent-500);
+  outline-offset: 2px;
+}
+
+.v4-spc-card-body {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--v4-line);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* — Pipeline flow visualization — */
+.v4-spc-flow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 4px;
+  padding: 4px 0;
+}
+.v4-spc-flow-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.v4-spc-flow-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--v4-line);
+  flex-shrink: 0;
+  transition: background 200ms, box-shadow 200ms;
+}
+.v4-spc-flow-dot.is-active {
+  background: var(--v4-success-500);
+  box-shadow: 0 0 0 3px var(--v4-success-50);
+}
+.v4-spc-flow-label {
+  font-size: 12px;
+  color: var(--v4-ink-800);
+  white-space: nowrap;
+}
+.v4-spc-flow-label.is-inactive { color: var(--v4-ink-400); }
+.v4-spc-flow-line {
+  width: 28px;
+  height: 2px;
+  background: var(--v4-line);
+  margin: 0 2px;
+}
+.v4-spc-flow-line.is-active { background: var(--v4-success-300, var(--v4-success-500)); }
+
+/* — PRD meta block — */
+.v4-spc-prd-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 16px;
+  font-size: 12px;
+  color: var(--v4-ink-700);
+}
+
+/* — Epic list — */
+.v4-spc-epics {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.v4-spc-epic {
+  border: 1px solid var(--v4-line);
+  border-radius: 10px;
+  background: var(--v4-soft);
+  overflow: hidden;
+}
+.v4-spc-epic.is-expanded {
+  background: var(--v4-card);
+  border-color: var(--v4-accent-500);
+}
+
+.v4-spc-epic-header {
+  width: 100%;
+  background: transparent;
+  border: 0;
+  padding: 10px 14px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  gap: 12px;
+  align-items: center;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  transition: background 120ms;
+}
+.v4-spc-epic-header:hover { background: rgba(0, 0, 0, 0.02); }
+.v4-spc-epic-header:focus-visible {
+  outline: 2px solid var(--v4-accent-500);
+  outline-offset: -2px;
+}
+.v4-spc-epic-id {
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+.v4-spc-epic-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--v4-ink-900);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.v4-spc-epic-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.v4-spc-epic-stat {
+  font-size: 11px;
+  color: var(--v4-ink-600);
+  white-space: nowrap;
+}
+.v4-spc-chevron {
+  color: var(--v4-ink-500);
+  font-size: 12px;
+  width: 16px;
+  text-align: center;
+}
+
+.v4-spc-epic-body {
+  padding: 4px 14px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.v4-spc-epic-overview {
+  margin: 0;
+  font-size: 13px;
+  color: var(--v4-ink-700);
+  line-height: 1.5;
+}
+
+/* — Tasks table — */
+.v4-spc-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--v4-line);
+  border-radius: 8px;
+}
+.v4-spc-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.v4-spc-table thead {
+  background: var(--v4-soft);
+}
+.v4-spc-table th {
+  padding: 8px 12px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--v4-ink-600);
+  border-bottom: 1px solid var(--v4-line);
+}
+.v4-spc-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--v4-line);
+  color: var(--v4-ink-800);
+  vertical-align: top;
+}
+.v4-spc-table tr:last-child td { border-bottom: 0; }
+.v4-spc-th-num,
+.v4-spc-td-num { width: 60px; white-space: nowrap; color: var(--v4-ink-500); }
+.v4-spc-th-size { width: 80px; }
+.v4-spc-td-title { font-weight: 500; color: var(--v4-ink-900); }
+.v4-spc-td-deps,
+.v4-spc-td-repo { font-size: 11px; }
+
+/* — Inline empty hint — */
+.v4-spc-empty-inline {
+  padding: 12px;
+  font-size: 12px;
+  color: var(--v4-ink-500);
+  text-align: center;
+  background: var(--v4-soft);
+  border-radius: 8px;
+}
+
+/* — Empty state (no specs at all) — */
+.v4-spc-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 36px 24px;
+  gap: 14px;
+}
+.v4-spc-empty svg {
+  width: 56px;
+  height: 56px;
+  color: var(--v4-ink-400);
+}
+.v4-spc-empty h3 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--v4-ink-900);
+}
+.v4-spc-empty p {
+  margin: 0;
+  max-width: 480px;
+  color: var(--v4-ink-700);
+  line-height: 1.5;
+}
+.v4-spc-empty-cmd {
+  background: var(--v4-soft);
+  border: 1px solid var(--v4-line);
+  padding: 8px 14px;
+  border-radius: 8px;
+}
+.v4-spc-empty-cmd code {
+  font-family: var(--v4-font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 13px;
+  color: var(--v4-accent-500);
+}
+
+@media (max-width: 700px) {
+  .v4-spc-card-head {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+  .v4-spc-card-meta { justify-content: flex-start; }
+  .v4-spc-epic-header {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-rows: auto auto;
+    gap: 6px 12px;
+  }
+  .v4-spc-epic-meta {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+  }
+  .v4-spc-chevron {
+    grid-row: 1;
+    grid-column: 3;
+  }
+  .v4-spc-epic-title { white-space: normal; }
+}
+
+/* ────────────────────────────────────────
    RESPONSIVE
    ──────────────────────────────────────── */
 @media (max-width: 1100px) {


### PR DESCRIPTION
## Summary

- Заменил легаси-bento `SpecsTab` (PRD → Epic → Tasks из makeit-pipeline) на V4-нативный `SpecsView` — последняя вкладка в серии редизайна.
- Hero с health-классификацией, KPI-стрип на 7 метрик, фильтр-пиллы (Все / В разработке / Спека готова / Черновики / Завершено) и поиск по PRD/эпикам с localStorage (`v4spc:filter`).
- Карточка PRD `SpecCardV4` со сворачиваемым телом, badges (статус / приоритет), счётчиками epics/tasks. Внутри — `PipelineFlow` (PRD → Epic → Tasks → Dev → Done) и сворачиваемые `EpicPanel` с таблицами задач (#, заголовок, размер, зависимости, repo). Размер задачи — v4-tag (S=ok / M=neutral / L=warn / XL=danger).
- Первый PRD в статусе \"in_development\" автоматически разворачивается.
- Hook `useSpecs` и парсер `specs-parser.ts` не тронуты — переписана только презентация.
- ~330 LOC в `v4-spc-*` секции `v4.css` плюс мобильный responsive-блок.
- A11y: нет вложенных interactive-элементов в шапке карточки (chevron — единственная кнопка), `aria-expanded` на тогглах, focus-visible outlines.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean (157ms, 247KB CSS / 758KB JS)
- [x] Preview на desktop: hero-ошибка / KPI / фильтры / empty-state с командой \`makeit-plan\` рендерятся корректно
- [x] Preview на mobile (375px): hero стекируется, KPI-стрип в 3 колонки, пиллы wrap'ятся
- [ ] Проверка с реальными данными (нужен валидный GitHub token + PRD/Epic файлы в makeit-pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)