### PR TITLE
feat(milestones): redesign Milestones tab in V4 design system

### DIFF
--- a/src/components/v4/milestones/MilestoneCardV4.tsx
+++ b/src/components/v4/milestones/MilestoneCardV4.tsx
@@ -2,197 +2,247 @@ import { useState } from "react";
 import type { Milestone } from "../../../types";
 import { daysUntil, formatShortDate } from "../../../utils/date";
 import { classifyMilestone } from "./classifyMilestone";
+import {
+  countBlocked,
+  countByPriority,
+  inferPriority,
+  repoGlyphColor,
+} from "./utils";
 
 interface Props {
   milestone: Milestone;
+  density: "comfortable" | "compact";
 }
 
-const PRIORITY_TAG: Record<string, string> = {
-  P1: "v4-ptag--p1",
-  P2: "v4-ptag--p2",
-  P3: "v4-ptag--p3",
-  P4: "v4-ptag--p4",
+const DESC_LIMIT = 140;
+
+const FILL_BY_CLS: Record<string, string> = {
+  overdue: "v4-mscv-fill--overdue",
+  warn: "v4-mscv-fill--warn",
+  soon: "v4-mscv-fill--soon",
+  norm: "v4-mscv-fill--norm",
+  done: "v4-mscv-fill--done",
+  noeta: "v4-mscv-fill--noeta",
 };
 
-function inferPriority(m: Milestone): string | null {
-  const labels = (m.issues ?? []).flatMap((i) => i.labels);
-  for (const p of ["P1", "P2", "P3", "P4"]) {
-    if (labels.some((l) => l.startsWith(p))) return p;
-  }
-  return null;
-}
-
-function DeadlineBadge({ dueOn, days }: { dueOn: string | null; days: number | null }) {
-  if (!dueOn) return <span className="v4-ms-badge v4-ms-badge--neutral">без дедлайна</span>;
-  if (days === null) return null;
-  if (days < 0) return <span className="v4-ms-badge v4-ms-badge--overdue">просрочен {Math.abs(days)}д</span>;
-  if (days === 0) return <span className="v4-ms-badge v4-ms-badge--warn">сегодня</span>;
-  if (days <= 3) return <span className="v4-ms-badge v4-ms-badge--warn">{days}д осталось</span>;
-  if (days <= 14) return <span className="v4-ms-badge v4-ms-badge--info">{days}д · {formatShortDate(dueOn)}</span>;
-  return <span className="v4-ms-badge v4-ms-badge--neutral">{formatShortDate(dueOn)}</span>;
-}
-
-const DESC_LIMIT = 160;
-
-export function MilestoneCardV4({ milestone }: Props) {
+export function MilestoneCardV4({ milestone, density }: Props) {
   const [expanded, setExpanded] = useState(false);
-  const [descOpen, setDescOpen] = useState(false);
 
   const total = milestone.openIssues + milestone.closedIssues;
-  const progress = total > 0 ? Math.round((milestone.closedIssues / total) * 100) : 0;
+  const pct = total > 0 ? Math.round((milestone.closedIssues / total) * 100) : 0;
+  const left = total - milestone.closedIssues;
   const days = milestone.dueOn ? daysUntil(milestone.dueOn) : null;
   const cls = classifyMilestone(milestone, days);
   const isDone = cls === "done";
 
-  const fillColor =
-    isDone
-      ? "var(--v4-success-500)"
-      : progress >= 70
-      ? "var(--v4-success-500)"
-      : progress >= 30
-      ? "var(--v4-accent-500)"
-      : "var(--v4-warn-500)";
+  const pctClass =
+    pct >= 80
+      ? "v4-mscv-pct--good"
+      : pct >= 40
+      ? ""
+      : pct >= 1
+      ? "v4-mscv-pct--warn"
+      : "v4-mscv-pct--bad";
 
-  const priority = inferPriority(milestone);
+  let dueText: string;
+  if (isDone) dueText = "✓ завершён";
+  else if (days === null) dueText = "без даты";
+  else if (days < 0) dueText = `просрочен ${Math.abs(days)} дн`;
+  else if (days === 0) dueText = "сегодня";
+  else dueText = `${days} дн · ${formatShortDate(milestone.dueOn!)}`;
+
+  const inferred = inferPriority(milestone);
+  const showPTag = !isDone && (inferred === "P1" || inferred === "P2");
+
+  const p1 = countByPriority(milestone, "P1");
+  const p2 = countByPriority(milestone, "P2");
+  const blocked = countBlocked(milestone);
+
+  const chips: { k: string; l: string; cls: string }[] = [];
+  if (!isDone) {
+    if (p1 > 0)
+      chips.push({ k: "p1", l: `P1 · ${p1}`, cls: "v4-mscv-chip--p1" });
+    else if (p2 > 0 && pct < 80)
+      chips.push({ k: "p2", l: `P2 · ${p2}`, cls: "v4-mscv-chip--p2" });
+    if (blocked > 0)
+      chips.push({
+        k: "blocked",
+        l: `Blocked · ${blocked}`,
+        cls: "v4-mscv-chip--blocked",
+      });
+    if (left > 0)
+      chips.push({ k: "open", l: `${left} осталось`, cls: "" });
+  }
+
+  const desc = milestone.description ?? "";
+  const descTrunc =
+    desc.length > DESC_LIMIT ? desc.slice(0, DESC_LIMIT).trimEnd() + "…" : desc;
+
   const sortedIssues = [...(milestone.issues ?? [])].sort((a, b) => {
     if (a.state === b.state) return 0;
     return a.state === "OPEN" ? -1 : 1;
   });
 
-  const desc = milestone.description ?? "";
-  const descTruncated = desc.length > DESC_LIMIT && !descOpen ? desc.slice(0, DESC_LIMIT).trimEnd() + "…" : desc;
-
   return (
-    <div className={`v4-mscard-full v4-mscard-full--${cls}`}>
-      {/* Header */}
-      <div
-        className="v4-mscard-full-h"
+    <article
+      className={`v4-mscv v4-mscv--${cls}${
+        density === "compact" ? " v4-mscv--compact" : ""
+      }`}
+    >
+      <header
+        className="v4-mscv-head"
         role="button"
         tabIndex={0}
         aria-expanded={expanded}
-        aria-label={`Milestone ${milestone.title}, ${milestone.closedIssues} из ${total} задач закрыто. ${expanded ? "Свернуть" : "Раскрыть"} список.`}
-        onClick={() => setExpanded(!expanded)}
+        aria-label={`Milestone ${milestone.title}, ${milestone.closedIssues} из ${total} задач закрыто. ${
+          expanded ? "Свернуть" : "Раскрыть"
+        } список.`}
+        onClick={() => setExpanded((v) => !v)}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
-            setExpanded(!expanded);
+            setExpanded((v) => !v);
           }
         }}
       >
-        <div className="v4-mscard-full-titlerow">
-          <div className="v4-mscard-full-meta">
-            <span className="v4-mscard-full-repo">{milestone.repo}</span>
-            <span className={`v4-mscard-full-arrow ${expanded ? "is-open" : ""}`}>▸</span>
+        <div className="v4-mscv-meta">
+          <div className="v4-mscv-repo">
+            <span
+              className="v4-mscv-repo-glyph"
+              style={{ background: repoGlyphColor(milestone.repo) }}
+            />
+            {milestone.repo}
+            <svg
+              className={`v4-mscv-chev${expanded ? " is-open" : ""}`}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
           </div>
-          <div className="v4-mscard-full-badges">
-            {priority && !isDone && (
-              <span className={`v4-ptag ${PRIORITY_TAG[priority] ?? "v4-ptag--p4"}`}>
-                {priority}
+          <div className="v4-mscv-meta-right">
+            {showPTag && inferred && (
+              <span
+                className={`v4-ptag v4-ptag--${inferred.toLowerCase()}`}
+              >
+                {inferred}
               </span>
             )}
-            {isDone ? (
-              <span className="v4-ms-badge v4-ms-badge--done">done ✓</span>
-            ) : (
-              <DeadlineBadge dueOn={milestone.dueOn} days={days} />
-            )}
+            <span className={`v4-mscv-due v4-mscv-due--${cls}`}>
+              {!isDone && cls !== "noeta" && (
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <circle cx="12" cy="12" r="9" />
+                  <path d="M12 7v5l3 2" />
+                </svg>
+              )}
+              {dueText}
+            </span>
           </div>
         </div>
-        <div className="v4-mscard-full-title">
+
+        <div className="v4-mscv-title">
           <a
             href={milestone.url}
             target="_blank"
             rel="noopener noreferrer"
+            className="v4-mscv-titlelink"
             onClick={(e) => e.stopPropagation()}
-            className="v4-mscard-full-titlelink"
           >
-            {isDone && <span className="v4-mscard-full-check">✓ </span>}
             {milestone.title}
           </a>
         </div>
-        {desc && (
-          <div className="v4-mscard-full-desc">
-            {descTruncated}
-            {desc.length > DESC_LIMIT && (
-              <button
-                type="button"
-                className="v4-linkbtn"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setDescOpen((v) => !v);
-                }}
-              >
-                {descOpen ? "свернуть" : "ещё"}
-              </button>
-            )}
-          </div>
-        )}
-      </div>
 
-      {/* Progress */}
-      <div className="v4-mscard-full-progress">
-        <div className="v4-ptrack v4-mscard-full-track">
+        {density !== "compact" && desc && (
+          <div className="v4-mscv-desc">{descTrunc}</div>
+        )}
+      </header>
+
+      <div className="v4-mscv-bar">
+        <div className="v4-mscv-bar-meta">
+          <div className="v4-mscv-bar-meta-left">
+            <span className="v4-mscv-bar-closed num">
+              {milestone.closedIssues}
+            </span>
+            <span className="v4-mscv-bar-total"> / {total} issues</span>
+          </div>
+          <div className={`v4-mscv-bar-pct num ${pctClass}`}>{pct}%</div>
+        </div>
+        <div className="v4-mscv-track">
           <div
-            className="v4-pfill"
-            style={{ width: `${progress}%`, background: fillColor }}
+            className={`v4-mscv-fill ${FILL_BY_CLS[cls] ?? ""}`}
+            style={{ width: `${pct}%` }}
           />
         </div>
-        <span className="v4-mscard-full-pct num">
-          {milestone.closedIssues}/{total} ({progress}%)
-        </span>
       </div>
 
-      {/* Expanded issue list */}
-      {expanded && sortedIssues.length > 0 && (
-        <div className="v4-mscard-full-issues">
-          {sortedIssues.map((issue) => {
-            const isClosed = issue.state === "CLOSED";
-            return (
-              <div
-                key={issue.number}
-                className={`v4-ms-issue ${isClosed ? "v4-ms-issue--closed" : ""}`}
-              >
-                <span
-                  className={`v4-ms-issue-status ${isClosed ? "v4-ms-issue-status--closed" : "v4-ms-issue-status--open"}`}
-                  aria-hidden="true"
-                >
-                  {isClosed ? "✓" : "○"}
-                </span>
-                <a
-                  href={issue.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="v4-ms-issue-title"
-                >
-                  #{issue.number} {issue.title}
-                </a>
-                <span className="v4-ms-issue-labels">
-                  {issue.labels
-                    .filter((l) => /^P[1-4]/.test(l))
-                    .map((l) => {
-                      const p = l.split("-")[0];
-                      return (
-                        <span
-                          key={l}
-                          className={`v4-ptag ${PRIORITY_TAG[p] ?? "v4-ptag--p4"}`}
-                        >
-                          {p}
-                        </span>
-                      );
-                    })}
-                  {issue.labels.includes("blocked") && (
-                    <span className="v4-ms-issue-blocked">blocked</span>
-                  )}
-                </span>
-              </div>
-            );
-          })}
+      {density !== "compact" && chips.length > 0 && (
+        <div className="v4-mscv-foot">
+          {chips.map((ch) => (
+            <span key={ch.k} className={`v4-mscv-chip ${ch.cls}`}>
+              {ch.l}
+            </span>
+          ))}
         </div>
       )}
-      {expanded && sortedIssues.length === 0 && (
-        <div className="v4-mscard-full-issues v4-mscard-full-issues--empty">
-          Нет привязанных issues
+
+      {expanded && (
+        <div className="v4-mscv-issues">
+          {sortedIssues.length === 0 ? (
+            <div className="v4-mscv-issues-empty">Нет привязанных issues</div>
+          ) : (
+            sortedIssues.map((issue) => {
+              const isClosed = issue.state === "CLOSED";
+              return (
+                <div
+                  key={issue.number}
+                  className={`v4-ms-issue${isClosed ? " v4-ms-issue--closed" : ""}`}
+                >
+                  <span
+                    className={`v4-ms-issue-status ${
+                      isClosed
+                        ? "v4-ms-issue-status--closed"
+                        : "v4-ms-issue-status--open"
+                    }`}
+                    aria-hidden="true"
+                  >
+                    {isClosed ? "✓" : "○"}
+                  </span>
+                  <a
+                    href={issue.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="v4-ms-issue-title"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    #{issue.number} {issue.title}
+                  </a>
+                  <span className="v4-ms-issue-labels">
+                    {issue.labels
+                      .filter((l) => /^P[1-4]/i.test(l))
+                      .map((l) => {
+                        const p = l.split("-")[0].toUpperCase();
+                        return (
+                          <span
+                            key={l}
+                            className={`v4-ptag v4-ptag--${p.toLowerCase()}`}
+                          >
+                            {p}
+                          </span>
+                        );
+                      })}
+                    {issue.labels.some((l) => l.toLowerCase() === "blocked") && (
+                      <span className="v4-ms-issue-blocked">blocked</span>
+                    )}
+                  </span>
+                </div>
+              );
+            })
+          )}
         </div>
       )}
-    </div>
+    </article>
   );
 }

--- a/src/components/v4/milestones/MilestoneCardV4.tsx
+++ b/src/components/v4/milestones/MilestoneCardV4.tsx
@@ -12,6 +12,9 @@ import {
 interface Props {
   milestone: Milestone;
   density: "comfortable" | "compact";
+  /** Anchor for daysUntil — passed from the view to keep classification
+   *  consistent with the data refresh timestamp. */
+  now: Date;
 }
 
 const DESC_LIMIT = 140;
@@ -25,13 +28,13 @@ const FILL_BY_CLS: Record<string, string> = {
   noeta: "v4-mscv-fill--noeta",
 };
 
-export function MilestoneCardV4({ milestone, density }: Props) {
+export function MilestoneCardV4({ milestone, density, now }: Props) {
   const [expanded, setExpanded] = useState(false);
 
   const total = milestone.openIssues + milestone.closedIssues;
   const pct = total > 0 ? Math.round((milestone.closedIssues / total) * 100) : 0;
   const left = total - milestone.closedIssues;
-  const days = milestone.dueOn ? daysUntil(milestone.dueOn) : null;
+  const days = milestone.dueOn ? daysUntil(milestone.dueOn, now) : null;
   const cls = classifyMilestone(milestone, days);
   const isDone = cls === "done";
 

--- a/src/components/v4/milestones/MilestonesClosedSection.tsx
+++ b/src/components/v4/milestones/MilestonesClosedSection.tsx
@@ -112,6 +112,9 @@ export function MilestonesClosedSection({ milestones }: Props) {
                 </div>
                 {slice.map((m) => {
                   const total = m.openIssues + m.closedIssues;
+                  // GitHub allows closing a milestone with open issues, so
+                  // a CLOSED state doesn't imply 100% completion.
+                  const pct = total > 0 ? Math.round((m.closedIssues / total) * 100) : 100;
                   return (
                     <a
                       key={m.url}
@@ -138,7 +141,7 @@ export function MilestonesClosedSection({ milestones }: Props) {
                       <div className="v4-msclosed-row-issues num">
                         {m.closedIssues}/{total}
                       </div>
-                      <div className="v4-msclosed-row-pct num">100%</div>
+                      <div className="v4-msclosed-row-pct num">{pct}%</div>
                     </a>
                   );
                 })}

--- a/src/components/v4/milestones/MilestonesClosedSection.tsx
+++ b/src/components/v4/milestones/MilestonesClosedSection.tsx
@@ -1,0 +1,186 @@
+import { useMemo, useState } from "react";
+import type { Milestone } from "../../../types";
+import { formatShortDate } from "../../../utils/date";
+import { repoGlyphColor } from "./utils";
+
+interface Props {
+  milestones: Milestone[];
+}
+
+const PAGE_SIZE = 12;
+
+export function MilestonesClosedSection({ milestones }: Props) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(0);
+
+  const sorted = useMemo(() => {
+    return [...milestones].sort((a, b) => {
+      const aD = a.closedAt ?? a.dueOn ?? "";
+      const bD = b.closedAt ?? b.dueOn ?? "";
+      return bD.localeCompare(aD);
+    });
+  }, [milestones]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return sorted;
+    return sorted.filter(
+      (m) =>
+        m.title.toLowerCase().includes(q) || m.repo.toLowerCase().includes(q)
+    );
+  }, [sorted, query]);
+
+  // Derive a safe page from current state — when search trims results below
+  // the current page, we just clamp during render rather than setState in
+  // an effect (which would cascade re-renders).
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const pageSafe = Math.min(page, totalPages - 1);
+  const slice = filtered.slice(
+    pageSafe * PAGE_SIZE,
+    (pageSafe + 1) * PAGE_SIZE
+  );
+
+  const totalIssues = milestones.reduce(
+    (s, m) => s + m.openIssues + m.closedIssues,
+    0
+  );
+  const lastClosed = sorted[0]?.closedAt
+    ? formatShortDate(sorted[0].closedAt!)
+    : "—";
+
+  if (milestones.length === 0) return null;
+
+  return (
+    <div className="v4-msclosed">
+      <button
+        type="button"
+        className={`v4-msclosed-h${open ? " is-open" : ""}`}
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <span className="v4-msclosed-t">
+          <svg
+            className="v4-msclosed-chev"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+          Завершённые milestones
+          <span className="v4-msclosed-count num">{milestones.length}</span>
+        </span>
+        <span className="v4-msclosed-meta">
+          {totalIssues} issues · последнее: {lastClosed}
+        </span>
+      </button>
+
+      {open && (
+        <div className="v4-msclosed-body">
+          {milestones.length > 8 && (
+            <div className="v4-msclosed-search">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="11" cy="11" r="8" />
+                <path d="M21 21l-4.35-4.35" />
+              </svg>
+              <input
+                placeholder="Поиск по названию или репо…"
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setPage(0);
+                }}
+                aria-label="Поиск завершённых milestones"
+              />
+            </div>
+          )}
+
+          {filtered.length === 0 ? (
+            <div className="v4-msclosed-empty">Ничего не найдено</div>
+          ) : (
+            <>
+              <div className="v4-msclosed-table">
+                <div className="v4-msclosed-table-head">
+                  <div />
+                  <div>Milestone</div>
+                  <div>Репозиторий</div>
+                  <div>Закрыт</div>
+                  <div>Issues</div>
+                  <div className="v4-msclosed-th-pct">%</div>
+                </div>
+                {slice.map((m) => {
+                  const total = m.openIssues + m.closedIssues;
+                  return (
+                    <a
+                      key={m.url}
+                      className="v4-msclosed-row"
+                      href={m.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <div>
+                        <span
+                          className="v4-msclosed-row-glyph"
+                          style={{ background: repoGlyphColor(m.repo) }}
+                        />
+                      </div>
+                      <div>
+                        <span className="v4-msclosed-row-title" title={m.title}>
+                          {m.title}
+                        </span>
+                      </div>
+                      <div className="v4-msclosed-row-repo">{m.repo}</div>
+                      <div className="v4-msclosed-row-date num">
+                        {m.closedAt ? formatShortDate(m.closedAt) : "—"}
+                      </div>
+                      <div className="v4-msclosed-row-issues num">
+                        {m.closedIssues}/{total}
+                      </div>
+                      <div className="v4-msclosed-row-pct num">100%</div>
+                    </a>
+                  );
+                })}
+              </div>
+
+              {totalPages > 1 && (
+                <div className="v4-msclosed-pager">
+                  <span>
+                    {pageSafe * PAGE_SIZE + 1}–
+                    {Math.min(
+                      (pageSafe + 1) * PAGE_SIZE,
+                      filtered.length
+                    )}{" "}
+                    из {filtered.length}
+                  </span>
+                  <div className="v4-msclosed-pager-ctrl">
+                    <button
+                      type="button"
+                      onClick={() => setPage((p) => Math.max(0, p - 1))}
+                      disabled={pageSafe === 0}
+                    >
+                      ← Назад
+                    </button>
+                    <span className="v4-msclosed-pager-num">
+                      {pageSafe + 1} / {totalPages}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setPage((p) => Math.min(totalPages - 1, p + 1))
+                      }
+                      disabled={pageSafe >= totalPages - 1}
+                    >
+                      Вперёд →
+                    </button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/milestones/MilestonesGantt.tsx
+++ b/src/components/v4/milestones/MilestonesGantt.tsx
@@ -53,7 +53,7 @@ export function MilestonesGantt({ milestones, zoom, onZoom, now }: Props) {
       .map((m) => {
         const startD = milestoneStart(m, now);
         const dueD = m.dueOn ? startOfDay(new Date(m.dueOn)) : null;
-        const days = m.dueOn ? daysUntil(m.dueOn) : null;
+        const days = m.dueOn ? daysUntil(m.dueOn, now) : null;
         return { m, startD, dueD, days, cls: classifyMilestone(m, days) };
       })
       .sort(

--- a/src/components/v4/milestones/MilestonesGantt.tsx
+++ b/src/components/v4/milestones/MilestonesGantt.tsx
@@ -1,0 +1,362 @@
+import { useMemo } from "react";
+import type { Milestone } from "../../../types";
+import { daysUntil, formatShortDate } from "../../../utils/date";
+import { classifyMilestone, type MilestoneStatusKind } from "./classifyMilestone";
+import {
+  addDays,
+  clsPriority,
+  diffDays,
+  milestoneStart,
+  repoGlyphColor,
+  ruDow,
+  ruMonthShort,
+  startOfDay,
+  stripEpicPrefix,
+} from "./utils";
+
+export type GanttZoom = "day" | "week" | "month";
+
+const ZOOMS: Record<GanttZoom, { dayW: number; label: string }> = {
+  day: { dayW: 36, label: "День" },
+  week: { dayW: 22, label: "Неделя" },
+  month: { dayW: 12, label: "Месяц" },
+};
+
+const WINDOW_BACK = 21;
+const WINDOW_FWD = 60;
+const ROW_H = 44;
+
+interface Props {
+  milestones: Milestone[];
+  zoom: GanttZoom;
+  onZoom: (z: GanttZoom) => void;
+  now: Date;
+}
+
+interface Enriched {
+  m: Milestone;
+  startD: Date;
+  dueD: Date | null;
+  days: number | null;
+  cls: MilestoneStatusKind;
+}
+
+export function MilestonesGantt({ milestones, zoom, onZoom, now }: Props) {
+  const data = useMemo(() => {
+    const startWindow = startOfDay(addDays(now, -WINDOW_BACK));
+    const endWindow = startOfDay(addDays(now, WINDOW_FWD));
+    const totalDays = diffDays(endWindow, startWindow);
+    const dayW = ZOOMS[zoom].dayW;
+    const totalW = totalDays * dayW;
+
+    const enriched: Enriched[] = milestones
+      .map((m) => {
+        const startD = milestoneStart(m, now);
+        const dueD = m.dueOn ? startOfDay(new Date(m.dueOn)) : null;
+        const days = m.dueOn ? daysUntil(m.dueOn) : null;
+        return { m, startD, dueD, days, cls: classifyMilestone(m, days) };
+      })
+      .sort(
+        (a, b) =>
+          clsPriority(a.cls) - clsPriority(b.cls) ||
+          a.startD.getTime() - b.startD.getTime()
+      );
+
+    const days: Date[] = [];
+    for (let i = 0; i < totalDays; i++) {
+      days.push(addDays(startWindow, i));
+    }
+
+    const monthRuns: { count: number; label: string }[] = [];
+    for (const d of days) {
+      const last = monthRuns[monthRuns.length - 1];
+      const lbl = `${ruMonthShort(d)} ’${String(d.getFullYear()).slice(2)}`;
+      if (last && last.label === lbl) last.count++;
+      else monthRuns.push({ count: 1, label: lbl });
+    }
+
+    const todayLeft = diffDays(startOfDay(now), startWindow) * dayW;
+
+    const weekendCols: { start: number; len: number }[] = [];
+    let i = 0;
+    while (i < days.length) {
+      const dow = days[i].getDay();
+      if (dow === 0 || dow === 6) {
+        let j = i;
+        while (
+          j < days.length &&
+          (days[j].getDay() === 0 || days[j].getDay() === 6)
+        )
+          j++;
+        weekendCols.push({ start: i, len: j - i });
+        i = j;
+      } else i++;
+    }
+
+    return {
+      enriched,
+      days,
+      monthRuns,
+      dayW,
+      totalDays,
+      totalW,
+      todayLeft,
+      weekendCols,
+      startWindow,
+    };
+  }, [milestones, zoom, now]);
+
+  const todaySod = useMemo(() => startOfDay(now), [now]);
+
+  return (
+    <div className="v4-msgantt">
+      <div className="v4-msgantt-h">
+        <div className="v4-msgantt-t">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <rect x="3" y="4" width="18" height="18" rx="2" />
+            <path d="M16 2v4M8 2v4M3 10h18" />
+          </svg>
+          Дедлайн-план · {milestones.length} milestones
+        </div>
+        <div className="v4-msgantt-controls">
+          <div className="v4-msgantt-legend">
+            <span className="v4-msgantt-lg">
+              <span
+                className="v4-msgantt-dot"
+                style={{ background: "var(--v4-danger-500)" }}
+              />
+              просрочено
+            </span>
+            <span className="v4-msgantt-lg">
+              <span
+                className="v4-msgantt-dot"
+                style={{ background: "var(--v4-warn-500)" }}
+              />
+              ≤ 3 дн
+            </span>
+            <span className="v4-msgantt-lg">
+              <span
+                className="v4-msgantt-dot"
+                style={{ background: "var(--v4-accent-500)" }}
+              />
+              ≤ 14 дн
+            </span>
+            <span className="v4-msgantt-lg">
+              <span
+                className="v4-msgantt-dot"
+                style={{ background: "var(--v4-success-500)" }}
+              />
+              готов
+            </span>
+            <span className="v4-msgantt-lg">
+              <span className="v4-msgantt-mini-bar" />
+              fill = % done
+            </span>
+          </div>
+          <div className="v4-pillgrp">
+            {(Object.entries(ZOOMS) as [GanttZoom, { label: string }][]).map(
+              ([k, v]) => (
+                <button
+                  key={k}
+                  type="button"
+                  className={zoom === k ? "is-active" : ""}
+                  onClick={() => onZoom(k)}
+                >
+                  {v.label}
+                </button>
+              )
+            )}
+          </div>
+        </div>
+      </div>
+
+      {data.enriched.length === 0 ? (
+        <div className="v4-msgantt-empty">Нет milestones для отображения</div>
+      ) : (
+        <div className="v4-msgantt-body">
+          <div className="v4-msgantt-list">
+            <div className="v4-msgantt-list-h">Milestone</div>
+            {data.enriched.map((x, idx) => {
+              const total = x.m.openIssues + x.m.closedIssues;
+              const pct =
+                total > 0 ? Math.round((x.m.closedIssues / total) * 100) : 0;
+              return (
+                <a
+                  key={`${x.m.url}-${idx}`}
+                  href={x.m.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`v4-msgantt-row v4-msgantt-row--${x.cls}`}
+                  title={x.m.title}
+                >
+                  <span
+                    className="v4-msgantt-row-glyph"
+                    style={{ background: repoGlyphColor(x.m.repo) }}
+                  />
+                  <div className="v4-msgantt-row-info">
+                    <div className="v4-msgantt-row-title">
+                      {stripEpicPrefix(x.m.title) || x.m.title}
+                    </div>
+                    <div className="v4-msgantt-row-sub">
+                      <span>{x.m.repo}</span>
+                      <span className="v4-msgantt-row-dot" />
+                      <span>
+                        {x.m.closedIssues}/{total}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="v4-msgantt-row-pct num">{pct}%</div>
+                </a>
+              );
+            })}
+          </div>
+
+          <div className="v4-msgantt-chart">
+            <div
+              className="v4-msgantt-chart-inner"
+              style={{ width: `${data.totalW}px` }}
+            >
+              <div className="v4-msgantt-axis">
+                <div className="v4-msgantt-axis-months">
+                  {data.monthRuns.map((mo, i) => (
+                    <div
+                      key={i}
+                      className="v4-msgantt-axis-month"
+                      style={{ width: `${mo.count * data.dayW}px` }}
+                    >
+                      {mo.label}
+                    </div>
+                  ))}
+                </div>
+                <div className="v4-msgantt-axis-days">
+                  {data.days.map((d, i) => {
+                    const isWE = d.getDay() === 0 || d.getDay() === 6;
+                    const isToday = diffDays(d, todaySod) === 0;
+                    const cls = [
+                      "v4-msgantt-axis-day",
+                      isWE ? "v4-msgantt-axis-day--weekend" : "",
+                      isToday ? "v4-msgantt-axis-day--today" : "",
+                    ]
+                      .filter(Boolean)
+                      .join(" ");
+                    return (
+                      <div
+                        key={i}
+                        className={cls}
+                        style={{ width: `${data.dayW}px` }}
+                      >
+                        <div className="v4-msgantt-axis-day-num num">
+                          {d.getDate()}
+                        </div>
+                        {data.dayW >= 18 && (
+                          <div className="v4-msgantt-axis-day-dow">
+                            {ruDow(d)}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div
+                className="v4-msgantt-grid"
+                style={{ backgroundSize: `${data.dayW}px 100%` }}
+              >
+                {data.weekendCols.map((w, i) => (
+                  <div
+                    key={i}
+                    className="v4-msgantt-weekend"
+                    style={{
+                      left: `${w.start * data.dayW}px`,
+                      width: `${w.len * data.dayW}px`,
+                    }}
+                  />
+                ))}
+                <div
+                  className="v4-msgantt-today"
+                  style={{ left: `${data.todayLeft}px` }}
+                />
+
+                {data.enriched.map((x, idx) => {
+                  const total = x.m.openIssues + x.m.closedIssues;
+                  const pct =
+                    total > 0
+                      ? Math.round((x.m.closedIssues / total) * 100)
+                      : 0;
+                  const startIdx = Math.max(
+                    0,
+                    diffDays(x.startD, data.startWindow)
+                  );
+                  const endDate =
+                    x.dueD ??
+                    addDays(x.startD, Math.max(7, Math.round(total * 1.5)));
+                  const endIdx = Math.min(
+                    data.totalDays,
+                    diffDays(endDate, data.startWindow) + 1
+                  );
+                  const left = startIdx * data.dayW;
+                  const width = Math.max(28, (endIdx - startIdx) * data.dayW);
+                  const fillW = (width * pct) / 100;
+                  const hasFill = pct > 0;
+
+                  const duePos = x.dueD
+                    ? diffDays(x.dueD, data.startWindow) * data.dayW +
+                      data.dayW / 2 -
+                      7
+                    : null;
+                  const showDiamond =
+                    duePos !== null && duePos >= -10 && duePos <= data.totalW + 10;
+                  const showText = width >= 90;
+
+                  const dueLabel = x.m.dueOn ? formatShortDate(x.m.dueOn) : "";
+
+                  return (
+                    <div key={`${x.m.url}-${idx}`} className="v4-msgantt-grid-row">
+                      <a
+                        className={`v4-msgantt-bar v4-msgantt-bar--${x.cls}${
+                          hasFill ? " has-fill" : ""
+                        }`}
+                        href={x.m.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{ left: `${left}px`, width: `${width}px` }}
+                        title={`${x.m.title} · ${x.m.closedIssues}/${total} (${pct}%)${
+                          dueLabel ? " · до " + dueLabel : ""
+                        }`}
+                      >
+                        {hasFill && (
+                          <div
+                            className="v4-msgantt-bar-fill"
+                            style={{ width: `${fillW}px` }}
+                          />
+                        )}
+                        {showText && (
+                          <div className="v4-msgantt-bar-text">
+                            <span className="v4-msgantt-bar-title">
+                              {stripEpicPrefix(x.m.title) || x.m.title}
+                            </span>
+                            <span className="v4-msgantt-bar-pct num">{pct}%</span>
+                          </div>
+                        )}
+                      </a>
+                      {showDiamond && duePos !== null && (
+                        <div
+                          className={`v4-msgantt-due v4-msgantt-due--${x.cls}`}
+                          style={{ left: `${duePos}px` }}
+                          title={dueLabel ? `Дедлайн: ${dueLabel}` : "Дедлайн"}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const GANTT_ROW_H = ROW_H;

--- a/src/components/v4/milestones/MilestonesHero.tsx
+++ b/src/components/v4/milestones/MilestonesHero.tsx
@@ -15,7 +15,7 @@ const RING_C = 2 * Math.PI * RING_R;
 export function MilestonesHero({ milestones, now }: Props) {
   const stats = useMemo(() => {
     const enriched = milestones.map((m) => {
-      const days = m.dueOn ? daysUntil(m.dueOn) : null;
+      const days = m.dueOn ? daysUntil(m.dueOn, now) : null;
       return { m, days, cls: classifyMilestone(m, days) };
     });
 

--- a/src/components/v4/milestones/MilestonesHero.tsx
+++ b/src/components/v4/milestones/MilestonesHero.tsx
@@ -1,0 +1,235 @@
+import { useMemo } from "react";
+import type { Milestone } from "../../../types";
+import { daysUntil } from "../../../utils/date";
+import { classifyMilestone } from "./classifyMilestone";
+import { buildDaily14, buildSparkPath, stripEpicPrefix } from "./utils";
+
+interface Props {
+  milestones: Milestone[];
+  now: Date;
+}
+
+const RING_R = 46;
+const RING_C = 2 * Math.PI * RING_R;
+
+export function MilestonesHero({ milestones, now }: Props) {
+  const stats = useMemo(() => {
+    const enriched = milestones.map((m) => {
+      const days = m.dueOn ? daysUntil(m.dueOn) : null;
+      return { m, days, cls: classifyMilestone(m, days) };
+    });
+
+    const totalIssues = enriched.reduce(
+      (s, x) => s + x.m.openIssues + x.m.closedIssues,
+      0
+    );
+    const closedIssues = enriched.reduce((s, x) => s + x.m.closedIssues, 0);
+    const pct = totalIssues > 0 ? Math.round((closedIssues / totalIssues) * 100) : 0;
+    const overdue = enriched.filter((x) => x.cls === "overdue").length;
+    const inProgress = enriched.filter(
+      (x) => x.cls !== "done" && x.cls !== "noeta"
+    ).length;
+    const done = enriched.filter((x) => x.cls === "done").length;
+
+    // Velocity over last 14 days (combined across all milestones' issues)
+    const allIssues = milestones.flatMap((m) => m.issues ?? []);
+    const daily14 = buildDaily14(allIssues, now);
+    const closed7 = daily14.slice(7).reduce((a, b) => a + b, 0);
+    const closedPrev7 = daily14.slice(0, 7).reduce((a, b) => a + b, 0);
+    const velocityPerDay = closed7 / 7;
+    const velocityDelta =
+      closedPrev7 > 0
+        ? Math.round(((closed7 - closedPrev7) / closedPrev7) * 100)
+        : closed7 > 0
+        ? 100
+        : 0;
+
+    // Next deadline (skip done & noeta, only future or today)
+    const upcoming = enriched
+      .filter((x) => x.cls !== "done" && x.days !== null && x.days >= 0)
+      .sort((a, b) => (a.days ?? 0) - (b.days ?? 0))[0];
+
+    const cnt7 = enriched.filter(
+      (x) =>
+        x.cls !== "done" && x.days !== null && x.days >= 0 && x.days <= 7
+    ).length;
+    const cnt30 = enriched.filter(
+      (x) =>
+        x.cls !== "done" && x.days !== null && x.days > 7 && x.days <= 30
+    ).length;
+    const cntFar = enriched.filter(
+      (x) => x.cls !== "done" && (x.days === null || x.days > 30)
+    ).length;
+
+    return {
+      totalIssues,
+      closedIssues,
+      pct,
+      overdue,
+      inProgress,
+      done,
+      daily14,
+      closed7,
+      velocityPerDay,
+      velocityDelta,
+      upcoming,
+      cnt7,
+      cnt30,
+      cntFar,
+    };
+  }, [milestones, now]);
+
+  const spark = buildSparkPath(stats.daily14, 220, 36);
+  const velocityStr = stats.velocityPerDay.toFixed(1).replace(".", ",");
+
+  return (
+    <div className="v4-mshero">
+      {/* DOMINANT: portfolio progress */}
+      <div className="v4-mshero-tile v4-mshero-tile--main">
+        <div className="v4-mshero-lbl">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <polyline points="9 11 12 14 22 4" />
+            <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" />
+          </svg>
+          Портфель milestones
+        </div>
+        <div className="v4-mshero-main-body">
+          <div className="v4-mshero-ring">
+            <svg viewBox="0 0 110 110" aria-hidden="true">
+              <circle
+                cx="55"
+                cy="55"
+                r={RING_R}
+                fill="none"
+                stroke="rgba(255,255,255,0.15)"
+                strokeWidth="8"
+              />
+              <circle
+                cx="55"
+                cy="55"
+                r={RING_R}
+                fill="none"
+                stroke="#fff"
+                strokeWidth="8"
+                strokeDasharray={RING_C}
+                strokeDashoffset={RING_C * (1 - stats.pct / 100)}
+                strokeLinecap="round"
+              />
+            </svg>
+            <div className="v4-mshero-ring-c">
+              <div className="v4-mshero-ring-pct num">{stats.pct}%</div>
+              <div className="v4-mshero-ring-lbl">issues done</div>
+            </div>
+          </div>
+          <div className="v4-mshero-main-side">
+            <div className="v4-mshero-row">
+              <span className="v4-mshero-sw" style={{ background: "#fff" }} />
+              <span className="v4-mshero-row-l">в работе</span>
+              <b className="num">{stats.inProgress}</b>
+            </div>
+            <div className="v4-mshero-row">
+              <span
+                className="v4-mshero-sw"
+                style={{ background: "rgba(239,68,68,0.95)" }}
+              />
+              <span className="v4-mshero-row-l">просрочено</span>
+              <b className="num">{stats.overdue}</b>
+            </div>
+            <div className="v4-mshero-row">
+              <span
+                className="v4-mshero-sw"
+                style={{ background: "rgba(255,255,255,0.35)" }}
+              />
+              <span className="v4-mshero-row-l">завершено</span>
+              <b className="num">{stats.done}</b>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* SUPPORT 1: velocity */}
+      <div className="v4-mshero-tile">
+        <div className="v4-mshero-lbl">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+          </svg>
+          Velocity · 7 дней
+        </div>
+        <div className="v4-mshero-num num">
+          {velocityStr}
+          <span className="v4-mshero-num-u">issue/день</span>
+        </div>
+        <div className="v4-mshero-meta">
+          {stats.velocityDelta !== 0 && (
+            <span
+              className={
+                stats.velocityDelta >= 0
+                  ? "v4-mshero-delta-pos"
+                  : "v4-mshero-delta-neg"
+              }
+            >
+              {stats.velocityDelta >= 0 ? "↑" : "↓"} {Math.abs(stats.velocityDelta)}%
+            </span>
+          )}
+          <span>vs предыдущая неделя</span>
+        </div>
+        <div className="v4-mshero-spark">
+          <svg viewBox="0 0 220 36" preserveAspectRatio="none" aria-hidden="true">
+            <path d={spark.area} fill="rgba(18,183,106,0.12)" />
+            <path
+              d={spark.line}
+              fill="none"
+              stroke="var(--v4-success-500)"
+              strokeWidth="2"
+            />
+          </svg>
+        </div>
+      </div>
+
+      {/* SUPPORT 2: next deadline */}
+      <div className="v4-mshero-tile">
+        <div className="v4-mshero-lbl">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <rect x="3" y="4" width="18" height="18" rx="2" />
+            <path d="M16 2v4M8 2v4M3 10h18" />
+          </svg>
+          Ближайший дедлайн
+        </div>
+        <div className="v4-mshero-num num">
+          {stats.upcoming === undefined ? (
+            "—"
+          ) : stats.upcoming.days === 0 ? (
+            "сегодня"
+          ) : (
+            <>
+              {stats.upcoming.days}
+              <span className="v4-mshero-num-u">дн</span>
+            </>
+          )}
+        </div>
+        <div className="v4-mshero-meta">
+          {stats.upcoming && (
+            <span className="v4-mshero-meta-strong">
+              {stats.upcoming.m.repo} ·{" "}
+              {stripEpicPrefix(stats.upcoming.m.title).slice(0, 38)}
+            </span>
+          )}
+        </div>
+        <div className="v4-mshero-break">
+          <div className="v4-mshero-break-it">
+            <div className="v4-mshero-break-n num">{stats.cnt7}</div>
+            <div className="v4-mshero-break-l">≤ 7 дн</div>
+          </div>
+          <div className="v4-mshero-break-it">
+            <div className="v4-mshero-break-n num">{stats.cnt30}</div>
+            <div className="v4-mshero-break-l">≤ 30 дн</div>
+          </div>
+          <div className="v4-mshero-break-it">
+            <div className="v4-mshero-break-n num">{stats.cntFar}</div>
+            <div className="v4-mshero-break-l">дальше</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/milestones/MilestonesStatusBar.tsx
+++ b/src/components/v4/milestones/MilestonesStatusBar.tsx
@@ -1,0 +1,79 @@
+import { useMemo } from "react";
+import type { Milestone } from "../../../types";
+import { daysUntil } from "../../../utils/date";
+import { classifyMilestone, type MilestoneStatusKind } from "./classifyMilestone";
+
+interface Props {
+  milestones: Milestone[];
+}
+
+const ORDER: {
+  k: MilestoneStatusKind;
+  l: string;
+  c: string;
+}[] = [
+  { k: "overdue", l: "Просрочено", c: "var(--v4-danger-500)" },
+  { k: "warn", l: "≤ 3 дн", c: "var(--v4-warn-500)" },
+  { k: "soon", l: "≤ 14 дн", c: "var(--v4-accent-500)" },
+  { k: "norm", l: "Дальше", c: "var(--v4-ink-400)" },
+  { k: "noeta", l: "Без даты", c: "var(--v4-ink-300)" },
+  { k: "done", l: "Завершено", c: "var(--v4-success-500)" },
+];
+
+export function MilestonesStatusBar({ milestones }: Props) {
+  const { buckets, total } = useMemo(() => {
+    const b: Record<MilestoneStatusKind, number> = {
+      overdue: 0,
+      warn: 0,
+      soon: 0,
+      norm: 0,
+      noeta: 0,
+      done: 0,
+    };
+    for (const m of milestones) {
+      const days = m.dueOn ? daysUntil(m.dueOn) : null;
+      b[classifyMilestone(m, days)]++;
+    }
+    return { buckets: b, total: Math.max(1, milestones.length) };
+  }, [milestones]);
+
+  if (milestones.length === 0) return null;
+
+  return (
+    <div className="v4-msstatus">
+      <div className="v4-msstatus-h">
+        <div className="v4-msstatus-t">
+          Распределение по статусам
+          <span className="v4-msstatus-tag num">
+            {milestones.length} milestone
+          </span>
+        </div>
+      </div>
+      <div className="v4-msstatus-bar">
+        {ORDER.filter((o) => buckets[o.k] > 0).map((o) => {
+          const w = (buckets[o.k] / total) * 100;
+          return (
+            <div
+              key={o.k}
+              className="v4-msstatus-seg"
+              style={{ width: `${w}%`, background: o.c }}
+              title={`${o.l}: ${buckets[o.k]}`}
+            >
+              <span className="v4-msstatus-seg-n num">{buckets[o.k]}</span>
+              {w >= 15 && <span className="v4-msstatus-seg-l">{o.l}</span>}
+            </div>
+          );
+        })}
+      </div>
+      <div className="v4-msstatus-legend">
+        {ORDER.map((o) => (
+          <div key={o.k} className="v4-msstatus-legend-it">
+            <span className="v4-msstatus-sw" style={{ background: o.c }} />
+            <span>{o.l}</span>
+            <b className="num">{buckets[o.k]}</b>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/milestones/MilestonesStatusBar.tsx
+++ b/src/components/v4/milestones/MilestonesStatusBar.tsx
@@ -5,6 +5,7 @@ import { classifyMilestone, type MilestoneStatusKind } from "./classifyMilestone
 
 interface Props {
   milestones: Milestone[];
+  now: Date;
 }
 
 const ORDER: {
@@ -20,7 +21,7 @@ const ORDER: {
   { k: "done", l: "Завершено", c: "var(--v4-success-500)" },
 ];
 
-export function MilestonesStatusBar({ milestones }: Props) {
+export function MilestonesStatusBar({ milestones, now }: Props) {
   const { buckets, total } = useMemo(() => {
     const b: Record<MilestoneStatusKind, number> = {
       overdue: 0,
@@ -31,11 +32,11 @@ export function MilestonesStatusBar({ milestones }: Props) {
       done: 0,
     };
     for (const m of milestones) {
-      const days = m.dueOn ? daysUntil(m.dueOn) : null;
+      const days = m.dueOn ? daysUntil(m.dueOn, now) : null;
       b[classifyMilestone(m, days)]++;
     }
     return { buckets: b, total: Math.max(1, milestones.length) };
-  }, [milestones]);
+  }, [milestones, now]);
 
   if (milestones.length === 0) return null;
 

--- a/src/components/v4/milestones/MilestonesView.tsx
+++ b/src/components/v4/milestones/MilestonesView.tsx
@@ -84,11 +84,10 @@ export function MilestonesView({ milestones, lastUpdated }: Props) {
 
   const enriched: Enriched[] = useMemo(() => {
     return milestones.map((m) => {
-      const days = m.dueOn ? daysUntil(m.dueOn) : null;
+      const days = m.dueOn ? daysUntil(m.dueOn, now) : null;
       return { m, days, cls: classifyMilestone(m, days) };
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [milestones, lastUpdated?.getTime()]);
+  }, [milestones, now]);
 
   const open = useMemo(() => enriched.filter((e) => e.cls !== "done"), [enriched]);
   const done = useMemo(() => enriched.filter((e) => e.cls === "done"), [enriched]);
@@ -119,7 +118,10 @@ export function MilestonesView({ milestones, lastUpdated }: Props) {
       return Array.from(map.entries())
         .sort((a, b) => a[0].localeCompare(b[0], "ru"))
         .map(([repo, items]) => ({
-          key: "norm",
+          // "repo" key falls through to the default `.v4-msgroup-dot`
+          // background (var(--v4-ink-400)) — handoff: repo grouping
+          // intentionally has no per-bucket colour.
+          key: "repo",
           title: repo,
           items: items.sort((a, b) => {
             if (a.days === null && b.days === null) return 0;
@@ -191,7 +193,7 @@ export function MilestonesView({ milestones, lastUpdated }: Props) {
 
       {/* Status distribution */}
       <div className="v4-msstatus-wrap">
-        <MilestonesStatusBar milestones={openMs} />
+        <MilestonesStatusBar milestones={openMs} now={now} />
       </div>
 
       {/* Toolbar */}
@@ -322,6 +324,7 @@ export function MilestonesView({ milestones, lastUpdated }: Props) {
                       key={e.m.url}
                       milestone={e.m}
                       density={state.density}
+                      now={now}
                     />
                   ))}
                 </div>

--- a/src/components/v4/milestones/MilestonesView.tsx
+++ b/src/components/v4/milestones/MilestonesView.tsx
@@ -1,8 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { Milestone } from "../../../types";
 import { daysUntil } from "../../../utils/date";
 import { MilestoneCardV4 } from "./MilestoneCardV4";
+import { MilestonesHero } from "./MilestonesHero";
+import { MilestonesGantt, type GanttZoom } from "./MilestonesGantt";
+import { MilestonesClosedSection } from "./MilestonesClosedSection";
+import { MilestonesStatusBar } from "./MilestonesStatusBar";
 import { classifyMilestone } from "./classifyMilestone";
+import { deadlineBucket } from "./utils";
 
 interface Props {
   milestones: Milestone[];
@@ -10,52 +15,44 @@ interface Props {
   lastUpdated: Date | null;
 }
 
-type SubTab = "open" | "done";
-type Grouping = "repo" | "deadline";
-type SortKey = "deadline" | "progress" | "name" | "repo";
+type Density = "comfortable" | "compact";
+type Grouping = "deadline" | "repo";
 
 interface ToolbarState {
-  sub: SubTab;
+  density: Density;
   grouping: Grouping;
-  sort: SortKey;
-  asc: boolean;
+  zoom: GanttZoom;
   query: string;
 }
 
-const STORAGE_KEY = "makeit.milestonesView.v1";
+const STORAGE_KEY = "makeit.milestonesView.v2";
 
-const SORT_LABELS: Record<SortKey, string> = {
-  deadline: "Дедлайн",
-  progress: "Прогресс",
-  name: "Имя",
-  repo: "Репо",
-};
-
-const VALID_SUBS: readonly SubTab[] = ["open", "done"];
-const VALID_GROUPINGS: readonly Grouping[] = ["repo", "deadline"];
-const VALID_SORTS: readonly SortKey[] = ["deadline", "progress", "name", "repo"];
+const VALID_DENSITY: readonly Density[] = ["comfortable", "compact"];
+const VALID_GROUPING: readonly Grouping[] = ["deadline", "repo"];
+const VALID_ZOOM: readonly GanttZoom[] = ["day", "week", "month"];
 
 function loadState(): ToolbarState {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
       const p = JSON.parse(raw) as Partial<ToolbarState>;
-      // Validate against allow-lists — protects against stale localStorage
-      // values from older/future schema versions.
       return {
-        sub: VALID_SUBS.includes(p.sub as SubTab) ? (p.sub as SubTab) : "open",
-        grouping: VALID_GROUPINGS.includes(p.grouping as Grouping)
+        density: VALID_DENSITY.includes(p.density as Density)
+          ? (p.density as Density)
+          : "compact",
+        grouping: VALID_GROUPING.includes(p.grouping as Grouping)
           ? (p.grouping as Grouping)
           : "deadline",
-        sort: VALID_SORTS.includes(p.sort as SortKey) ? (p.sort as SortKey) : "deadline",
-        asc: typeof p.asc === "boolean" ? p.asc : true,
+        zoom: VALID_ZOOM.includes(p.zoom as GanttZoom)
+          ? (p.zoom as GanttZoom)
+          : "week",
         query: "",
       };
     }
   } catch {
     /* ignore */
   }
-  return { sub: "open", grouping: "deadline", sort: "deadline", asc: true, query: "" };
+  return { density: "compact", grouping: "deadline", zoom: "week", query: "" };
 }
 
 function saveState(s: ToolbarState) {
@@ -68,158 +65,105 @@ function saveState(s: ToolbarState) {
   }
 }
 
-interface EnrichedMilestone {
+interface Enriched {
   m: Milestone;
   days: number | null;
   cls: ReturnType<typeof classifyMilestone>;
-  progressPct: number;
-}
-
-function deadlineBucket(days: number | null): {
-  key: string;
-  label: string;
-  order: number;
-} {
-  if (days === null) return { key: "noeta", label: "Без дедлайна", order: 99 };
-  if (days < 0) return { key: "overdue", label: "Просрочено", order: 0 };
-  if (days <= 7) return { key: "week", label: "Эта неделя", order: 1 };
-  if (days <= 30) return { key: "month", label: "Этот месяц", order: 2 };
-  return { key: "later", label: "Дальше", order: 3 };
 }
 
 export function MilestonesView({ milestones, lastUpdated }: Props) {
   const [state, setState] = useState<ToolbarState>(() => loadState());
-  const [sortMenuOpen, setSortMenuOpen] = useState(false);
-  const sortMenuRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     saveState(state);
   }, [state]);
 
-  // Close sort menu on outside / Escape
-  useEffect(() => {
-    if (!sortMenuOpen) return;
-    const onDoc = (e: MouseEvent) => {
-      if (!sortMenuRef.current?.contains(e.target as Node)) setSortMenuOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setSortMenuOpen(false);
-    };
-    window.addEventListener("mousedown", onDoc);
-    window.addEventListener("keydown", onKey);
-    return () => {
-      window.removeEventListener("mousedown", onDoc);
-      window.removeEventListener("keydown", onKey);
-    };
-  }, [sortMenuOpen]);
+  // Anchor "now" to lastUpdated so daysUntil/Gantt today line stay consistent
+  // with the data refresh (otherwise minor drift between refreshes shows).
+  const now = useMemo(() => lastUpdated ?? new Date(), [lastUpdated]);
 
-  // Enrich: precompute days/cls/progress once per refresh
-  const enriched: EnrichedMilestone[] = useMemo(() => {
+  const enriched: Enriched[] = useMemo(() => {
     return milestones.map((m) => {
       const days = m.dueOn ? daysUntil(m.dueOn) : null;
-      const total = m.openIssues + m.closedIssues;
-      const progressPct = total > 0 ? Math.round((m.closedIssues / total) * 100) : 0;
-      return { m, days, cls: classifyMilestone(m, days), progressPct };
+      return { m, days, cls: classifyMilestone(m, days) };
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [milestones, lastUpdated?.getTime()]);
 
   const open = useMemo(() => enriched.filter((e) => e.cls !== "done"), [enriched]);
   const done = useMemo(() => enriched.filter((e) => e.cls === "done"), [enriched]);
+  const openMs = useMemo(() => open.map((x) => x.m), [open]);
+  const doneMs = useMemo(() => done.map((x) => x.m), [done]);
 
-  const baseList = state.sub === "open" ? open : done;
-
-  // Filter by query
-  const filtered = useMemo(() => {
+  // Filter (applies to cards / status panel; gantt+closed are full sets)
+  const filteredOpen = useMemo(() => {
     const q = state.query.trim().toLowerCase();
-    if (!q) return baseList;
-    return baseList.filter(
+    if (!q) return open;
+    return open.filter(
       (e) =>
         e.m.title.toLowerCase().includes(q) ||
         e.m.repo.toLowerCase().includes(q) ||
         (e.m.description?.toLowerCase().includes(q) ?? false)
     );
-  }, [baseList, state.query]);
+  }, [open, state.query]);
 
-  // Sort
-  const sorted = useMemo(() => {
-    const out = [...filtered];
-    out.sort((a, b) => {
-      let cmp = 0;
-      switch (state.sort) {
-        case "deadline":
-          // null deadlines last; otherwise compare days
-          if (a.days === null && b.days === null) cmp = 0;
-          else if (a.days === null) cmp = 1;
-          else if (b.days === null) cmp = -1;
-          else cmp = a.days - b.days;
-          break;
-        case "progress":
-          cmp = a.progressPct - b.progressPct;
-          break;
-        case "name":
-          cmp = a.m.title.localeCompare(b.m.title, "ru");
-          break;
-        case "repo":
-          cmp = a.m.repo.localeCompare(b.m.repo, "ru") || a.m.title.localeCompare(b.m.title, "ru");
-          break;
-      }
-      return state.asc ? cmp : -cmp;
-    });
-    return out;
-  }, [filtered, state.sort, state.asc]);
-
-  // Aggregate stats
-  const agg = useMemo(() => {
-    const totalIssues = baseList.reduce((s, e) => s + e.m.openIssues + e.m.closedIssues, 0);
-    const closedIssues = baseList.reduce((s, e) => s + e.m.closedIssues, 0);
-    const overdue = baseList.filter((e) => e.cls === "overdue").length;
-    const thisWeek = baseList.filter((e) => e.cls === "warn" || (e.days !== null && e.days >= 0 && e.days <= 7)).length;
-    const noEta = baseList.filter((e) => e.cls === "noeta").length;
-    return {
-      count: baseList.length,
-      totalIssues,
-      closedIssues,
-      progress: totalIssues > 0 ? Math.round((closedIssues / totalIssues) * 100) : 0,
-      overdue,
-      thisWeek,
-      noEta,
-    };
-  }, [baseList]);
-
-  // Group output
-  const groups: { key: string; title: string; items: EnrichedMilestone[] }[] = useMemo(() => {
-    // Done sub-tab: deadline-bucketing makes no sense (a closed milestone
-    // can't be "Просрочено"). Always render as a single "Завершённые" group.
-    if (state.sub === "done") {
-      return [{ key: "done", title: "Завершённые", items: sorted }];
-    }
+  // Group output for cards
+  const groups = useMemo(() => {
     if (state.grouping === "repo") {
-      const map = new Map<string, EnrichedMilestone[]>();
-      for (const e of sorted) {
+      const map = new Map<string, Enriched[]>();
+      for (const e of filteredOpen) {
         const arr = map.get(e.m.repo) ?? [];
         arr.push(e);
         map.set(e.m.repo, arr);
       }
       return Array.from(map.entries())
         .sort((a, b) => a[0].localeCompare(b[0], "ru"))
-        .map(([repo, items]) => ({ key: repo, title: repo, items }));
+        .map(([repo, items]) => ({
+          key: "norm",
+          title: repo,
+          items: items.sort((a, b) => {
+            if (a.days === null && b.days === null) return 0;
+            if (a.days === null) return 1;
+            if (b.days === null) return -1;
+            return a.days - b.days;
+          }),
+        }));
     }
-    // by deadline
-    const map = new Map<string, { label: string; order: number; items: EnrichedMilestone[] }>();
-    for (const e of sorted) {
+
+    const map = new Map<
+      string,
+      { label: string; order: number; items: Enriched[] }
+    >();
+    for (const e of filteredOpen) {
       const b = deadlineBucket(e.days);
       const cell = map.get(b.key);
-      if (cell) {
-        cell.items.push(e);
-      } else {
-        map.set(b.key, { label: b.label, order: b.order, items: [e] });
-      }
+      if (cell) cell.items.push(e);
+      else map.set(b.key, { label: b.label, order: b.order, items: [e] });
     }
     return Array.from(map.entries())
       .sort(([, a], [, b]) => a.order - b.order)
-      .map(([key, v]) => ({ key, title: v.label, items: v.items }));
-  }, [sorted, state.grouping, state.sub]);
+      .map(([key, v]) => ({
+        key,
+        title: v.label,
+        items: v.items.sort((a, b) => {
+          if (a.days === null && b.days === null) return 0;
+          if (a.days === null) return 1;
+          if (b.days === null) return -1;
+          return a.days - b.days;
+        }),
+      }));
+  }, [filteredOpen, state.grouping]);
+
+  const subText = (() => {
+    const stamp = lastUpdated
+      ? lastUpdated.toLocaleTimeString("ru-RU", {
+          hour: "2-digit",
+          minute: "2-digit",
+        })
+      : null;
+    const base = `${open.length} открытых · ${done.length} завершённых`;
+    return stamp ? `${base} · обновлено ${stamp}` : base;
+  })();
 
   return (
     <div className="v4-content">
@@ -227,105 +171,42 @@ export function MilestonesView({ milestones, lastUpdated }: Props) {
       <div className="v4-ph">
         <div>
           <h1>Milestones</h1>
-          <div className="v4-sub">
-            {open.length + done.length} в портфеле · {agg.count} в выборке
-          </div>
-        </div>
-        <div className="v4-ph-right">
-          <div className="v4-pillgrp">
-            <button
-              type="button"
-              className={state.sub === "open" ? "is-active" : ""}
-              onClick={() => setState((s) => ({ ...s, sub: "open" }))}
-            >
-              Открытые · {open.length}
-            </button>
-            <button
-              type="button"
-              className={state.sub === "done" ? "is-active" : ""}
-              onClick={() => setState((s) => ({ ...s, sub: "done" }))}
-            >
-              Завершённые · {done.length}
-            </button>
-          </div>
+          <div className="v4-sub">{subText}</div>
         </div>
       </div>
 
-      <div style={{ height: 10 }} />
+      {/* Hero — three tiles */}
+      <MilestonesHero milestones={openMs} now={now} />
 
-      {/* Toolbar: aggregate + tools */}
-      <div className="v4-projects-toolbar">
-        <div className="v4-projects-agg">
-          <div className="v4-projects-agg-cell">
-            <div className="v4-projects-agg-n num">{agg.count}</div>
-            <div className="v4-projects-agg-l">milestones</div>
-          </div>
-          <div className="v4-projects-agg-cell" title="Всего issues across milestones">
-            <div className="v4-projects-agg-n num">
-              {agg.closedIssues}/{agg.totalIssues}
-            </div>
-            <div className="v4-projects-agg-l">issues done</div>
-          </div>
-          <div className="v4-projects-agg-cell">
-            <div className="v4-projects-agg-n num">{agg.progress}%</div>
-            <div className="v4-projects-agg-l">прогресс</div>
-          </div>
-          {state.sub === "open" && (
-            <>
-              <div className="v4-projects-agg-cell">
-                <div
-                  className="v4-projects-agg-n num"
-                  style={{ color: agg.overdue > 0 ? "var(--v4-danger-700)" : undefined }}
-                >
-                  {agg.overdue}
-                </div>
-                <div className="v4-projects-agg-l">просрочено</div>
-              </div>
-              <div className="v4-projects-agg-cell">
-                <div
-                  className="v4-projects-agg-n num"
-                  style={{ color: agg.thisWeek > 0 ? "var(--v4-warn-700)" : undefined }}
-                >
-                  {agg.thisWeek}
-                </div>
-                <div className="v4-projects-agg-l">≤ 7д</div>
-              </div>
-              {agg.noEta > 0 && (
-                <div className="v4-projects-agg-cell">
-                  <div className="v4-projects-agg-n num">{agg.noEta}</div>
-                  <div className="v4-projects-agg-l">без даты</div>
-                </div>
-              )}
-            </>
-          )}
-        </div>
+      {/* Gantt */}
+      <MilestonesGantt
+        milestones={openMs}
+        zoom={state.zoom}
+        onZoom={(z) => setState((s) => ({ ...s, zoom: z }))}
+        now={now}
+      />
 
-        <div className="v4-projects-tools">
-          <div className="v4-pillgrp">
-            <button
-              type="button"
-              className={state.grouping === "deadline" ? "is-active" : ""}
-              onClick={() => setState((s) => ({ ...s, grouping: "deadline" }))}
-            >
-              По дедлайну
-            </button>
-            <button
-              type="button"
-              className={state.grouping === "repo" ? "is-active" : ""}
-              onClick={() => setState((s) => ({ ...s, grouping: "repo" }))}
-            >
-              По репо
-            </button>
-          </div>
+      {/* Closed section (collapsible) */}
+      <MilestonesClosedSection milestones={doneMs} />
 
-          <div className="v4-search v4-projects-search">
+      {/* Status distribution */}
+      <div className="v4-msstatus-wrap">
+        <MilestonesStatusBar milestones={openMs} />
+      </div>
+
+      {/* Toolbar */}
+      <div className="v4-mstoolbar">
+        <div className="v4-mstoolbar-left">
+          <div className="v4-search v4-mstoolbar-search">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <circle cx="11" cy="11" r="8" />
               <path d="M21 21l-4.35-4.35" />
             </svg>
             <input
               value={state.query}
-              onChange={(e) => setState((s) => ({ ...s, query: e.target.value }))}
+              onChange={(e) =>
+                setState((s) => ({ ...s, query: e.target.value }))
+              }
               placeholder="Поиск по имени, репо, описанию…"
               aria-label="Поиск milestones"
             />
@@ -340,83 +221,113 @@ export function MilestonesView({ milestones, lastUpdated }: Props) {
               </button>
             )}
           </div>
-
-          <div className="v4-projects-sort" ref={sortMenuRef}>
+        </div>
+        <div className="v4-mstoolbar-tools">
+          <div className="v4-pillgrp">
             <button
               type="button"
-              className="v4-btn"
-              onClick={() => setSortMenuOpen((v) => !v)}
-              aria-haspopup="menu"
-              aria-expanded={sortMenuOpen}
+              className={state.grouping === "deadline" ? "is-active" : ""}
+              onClick={() =>
+                setState((s) => ({ ...s, grouping: "deadline" }))
+              }
             >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M3 6h18M6 12h12M10 18h4" />
-              </svg>
-              {SORT_LABELS[state.sort]} {state.asc ? "↑" : "↓"}
+              По дедлайну
             </button>
-            {sortMenuOpen && (
-              <div className="v4-projects-sort-menu" role="menu">
-                {(Object.keys(SORT_LABELS) as SortKey[]).map((k) => (
-                  <button
-                    key={k}
-                    type="button"
-                    role="menuitemradio"
-                    aria-checked={state.sort === k}
-                    className={state.sort === k ? "is-active" : ""}
-                    onClick={() => {
-                      setState((s) => ({ ...s, sort: k }));
-                      setSortMenuOpen(false);
-                    }}
-                  >
-                    {SORT_LABELS[k]}
-                  </button>
-                ))}
-                <div className="v4-projects-sort-sep" />
-                <button
-                  type="button"
-                  role="menuitemcheckbox"
-                  aria-checked={state.asc}
-                  className={state.asc ? "is-active" : ""}
-                  onClick={() => setState((s) => ({ ...s, asc: !s.asc }))}
-                >
-                  {state.asc ? "↑ По возрастанию" : "↓ По убыванию"}
-                </button>
-              </div>
-            )}
+            <button
+              type="button"
+              className={state.grouping === "repo" ? "is-active" : ""}
+              onClick={() => setState((s) => ({ ...s, grouping: "repo" }))}
+            >
+              По репо
+            </button>
+          </div>
+          <div className="v4-pillgrp">
+            <button
+              type="button"
+              className={state.density === "comfortable" ? "is-active" : ""}
+              onClick={() =>
+                setState((s) => ({ ...s, density: "comfortable" }))
+              }
+              title="Обычная плотность"
+            >
+              Обычная
+            </button>
+            <button
+              type="button"
+              className={state.density === "compact" ? "is-active" : ""}
+              onClick={() => setState((s) => ({ ...s, density: "compact" }))}
+              title="Компактная плотность"
+            >
+              Компакт
+            </button>
           </div>
         </div>
       </div>
 
-      {/* Empty state — keyed off post-search count so search-with-no-results
-          shows the proper feedback message instead of a blank card area. */}
-      {filtered.length === 0 && (
+      {/* Cards */}
+      {filteredOpen.length === 0 ? (
         <div className="v4-panel">
           <div className="v4-empty">
             {state.query
               ? `По запросу «${state.query}» ничего не найдено`
-              : state.sub === "open"
-              ? "Нет открытых milestones"
-              : "Пока нет завершённых milestones"}
+              : "Нет открытых milestones"}
           </div>
         </div>
-      )}
-
-      {/* Cards */}
-      {filtered.length > 0 && (
-        <div className="v4-ms-groups">
-          {groups.map((g) => (
-            <section key={g.key} className="v4-ms-group">
-              <h2 className={`v4-ms-group-title v4-ms-group-title--${g.key}`}>
-                {g.title}{" "}
-                <span className="v4-ms-group-count">({g.items.length})</span>
-              </h2>
-              <div className="v4-ms-grid-full">
-                {g.items.map((e) => (
-                  <MilestoneCardV4 key={e.m.url} milestone={e.m} />
-                ))}
-              </div>
-            </section>
-          ))}
+      ) : (
+        <div className="v4-msgroups">
+          {groups.map((g) => {
+            const totalIssues = g.items.reduce(
+              (s, x) => s + x.m.openIssues + x.m.closedIssues,
+              0
+            );
+            const closedIssues = g.items.reduce(
+              (s, x) => s + x.m.closedIssues,
+              0
+            );
+            const pct =
+              totalIssues > 0
+                ? Math.round((closedIssues / totalIssues) * 100)
+                : 0;
+            return (
+              <section
+                key={`${g.key}-${g.title}`}
+                className="v4-msgroup"
+              >
+                <header className={`v4-msgroup-head v4-msgroup-head--${g.key}`}>
+                  <div className="v4-msgroup-title">
+                    <span className="v4-msgroup-dot" />
+                    {g.title}{" "}
+                    <span className="v4-msgroup-count">({g.items.length})</span>
+                  </div>
+                  <div className="v4-msgroup-rollup num">
+                    <span>
+                      {closedIssues}/{totalIssues}
+                    </span>
+                    <div className="v4-msgroup-rollup-bar">
+                      <div
+                        className="v4-msgroup-rollup-fill"
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                    <span>{pct}%</span>
+                  </div>
+                </header>
+                <div
+                  className={`v4-msgrid${
+                    state.density === "compact" ? " v4-msgrid--compact" : ""
+                  }`}
+                >
+                  {g.items.map((e) => (
+                    <MilestoneCardV4
+                      key={e.m.url}
+                      milestone={e.m}
+                      density={state.density}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/v4/milestones/utils.ts
+++ b/src/components/v4/milestones/utils.ts
@@ -1,0 +1,167 @@
+import type { Milestone, MilestoneIssue } from "../../../types";
+import type { MilestoneStatusKind } from "./classifyMilestone";
+
+export const REPO_GLYPH: Record<string, string> = {
+  "Sewing-ERP": "#2563EB",
+  "mankassa-app": "#12B76A",
+  "makeit-pipeline": "#7C3AED",
+  "moliyakg": "#F79009",
+  "Business-News": "#EF4444",
+  "biznews-kg": "#EF4444",
+  "solotax-kg": "#0EA5E9",
+  "quiet-walls": "#A855F7",
+  "MyMoney": "#10B981",
+  "makeit-auditor": "#64748B",
+  "makeit-dashboard": "#0EA5E9",
+  "Beer_bot": "#F97316",
+  "uchet-bot": "#14B8A6",
+};
+
+export function repoGlyphColor(repo: string): string {
+  return REPO_GLYPH[repo] ?? "var(--v4-ink-400)";
+}
+
+const RU_MONTHS_SHORT = [
+  "янв", "фев", "мар", "апр", "май", "июн",
+  "июл", "авг", "сен", "окт", "ноя", "дек",
+];
+const RU_DOW = ["вс", "пн", "вт", "ср", "чт", "пт", "сб"];
+
+export function ruMonthShort(d: Date): string {
+  return RU_MONTHS_SHORT[d.getMonth()];
+}
+
+export function ruDow(d: Date): string {
+  return RU_DOW[d.getDay()];
+}
+
+export function deadlineBucket(days: number | null): {
+  key: "overdue" | "week" | "month" | "later" | "noeta";
+  label: string;
+  order: number;
+} {
+  if (days === null) return { key: "noeta", label: "Без дедлайна", order: 99 };
+  if (days < 0) return { key: "overdue", label: "Просрочено", order: 0 };
+  if (days <= 7) return { key: "week", label: "Эта неделя", order: 1 };
+  if (days <= 30) return { key: "month", label: "Этот месяц", order: 2 };
+  return { key: "later", label: "Дальше", order: 3 };
+}
+
+export function diffDays(a: Date, b: Date): number {
+  return Math.round((a.getTime() - b.getTime()) / 86400000);
+}
+
+export function addDays(d: Date, n: number): Date {
+  const r = new Date(d);
+  r.setDate(r.getDate() + n);
+  return r;
+}
+
+/**
+ * Truncate to local midnight. Gantt math compares "calendar days" — using a
+ * timestamp anchored at noon would break the diffDays rounding near DST.
+ */
+export function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+/**
+ * Build a 14-bucket array of issue closures, oldest first, ending with `now`.
+ * Used by the Velocity hero tile sparkline & 7-day delta.
+ */
+export function buildDaily14(issues: MilestoneIssue[], now: Date): number[] {
+  const buckets = new Array<number>(14).fill(0);
+  const start = startOfDay(addDays(now, -13));
+  for (const i of issues) {
+    if (i.state !== "CLOSED" || !i.closedAt) continue;
+    const d = startOfDay(new Date(i.closedAt));
+    const idx = diffDays(d, start);
+    if (idx >= 0 && idx < 14) buckets[idx]++;
+  }
+  return buckets;
+}
+
+export interface SparkPath {
+  line: string;
+  area: string;
+}
+
+export function buildSparkPath(values: number[], w: number, h: number): SparkPath {
+  if (values.length === 0) return { line: "", area: "" };
+  const max = Math.max(...values, 1);
+  const stepX = values.length > 1 ? w / (values.length - 1) : w;
+  const pts = values.map<[number, number]>((v, i) => [
+    i * stepX,
+    h - (v / max) * (h - 4) - 2,
+  ]);
+  const line = pts
+    .map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`)
+    .join(" ");
+  const last = pts[pts.length - 1];
+  const area = `${line} L${last[0].toFixed(1)},${h} L0,${h} Z`;
+  return { line, area };
+}
+
+export function inferPriority(m: Milestone): "P1" | "P2" | "P3" | "P4" | null {
+  const labels = (m.issues ?? []).flatMap((i) => i.labels);
+  for (const p of ["P1", "P2", "P3", "P4"] as const) {
+    if (labels.some((l) => l.toUpperCase().startsWith(p))) return p;
+  }
+  return null;
+}
+
+export function countBlocked(m: Milestone): number {
+  return (m.issues ?? []).filter(
+    (i) => i.state === "OPEN" && i.labels.some((l) => l.toLowerCase() === "blocked")
+  ).length;
+}
+
+export function countByPriority(m: Milestone, priority: "P1" | "P2"): number {
+  return (m.issues ?? []).filter(
+    (i) =>
+      i.state === "OPEN" &&
+      i.labels.some((l) => l.toUpperCase().startsWith(priority))
+  ).length;
+}
+
+/**
+ * Strip "Epic-007:" / "Sprint 12:" prefixes for compact contexts (Gantt rows
+ * and "Next deadline" hero tile).
+ */
+export function stripEpicPrefix(title: string): string {
+  return title
+    .replace(/^Epic-?\d+:?\s*/i, "")
+    .replace(/^Sprint\s+\d+:?\s*/i, "")
+    .trim();
+}
+
+export function clsPriority(cls: MilestoneStatusKind): number {
+  switch (cls) {
+    case "overdue":
+      return 0;
+    case "warn":
+      return 1;
+    case "soon":
+      return 2;
+    case "norm":
+      return 3;
+    case "noeta":
+      return 4;
+    case "done":
+      return 5;
+  }
+}
+
+/**
+ * Best-guess milestone start: createdAt if present, otherwise dueOn − fallback,
+ * otherwise NOW − 7d. Used as the left edge of the Gantt bar.
+ */
+export function milestoneStart(m: Milestone, fallbackNow: Date): Date {
+  if (m.createdAt) return startOfDay(new Date(m.createdAt));
+  if (m.dueOn) {
+    const due = startOfDay(new Date(m.dueOn));
+    const total = m.openIssues + m.closedIssues;
+    return addDays(due, -Math.max(7, Math.round(total * 1.5)));
+  }
+  return addDays(startOfDay(fallbackNow), -7);
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -5863,3 +5863,791 @@ ul.v4-rsh-list {
   }
   .v4-search { display: none; }
 }
+
+/* ──────────────────────────────────────────────────────────────────
+ * Milestones V4 redesign (handoff: design_handoff_milestones)
+ * ────────────────────────────────────────────────────────────────── */
+
+/* Hero: 1 dominant + 2 supports */
+.v4-mshero {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr;
+  gap: 14px;
+  margin-top: 14px;
+}
+.v4-mshero-tile {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: 12px;
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  position: relative;
+  overflow: hidden;
+  min-height: 156px;
+}
+.v4-mshero-tile--main {
+  background:
+    radial-gradient(140% 100% at 100% 0%, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0) 60%),
+    linear-gradient(135deg, #1E293B 0%, var(--v4-accent-700) 100%);
+  border-color: var(--v4-accent-700);
+  color: #fff;
+}
+.v4-mshero-lbl {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 11px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--v4-ink-500);
+}
+.v4-mshero-tile--main .v4-mshero-lbl { color: rgba(255,255,255,0.78); }
+.v4-mshero-tile--main .v4-mshero-lbl svg { color: rgba(255,255,255,0.85); }
+.v4-mshero-lbl svg { width: 13px; height: 13px; }
+
+.v4-mshero-main-body { display: flex; align-items: center; gap: 22px; }
+.v4-mshero-ring { position: relative; width: 110px; height: 110px; flex-shrink: 0; }
+.v4-mshero-ring svg { width: 100%; height: 100%; transform: rotate(-90deg); }
+.v4-mshero-ring-c {
+  position: absolute; inset: 0;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+}
+.v4-mshero-ring-pct {
+  font-family: var(--v4-mono); font-size: 28px; font-weight: 700;
+  color: #fff; letter-spacing: -0.02em; line-height: 1;
+}
+.v4-mshero-ring-lbl {
+  font-family: var(--v4-mono); font-size: 9px; color: rgba(255,255,255,0.7);
+  margin-top: 4px; text-transform: uppercase; letter-spacing: 0.08em;
+}
+.v4-mshero-main-side {
+  display: flex; flex-direction: column; gap: 10px; min-width: 0; flex: 1;
+}
+.v4-mshero-row {
+  display: flex; align-items: center; gap: 10px;
+  font-size: 13px; color: rgba(255,255,255,0.92);
+}
+.v4-mshero-sw { width: 10px; height: 10px; border-radius: 3px; flex-shrink: 0; }
+.v4-mshero-row-l { font-size: 12px; flex: 1; }
+.v4-mshero-row b {
+  font-family: var(--v4-mono); font-weight: 700; color: #fff;
+  font-size: 16px; min-width: 28px; text-align: right;
+}
+
+.v4-mshero-num {
+  font-family: var(--v4-mono); font-size: 40px; font-weight: 700;
+  color: var(--v4-ink-900); line-height: 1; letter-spacing: -0.02em;
+}
+.v4-mshero-num-u {
+  font-size: 18px; font-weight: 600;
+  color: var(--v4-ink-500); margin-left: 4px;
+}
+.v4-mshero-meta {
+  display: flex; align-items: center; gap: 6px;
+  font-family: var(--v4-mono); font-size: 11px; color: var(--v4-ink-500);
+  min-width: 0;
+}
+.v4-mshero-meta-strong {
+  color: var(--v4-ink-700); font-weight: 600;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.v4-mshero-delta-pos { color: var(--v4-success-700); font-weight: 700; }
+.v4-mshero-delta-neg { color: var(--v4-danger-700); font-weight: 700; }
+.v4-mshero-spark { width: 100%; height: 36px; }
+.v4-mshero-spark svg { width: 100%; height: 100%; }
+.v4-mshero-break {
+  display: flex; gap: 16px; padding-top: 8px;
+  border-top: 1px dashed var(--v4-line-soft);
+  margin-top: auto;
+}
+.v4-mshero-break-it { display: flex; flex-direction: column; gap: 1px; }
+.v4-mshero-break-n {
+  font-family: var(--v4-mono); font-size: 13px; font-weight: 700;
+  color: var(--v4-ink-900);
+}
+.v4-mshero-break-l {
+  font-size: 10px; font-family: var(--v4-mono);
+  color: var(--v4-ink-500); text-transform: uppercase; letter-spacing: 0.04em;
+}
+
+/* Gantt */
+.v4-msgantt {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: 12px;
+  margin-top: 14px;
+  overflow: hidden;
+}
+.v4-msgantt-h {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--v4-line-soft);
+  flex-wrap: wrap; gap: 12px;
+}
+.v4-msgantt-t {
+  font-size: 13px; font-weight: 600; color: var(--v4-ink-900);
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.v4-msgantt-t svg { width: 14px; height: 14px; }
+.v4-msgantt-controls { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.v4-msgantt-legend {
+  display: flex; gap: 14px;
+  font-family: var(--v4-mono); font-size: 11px; color: var(--v4-ink-500);
+  flex-wrap: wrap;
+}
+.v4-msgantt-lg { display: inline-flex; align-items: center; gap: 6px; }
+.v4-msgantt-dot { width: 8px; height: 8px; border-radius: 99px; }
+.v4-msgantt-mini-bar {
+  width: 18px; height: 6px; border-radius: 99px;
+  background: var(--v4-surface-3); position: relative;
+}
+.v4-msgantt-mini-bar::after {
+  content: ''; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 60%; border-radius: 99px; background: var(--v4-accent-500);
+}
+.v4-msgantt-empty {
+  padding: 36px 18px; text-align: center;
+  color: var(--v4-ink-500); font-size: 13px;
+}
+.v4-msgantt-body {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+}
+
+.v4-msgantt-list {
+  background: var(--v4-paper);
+  border-right: 1px solid var(--v4-line);
+  display: flex; flex-direction: column;
+  min-width: 0;
+}
+.v4-msgantt-list-h {
+  height: 56px; padding: 0 14px;
+  display: flex; align-items: center;
+  font-family: var(--v4-mono); font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--v4-ink-500);
+  border-bottom: 1px solid var(--v4-line-soft);
+  background: var(--v4-surface-2);
+}
+.v4-msgantt-row {
+  height: 44px; padding: 0 14px;
+  display: flex; align-items: center; gap: 10px;
+  border-bottom: 1px solid var(--v4-line-soft);
+  cursor: pointer;
+  transition: background 120ms;
+  position: relative;
+  text-decoration: none;
+  color: inherit;
+  min-width: 0;
+}
+.v4-msgantt-row:hover { background: var(--v4-surface-2); }
+.v4-msgantt-row:last-child { border-bottom: 0; }
+.v4-msgantt-row::before {
+  content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 3px;
+}
+.v4-msgantt-row--overdue::before { background: var(--v4-danger-500); }
+.v4-msgantt-row--warn::before    { background: var(--v4-warn-500); }
+.v4-msgantt-row--soon::before    { background: var(--v4-accent-500); }
+.v4-msgantt-row--norm::before    { background: var(--v4-ink-300); }
+.v4-msgantt-row--done::before    { background: var(--v4-success-500); }
+.v4-msgantt-row--noeta::before   { background: var(--v4-ink-300); }
+.v4-msgantt-row-glyph { width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; }
+.v4-msgantt-row-info { flex: 1; min-width: 0; line-height: 1.1; }
+.v4-msgantt-row-title {
+  font-size: 12.5px; font-weight: 600; color: var(--v4-ink-900);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  letter-spacing: -0.005em;
+}
+.v4-msgantt-row-sub {
+  font-family: var(--v4-mono); font-size: 10px; color: var(--v4-ink-500);
+  margin-top: 2px;
+  display: flex; gap: 6px; align-items: center;
+}
+.v4-msgantt-row-dot {
+  width: 2px; height: 2px; border-radius: 50%; background: var(--v4-ink-400);
+}
+.v4-msgantt-row-pct {
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 700;
+  color: var(--v4-ink-700); flex-shrink: 0;
+  min-width: 36px; text-align: right;
+}
+
+.v4-msgantt-chart {
+  position: relative;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+.v4-msgantt-chart-inner { position: relative; min-width: 100%; }
+.v4-msgantt-axis {
+  height: 56px;
+  position: sticky; top: 0; z-index: 3;
+  background: var(--v4-surface-2);
+  border-bottom: 1px solid var(--v4-line-soft);
+}
+.v4-msgantt-axis-months {
+  display: flex; height: 26px;
+  border-bottom: 1px solid var(--v4-line-soft);
+}
+.v4-msgantt-axis-month {
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 700;
+  color: var(--v4-ink-700);
+  text-transform: uppercase; letter-spacing: 0.05em;
+  border-right: 1px solid var(--v4-line-soft);
+}
+.v4-msgantt-axis-month:last-child { border-right: 0; }
+.v4-msgantt-axis-days { display: flex; height: 30px; }
+.v4-msgantt-axis-day {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  border-right: 1px solid var(--v4-line-soft);
+  font-family: var(--v4-mono);
+  flex-shrink: 0;
+}
+.v4-msgantt-axis-day:last-child { border-right: 0; }
+.v4-msgantt-axis-day-num {
+  font-size: 11px; font-weight: 600;
+  color: var(--v4-ink-700); line-height: 1;
+}
+.v4-msgantt-axis-day-dow {
+  font-size: 9px; color: var(--v4-ink-400);
+  margin-top: 2px; text-transform: uppercase;
+}
+.v4-msgantt-axis-day--weekend { background: rgba(148,160,184,0.08); }
+.v4-msgantt-axis-day--weekend .v4-msgantt-axis-day-num,
+.v4-msgantt-axis-day--weekend .v4-msgantt-axis-day-dow {
+  color: var(--v4-ink-400);
+}
+.v4-msgantt-axis-day--today { background: var(--v4-accent-50); }
+.v4-msgantt-axis-day--today .v4-msgantt-axis-day-num { color: var(--v4-accent-700); }
+
+.v4-msgantt-grid {
+  position: relative;
+  background-color: var(--v4-paper);
+  background-image: linear-gradient(to right, var(--v4-line-soft) 0, var(--v4-line-soft) 1px, transparent 1px);
+  background-repeat: repeat;
+}
+.v4-msgantt-grid-row {
+  height: 44px;
+  border-bottom: 1px solid var(--v4-line-soft);
+  position: relative;
+}
+.v4-msgantt-grid-row:last-child { border-bottom: 0; }
+.v4-msgantt-grid-row:hover { background: rgba(245,247,250,0.6); }
+
+.v4-msgantt-weekend {
+  position: absolute; top: 0; bottom: 0;
+  background: rgba(148,160,184,0.06);
+  pointer-events: none;
+  z-index: 0;
+}
+.v4-msgantt-today {
+  position: absolute; top: 0; bottom: 0;
+  width: 2px; background: var(--v4-accent-500);
+  z-index: 4; pointer-events: none;
+}
+.v4-msgantt-today::before {
+  content: 'СЕГОДНЯ';
+  position: absolute; top: -4px; left: 50%; transform: translateX(-50%);
+  background: var(--v4-accent-500); color: #fff;
+  font-family: var(--v4-mono); font-size: 9px; font-weight: 700;
+  padding: 2px 7px; border-radius: 4px; letter-spacing: 0.05em;
+  white-space: nowrap; z-index: 5;
+}
+
+.v4-msgantt-bar {
+  position: absolute;
+  height: 26px; top: 9px;
+  border-radius: 6px;
+  overflow: hidden;
+  cursor: pointer;
+  z-index: 1;
+  transition: transform 120ms, box-shadow 120ms;
+  display: flex; align-items: center;
+  padding: 0 8px;
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 600;
+  color: #fff; white-space: nowrap;
+  text-decoration: none;
+}
+.v4-msgantt-bar:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(14,19,32,0.12);
+  z-index: 5;
+}
+.v4-msgantt-bar-fill {
+  position: absolute; left: 0; top: 0; bottom: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+.v4-msgantt-bar-text {
+  position: relative; z-index: 1;
+  display: flex; align-items: center; gap: 8px;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.18);
+  min-width: 0;
+}
+.v4-msgantt-bar-title { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.v4-msgantt-bar-pct {
+  font-size: 10px;
+  background: rgba(255,255,255,0.22);
+  border: 1px solid rgba(255,255,255,0.18);
+  padding: 1px 5px; border-radius: 99px;
+  flex-shrink: 0;
+}
+
+.v4-msgantt-bar--overdue {
+  background: var(--v4-danger-100); color: var(--v4-danger-700);
+  border: 1px solid var(--v4-danger-500);
+}
+.v4-msgantt-bar--overdue .v4-msgantt-bar-fill { background: var(--v4-danger-500); }
+.v4-msgantt-bar--overdue .v4-msgantt-bar-text { text-shadow: none; }
+.v4-msgantt-bar--overdue.has-fill .v4-msgantt-bar-text {
+  color: #fff; text-shadow: 0 1px 2px rgba(0,0,0,0.18);
+}
+.v4-msgantt-bar--overdue .v4-msgantt-bar-pct {
+  background: rgba(255,255,255,0.3); border-color: rgba(255,255,255,0.25);
+}
+.v4-msgantt-bar--warn {
+  background: var(--v4-warn-100); color: var(--v4-warn-700);
+  border: 1px solid var(--v4-warn-500);
+}
+.v4-msgantt-bar--warn .v4-msgantt-bar-fill { background: var(--v4-warn-500); }
+.v4-msgantt-bar--warn .v4-msgantt-bar-text { text-shadow: none; }
+.v4-msgantt-bar--soon {
+  background: var(--v4-accent-100); color: var(--v4-accent-700);
+  border: 1px solid var(--v4-accent-500);
+}
+.v4-msgantt-bar--soon .v4-msgantt-bar-fill { background: var(--v4-accent-500); }
+.v4-msgantt-bar--soon .v4-msgantt-bar-text { text-shadow: none; }
+.v4-msgantt-bar--norm {
+  background: #DDE3EE; color: var(--v4-ink-800);
+  border: 1px solid var(--v4-ink-400);
+}
+.v4-msgantt-bar--norm .v4-msgantt-bar-fill { background: var(--v4-ink-500); }
+.v4-msgantt-bar--norm .v4-msgantt-bar-text { text-shadow: none; }
+.v4-msgantt-bar--done {
+  background: var(--v4-success-100); color: var(--v4-success-700);
+  border: 1px solid var(--v4-success-500);
+}
+.v4-msgantt-bar--done .v4-msgantt-bar-fill { background: var(--v4-success-500); }
+.v4-msgantt-bar--done .v4-msgantt-bar-text { text-shadow: none; }
+.v4-msgantt-bar--noeta {
+  background: repeating-linear-gradient(135deg, #F4F5F8 0 6px, #EDEFF3 6px 12px);
+  color: var(--v4-ink-600);
+  border: 1px dashed var(--v4-ink-400);
+}
+.v4-msgantt-bar--noeta .v4-msgantt-bar-fill { background: rgba(74,85,112,0.25); }
+.v4-msgantt-bar--noeta .v4-msgantt-bar-text { text-shadow: none; }
+
+.v4-msgantt-due {
+  position: absolute;
+  width: 14px; height: 14px;
+  background: var(--v4-paper);
+  border: 2px solid currentColor;
+  transform: rotate(45deg);
+  top: 15px;
+  z-index: 2;
+}
+.v4-msgantt-due--overdue { color: var(--v4-danger-500); background: var(--v4-danger-500); }
+.v4-msgantt-due--warn    { color: var(--v4-warn-500);  background: var(--v4-warn-500); }
+.v4-msgantt-due--soon    { color: var(--v4-accent-500); }
+.v4-msgantt-due--norm    { color: var(--v4-ink-500); }
+.v4-msgantt-due--done    { color: var(--v4-success-500); background: var(--v4-success-500); }
+.v4-msgantt-due--noeta   { display: none; }
+
+/* Closed section (collapsible) */
+.v4-msclosed {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: 12px;
+  margin-top: 14px;
+  overflow: hidden;
+}
+.v4-msclosed-h {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 18px;
+  cursor: pointer;
+  user-select: none;
+  transition: background 120ms;
+  background: transparent;
+  border: 0;
+  width: 100%;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+}
+.v4-msclosed-h:hover { background: var(--v4-surface-2); }
+.v4-msclosed-h.is-open { border-bottom: 1px solid var(--v4-line-soft); }
+.v4-msclosed-t {
+  font-size: 13px; font-weight: 600; color: var(--v4-ink-900);
+  display: inline-flex; align-items: center; gap: 10px;
+}
+.v4-msclosed-chev {
+  width: 18px; height: 18px; color: var(--v4-ink-500);
+  transition: transform 160ms;
+  flex-shrink: 0;
+}
+.v4-msclosed-h.is-open .v4-msclosed-chev { transform: rotate(90deg); }
+.v4-msclosed-count {
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 600;
+  background: var(--v4-success-50); color: var(--v4-success-700);
+  padding: 2px 8px; border-radius: 99px;
+}
+.v4-msclosed-meta {
+  font-family: var(--v4-mono); font-size: 11px; color: var(--v4-ink-500);
+}
+.v4-msclosed-body { display: grid; grid-template-columns: 1fr; }
+.v4-msclosed-search {
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--v4-line-soft);
+  display: flex; gap: 10px; align-items: center;
+  background: var(--v4-surface-2);
+}
+.v4-msclosed-search svg { width: 14px; height: 14px; color: var(--v4-ink-400); }
+.v4-msclosed-search input {
+  flex: 1;
+  border: 1px solid var(--v4-line);
+  background: var(--v4-paper);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: inherit; font-size: 12px;
+  color: var(--v4-ink-900);
+  outline: none;
+}
+.v4-msclosed-search input:focus { border-color: var(--v4-accent-500); }
+.v4-msclosed-table {
+  display: grid;
+  grid-template-columns: 14px 1.2fr 1fr 110px 90px 70px;
+  font-size: 12px;
+}
+.v4-msclosed-table-head { display: contents; }
+.v4-msclosed-table-head > div {
+  padding: 10px 12px;
+  background: var(--v4-surface-2);
+  border-bottom: 1px solid var(--v4-line);
+  font-family: var(--v4-mono); font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--v4-ink-500);
+}
+.v4-msclosed-th-pct { display: flex; justify-content: flex-end; }
+.v4-msclosed-row {
+  display: contents;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+}
+.v4-msclosed-row > div {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--v4-line-soft);
+  display: flex; align-items: center;
+  min-width: 0;
+}
+.v4-msclosed-row:hover > div { background: var(--v4-surface-2); }
+.v4-msclosed-row:last-child > div { border-bottom: 0; }
+.v4-msclosed-row-glyph { width: 8px; height: 8px; border-radius: 2px; margin: auto; }
+.v4-msclosed-row-title {
+  font-weight: 600; color: var(--v4-ink-900);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  display: block; max-width: 100%;
+}
+.v4-msclosed-row-repo { font-family: var(--v4-mono); color: var(--v4-ink-600); }
+.v4-msclosed-row-date { font-family: var(--v4-mono); color: var(--v4-ink-500); }
+.v4-msclosed-row-issues {
+  font-family: var(--v4-mono); color: var(--v4-ink-700); font-weight: 600;
+}
+.v4-msclosed-row-pct {
+  font-family: var(--v4-mono); color: var(--v4-success-700); font-weight: 700;
+  justify-content: flex-end;
+}
+.v4-msclosed-pager {
+  padding: 10px 18px;
+  display: flex; justify-content: space-between; align-items: center;
+  border-top: 1px solid var(--v4-line-soft);
+  background: var(--v4-surface-2);
+  font-family: var(--v4-mono); font-size: 11px; color: var(--v4-ink-500);
+  gap: 12px;
+}
+.v4-msclosed-pager-ctrl { display: flex; gap: 8px; align-items: center; }
+.v4-msclosed-pager-num { padding: 4px 8px; }
+.v4-msclosed-pager button {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 600;
+  color: var(--v4-ink-700);
+  cursor: pointer;
+}
+.v4-msclosed-pager button:hover:not(:disabled) { background: var(--v4-surface-2); }
+.v4-msclosed-pager button:disabled { opacity: 0.4; cursor: not-allowed; }
+.v4-msclosed-empty {
+  padding: 30px 18px;
+  text-align: center;
+  color: var(--v4-ink-500);
+  font-size: 12px;
+}
+
+/* Status bar */
+.v4-msstatus-wrap { margin-top: 14px; }
+.v4-msstatus {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: 12px;
+  padding: 14px 18px;
+  display: flex;
+  flex-direction: column;
+}
+.v4-msstatus-h {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 14px; gap: 8px; flex-wrap: wrap;
+}
+.v4-msstatus-t {
+  font-size: 13px; font-weight: 600; color: var(--v4-ink-900);
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.v4-msstatus-tag {
+  font-family: var(--v4-mono); font-size: 10px; font-weight: 600;
+  background: var(--v4-surface-2); color: var(--v4-ink-600);
+  padding: 2px 6px; border-radius: 4px;
+}
+.v4-msstatus-bar {
+  display: flex; height: 36px;
+  border-radius: 8px; overflow: hidden;
+  border: 1px solid var(--v4-line-soft);
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 700;
+}
+.v4-msstatus-seg {
+  display: flex; align-items: center; justify-content: center;
+  color: #fff; min-width: 0; position: relative;
+  gap: 6px;
+}
+.v4-msstatus-seg-n { font-size: 13px; }
+.v4-msstatus-seg-l { font-size: 10px; opacity: 0.85; font-weight: 600; }
+.v4-msstatus-legend {
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 8px 16px; margin-top: 12px;
+}
+.v4-msstatus-legend-it {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12px; color: var(--v4-ink-700);
+}
+.v4-msstatus-sw { width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; }
+.v4-msstatus-legend-it b {
+  margin-left: auto;
+  font-family: var(--v4-mono); color: var(--v4-ink-900);
+}
+
+/* Toolbar */
+.v4-mstoolbar {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: 12px;
+  display: flex; justify-content: space-between; align-items: center;
+  flex-wrap: wrap; gap: 14px;
+  padding: 8px 14px;
+  margin-top: 14px;
+}
+.v4-mstoolbar-left { display: flex; align-items: center; gap: 14px; flex: 1; min-width: 0; }
+.v4-mstoolbar-tools { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.v4-mstoolbar-search { min-width: 280px; }
+
+/* Group strip */
+.v4-msgroups {
+  display: flex; flex-direction: column;
+  gap: 28px; margin-top: 22px;
+}
+.v4-msgroup { display: flex; flex-direction: column; gap: 12px; }
+.v4-msgroup-head {
+  display: flex; align-items: center; gap: 12px;
+  border-bottom: 1px solid var(--v4-line);
+  padding-bottom: 10px;
+}
+.v4-msgroup-title {
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--v4-ink-700);
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.v4-msgroup-dot {
+  width: 8px; height: 8px; border-radius: 99px;
+  background: var(--v4-ink-400);
+}
+.v4-msgroup-head--overdue .v4-msgroup-dot { background: var(--v4-danger-500); }
+.v4-msgroup-head--week    .v4-msgroup-dot { background: var(--v4-warn-500); }
+.v4-msgroup-head--month   .v4-msgroup-dot { background: var(--v4-accent-500); }
+.v4-msgroup-head--later   .v4-msgroup-dot { background: var(--v4-ink-300); }
+.v4-msgroup-head--noeta   .v4-msgroup-dot { background: var(--v4-ink-400); }
+.v4-msgroup-head--norm    .v4-msgroup-dot { background: var(--v4-ink-400); }
+.v4-msgroup-count { color: var(--v4-ink-400); font-weight: 500; }
+.v4-msgroup-rollup {
+  margin-left: auto;
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--v4-mono); font-size: 11px; color: var(--v4-ink-500);
+}
+.v4-msgroup-rollup-bar {
+  width: 140px; height: 5px;
+  background: var(--v4-surface-3);
+  border-radius: 99px; overflow: hidden;
+}
+.v4-msgroup-rollup-fill {
+  height: 100%; border-radius: 99px;
+  background: var(--v4-ink-400);
+}
+.v4-msgroup-head--overdue .v4-msgroup-rollup-fill { background: var(--v4-danger-500); }
+.v4-msgroup-head--week    .v4-msgroup-rollup-fill { background: var(--v4-warn-500); }
+.v4-msgroup-head--month   .v4-msgroup-rollup-fill { background: var(--v4-accent-500); }
+.v4-msgroup-head--later   .v4-msgroup-rollup-fill { background: var(--v4-ink-300); }
+
+.v4-msgrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+.v4-msgrid--compact { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 1100px) {
+  .v4-msgrid, .v4-msgrid--compact { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 720px) {
+  .v4-msgrid, .v4-msgrid--compact { grid-template-columns: 1fr; }
+  .v4-mshero { grid-template-columns: 1fr; }
+  .v4-msgantt-body { grid-template-columns: 220px 1fr; }
+}
+
+/* Card (v4-mscv namespace) */
+.v4-mscv {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: 12px;
+  position: relative;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  padding: 16px 18px;
+  gap: 14px;
+  transition: border-color 120ms, box-shadow 120ms;
+}
+.v4-mscv:hover {
+  border-color: var(--v4-line-strong);
+  box-shadow: 0 4px 16px rgba(14,19,32,0.06);
+}
+.v4-mscv::before {
+  content: ''; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 3px;
+}
+.v4-mscv--overdue::before { background: var(--v4-danger-500); }
+.v4-mscv--warn::before    { background: var(--v4-warn-500); }
+.v4-mscv--soon::before    { background: var(--v4-accent-500); }
+.v4-mscv--norm::before    { background: var(--v4-ink-300); }
+.v4-mscv--done::before    { background: var(--v4-success-500); }
+.v4-mscv--noeta::before   { background: var(--v4-ink-300); }
+.v4-mscv--compact { padding: 14px; gap: 10px; }
+.v4-mscv--compact .v4-mscv-title { font-size: 13.5px; }
+
+.v4-mscv-head {
+  display: flex; flex-direction: column; gap: 10px;
+  cursor: pointer;
+  outline: none;
+}
+.v4-mscv-head:focus-visible {
+  outline: 2px solid var(--v4-accent-500);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+.v4-mscv-meta {
+  display: flex; justify-content: space-between; align-items: center;
+  gap: 10px;
+}
+.v4-mscv-repo {
+  display: inline-flex; align-items: center; gap: 7px;
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 600;
+  color: var(--v4-ink-700);
+  text-transform: lowercase;
+  min-width: 0;
+}
+.v4-mscv-repo-glyph { width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; }
+.v4-mscv-chev {
+  width: 12px; height: 12px;
+  color: var(--v4-ink-400);
+  transition: transform 160ms;
+  flex-shrink: 0;
+}
+.v4-mscv-chev.is-open { transform: rotate(90deg); color: var(--v4-ink-700); }
+.v4-mscv-meta-right { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+.v4-mscv-due {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 600;
+  white-space: nowrap;
+}
+.v4-mscv-due svg { width: 11px; height: 11px; }
+.v4-mscv-due--overdue { color: var(--v4-danger-700); }
+.v4-mscv-due--warn    { color: var(--v4-warn-700); }
+.v4-mscv-due--soon    { color: var(--v4-accent-700); }
+.v4-mscv-due--norm    { color: var(--v4-ink-500); }
+.v4-mscv-due--done    { color: var(--v4-success-700); }
+.v4-mscv-due--noeta   { color: var(--v4-ink-400); }
+
+.v4-mscv-title {
+  font-size: 16px; font-weight: 600; color: var(--v4-ink-900);
+  line-height: 1.35; letter-spacing: -0.01em;
+}
+.v4-mscv-titlelink { color: inherit; }
+.v4-mscv-titlelink:hover { color: var(--v4-accent-700); text-decoration: underline; }
+.v4-mscv-desc {
+  font-size: 12px; color: var(--v4-ink-500); line-height: 1.45;
+}
+
+.v4-mscv-bar { display: flex; flex-direction: column; gap: 7px; }
+.v4-mscv-bar-meta {
+  display: flex; justify-content: space-between; align-items: baseline;
+}
+.v4-mscv-bar-meta-left {
+  font-family: var(--v4-mono); font-size: 12px; color: var(--v4-ink-700);
+}
+.v4-mscv-bar-closed { font-weight: 700; color: var(--v4-ink-900); }
+.v4-mscv-bar-total { color: var(--v4-ink-500); }
+.v4-mscv-bar-pct {
+  font-family: var(--v4-mono);
+  font-size: 18px; font-weight: 700; line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--v4-ink-900);
+}
+.v4-mscv-pct--good { color: var(--v4-success-700); }
+.v4-mscv-pct--warn { color: var(--v4-warn-700); }
+.v4-mscv-pct--bad  { color: var(--v4-danger-700); }
+.v4-mscv-track {
+  height: 6px; background: var(--v4-surface-3); border-radius: 99px;
+  overflow: hidden; position: relative;
+}
+.v4-mscv-fill { height: 100%; border-radius: 99px; }
+.v4-mscv-fill--overdue { background: var(--v4-danger-500); }
+.v4-mscv-fill--warn    { background: var(--v4-warn-500); }
+.v4-mscv-fill--soon    { background: var(--v4-accent-500); }
+.v4-mscv-fill--norm    { background: var(--v4-ink-400); }
+.v4-mscv-fill--done    { background: var(--v4-success-500); }
+.v4-mscv-fill--noeta   { background: var(--v4-ink-400); }
+
+.v4-mscv-foot {
+  display: flex; gap: 6px; flex-wrap: wrap;
+  border-top: 1px dashed var(--v4-line-soft);
+  padding-top: 12px;
+  margin-top: -2px;
+}
+.v4-mscv-chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 600;
+  background: var(--v4-surface-2); color: var(--v4-ink-600);
+  padding: 3px 8px; border-radius: 99px;
+}
+.v4-mscv-chip--p1      { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-mscv-chip--p2      { background: var(--v4-warn-50);   color: var(--v4-warn-700); }
+.v4-mscv-chip--blocked { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+
+.v4-mscv-issues {
+  border-top: 1px solid var(--v4-line-soft);
+  padding-top: 10px;
+  display: flex; flex-direction: column; gap: 4px;
+  max-height: 280px;
+  overflow-y: auto;
+}
+.v4-mscv-issues-empty {
+  padding: 8px 0;
+  font-size: 12px; color: var(--v4-ink-500);
+  text-align: center;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,6 +77,8 @@ export interface MilestoneIssue {
   state: "OPEN" | "CLOSED";
   labels: string[];
   url: string;
+  createdAt: string | null;
+  closedAt: string | null;
 }
 
 export interface Milestone {
@@ -89,6 +91,8 @@ export interface Milestone {
   closedIssues: number;
   repo: string;
   issues: MilestoneIssue[];
+  createdAt: string | null;
+  closedAt: string | null;
 }
 
 export interface Filters {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,8 +1,14 @@
 /** Shared date helpers used across deadline / chart components. */
 
-/** Whole-day distance between today and `dueOn` (ISO string). Negative = overdue. */
-export function daysUntil(dueOn: string): number {
-  return Math.ceil((new Date(dueOn).getTime() - Date.now()) / 86400000);
+/**
+ * Whole-day distance between a reference time and `dueOn` (ISO string).
+ * Negative = overdue. Pass `reference` (e.g. the `lastUpdated` data anchor)
+ * to keep classification consistent with positions computed against the
+ * same anchor — without it, Date.now() drifts every render.
+ */
+export function daysUntil(dueOn: string, reference?: Date): number {
+  const ref = reference ? reference.getTime() : Date.now();
+  return Math.ceil((new Date(dueOn).getTime() - ref) / 86400000);
 }
 
 /** Localised "DD MMM" (Russian short month) — used in deadline badges. */

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -334,6 +334,8 @@ query($owner: String!, $repo: String!) {
         dueOn
         url
         state
+        createdAt
+        closedAt
         closedIssues: issues(states: CLOSED) { totalCount }
         openIssues: issues(states: OPEN) { totalCount }
         allIssues: issues(first: 50, orderBy: {field: CREATED_AT, direction: ASC}) {
@@ -342,6 +344,8 @@ query($owner: String!, $repo: String!) {
             title
             state
             url
+            createdAt
+            closedAt
             labels(first: 10) { nodes { name } }
           }
         }
@@ -354,6 +358,8 @@ query($owner: String!, $repo: String!) {
         dueOn
         url
         state
+        createdAt
+        closedAt
         closedIssues: issues(states: CLOSED) { totalCount }
         openIssues: issues(states: OPEN) { totalCount }
         allIssues: issues(first: 50, orderBy: {field: CREATED_AT, direction: ASC}) {
@@ -362,6 +368,8 @@ query($owner: String!, $repo: String!) {
             title
             state
             url
+            createdAt
+            closedAt
             labels(first: 10) { nodes { name } }
           }
         }
@@ -376,6 +384,8 @@ interface MilestoneIssueNode {
   title: string;
   state: "OPEN" | "CLOSED";
   url: string;
+  createdAt: string | null;
+  closedAt: string | null;
   labels: { nodes: { name: string }[] };
 }
 
@@ -385,6 +395,8 @@ interface MilestoneNode {
   dueOn: string | null;
   url: string;
   state: "OPEN" | "CLOSED";
+  createdAt: string | null;
+  closedAt: string | null;
   closedIssues: { totalCount: number };
   openIssues: { totalCount: number };
   allIssues: { nodes: MilestoneIssueNode[] };
@@ -435,6 +447,8 @@ async function fetchRepoInfo(token: string, owner: string, repo: string): Promis
       dueOn: m.dueOn,
       url: m.url,
       state: m.state,
+      createdAt: m.createdAt,
+      closedAt: m.closedAt,
       openIssues: m.openIssues.totalCount,
       closedIssues: m.closedIssues.totalCount,
       repo,
@@ -444,6 +458,8 @@ async function fetchRepoInfo(token: string, owner: string, repo: string): Promis
         state: i.state,
         labels: i.labels.nodes.map((l) => l.name),
         url: i.url,
+        createdAt: i.createdAt,
+        closedAt: i.closedAt,
       })),
     })),
     commitActivity,


### PR DESCRIPTION
## Summary
- Реализован редизайн вкладки **Milestones** по handoff-бандлу (`Dashboard-2.zip` / `design_handoff_milestones`).
- Замещает старую view (sub-tab + card grid) новой композицией: **Hero (3 плитки) → Gantt → ClosedSection → StatusBar → Toolbar → Grouped cards**.
- Расширен GraphQL-запрос: добавлены `createdAt` / `closedAt` для milestone и issues — нужно для Gantt-старта, velocity-спарклайна и сортировки завершённых.

## Что нового

**Компоненты** (`src/components/v4/milestones/`)
- `MilestonesHero` — 3 плитки: градиентный «Портфель» с SVG-кольцом (in-progress / overdue / done), Velocity (число + 14-дневный sparkline + 7-дневная дельта vs прошлая неделя), «Ближайший дедлайн» с countdown + repo + breakdown ≤ 7д / ≤ 30д / дальше.
- `MilestonesGantt` — полная Gantt-диаграмма [−21д, +60д] с тремя зумами (День 36px / Неделя 22px / Месяц 12px), sticky-axis по месяцам и дням, полосы выходных, today-линия с пилюлей «СЕГОДНЯ», бары со статусным цветом + progress-fill + pct-pill, ромбы дедлайна, левая колонка-список 280px.
- `MilestonesClosedSection` — сворачиваемая секция с шевроном, search-bar (показывается при >8 завершённых), grid-таблица 6 колонок (glyph / title / repo / closed / issues / %) и пагинатор (12 на страницу).
- `MilestonesStatusBar` — stacked-bar по 6 статусам + 3-колоночная легенда.
- `MilestoneCardV4` — карточка-плитка для compact-плотности: статусная боковая полоска, repo-глиф + шеврон-индикатор раскрытия, P1/P2 ptag, due-badge, progress-track, **раскрывающийся issue-list** (по запросу пользователя сохранён).
- `MilestonesView` — orchestrator: localStorage-persisted state (density / grouping / gantt zoom), поиск фильтрует только карточки (Gantt и ClosedSection остаются полными для стабильности обзора).
- `utils.ts` — REPO_GLYPH, daily14, sparkPath, deadlineBucket, milestoneStart, ru-форматирование месяцев/дней.

**Data layer**
- `Milestone` и `MilestoneIssue` расширены полями `createdAt` / `closedAt`; запрос `REPO_INFO_QUERY` обновлён.

**CSS** (~790 LOC в `src/styles/v4.css`)
- Новые namespace'ы: `v4-mshero-*`, `v4-msgantt-*`, `v4-msclosed-*`, `v4-msstatus-*`, `v4-mstoolbar-*`, `v4-msgroups`/`v4-msgroup-*`, `v4-msgrid`, `v4-mscv-*` (новый класс карточки, чтобы не пересекаться с legacy `v4-mscard-*`).
- Адаптив: ≤ 1100px — 2-колоночный grid, ≤ 720px — 1-колоночный + Hero вертикально + Gantt-list 220px.

## Test plan
- [x] `npx tsc --noEmit` — чисто
- [x] `npm run lint` — чисто
- [x] `npm run build` — чисто, размер CSS вырос на ~37 KB → 270 KB total
- [x] Визуально проверил все блоки на синтетических данных (временный `?demo=milestones` маршрут): Hero / Gantt (с zoomами и today-line) / ClosedSection (раскрытие, таблица) / StatusBar / карточки в compact-плотности / группы по дедлайну с rollup-bar
- [ ] **Проверить на проде после мержа**: подставится ли `createdAt` / `closedAt` корректно для всех milestone (для milestone без `createdAt` Gantt-бар начнётся с `dueOn − max(7, total*1.5)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)