### PR TITLE
fix(milestones): Gantt rendering — auto-scroll, project grouping, no-due bars

### DIFF
--- a/src/components/v4/milestones/MilestonesGantt.tsx
+++ b/src/components/v4/milestones/MilestonesGantt.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import type { Milestone } from "../../../types";
 import { daysUntil, formatShortDate } from "../../../utils/date";
 import { classifyMilestone, type MilestoneStatusKind } from "./classifyMilestone";
@@ -15,6 +15,7 @@ import {
 } from "./utils";
 
 export type GanttZoom = "day" | "week" | "month";
+export type GanttGrouping = "none" | "repo";
 
 const ZOOMS: Record<GanttZoom, { dayW: number; label: string }> = {
   day: { dayW: 36, label: "День" },
@@ -24,13 +25,17 @@ const ZOOMS: Record<GanttZoom, { dayW: number; label: string }> = {
 
 const WINDOW_BACK_MAX = 21;
 const WINDOW_BACK_MIN = 3;
-const WINDOW_FWD = 60;
+const WINDOW_FWD_MIN = 60;
+const WINDOW_FWD_MAX = 365;
 const ROW_H = 44;
+const GROUP_H = 30;
 
 interface Props {
   milestones: Milestone[];
   zoom: GanttZoom;
   onZoom: (z: GanttZoom) => void;
+  grouping: GanttGrouping;
+  onGrouping: (g: GanttGrouping) => void;
   now: Date;
 }
 
@@ -42,7 +47,18 @@ interface Enriched {
   cls: MilestoneStatusKind;
 }
 
-export function MilestonesGantt({ milestones, zoom, onZoom, now }: Props) {
+type Item =
+  | { kind: "group"; repo: string; count: number }
+  | { kind: "row"; e: Enriched };
+
+export function MilestonesGantt({
+  milestones,
+  zoom,
+  onZoom,
+  grouping,
+  onGrouping,
+  now,
+}: Props) {
   const data = useMemo(() => {
     const dayW = ZOOMS[zoom].dayW;
 
@@ -70,9 +86,45 @@ export function MilestonesGantt({ milestones, zoom, onZoom, now }: Props) {
       Math.max(WINDOW_BACK_MIN, backFromEarliest)
     );
     const startWindow = startOfDay(addDays(now, -back));
-    const endWindow = startOfDay(addDays(now, WINDOW_FWD));
+
+    // Extend forward window to include the latest deadline (capped) — milestones
+    // with dueOn beyond default 60d would otherwise get clipped to right edge.
+    const latestDue = enriched.reduce<number>(
+      (acc, x) => (x.dueD && x.dueD.getTime() > acc ? x.dueD.getTime() : acc),
+      0
+    );
+    const fwdFromLatest =
+      latestDue > 0
+        ? diffDays(startOfDay(new Date(latestDue)), today) + 7
+        : WINDOW_FWD_MIN;
+    const fwd = Math.min(
+      WINDOW_FWD_MAX,
+      Math.max(WINDOW_FWD_MIN, fwdFromLatest)
+    );
+    const endWindow = startOfDay(addDays(now, fwd));
     const totalDays = diffDays(endWindow, startWindow);
     const totalW = totalDays * dayW;
+
+    // Build flat list of items (group headers + rows) for rendering
+    const items: Item[] = [];
+    if (grouping === "repo") {
+      const map = new Map<string, Enriched[]>();
+      for (const x of enriched) {
+        const arr = map.get(x.m.repo) ?? [];
+        arr.push(x);
+        map.set(x.m.repo, arr);
+      }
+      const repos = Array.from(map.keys()).sort((a, b) =>
+        a.localeCompare(b, "ru")
+      );
+      for (const repo of repos) {
+        const arr = map.get(repo)!;
+        items.push({ kind: "group", repo, count: arr.length });
+        for (const e of arr) items.push({ kind: "row", e });
+      }
+    } else {
+      for (const e of enriched) items.push({ kind: "row", e });
+    }
 
     const days: Date[] = [];
     for (let i = 0; i < totalDays; i++) {
@@ -107,6 +159,7 @@ export function MilestonesGantt({ milestones, zoom, onZoom, now }: Props) {
 
     return {
       enriched,
+      items,
       days,
       monthRuns,
       dayW,
@@ -116,9 +169,32 @@ export function MilestonesGantt({ milestones, zoom, onZoom, now }: Props) {
       weekendCols,
       startWindow,
     };
-  }, [milestones, zoom, now]);
+  }, [milestones, zoom, now, grouping]);
 
   const todaySod = useMemo(() => startOfDay(now), [now]);
+
+  // Auto-scroll the chart so "today" sits ~12% from the left edge of the
+  // visible viewport. Without this the chart loads at scrollLeft=0, which
+  // shows the back-window (mostly empty space) and forces the user to hunt
+  // for the relevant near-future portion.
+  const chartRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const el = chartRef.current;
+    if (!el) return;
+    const target = Math.max(0, data.todayLeft - el.clientWidth * 0.12);
+    el.scrollLeft = target;
+  }, [data.todayLeft, data.totalW, zoom]);
+
+  // On window resize, re-anchor today (clientWidth changes).
+  useEffect(() => {
+    const el = chartRef.current;
+    if (!el) return;
+    const onResize = () => {
+      el.scrollLeft = Math.max(0, data.todayLeft - el.clientWidth * 0.12);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [data.todayLeft]);
 
   return (
     <div className="v4-msgantt">
@@ -165,7 +241,25 @@ export function MilestonesGantt({ milestones, zoom, onZoom, now }: Props) {
               fill = % done
             </span>
           </div>
-          <div className="v4-pillgrp">
+          <div className="v4-pillgrp" role="group" aria-label="Группировка">
+            <button
+              type="button"
+              className={grouping === "none" ? "is-active" : ""}
+              onClick={() => onGrouping("none")}
+              title="Без группировки (по статусу)"
+            >
+              Поток
+            </button>
+            <button
+              type="button"
+              className={grouping === "repo" ? "is-active" : ""}
+              onClick={() => onGrouping("repo")}
+              title="Группировать по проекту"
+            >
+              По проекту
+            </button>
+          </div>
+          <div className="v4-pillgrp" role="group" aria-label="Масштаб">
             {(Object.entries(ZOOMS) as [GanttZoom, { label: string }][]).map(
               ([k, v]) => (
                 <button
@@ -188,7 +282,28 @@ export function MilestonesGantt({ milestones, zoom, onZoom, now }: Props) {
         <div className="v4-msgantt-body">
           <div className="v4-msgantt-list">
             <div className="v4-msgantt-list-h">Milestone</div>
-            {data.enriched.map((x, idx) => {
+            {data.items.map((it, idx) => {
+              if (it.kind === "group") {
+                return (
+                  <div
+                    key={`g-${it.repo}`}
+                    className="v4-msgantt-list-group"
+                    title={it.repo}
+                  >
+                    <span
+                      className="v4-msgantt-list-group-glyph"
+                      style={{ background: repoGlyphColor(it.repo) }}
+                    />
+                    <span className="v4-msgantt-list-group-name">
+                      {it.repo}
+                    </span>
+                    <span className="v4-msgantt-list-group-count num">
+                      {it.count}
+                    </span>
+                  </div>
+                );
+              }
+              const x = it.e;
               const total = x.m.openIssues + x.m.closedIssues;
               const pct =
                 total > 0 ? Math.round((x.m.closedIssues / total) * 100) : 0;
@@ -223,7 +338,7 @@ export function MilestonesGantt({ milestones, zoom, onZoom, now }: Props) {
             })}
           </div>
 
-          <div className="v4-msgantt-chart">
+          <div className="v4-msgantt-chart" ref={chartRef}>
             <div
               className="v4-msgantt-chart-inner"
               style={{ width: `${data.totalW}px` }}
@@ -290,7 +405,16 @@ export function MilestonesGantt({ milestones, zoom, onZoom, now }: Props) {
                   style={{ left: `${data.todayLeft}px` }}
                 />
 
-                {data.enriched.map((x, idx) => {
+                {data.items.map((it, idx) => {
+                  if (it.kind === "group") {
+                    return (
+                      <div
+                        key={`gs-${it.repo}-${idx}`}
+                        className="v4-msgantt-grid-group"
+                      />
+                    );
+                  }
+                  const x = it.e;
                   const total = x.m.openIssues + x.m.closedIssues;
                   const pct =
                     total > 0
@@ -372,3 +496,4 @@ export function MilestonesGantt({ milestones, zoom, onZoom, now }: Props) {
 }
 
 export const GANTT_ROW_H = ROW_H;
+export const GANTT_GROUP_H = GROUP_H;

--- a/src/components/v4/milestones/MilestonesGantt.tsx
+++ b/src/components/v4/milestones/MilestonesGantt.tsx
@@ -409,7 +409,7 @@ export function MilestonesGantt({
                   if (it.kind === "group") {
                     return (
                       <div
-                        key={`gs-${it.repo}-${idx}`}
+                        key={`gs-${it.repo}`}
                         className="v4-msgantt-grid-group"
                       />
                     );

--- a/src/components/v4/milestones/MilestonesView.tsx
+++ b/src/components/v4/milestones/MilestonesView.tsx
@@ -3,7 +3,11 @@ import type { Milestone } from "../../../types";
 import { daysUntil } from "../../../utils/date";
 import { MilestoneCardV4 } from "./MilestoneCardV4";
 import { MilestonesHero } from "./MilestonesHero";
-import { MilestonesGantt, type GanttZoom } from "./MilestonesGantt";
+import {
+  MilestonesGantt,
+  type GanttGrouping,
+  type GanttZoom,
+} from "./MilestonesGantt";
 import { MilestonesClosedSection } from "./MilestonesClosedSection";
 import { MilestonesStatusBar } from "./MilestonesStatusBar";
 import { classifyMilestone } from "./classifyMilestone";
@@ -21,6 +25,7 @@ type Grouping = "deadline" | "repo";
 interface ToolbarState {
   density: Density;
   grouping: Grouping;
+  ganttGrouping: GanttGrouping;
   zoom: GanttZoom;
   query: string;
 }
@@ -29,6 +34,7 @@ const STORAGE_KEY = "makeit.milestonesView.v2";
 
 const VALID_DENSITY: readonly Density[] = ["comfortable", "compact"];
 const VALID_GROUPING: readonly Grouping[] = ["deadline", "repo"];
+const VALID_GANTT_GROUPING: readonly GanttGrouping[] = ["none", "repo"];
 const VALID_ZOOM: readonly GanttZoom[] = ["day", "week", "month"];
 
 function loadState(): ToolbarState {
@@ -43,6 +49,11 @@ function loadState(): ToolbarState {
         grouping: VALID_GROUPING.includes(p.grouping as Grouping)
           ? (p.grouping as Grouping)
           : "deadline",
+        ganttGrouping: VALID_GANTT_GROUPING.includes(
+          p.ganttGrouping as GanttGrouping
+        )
+          ? (p.ganttGrouping as GanttGrouping)
+          : "repo",
         zoom: VALID_ZOOM.includes(p.zoom as GanttZoom)
           ? (p.zoom as GanttZoom)
           : "week",
@@ -52,7 +63,13 @@ function loadState(): ToolbarState {
   } catch {
     /* ignore */
   }
-  return { density: "compact", grouping: "deadline", zoom: "week", query: "" };
+  return {
+    density: "compact",
+    grouping: "deadline",
+    ganttGrouping: "repo",
+    zoom: "week",
+    query: "",
+  };
 }
 
 function saveState(s: ToolbarState) {
@@ -185,6 +202,8 @@ export function MilestonesView({ milestones, lastUpdated }: Props) {
         milestones={openMs}
         zoom={state.zoom}
         onZoom={(z) => setState((s) => ({ ...s, zoom: z }))}
+        grouping={state.ganttGrouping}
+        onGrouping={(g) => setState((s) => ({ ...s, ganttGrouping: g }))}
         now={now}
       />
 

--- a/src/components/v4/milestones/utils.ts
+++ b/src/components/v4/milestones/utils.ts
@@ -153,15 +153,27 @@ export function clsPriority(cls: MilestoneStatusKind): number {
 }
 
 /**
- * Best-guess milestone start: createdAt if present, otherwise dueOn − fallback,
- * otherwise NOW − 7d. Used as the left edge of the Gantt bar.
+ * Best-guess milestone start used as the left edge of the Gantt bar.
+ *
+ * Strategy keeps bars compact within the visible window:
+ * - dueOn present: max(createdAt, due − issue-scaled offset). Using the LATER
+ *   of the two avoids showing year-long bars when a milestone was created
+ *   long before its deadline.
+ * - dueOn missing: today. The bar projects forward by issue count, so the
+ *   chart doesn't get a 28-px stub stuck at the left edge for milestones
+ *   created months ago without a deadline.
  */
 export function milestoneStart(m: Milestone, fallbackNow: Date): Date {
-  if (m.createdAt) return startOfDay(new Date(m.createdAt));
+  const today = startOfDay(fallbackNow);
   if (m.dueOn) {
     const due = startOfDay(new Date(m.dueOn));
     const total = m.openIssues + m.closedIssues;
-    return addDays(due, -Math.max(7, Math.round(total * 1.5)));
+    const projected = addDays(due, -Math.max(7, Math.round(total * 1.5)));
+    if (m.createdAt) {
+      const created = startOfDay(new Date(m.createdAt));
+      return created > projected ? created : projected;
+    }
+    return projected;
   }
-  return addDays(startOfDay(fallbackNow), -7);
+  return today;
 }

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -6134,6 +6134,40 @@ ul.v4-rsh-list {
 .v4-msgantt-grid-row:last-child { border-bottom: 0; }
 .v4-msgantt-grid-row:hover { background: rgba(245,247,250,0.6); }
 
+/* Repo grouping in Gantt: group header row in left list + matching spacer
+   in chart grid. Heights MUST match (30px) so list rows stay aligned with
+   their bar rows. */
+.v4-msgantt-list-group {
+  height: 30px;
+  padding: 0 14px;
+  display: flex; align-items: center; gap: 8px;
+  background: var(--v4-surface-2);
+  border-bottom: 1px solid var(--v4-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
+}
+.v4-msgantt-list-group-glyph {
+  width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0;
+}
+.v4-msgantt-list-group-name {
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 700;
+  color: var(--v4-ink-700);
+  text-transform: uppercase; letter-spacing: 0.06em;
+  flex: 1; min-width: 0;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.v4-msgantt-list-group-count {
+  font-size: 11px; font-weight: 700;
+  color: var(--v4-ink-500); flex-shrink: 0;
+}
+.v4-msgantt-grid-group {
+  height: 30px;
+  background: var(--v4-surface-2);
+  border-bottom: 1px solid var(--v4-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
+  position: relative;
+  z-index: 0;
+}
+
 .v4-msgantt-weekend {
   position: absolute; top: 0; bottom: 0;
   background: rgba(148,160,184,0.06);


### PR DESCRIPTION
## Summary
Addresses two user-reported issues with the Milestones Gantt:

1. **«неотрендеренный календарь»** — chart loaded scrolled to `scrollLeft=0` (the back-window, mostly empty), and milestones without `dueOn` collapsed into a 28-px stub at `left=0`, leaving most rows visually empty.
2. **«отсутствие группировки по проекту»** — Gantt had no way to group milestones by repo.

## Changes

- **Auto-scroll** ([MilestonesGantt.tsx:160](https://github.com/Sergio1990-1/makeit-dashboard/blob/fix/milestones-gantt-grouping-render/src/components/v4/milestones/MilestonesGantt.tsx#L160)): chart positions today at ~12% from left edge on mount, zoom change, and window resize.
- **Dynamic WINDOW_FWD** ([MilestonesGantt.tsx:99](https://github.com/Sergio1990-1/makeit-dashboard/blob/fix/milestones-gantt-grouping-render/src/components/v4/milestones/MilestonesGantt.tsx#L99)): extends forward window to fit latest `dueOn` (60–365 days).
- **No-due milestone bars** ([utils.ts:159](https://github.com/Sergio1990-1/makeit-dashboard/blob/fix/milestones-gantt-grouping-render/src/components/v4/milestones/utils.ts#L159)): `milestoneStart()` returns today for milestones without `dueOn`, so they project forward rather than getting stuck at `left=0`. For dated milestones, uses the *later* of `createdAt` / projected start to keep bars compact.
- **Project grouping**: new «Поток / По проекту» pill toggle in Gantt header; group headers (repo glyph + name + count) interleaved at 30-px height in both list and grid columns; persisted in `makeit.milestonesView.v2`.

## Test plan
- [x] Type check (`npx tsc --noEmit`)
- [x] Lint (`npm run lint`)
- [x] Build (`npm run build`)
- [x] Local preview with mock data: today line correctly anchored, group headers render in both list/grid, no-due bars project forward, both modes (Поток / По проекту) toggle cleanly
- [ ] Verify on VPS with real data after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)