### PR TITLE
feat(health): issue builder + dedup helper

### DIFF
--- a/src/utils/github-actions.ts
+++ b/src/utils/github-actions.ts
@@ -182,6 +182,44 @@ export async function createIssue(
   return { number: data.number, url: data.html_url };
 }
 
+// Look up an existing open issue with the exact title under the `tech-debt`
+// label. Used by the health → issue flow to dedup before creating duplicates.
+//
+// Returns `null` when:
+//   - no open `tech-debt` issue with this exact title exists; or
+//   - the GitHub call returns a non-2xx (we treat this as "couldn't confirm,
+//     don't dedup" — `rest()` already throws on auth/network errors which we
+//     let bubble up so the caller can decide).
+//
+// Title comparison is exact (case-sensitive). GitHub's `?labels=` filter is
+// already an AND, so the returned page only contains tech-debt issues; we
+// scan the first 100 (per_page max) which is plenty for the per-repo health
+// surface area.
+export async function findOpenIssueByTitle(
+  token: string,
+  owner: string,
+  repo: string,
+  title: string,
+): Promise<{ number: number; url: string } | null> {
+  const data = await rest(
+    token,
+    `/repos/${owner}/${repo}/issues?state=open&per_page=100&labels=tech-debt`,
+  );
+  if (!Array.isArray(data)) return null;
+  for (const issue of data as Array<{
+    number: number;
+    title: string;
+    html_url: string;
+    pull_request?: unknown;
+  }>) {
+    if (issue.pull_request) continue;
+    if (issue.title === title) {
+      return { number: issue.number, url: issue.html_url };
+    }
+  }
+  return null;
+}
+
 export async function closeIssue(
   token: string,
   owner: string,

--- a/src/utils/github-actions.ts
+++ b/src/utils/github-actions.ts
@@ -185,37 +185,41 @@ export async function createIssue(
 // Look up an existing open issue with the exact title under the `tech-debt`
 // label. Used by the health → issue flow to dedup before creating duplicates.
 //
-// Returns `null` when:
-//   - no open `tech-debt` issue with this exact title exists; or
-//   - the GitHub call returns a non-2xx (we treat this as "couldn't confirm,
-//     don't dedup" — `rest()` already throws on auth/network errors which we
-//     let bubble up so the caller can decide).
+// Returns `null` only when no open `tech-debt` issue with this exact title is
+// found within the scanned pages. `rest()` throws on auth/network/HTTP errors
+// (4xx/5xx) — those bubble up so the caller can decide whether to retry or
+// proceed without dedup.
 //
-// Title comparison is exact (case-sensitive). GitHub's `?labels=` filter is
-// already an AND, so the returned page only contains tech-debt issues; we
-// scan the first 100 (per_page max) which is plenty for the per-repo health
-// surface area.
+// Title comparison is exact (case-sensitive). We paginate up to MAX_PAGES so
+// repos with >100 open tech-debt issues still get correctly deduped instead of
+// silently creating duplicates for issues pushed off page 1. Sorted by
+// `updated` desc so freshly-touched dups land first and we can short-circuit.
 export async function findOpenIssueByTitle(
   token: string,
   owner: string,
   repo: string,
   title: string,
 ): Promise<{ number: number; url: string } | null> {
-  const data = await rest(
-    token,
-    `/repos/${owner}/${repo}/issues?state=open&per_page=100&labels=tech-debt`,
-  );
-  if (!Array.isArray(data)) return null;
-  for (const issue of data as Array<{
-    number: number;
-    title: string;
-    html_url: string;
-    pull_request?: unknown;
-  }>) {
-    if (issue.pull_request) continue;
-    if (issue.title === title) {
-      return { number: issue.number, url: issue.html_url };
+  const PER_PAGE = 100;
+  const MAX_PAGES = 5; // 500 issues max — enough for any realistic health surface area
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const data = await rest(
+      token,
+      `/repos/${owner}/${repo}/issues?state=open&per_page=${PER_PAGE}&labels=tech-debt&sort=updated&direction=desc&page=${page}`,
+    );
+    if (!Array.isArray(data)) return null;
+    for (const issue of data as Array<{
+      number: number;
+      title: string;
+      html_url: string;
+      pull_request?: unknown;
+    }>) {
+      if (issue.pull_request) continue;
+      if (issue.title === title) {
+        return { number: issue.number, url: issue.html_url };
+      }
     }
+    if (data.length < PER_PAGE) return null; // last page reached
   }
   return null;
 }

--- a/src/utils/health-issue.ts
+++ b/src/utils/health-issue.ts
@@ -1,0 +1,86 @@
+// Pure helpers for turning a HealthFinding into a GitHub Issue payload.
+//
+// These functions are deliberately side-effect-free so they can be unit-tested
+// in isolation. The actual REST call (createIssue) lives in github-actions.ts.
+//
+// ── Expected behaviour (informal spec; no test runner configured yet) ──
+//
+// buildIssueTitle({ rule_id: "hygiene.contributing", title: "CONTRIBUTING.md в корне", ... })
+//   → "[health] CONTRIBUTING.md в корне"
+//
+// buildIssueLabels({ severity: "critical", ... })  → ["tech-debt", "P1-critical"]
+// buildIssueLabels({ severity: "high",     ... })  → ["tech-debt", "P2-high"]
+// buildIssueLabels({ severity: "medium",   ... })  → ["tech-debt", "P3-medium"]
+// buildIssueLabels({ severity: "low",      ... })  → ["tech-debt"]
+//
+// buildIssueBody(finding, "owner/repo", classification, "2026-05-03T10:00:00Z")
+//   → markdown-formatted body containing severity, repo, project tier/flags,
+//     finding detail, remediation hint and a generated_at footer. User-supplied
+//     text (title/detail/remediation) is inserted verbatim — GitHub renders
+//     issue bodies as Markdown, which already handles HTML escaping for us, so
+//     no extra sanitisation is required (and we don't want to mangle legitimate
+//     markdown in remediation hints).
+
+import type { HealthFinding, HealthSeverity, ProjectClassification } from "../types/health";
+
+const TITLE_PREFIX = "[health]";
+const BASE_LABELS: readonly string[] = ["tech-debt"];
+
+// Severity → priority label. `null` means "no priority label" (e.g. "low").
+const SEVERITY_PRIORITY_LABEL: Record<HealthSeverity, string | null> = {
+  critical: "P1-critical",
+  high: "P2-high",
+  medium: "P3-medium",
+  low: null,
+};
+
+export function buildIssueTitle(finding: HealthFinding): string {
+  return `${TITLE_PREFIX} ${finding.title}`;
+}
+
+export function buildIssueLabels(finding: HealthFinding): string[] {
+  const priority = SEVERITY_PRIORITY_LABEL[finding.severity];
+  return priority ? [...BASE_LABELS, priority] : [...BASE_LABELS];
+}
+
+export function buildIssueBody(
+  finding: HealthFinding,
+  repo: string,
+  classification: ProjectClassification,
+  generatedAt: string,
+): string {
+  const flags: string[] = [`tier ${classification.tier}`];
+  if (classification.complex) flags.push("complex");
+  if (classification.client) flags.push("client");
+
+  const lines: string[] = [
+    `**Severity:** ${finding.severity}`,
+    `**Layer:** ${finding.layer}`,
+    `**Rule:** \`${finding.rule_id}\``,
+    `**Repo:** \`${repo}\``,
+    `**Project:** ${flags.join(", ")}`,
+    "",
+    "## Что не так",
+    finding.detail?.trim() || "_(детали не предоставлены health-движком)_",
+  ];
+
+  if (finding.remediation?.trim()) {
+    lines.push("", "## Как починить", finding.remediation.trim());
+  }
+
+  if (finding.source) {
+    lines.push("", `**Источник правила:** ${finding.source}`);
+  }
+
+  lines.push(
+    "",
+    "## Как воспроизвести",
+    `1. Открыть дашборд → вкладка «Аудит» → выбрать репо \`${repo}\`.`,
+    `2. Запустить Project Health и найти правило \`${finding.rule_id}\`.`,
+    "",
+    "---",
+    `_Сгенерировано Project Health движком: ${generatedAt}_`,
+  );
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
Closes #146

## Что сделано
- `src/utils/health-issue.ts`: чистые функции `buildIssueTitle`, `buildIssueBody`, `buildIssueLabels`
- `src/utils/github-actions.ts`: `findOpenIssueByTitle` (REST `/issues?state=open&labels=tech-debt`, фильтр в JS по точному `title`)
- Severity → priority label маппинг (critical→P1-critical, high→P2-high, medium→P3-medium, low → нет priority)

## Замечания по дизайну
- Test runner в проекте не настроен — ожидаемое поведение задокументировано в шапке `health-issue.ts` (раздел "Expected behaviour"). Настройка vitest/jest вне scope этой задачи.
- `findOpenIssueByTitle` reuse'ает существующий `rest()` хелпер — auth/network ошибки бросают единообразный Error, dedup-вызов на 4xx/5xx падает (callers могут поймать и решить, нужно ли создавать issue).
- Constants (`TITLE_PREFIX`, `BASE_LABELS`, `SEVERITY_PRIORITY_LABEL`) вынесены в module-scope как просил self-review.
- GitHub рендерит body как markdown — экранирование HTML делает он сам, доп. sanitisation не нужна (и сломала бы валидную markdown в `remediation`).

## Проверки
- [x] npm run lint
- [x] npx tsc --noEmit
- [x] npm run build