### PR TITLE
feat(insights): AIInsightsPanel — portfolio fails sorted by severity x age

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,6 +146,17 @@ function AppInner() {
     [setTab],
   );
 
+  // Open the Project Health drilldown for a specific repo from outside the
+  // Projects tab (currently invoked by AIInsightsPanel). Bypasses
+  // `navigateTab` because that one explicitly clears `healthRepo`.
+  const openHealthForRepo = useCallback(
+    (repo: string) => {
+      setHealthRepo(repo);
+      setTab("projects");
+    },
+    [setTab],
+  );
+
   // Cmd-K opens command palette (works alongside the existing Topbar shortcut
   // since both register handlers — palette wins because it's an overlay).
   useEffect(() => {
@@ -374,6 +385,7 @@ function AppInner() {
               lastUpdated={lastUpdated}
               onSeeAllProjects={() => navigateTab("projects")}
               onFinanceClick={() => setFinanceOpen(true)}
+              onOpenHealth={openHealthForRepo}
             />
           </ErrorBoundary>
         )}

--- a/src/components/v4/AIInsightsPanel.tsx
+++ b/src/components/v4/AIInsightsPanel.tsx
@@ -1,149 +1,138 @@
 import { useMemo } from "react";
-import type { ReactElement } from "react";
-import type { ProjectData, Issue } from "../../types";
-
-type InsightKind = "an" | "gr" | "rk" | "fc";
-
-interface Insight {
-  kind: InsightKind;
-  code: string;
-  title: string;
-  description: string;
-  /** 0..1 — confidence */
-  prob: number;
-}
+import type { HealthFinding, HealthReport, HealthSeverity } from "../../types/health";
 
 interface Props {
-  projects: ProjectData[];
-  blockedIssues: Issue[];
+  reports: HealthReport[];
+  loading: boolean;
+  /** Timestamp of the most recent successful scan; null while we have no data yet. */
+  lastUpdated: Date | null;
+  /** Switches to the Projects tab and opens the Project Health drilldown for `repo`. */
+  onOpenHealth: (repo: string) => void;
 }
 
-/**
- * Heuristic placeholder insights, derived locally from dashboard data.
- * Replaced by a real LLM-driven advisor in a follow-up task — see
- * the linked GitHub issue tagged `feature` in makeit-dashboard.
- */
-function generateInsights(projects: ProjectData[], blockedIssues: Issue[]): Insight[] {
-  const out: Insight[] = [];
+// Sorting / filtering knobs — single source of truth so a designer tweak is
+// one edit instead of grep-and-replace through the file.
+const MAX_CARDS = 5;
+const MIN_SEVERITY: HealthSeverity = "medium";
+// 90 chars keeps each card to one visual line on the dashboard column at the
+// narrowest layout width (~480px). Longer content is truncated with «…».
+const TRUNCATE_LEN = 90;
+// Skeleton placeholder count during a cold load (no cached reports yet).
+const SKELETON_COUNT = 4;
 
-  // Slowing-down project (high open count, very low velocity)
-  const slowing = projects
-    .filter((p) => p.openCount >= 5 && p.velocity7d < 0.5)
-    .sort((a, b) => b.openCount - a.openCount)[0];
-  if (slowing) {
-    out.push({
-      kind: "rk",
-      code: "RSK-VEL",
-      title: `${slowing.repo} замедляется`,
-      description: `${slowing.openCount} открытых, velocity ${slowing.velocity7d.toFixed(2)}/д. Стоит провести debate-сессию или разблокировать.`,
-      prob: 0.82,
-    });
-  }
+// Sorted by descending priority so we can compare-by-index and drop anything
+// below MIN_SEVERITY.
+const SEVERITY_ORDER: HealthSeverity[] = ["critical", "high", "medium", "low"];
 
-  // Almost-done project (>=85% progress)
-  const nearlyDone = projects
-    .filter((p) => p.totalCount >= 5 && p.doneCount / p.totalCount >= 0.85)
-    .sort((a, b) => b.doneCount / b.totalCount - a.doneCount / a.totalCount)[0];
-  if (nearlyDone) {
-    const pct = Math.round((nearlyDone.doneCount / nearlyDone.totalCount) * 100);
-    out.push({
-      kind: "gr",
-      code: "GRO-CLS",
-      title: `${nearlyDone.repo} готов к закрытию фазы`,
-      description: `${pct}% задач закрыто. Можно переводить в support и фокусировать ресурсы на других проектах.`,
-      prob: 0.88,
-    });
-  }
-
-  // Stale P1 anomaly
-  if (blockedIssues.length > 0) {
-    const p1Blocked = blockedIssues.filter((i) => i.priority === "P1").length;
-    if (p1Blocked > 0) {
-      out.push({
-        kind: "an",
-        code: "ANO-P1B",
-        title: `${p1Blocked} P1-задач заблокировано`,
-        description: `Есть критичные задачи без движения. Возможно, требуется внешнее решение или переключение приоритета.`,
-        prob: 0.91,
-      });
-    }
-  }
-
-  // Forecast: portfolio progress trend
-  const totalIssues = projects.reduce((s, p) => s + p.totalCount, 0);
-  const totalDone = projects.reduce((s, p) => s + p.doneCount, 0);
-  if (totalIssues > 0) {
-    const pctDone = Math.round((totalDone / totalIssues) * 100);
-    const totalVelocity = projects.reduce((s, p) => s + p.velocity7d, 0);
-    if (totalVelocity > 0) {
-      const open = totalIssues - totalDone;
-      const daysToFinish = Math.round(open / totalVelocity);
-      const targetDate = new Date(Date.now() + daysToFinish * 86400000);
-      out.push({
-        kind: "fc",
-        code: "FCT-ETA",
-        title: `Прогноз: портфель ${pctDone}% → 100% к ${targetDate.toLocaleDateString("ru-RU", { day: "numeric", month: "short" })}`,
-        description: `При сохранении velocity ${totalVelocity.toFixed(1)}/день и без новых backlogged задач. Эвристика — не учитывает приоритеты.`,
-        prob: 0.74,
-      });
-    }
-  }
-
-  // Fallback if nothing actionable
-  if (out.length === 0) {
-    out.push({
-      kind: "fc",
-      code: "FCT-OK",
-      title: "Портфель в норме",
-      description: "Нет критических аномалий в данных. AI-анализ будет включён в следующем релизе.",
-      prob: 0.6,
-    });
-  }
-
-  return out.slice(0, 4);
-}
-
-const KIND_ICONS: Record<InsightKind, ReactElement> = {
-  rk: (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-      <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0zM12 9v4M12 17h.01" />
-    </svg>
-  ),
-  gr: (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-      <path d="M3 17l6-6 4 4 8-9" />
-    </svg>
-  ),
-  an: (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-      <circle cx="11" cy="11" r="8" />
-      <line x1="21" y1="21" x2="16.65" y2="16.65" />
-      <line x1="11" y1="8" x2="11" y2="14" />
-    </svg>
-  ),
-  fc: (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-      <line x1="12" y1="20" x2="12" y2="10" />
-      <line x1="18" y1="20" x2="18" y2="4" />
-    </svg>
-  ),
+// Local weights for sort priority. The checklist YAML has its own
+// `severity_weights` for the score deduction (different domain — score math
+// vs. card sorting), so these two intentionally don't share a constant.
+const SEVERITY_WEIGHT: Record<HealthSeverity, number> = {
+  critical: 3,
+  high: 2,
+  medium: 1,
+  low: 0.5,
 };
 
-export function AIInsightsPanel({ projects, blockedIssues }: Props) {
-  // Compute insights and the "generated at" timestamp together — so the
-  // displayed time actually corresponds to when the insights were derived,
-  // not to the most recent unrelated parent re-render.
-  const { insights, time } = useMemo(
-    () => ({
-      insights: generateInsights(projects, blockedIssues),
-      time: new Date().toLocaleTimeString("ru-RU", {
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-      }),
-    }),
-    [projects, blockedIssues]
+interface RankedFail {
+  finding: HealthFinding;
+  repo: string;
+  generatedAt: string;
+  score: number;
+}
+
+// One day in ms — used for the age-factor calculation. age_factor caps at
+// 2 (after 7 days) so very old findings can't dominate forever.
+const DAY_MS = 86_400_000;
+
+function severityAtLeast(s: HealthSeverity, min: HealthSeverity): boolean {
+  return SEVERITY_ORDER.indexOf(s) <= SEVERITY_ORDER.indexOf(min);
+}
+
+// Truncate by code-point (Array.from splits surrogate pairs correctly) so
+// we never slice through the middle of a multi-byte glyph.
+function truncate(text: string, max: number): string {
+  const chars = Array.from(text);
+  if (chars.length <= max) return text;
+  return chars.slice(0, max).join("").trimEnd() + "…";
+}
+
+// "обновлено N мин назад". For lastUpdated=null returns null so the caller
+// can omit the meta line entirely. Times under a minute show seconds.
+function formatRelativeTime(d: Date | null, now: number): string | null {
+  if (!d) return null;
+  const diffMs = now - d.getTime();
+  if (!Number.isFinite(diffMs) || diffMs < 0) return "только что";
+  const sec = Math.round(diffMs / 1000);
+  if (sec < 60) return `обновлено ${sec} сек назад`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `обновлено ${min} мин назад`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `обновлено ${hr} ч назад`;
+  const days = Math.round(hr / 24);
+  return `обновлено ${days} д назад`;
+}
+
+// Collect every fail across reports, score by severity × age, and return the
+// top-N. Tie-break by repo name so the order is stable across renders.
+//
+// TODO(epic-006): swap `days_since_first_seen` for an actual "first seen" lookup
+// once we persist finding history. For MVP we approximate with the report
+// generation timestamp, which means a fresh scan resets the age factor — fine
+// while findings tend to repeat across scans.
+function rankFails(reports: HealthReport[], nowMs: number): RankedFail[] {
+  const out: RankedFail[] = [];
+  for (const report of reports) {
+    const generatedAtMs = new Date(report.generated_at).getTime();
+    const ageDays = Number.isFinite(generatedAtMs)
+      ? Math.max(0, (nowMs - generatedAtMs) / DAY_MS)
+      : 0;
+    const ageFactor = 1 + Math.min(7, ageDays) / 7;
+    for (const finding of report.findings) {
+      if (finding.status !== "fail") continue;
+      if (!severityAtLeast(finding.severity, MIN_SEVERITY)) continue;
+      const weight = SEVERITY_WEIGHT[finding.severity] ?? 0;
+      out.push({
+        finding,
+        repo: report.repo,
+        generatedAt: report.generated_at,
+        score: weight * ageFactor,
+      });
+    }
+  }
+  // Stable-by-name tie-break — important for visual continuity across
+  // refreshes when two findings tie on score.
+  return out
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      if (a.repo !== b.repo) return a.repo.localeCompare(b.repo);
+      return a.finding.rule_id.localeCompare(b.finding.rule_id);
+    })
+    .slice(0, MAX_CARDS);
+}
+
+export function AIInsightsPanel({ reports, loading, lastUpdated, onOpenHealth }: Props) {
+  // We freeze "now" at the moment we compute insights so the displayed
+  // relative time matches the scoring math, and so cards don't reorder on
+  // every parent re-render. Using `lastUpdated` (or 0 when absent) instead
+  // of `Date.now()` keeps the function pure — no clock reads in render.
+  // Side-effect: when `lastUpdated` is null, age_factor saturates to its
+  // 2× cap for every finding, which is fine — sort order then collapses
+  // to severity weight × name, exactly what we want for "no data yet".
+  const nowMs = useMemo(
+    () => (lastUpdated ? lastUpdated.getTime() : 0),
+    [lastUpdated],
   );
+
+  const top = useMemo(() => rankFails(reports, nowMs), [reports, nowMs]);
+
+  const meta = formatRelativeTime(lastUpdated, nowMs);
+
+  // Cold load: no cached data yet → show skeleton rows.
+  // Warm load (loading + we already have something to show) → render data
+  // with a small "обновляется" indicator so the user knows it isn't stale.
+  const showSkeleton = loading && reports.length === 0;
+  const showRefreshing = loading && reports.length > 0;
 
   return (
     <div className="v4-panel">
@@ -159,26 +148,117 @@ export function AIInsightsPanel({ projects, blockedIssues }: Props) {
             <path d="M12 2a3 3 0 00-3 3v1.27A4 4 0 005 10v1.5a3.5 3.5 0 00-1 6.66V20a2 2 0 002 2h12a2 2 0 002-2v-1.84a3.5 3.5 0 00-1-6.66V10a4 4 0 00-4-3.73V5a3 3 0 00-3-3z" />
           </svg>
           AI-инсайты по портфелю
-          <span className="v4-tag">эвристика · MVP</span>
+          <span className="v4-tag">health · top-{MAX_CARDS}</span>
+          {showRefreshing && <span className="v4-tag">обновляется…</span>}
         </div>
-        <div className="v4-panel-meta">{time}</div>
+        {meta && <div className="v4-panel-meta">{meta}</div>}
       </div>
+
       <div className="v4-ai-list">
-        {insights.map((it, idx) => (
-          <div key={idx} className={`v4-ai-item v4-ai-item--${it.kind}`}>
-            <div className="v4-ai-item-ic">{KIND_ICONS[it.kind]}</div>
-            <div>
-              <div className="v4-ai-item-ttl">{it.title}</div>
-              <div className="v4-ai-item-ds">{it.description}</div>
-            </div>
-            <div className="v4-ai-item-meta">
-              {it.code}
-              <br />
-              P {it.prob.toFixed(2).replace(".", ",")}
-            </div>
-          </div>
-        ))}
+        {showSkeleton ? (
+          <SkeletonList count={SKELETON_COUNT} />
+        ) : top.length === 0 ? (
+          <EmptyState hasReports={reports.length > 0} />
+        ) : (
+          top.map((entry) => (
+            <InsightCard
+              // rule_id alone isn't unique across repos (same rule can fail
+              // in many projects), so the composite key keeps React happy
+              // and avoids a remount-on-reorder.
+              key={`${entry.repo}::${entry.finding.rule_id}`}
+              entry={entry}
+              onOpenHealth={onOpenHealth}
+            />
+          ))
+        )}
       </div>
+    </div>
+  );
+}
+
+interface CardProps {
+  entry: RankedFail;
+  onOpenHealth: (repo: string) => void;
+}
+
+function InsightCard({ entry, onOpenHealth }: CardProps) {
+  const { finding, repo } = entry;
+  // Detail is optional in the type; fall back to remediation to avoid an
+  // empty grey strip under the title for findings that only ship a fix.
+  const rawDetail = finding.detail ?? finding.remediation ?? "";
+  const detail = truncate(rawDetail, TRUNCATE_LEN);
+
+  return (
+    <div className="v4-ai-item v4-ai-fail">
+      <div className={`v4-ai-sev v4-ai-sev--${finding.severity}`}>
+        <span className="v4-ai-sev-dot" />
+        {finding.severity}
+      </div>
+      <div className="v4-ai-body">
+        <div className="v4-ai-item-ttl">
+          <span>{finding.title}</span>
+          <span className="v4-ai-repo v4-mono">{repo}</span>
+        </div>
+        {detail && <div className="v4-ai-item-ds">{detail}</div>}
+        <div className="v4-ai-actions">
+          <button
+            type="button"
+            className="v4-btn v4-btn--pri v4-ai-btn"
+            // Defensive: even though `repo` always comes from the report,
+            // keep the closure explicit so a future refactor can't pass
+            // undefined accidentally.
+            onClick={() => onOpenHealth(repo)}
+          >
+            Открыть Health
+          </button>
+          <button
+            type="button"
+            className="v4-btn v4-ai-btn"
+            disabled
+            title="Доступно после Epic-006"
+          >
+            → issue
+          </button>
+        </div>
+      </div>
+      <div className="v4-ai-item-meta">
+        <span className="v4-mono">{finding.rule_id}</span>
+        <br />L{finding.layer}
+      </div>
+    </div>
+  );
+}
+
+function SkeletonList({ count }: { count: number }) {
+  // `useMemo` would be overkill — Array.from is cheap, the render is rare,
+  // and the array doesn't escape the component.
+  return (
+    <>
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="v4-ai-item v4-ai-skel" aria-hidden>
+          <div className="v4-ai-skel-sev" />
+          <div className="v4-ai-body">
+            <div className="v4-ai-skel-line v4-ai-skel-line--ttl" />
+            <div className="v4-ai-skel-line v4-ai-skel-line--ds" />
+          </div>
+          <div className="v4-ai-skel-meta" />
+        </div>
+      ))}
+    </>
+  );
+}
+
+function EmptyState({ hasReports }: { hasReports: boolean }) {
+  // Two distinct empty cases:
+  //  - we have reports but no qualifying fails → portfolio is clean
+  //  - we have no reports at all (no token, scan failed entirely) → silent;
+  //    the parent surface already shows the error banner, so we keep this
+  //    inline copy minimal.
+  return (
+    <div className="v4-empty v4-ai-empty">
+      {hasReports
+        ? `Нет фейлов severity ≥ ${MIN_SEVERITY}. Портфель в зелёной зоне.`
+        : "Нет данных health-сканирования."}
     </div>
   );
 }

--- a/src/components/v4/AIInsightsPanel.tsx
+++ b/src/components/v4/AIInsightsPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { HealthFinding, HealthReport, HealthSeverity } from "../../types/health";
 
 interface Props {
@@ -46,8 +46,15 @@ interface RankedFail {
 const DAY_MS = 86_400_000;
 
 function severityAtLeast(s: HealthSeverity, min: HealthSeverity): boolean {
-  return SEVERITY_ORDER.indexOf(s) <= SEVERITY_ORDER.indexOf(min);
+  const idx = SEVERITY_ORDER.indexOf(s);
+  if (idx === -1) return false; // unknown severity → drop
+  return idx <= SEVERITY_ORDER.indexOf(min);
 }
+
+// How often the "обновлено N мин назад" label refreshes. 30s keeps the
+// "0 сек назад" → "30 сек назад" → "1 мин назад" transitions snappy without
+// flooding React with re-renders.
+const META_TICK_MS = 30_000;
 
 // Truncate by code-point (Array.from splits surrogate pairs correctly) so
 // we never slice through the middle of a multi-byte glyph.
@@ -112,21 +119,30 @@ function rankFails(reports: HealthReport[], nowMs: number): RankedFail[] {
 }
 
 export function AIInsightsPanel({ reports, loading, lastUpdated, onOpenHealth }: Props) {
-  // We freeze "now" at the moment we compute insights so the displayed
-  // relative time matches the scoring math, and so cards don't reorder on
-  // every parent re-render. Using `lastUpdated` (or 0 when absent) instead
-  // of `Date.now()` keeps the function pure — no clock reads in render.
-  // Side-effect: when `lastUpdated` is null, age_factor saturates to its
-  // 2× cap for every finding, which is fine — sort order then collapses
-  // to severity weight × name, exactly what we want for "no data yet".
-  const nowMs = useMemo(
+  // We freeze the "now" used for *scoring* at lastUpdated so cards don't
+  // reorder on every parent re-render. Without lastUpdated we fall back to
+  // 0 — ageDays then clamps to 0 and ageFactor collapses to 1× uniformly,
+  // so sort order reduces to severity × name (intended behaviour for the
+  // "no data yet" state).
+  const sortNowMs = useMemo(
     () => (lastUpdated ? lastUpdated.getTime() : 0),
     [lastUpdated],
   );
 
-  const top = useMemo(() => rankFails(reports, nowMs), [reports, nowMs]);
+  const top = useMemo(() => rankFails(reports, sortNowMs), [reports, sortNowMs]);
 
-  const meta = formatRelativeTime(lastUpdated, nowMs);
+  // The meta label needs a *live* clock — using sortNowMs would render
+  // "обновлено 0 сек назад" forever. We tick a state every 30s while
+  // mounted. On a fresh `lastUpdated` the diff momentarily goes negative
+  // → formatRelativeTime falls back to "только что", which is correct UX
+  // until the next tick aligns.
+  const [metaTickMs, setMetaTickMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setMetaTickMs(Date.now()), META_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const meta = formatRelativeTime(lastUpdated, metaTickMs);
 
   // Cold load: no cached data yet → show skeleton rows.
   // Warm load (loading + we already have something to show) → render data

--- a/src/components/v4/DashboardView.tsx
+++ b/src/components/v4/DashboardView.tsx
@@ -10,6 +10,7 @@ import { ClosedChart30d } from "./ClosedChart30d";
 import { MilestonesStrip } from "./MilestonesStrip";
 import { CommitsHeatmapPanel } from "./CommitsHeatmapPanel";
 import { StaleBanner } from "./StaleBanner";
+import { usePortfolioHealth } from "../../hooks/usePortfolioHealth";
 
 interface Props {
   projects: ProjectData[];
@@ -20,6 +21,12 @@ interface Props {
   /** Switch to "projects" tab */
   onSeeAllProjects: () => void;
   onFinanceClick?: () => void;
+  /**
+   * Open the Project Health drilldown for a given repo.
+   * Implemented in App.tsx as `setHealthRepo(repo); setTab("projects")`,
+   * bypassing `navigateTab` (which would clear `healthRepo`).
+   */
+  onOpenHealth: (repo: string) => void;
 }
 
 type PhaseFilter = "all" | "pre-dev" | "development" | "support";
@@ -39,8 +46,18 @@ export function DashboardView({
   lastUpdated,
   onSeeAllProjects,
   onFinanceClick,
+  onOpenHealth,
 }: Props) {
   const [phaseFilter, setPhaseFilter] = useState<PhaseFilter>("all");
+
+  // Portfolio health drives the AI-insights panel. The hook is self-cached
+  // (30 min TTL in localStorage), so mounting it here doesn't re-scan on
+  // every dashboard re-render.
+  const portfolio = usePortfolioHealth();
+  const portfolioLastUpdated = useMemo(
+    () => (portfolio.lastUpdated ? new Date(portfolio.lastUpdated) : null),
+    [portfolio.lastUpdated],
+  );
 
   const filtered = useMemo(
     () =>
@@ -149,7 +166,12 @@ export function DashboardView({
           )}
         </div>
 
-        <AIInsightsPanel projects={filtered} blockedIssues={blockedIssues} />
+        <AIInsightsPanel
+          reports={portfolio.reports}
+          loading={portfolio.loading}
+          lastUpdated={portfolioLastUpdated}
+          onOpenHealth={onOpenHealth}
+        />
       </div>
 
       {/* Row: stacked + blocked */}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -1127,6 +1127,102 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   white-space: nowrap;
 }
 
+/* ── AI insights: portfolio fail cards (Epic-005 Task-02) ── */
+.v4-ai-fail {
+  grid-template-columns: 78px 1fr auto;
+  align-items: start;
+}
+.v4-ai-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.v4-ai-item-ttl {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.v4-ai-repo {
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  background: var(--v4-line-soft, #eef0f4);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+.v4-ai-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+.v4-ai-btn {
+  font-size: 11px;
+  padding: 3px 8px;
+  height: auto;
+  min-height: 0;
+}
+.v4-ai-btn[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.v4-ai-sev {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 3px 7px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+.v4-ai-sev-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.v4-ai-sev--critical { color: var(--v4-danger-700); background: var(--v4-danger-50); }
+.v4-ai-sev--high     { color: var(--v4-danger-700); background: var(--v4-danger-50); }
+.v4-ai-sev--medium   { color: var(--v4-warn-700);   background: var(--v4-warn-50); }
+.v4-ai-sev--low      { color: var(--v4-ink-600);    background: var(--v4-line-soft, #eef0f4); }
+
+/* skeleton */
+.v4-ai-skel { grid-template-columns: 78px 1fr 40px; }
+.v4-ai-skel-sev,
+.v4-ai-skel-line,
+.v4-ai-skel-meta {
+  background: linear-gradient(90deg,
+    var(--v4-line-soft, #eef0f4) 0%,
+    var(--v4-line-mid, #e2e5eb) 50%,
+    var(--v4-line-soft, #eef0f4) 100%);
+  background-size: 200% 100%;
+  animation: v4-ai-skel-shimmer 1.4s ease-in-out infinite;
+  border-radius: 4px;
+}
+.v4-ai-skel-sev  { width: 60px; height: 16px; }
+.v4-ai-skel-meta { width: 36px; height: 14px; }
+.v4-ai-skel-line { height: 10px; margin: 4px 0; }
+.v4-ai-skel-line--ttl { width: 70%; height: 12px; }
+.v4-ai-skel-line--ds  { width: 90%; }
+@keyframes v4-ai-skel-shimmer {
+  0%   { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .v4-ai-skel-sev,
+  .v4-ai-skel-line,
+  .v4-ai-skel-meta { animation: none; }
+}
+
+.v4-ai-empty {
+  padding: 16px 18px;
+  font-size: 12px;
+  color: var(--v4-ink-500);
+}
+
 /* ────────────────────────────────────────
    LISTS: blocked + deadlines
    ──────────────────────────────────────── */


### PR DESCRIPTION
Closes #142

## Что сделано
- Полный rewrite `src/components/v4/AIInsightsPanel.tsx`
- Новый prop API: `{reports, loading, lastUpdated, onOpenHealth}`
- Top-5 fail-карточки с сортировкой `severity_weight × age_factor`, фильтр `severity ≥ medium`
- Skeleton при cold load, тег «обновляется…» при warm refresh
- Composite key `repo + rule_id` — стабильный при reorder
- Code-point-safe truncate (utf-8 emoji не ломает)
- Wired в `DashboardView` через `usePortfolioHealth`
- В `App.tsx` добавлен `openHealthForRepo` callback (обходит `navigateTab`, который очищает `healthRepo`)
- Новые CSS классы: severity-бейджи, action-row, shimmer-скелетон

## Решения по архитектуре
- **`onOpenHealth` отдельный callback в App, не reuse `navigateTab`** — потому что `navigateTab` намеренно сбрасывает `healthRepo` при смене вкладки. Нам нужно ровно противоположное: установить `healthRepo`, потом `setTab("projects")`.
- **`nowMs = lastUpdated?.getTime() ?? 0`** вместо `Date.now()` — `react-hooks/purity` не разрешает clock reads в render. Когда `lastUpdated=null`, age_factor у всех findings = 1, сортировка корректно деградирует до severity × name.
- **Severity weights в файле**, не reuse YAML `severity_weights` — это два разных домена (сортировка карточек vs. вычитание баллов в score). Разделение явное.

## Known limitations / follow-up
- `days_since_first_seen` берётся из `report.generated_at` — реальный «когда впервые увидели finding» появится в Epic-006 (TODO в коде)
- Кнопка «→ issue» disabled с tooltip «доступно после Epic-006»

## Проверки
- [x] npm run lint
- [x] npx tsc --noEmit
- [x] npm run build