### PR TITLE
feat(health): single-issue button on FindingsBoard fail cards

### DIFF
--- a/src/components/v4/health/FindingsBoard.tsx
+++ b/src/components/v4/health/FindingsBoard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { HealthFinding, HealthReport, ProjectClassification } from "../../../types/health";
+import type { HealthFinding, HealthReport } from "../../../types/health";
 import { LAYER_NAMES } from "../../../types/health";
 import { Icon, type IconName } from "./Icon";
 import { groupByLayer, pluralize, sortFindings } from "./utils";
@@ -415,6 +415,3 @@ function CleanCelebration({ repo, count }: { repo: string; count: number }) {
   );
 }
 
-// Re-export for tests / external users that build a custom container around
-// FindingsBoard but still want to type the action map / classification.
-export type { ProjectClassification };

--- a/src/components/v4/health/FindingsBoard.tsx
+++ b/src/components/v4/health/FindingsBoard.tsx
@@ -1,16 +1,31 @@
 import { useState } from "react";
-import type { HealthFinding, HealthReport } from "../../../types/health";
+import type { HealthFinding, HealthReport, ProjectClassification } from "../../../types/health";
 import { LAYER_NAMES } from "../../../types/health";
 import { Icon, type IconName } from "./Icon";
 import { groupByLayer, pluralize, sortFindings } from "./utils";
 
-interface BoardProps {
+// Per-finding action state machine for the «→ issue» button.
+// Lives in ProjectHealthPage so re-renders of FindingsBoard don't reset it
+// and a finding's terminal state (created/duplicate) is preserved.
+export type FindingActionState =
+  | { kind: "idle" }
+  | { kind: "creating" }
+  | { kind: "created"; number: number; url: string }
+  | { kind: "duplicate"; number: number; url: string }
+  | { kind: "error"; message: string };
+
+export interface FindingsBoardProps {
   report: HealthReport;
+  // Optional: when omitted (e.g. tests / preview) the «→ issue» button is
+  // not rendered at all — the board stays a pure presentational component.
+  actionStates?: Map<string, FindingActionState>;
+  onCreateIssue?: (finding: HealthFinding) => void;
+  hasToken?: boolean;
 }
 
 // Top-level findings layout. fails + unknowns get rich grouped views;
 // pass and skipped collapse into compact lists below.
-export function FindingsBoard({ report }: BoardProps) {
+export function FindingsBoard({ report, actionStates, onCreateIssue, hasToken }: FindingsBoardProps) {
   const fails = sortFindings(report.findings.filter((f) => f.status === "fail"));
   const unknowns = sortFindings(report.findings.filter((f) => f.status === "unknown"));
   const passes = report.findings.filter((f) => f.status === "pass");
@@ -30,6 +45,9 @@ export function FindingsBoard({ report }: BoardProps) {
           findings={fails}
           showActions
           defaultOpen
+          actionStates={actionStates}
+          onCreateIssue={onCreateIssue}
+          hasToken={hasToken}
         />
       )}
       {unknowns.length > 0 && (
@@ -64,9 +82,23 @@ interface ActionGroupProps {
   findings: HealthFinding[];
   showActions?: boolean;
   defaultOpen?: boolean;
+  actionStates?: Map<string, FindingActionState>;
+  onCreateIssue?: (finding: HealthFinding) => void;
+  hasToken?: boolean;
 }
 
-function ActionGroup({ title, subtitle, tone, icon, findings, showActions, defaultOpen }: ActionGroupProps) {
+function ActionGroup({
+  title,
+  subtitle,
+  tone,
+  icon,
+  findings,
+  showActions,
+  defaultOpen,
+  actionStates,
+  onCreateIssue,
+  hasToken,
+}: ActionGroupProps) {
   const [open, setOpen] = useState(!!defaultOpen);
   const byLayer = groupByLayer(findings);
   const layerIds = (Object.keys(byLayer) as unknown as Array<keyof typeof byLayer>)
@@ -86,7 +118,15 @@ function ActionGroup({ title, subtitle, tone, icon, findings, showActions, defau
       {open && (
         <div className="ph-group-body">
           {layerIds.map((layerId) => (
-            <LayerBlock key={layerId} layerId={layerId} findings={byLayer[layerId]} showActions={showActions} />
+            <LayerBlock
+              key={layerId}
+              layerId={layerId}
+              findings={byLayer[layerId]}
+              showActions={showActions}
+              actionStates={actionStates}
+              onCreateIssue={onCreateIssue}
+              hasToken={hasToken}
+            />
           ))}
         </div>
       )}
@@ -98,9 +138,12 @@ interface LayerBlockProps {
   layerId: 1 | 2 | 3 | 4;
   findings: HealthFinding[];
   showActions?: boolean;
+  actionStates?: Map<string, FindingActionState>;
+  onCreateIssue?: (finding: HealthFinding) => void;
+  hasToken?: boolean;
 }
 
-function LayerBlock({ layerId, findings, showActions }: LayerBlockProps) {
+function LayerBlock({ layerId, findings, showActions, actionStates, onCreateIssue, hasToken }: LayerBlockProps) {
   return (
     <div className="ph-layerblock">
       <div className="ph-layerblock-h">
@@ -112,7 +155,15 @@ function LayerBlock({ layerId, findings, showActions }: LayerBlockProps) {
       </div>
       <ul className="ph-finding-list">
         {findings.map((f, i) => (
-          <FindingItem key={f.rule_id} f={f} showActions={showActions} idx={i} />
+          <FindingItem
+            key={f.rule_id}
+            f={f}
+            showActions={showActions}
+            idx={i}
+            actionState={actionStates?.get(f.rule_id) ?? { kind: "idle" }}
+            onCreateIssue={onCreateIssue}
+            hasToken={hasToken}
+          />
         ))}
       </ul>
     </div>
@@ -123,10 +174,17 @@ interface FindingItemProps {
   f: HealthFinding;
   showActions?: boolean;
   idx: number;
+  actionState: FindingActionState;
+  onCreateIssue?: (finding: HealthFinding) => void;
+  hasToken?: boolean;
 }
 
-function FindingItem({ f, showActions, idx }: FindingItemProps) {
+function FindingItem({ f, showActions, idx, actionState, onCreateIssue, hasToken }: FindingItemProps) {
   const [open, setOpen] = useState(false);
+  // The «→ issue» button is only meaningful for fails. unknown/pass/skipped
+  // all live outside the actionable groups, but defend in depth so future
+  // refactors don't accidentally show it.
+  const canCreateIssue = showActions && f.status === "fail" && !!onCreateIssue;
   return (
     <li
       className={`ph-fi ph-fi--${f.status} ph-fi--sev-${f.severity}`}
@@ -153,10 +211,12 @@ function FindingItem({ f, showActions, idx }: FindingItemProps) {
               {open ? "Скрыть" : "Что делать"}
             </button>
           )}
-          {showActions && (
-            <button type="button" className="v4-btn v4-btn--pri ph-fi-issue" disabled title="Доступно после iteration 4">
-              <Icon name="git-branch" /> Создать issue
-            </button>
+          {canCreateIssue && (
+            <IssueButton
+              state={actionState}
+              hasToken={!!hasToken}
+              onCreate={() => onCreateIssue!(f)}
+            />
           )}
         </div>
       </div>
@@ -168,6 +228,86 @@ function FindingItem({ f, showActions, idx }: FindingItemProps) {
       )}
     </li>
   );
+}
+
+interface IssueButtonProps {
+  state: FindingActionState;
+  hasToken: boolean;
+  onCreate: () => void;
+}
+
+// Visual states:
+//   idle      — clickable «→ issue»
+//   creating  — disabled spinner
+//   created /
+//   duplicate — anchor «#{N} ✓» opening the issue in a new tab; second click
+//               just opens the existing issue, never creates a duplicate.
+//   error     — clickable «↻ повторить»; calling onCreate flips back to creating.
+//
+// When no GitHub token is present we render a disabled button with a tooltip
+// instead of trying to act and exploding inside github-actions.ts.
+function IssueButton({ state, hasToken, onCreate }: IssueButtonProps) {
+  if (!hasToken) {
+    return (
+      <button
+        type="button"
+        className="v4-btn v4-btn--pri ph-fi-issue"
+        disabled
+        title="Нужен GitHub токен — добавьте его в настройках"
+      >
+        <Icon name="git-branch" /> → issue
+      </button>
+    );
+  }
+
+  switch (state.kind) {
+    case "creating":
+      return (
+        <button
+          type="button"
+          className="v4-btn v4-btn--pri ph-fi-issue is-loading"
+          disabled
+          aria-label="Создаю issue…"
+        >
+          <span className="ph-fi-issue-spin" /> Создаю…
+        </button>
+      );
+    case "created":
+    case "duplicate":
+      return (
+        <a
+          href={state.url}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="v4-btn v4-btn--pri ph-fi-issue is-linked"
+          title={state.kind === "duplicate" ? `Issue уже существует: #${state.number}` : `Создан issue #${state.number}`}
+        >
+          <Icon name="check" /> #{state.number}
+        </a>
+      );
+    case "error":
+      return (
+        <button
+          type="button"
+          className="v4-btn ph-fi-issue is-error"
+          onClick={onCreate}
+          title={state.message}
+        >
+          <Icon name="refresh" /> Повторить
+        </button>
+      );
+    case "idle":
+    default:
+      return (
+        <button
+          type="button"
+          className="v4-btn v4-btn--pri ph-fi-issue"
+          onClick={onCreate}
+        >
+          <Icon name="git-branch" /> → issue
+        </button>
+      );
+  }
 }
 
 interface SeverityTagProps {
@@ -274,3 +414,7 @@ function CleanCelebration({ repo, count }: { repo: string; count: number }) {
     </div>
   );
 }
+
+// Re-export for tests / external users that build a custom container around
+// FindingsBoard but still want to type the action map / classification.
+export type { ProjectClassification };

--- a/src/components/v4/health/ProjectHealthPage.tsx
+++ b/src/components/v4/health/ProjectHealthPage.tsx
@@ -1,11 +1,23 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { ProjectData } from "../../../types";
+import type { HealthFinding } from "../../../types/health";
 import { useProjectHealth } from "../../../hooks/useProjectHealth";
 import { loadChecklist } from "../../../utils/checklist";
-import { getToken } from "../../../utils/config";
+import { GITHUB_OWNER, GITHUB_PROJECT_NUMBER, getToken } from "../../../utils/config";
+import {
+  addIssueToProject,
+  createIssue,
+  findOpenIssueByTitle,
+} from "../../../utils/github-actions";
+import {
+  buildIssueBody,
+  buildIssueLabels,
+  buildIssueTitle,
+} from "../../../utils/health-issue";
+import { useToast } from "../toastContext";
 import { Hero } from "./Hero";
 import { LayerStrip } from "./LayerStrip";
-import { FindingsBoard } from "./FindingsBoard";
+import { FindingsBoard, type FindingActionState } from "./FindingsBoard";
 import { Sidebar } from "./Sidebar";
 import { ClassificationMissing, ErrorState, LoadingState } from "./States";
 import { Icon } from "./Icon";
@@ -23,6 +35,7 @@ interface Props {
 
 export function ProjectHealthPage({ repo, project }: Props) {
   const { report, loading, error, classificationMissing, refresh } = useProjectHealth(repo);
+  const toast = useToast();
 
   // Load the rules count for the hero "N правил · makeit-knowledge" link.
   // Fire once when the page opens; the value is cached by loadChecklist.
@@ -42,6 +55,121 @@ export function ProjectHealthPage({ repo, project }: Props) {
       cancelled = true;
     };
   }, []);
+
+  // ─── Per-finding «→ issue» action state ─────────────────────────────
+  // Map<rule_id, FindingActionState>. rule_id is unique inside a single
+  // health report (one repo per page) so we don't need to namespace by repo.
+  // We always create a NEW Map on update so React notices the change instead
+  // of mutating in-place (which would skip re-renders of FindingsBoard).
+  const [actionStates, setActionStates] = useState<Map<string, FindingActionState>>(
+    () => new Map(),
+  );
+
+  const setActionState = useCallback((ruleId: string, next: FindingActionState) => {
+    setActionStates((prev) => {
+      const m = new Map(prev);
+      m.set(ruleId, next);
+      return m;
+    });
+  }, []);
+
+  // Friendly text for the most common failure modes. The raw error message
+  // from rest() is intentionally short ("GitHub API 422") because we don't
+  // want raw GitHub bodies bubbling into the UI.
+  const friendlyError = (err: unknown): string => {
+    if (err instanceof Error) return err.message;
+    return "Не удалось создать issue. Попробуйте ещё раз.";
+  };
+
+  const handleCreateIssue = useCallback(
+    async (finding: HealthFinding) => {
+      if (!report) return;
+      const token = getToken();
+      if (!token) {
+        // The button is disabled in this case, but defend in depth.
+        toast.push({
+          kind: "error",
+          title: "Нет GitHub токена",
+          description: "Добавьте токен в настройках, чтобы создавать issue.",
+        });
+        return;
+      }
+
+      // Race guard: if we're already mid-flight or finished, do nothing.
+      // For terminal states the button renders as <a> and never calls back.
+      const current = actionStates.get(finding.rule_id) ?? { kind: "idle" };
+      if (current.kind === "creating" || current.kind === "created" || current.kind === "duplicate") {
+        return;
+      }
+
+      setActionState(finding.rule_id, { kind: "creating" });
+
+      const title = buildIssueTitle(finding);
+      const labels = buildIssueLabels(finding);
+      const body = buildIssueBody(
+        finding,
+        `${GITHUB_OWNER}/${repo}`,
+        report.classification,
+        report.generated_at,
+      );
+
+      try {
+        const existing = await findOpenIssueByTitle(token, GITHUB_OWNER, repo, title);
+        if (existing) {
+          setActionState(finding.rule_id, {
+            kind: "duplicate",
+            number: existing.number,
+            url: existing.url,
+          });
+          toast.push({
+            kind: "info",
+            title: `Уже есть #${existing.number}`,
+            description: existing.url,
+          });
+          return;
+        }
+
+        const created = await createIssue(token, GITHUB_OWNER, repo, title, body, labels);
+
+        // Best-effort: add to MakeIT Tracker (Project v2 #1). If this fails
+        // the issue is already on GitHub, so we surface it as a warning toast
+        // and keep the «created» state — the user shouldn't think the whole
+        // operation failed.
+        try {
+          await addIssueToProject(token, GITHUB_OWNER, repo, created.number, GITHUB_PROJECT_NUMBER);
+        } catch (projErr) {
+          if (import.meta.env.DEV) {
+            console.warn("[health] addIssueToProject failed:", projErr);
+          }
+          toast.push({
+            kind: "info",
+            title: `Issue #${created.number} создан, но не попал в трекер`,
+            description: friendlyError(projErr),
+          });
+        }
+
+        setActionState(finding.rule_id, {
+          kind: "created",
+          number: created.number,
+          url: created.url,
+        });
+        toast.push({
+          kind: "success",
+          title: `Создан #${created.number}`,
+          description: created.url,
+        });
+      } catch (err) {
+        const message = friendlyError(err);
+        setActionState(finding.rule_id, { kind: "error", message });
+        toast.push({
+          kind: "error",
+          title: "Не удалось создать issue",
+          description: message,
+        });
+      }
+    },
+    [report, repo, actionStates, setActionState, toast],
+  );
 
   // ─── Edge states first ─────────────────────────────────────────────
   if (classificationMissing) {
@@ -129,7 +257,12 @@ export function ProjectHealthPage({ repo, project }: Props) {
             </div>
           )}
           <LayerStrip report={report} />
-          <FindingsBoard report={report} />
+          <FindingsBoard
+            report={report}
+            actionStates={actionStates}
+            onCreateIssue={handleCreateIssue}
+            hasToken={!!getToken()}
+          />
         </div>
         <Sidebar report={report} project={project} />
       </div>

--- a/src/components/v4/health/ProjectHealthPage.tsx
+++ b/src/components/v4/health/ProjectHealthPage.tsx
@@ -95,20 +95,33 @@ export function ProjectHealthPage({ repo, project }: Props) {
         return;
       }
 
-      // Race guard: if we're already mid-flight or finished, do nothing.
-      // For terminal states the button renders as <a> and never calls back.
-      const current = actionStates.get(finding.rule_id) ?? { kind: "idle" };
-      if (current.kind === "creating" || current.kind === "created" || current.kind === "duplicate") {
-        return;
-      }
-
-      setActionState(finding.rule_id, { kind: "creating" });
+      // Race-safe transition idle/error → creating: do the guard inside
+      // the functional updater so a rapid double-click can't both pass
+      // a stale "idle" snapshot and fire two parallel create requests.
+      // `transitioned` is captured from the updater so we know whether
+      // *this* call won the race.
+      let transitioned = false;
+      setActionStates((prev) => {
+        const current = prev.get(finding.rule_id) ?? { kind: "idle" };
+        if (
+          current.kind === "creating" ||
+          current.kind === "created" ||
+          current.kind === "duplicate"
+        ) {
+          return prev;
+        }
+        transitioned = true;
+        const m = new Map(prev);
+        m.set(finding.rule_id, { kind: "creating" });
+        return m;
+      });
+      if (!transitioned) return;
 
       const title = buildIssueTitle(finding);
       const labels = buildIssueLabels(finding);
       const body = buildIssueBody(
         finding,
-        `${GITHUB_OWNER}/${repo}`,
+        repo,
         report.classification,
         report.generated_at,
       );
@@ -168,7 +181,10 @@ export function ProjectHealthPage({ repo, project }: Props) {
         });
       }
     },
-    [report, repo, actionStates, setActionState, toast],
+    // No `actionStates` here — the race guard reads via setActionStates(prev)
+    // so the callback identity stays stable and FindingsBoard doesn't
+    // re-render on every per-finding state mutation.
+    [report, repo, setActionState, toast],
   );
 
   // ─── Edge states first ─────────────────────────────────────────────

--- a/src/styles/v4-health.css
+++ b/src/styles/v4-health.css
@@ -616,6 +616,30 @@
   align-items: flex-end; flex-shrink: 0;
 }
 .ph-fi-actions .v4-btn { white-space: nowrap; font-size: 11.5px; }
+
+/* «→ issue» button states */
+.ph-fi-issue.is-linked {
+  text-decoration: none;
+  font-family: var(--v4-mono);
+}
+.ph-fi-issue.is-error {
+  border-color: var(--v4-danger-500);
+  color: var(--v4-danger-700);
+  background: var(--v4-danger-50);
+}
+.ph-fi-issue.is-error:hover {
+  border-color: var(--v4-danger-700);
+  color: var(--v4-danger-700);
+}
+.ph-fi-issue.is-loading { cursor: progress; opacity: 0.85; }
+.ph-fi-issue-spin {
+  width: 12px; height: 12px;
+  border: 1.5px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  animation: v4-spin 0.9s linear infinite;
+}
 .ph-fi-rem {
   margin: 12px 0 2px 114px;
   background: var(--v4-accent-50);


### PR DESCRIPTION
Closes #147

## Что сделано
- Кнопка «→ issue» на fail-карточках FindingsBoard (была disabled-заглушка «Доступно после iteration 4»)
- Per-finding state machine: `idle → creating → created/duplicate/error` хранится в `Map<rule_id, FindingActionState>` в `ProjectHealthPage`
- Dedup через `findOpenIssueByTitle` перед `createIssue` — повторный клик не плодит дубли
- `addIssueToProject(... GITHUB_PROJECT_NUMBER)` после создания — issue попадает в MakeIT Tracker (Project v2 #1)
- Toast (`useToast`) с friendly текстом — без raw GitHub bodies в UI
- Disabled-кнопка с tooltip, если нет GitHub токена
- Failure addIssueToProject не ломает `created` state — issue в гитхабе уже есть, показываем warning toast
- Минимальные CSS-стили: spinner, anchor-link state, error-state

## Архитектурные решения
- **State в ProjectHealthPage**: одна карта на отчёт, переживает re-render `FindingsBoard`
- **Race**: `creating` блокирует повторный клик; `created/duplicate` рендерятся как `<a>` без onClick
- **Toast только в .then/.catch**: не в render, не в useEffect — не дублируется при re-mount

## Проверки
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean (bundle size warning — не от этого PR)
- [ ] Smoke-test в браузере с живым токеном — отложен (нужна сессия dev'а)

🤖 Generated with [Claude Code](https://claude.com/claude-code)