### PR TITLE
feat(insights): OrphanIssuesPanel — 30-day orphan-issues trend

### DIFF
--- a/src/components/v4/DashboardView.tsx
+++ b/src/components/v4/DashboardView.tsx
@@ -10,7 +10,9 @@ import { ClosedChart30d } from "./ClosedChart30d";
 import { MilestonesStrip } from "./MilestonesStrip";
 import { CommitsHeatmapPanel } from "./CommitsHeatmapPanel";
 import { StaleBanner } from "./StaleBanner";
+import { OrphanIssuesPanel } from "./OrphanIssuesPanel";
 import { usePortfolioHealth } from "../../hooks/usePortfolioHealth";
+import { usePortfolioOrphans } from "../../hooks/usePortfolioOrphans";
 
 interface Props {
   projects: ProjectData[];
@@ -57,6 +59,15 @@ export function DashboardView({
   const portfolioLastUpdated = useMemo(
     () => (portfolio.lastUpdated ? new Date(portfolio.lastUpdated) : null),
     [portfolio.lastUpdated],
+  );
+
+  // Orphan-issues trend uses its own hook (separate cache/refresh cadence
+  // from health) so a slow health scan doesn't block the chart and a
+  // forced "обновить orphans" doesn't trigger a 50-call health re-scan.
+  const orphans = usePortfolioOrphans();
+  const orphansLastUpdated = useMemo(
+    () => (orphans.lastUpdated ? new Date(orphans.lastUpdated) : null),
+    [orphans.lastUpdated],
   );
 
   const filtered = useMemo(
@@ -173,6 +184,13 @@ export function DashboardView({
           onOpenHealth={onOpenHealth}
         />
       </div>
+
+      {/* Full-width orphan-issues trend */}
+      <OrphanIssuesPanel
+        items={orphans.items}
+        loading={orphans.loading}
+        lastUpdated={orphansLastUpdated}
+      />
 
       {/* Row: stacked + blocked */}
       <div className="v4-grid">

--- a/src/components/v4/OrphanIssuesPanel.tsx
+++ b/src/components/v4/OrphanIssuesPanel.tsx
@@ -1,0 +1,385 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { OrphanIssueMeta } from "../../utils/github-actions";
+import { ruDow, ruMonthShort } from "./milestones/utils";
+
+interface Props {
+  items: OrphanIssueMeta[];
+  loading: boolean;
+  /** Timestamp of the most recent successful scan; null while we have no data yet. */
+  lastUpdated: Date | null;
+}
+
+// SVG viewBox dimensions — match ClosedChart30d so both panels feel like
+// siblings under the same header style.
+const W = 960;
+const H = 320;
+const PAD_L = 16;
+const PAD_R = 16;
+const PAD_T = 24;
+const PAD_B = 28;
+const INNER_W = W - PAD_L - PAD_R;
+const INNER_H = H - PAD_T - PAD_B;
+
+const DAYS = 30;
+const DAY_MS = 86_400_000;
+
+// How often the "обновлено N мин назад" label refreshes — same cadence as
+// AIInsightsPanel for visual consistency.
+const META_TICK_MS = 30_000;
+
+// Skeleton placeholder count used during a cold load (no cached items yet).
+const SKELETON_BARS = 30;
+
+// Shift the tooltip card to the left of the cursor once the hover point
+// crosses this fraction of the chart width — keeps the popover from
+// clipping the right edge of the panel.
+const TOOLTIP_FLIP_THRESHOLD = 0.7;
+
+interface DayBucket {
+  /** UTC midnight of the day. Used as React key + tooltip date source. */
+  iso: string;
+  /** Total orphan count active on this day. */
+  count: number;
+  /** Per-repo breakdown sorted desc — capped to top entries by the renderer. */
+  byRepo: Array<{ repo: string; count: number }>;
+}
+
+// Returns N consecutive UTC midnights ending at *today's* UTC midnight.
+// Anchoring to UTC keeps the chart stable across DST transitions and
+// matches GitHub's `created_at` (which is also UTC).
+function build30DayBuckets(items: OrphanIssueMeta[]): DayBucket[] {
+  const now = new Date();
+  const todayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const buckets: DayBucket[] = [];
+  for (let i = DAYS - 1; i >= 0; i--) {
+    const dayMs = todayUtc - i * DAY_MS;
+    // End-of-day cutoff: an issue created at 23:59 UTC counts on its own day.
+    const cutoff = dayMs + DAY_MS - 1;
+    const perRepo = new Map<string, number>();
+    let count = 0;
+    for (const it of items) {
+      const created = new Date(it.created_at).getTime();
+      if (Number.isFinite(created) && created <= cutoff) {
+        count++;
+        perRepo.set(it.repo, (perRepo.get(it.repo) ?? 0) + 1);
+      }
+    }
+    const byRepo = [...perRepo.entries()]
+      .map(([repo, c]) => ({ repo, count: c }))
+      .sort((a, b) => b.count - a.count || a.repo.localeCompare(b.repo));
+    buckets.push({ iso: new Date(dayMs).toISOString(), count, byRepo });
+  }
+  return buckets;
+}
+
+function smoothPath(points: ReadonlyArray<readonly [number, number]>): string {
+  if (points.length < 2) return "";
+  const out = [`M ${points[0][0]} ${points[0][1]}`];
+  for (let i = 0; i < points.length - 1; i++) {
+    const [p0x, p0y] = points[i - 1] ?? points[i];
+    const [p1x, p1y] = points[i];
+    const [p2x, p2y] = points[i + 1];
+    const [p3x, p3y] = points[i + 2] ?? points[i + 1];
+    const cp1x = p1x + (p2x - p0x) / 6;
+    const cp1y = p1y + (p2y - p0y) / 6;
+    const cp2x = p2x - (p3x - p1x) / 6;
+    const cp2y = p2y - (p3y - p1y) / 6;
+    out.push(`C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${p2x} ${p2y}`);
+  }
+  return out.join(" ");
+}
+
+function formatRelativeTime(d: Date | null, now: number): string | null {
+  if (!d) return null;
+  const diffMs = now - d.getTime();
+  if (!Number.isFinite(diffMs) || diffMs < 0) return "только что";
+  const sec = Math.round(diffMs / 1000);
+  if (sec < 60) return `обновлено ${sec} сек назад`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `обновлено ${min} мин назад`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `обновлено ${hr} ч назад`;
+  const days = Math.round(hr / 24);
+  return `обновлено ${days} д назад`;
+}
+
+export function OrphanIssuesPanel({ items, loading, lastUpdated }: Props) {
+  const buckets = useMemo(() => build30DayBuckets(items), [items]);
+  const today = buckets[buckets.length - 1] ?? null;
+  const totalToday = today?.count ?? 0;
+
+  // Y-axis: 10% headroom above the peak, never below 1 (otherwise the line
+  // sits flush against the top edge when count=0).
+  const peak = useMemo(() => buckets.reduce((m, b) => Math.max(m, b.count), 0), [buckets]);
+  const yMax = Math.max(peak, 1) * 1.1;
+
+  const stepX = INNER_W / Math.max(1, buckets.length - 1);
+  const xOf = (i: number) => PAD_L + i * stepX;
+  const yOf = (v: number) => PAD_T + INNER_H - (v / yMax) * INNER_H;
+
+  // 0→1 grow animation — drives the area-fill reveal and the line
+  // dash-offset. Same easing as ClosedChart30d.
+  const [t, setT] = useState(0);
+  useEffect(() => {
+    let raf = 0;
+    let start = 0;
+    const dur = 900;
+    const tick = (ts: number) => {
+      if (!start) start = ts;
+      const k = Math.min(1, (ts - start) / dur);
+      setT(1 - Math.pow(1 - k, 3));
+      if (k < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  const [hover, setHover] = useState<number | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const onMove = (e: React.MouseEvent<SVGSVGElement>) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const x = ((e.clientX - rect.left) * W) / rect.width;
+    if (x < PAD_L || x > W - PAD_R) {
+      setHover(null);
+      return;
+    }
+    const idx = Math.max(0, Math.min(buckets.length - 1, Math.round((x - PAD_L) / stepX)));
+    setHover(idx);
+  };
+
+  // Live "N мин назад" clock — ticks every 30s while mounted.
+  const [metaTickMs, setMetaTickMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setMetaTickMs(Date.now()), META_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+  const meta = formatRelativeTime(lastUpdated, metaTickMs);
+
+  const linePts = buckets.map((b, i) => [xOf(i), yOf(b.count)] as readonly [number, number]);
+  const lineD = smoothPath(linePts);
+  const areaD = lineD
+    ? `${lineD} L ${xOf(buckets.length - 1)} ${PAD_T + INNER_H} L ${xOf(0)} ${PAD_T + INNER_H} Z`
+    : "";
+  const pathRef = useRef<SVGPathElement | null>(null);
+  const [lineLen, setLineLen] = useState(0);
+  useEffect(() => {
+    if (pathRef.current) setLineLen(pathRef.current.getTotalLength());
+  }, [lineD]);
+
+  const grid = [0, 1, 2, 3].map((i) => PAD_T + (INNER_H / 3) * i);
+
+  const showSkeleton = loading && items.length === 0;
+  const showRefreshing = loading && items.length > 0;
+  const isEmpty = !loading && items.length === 0;
+
+  return (
+    <div className="v4-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">
+          <svg
+            style={{ width: 14, height: 14, color: "var(--v4-warn-700)" }}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M12 8v4M12 16h.01" />
+          </svg>
+          Orphan-issues по портфелю
+          <span className="v4-tag">30 дней · без milestone</span>
+          {showRefreshing && <span className="v4-tag">обновляется…</span>}
+        </div>
+        <div className="v4-panel-meta">
+          {totalToday > 0 ? `сейчас ${totalToday}` : meta ?? ""}
+          {totalToday > 0 && meta ? ` · ${meta}` : ""}
+        </div>
+      </div>
+
+      <div className="v4-closed-chart">
+        {showSkeleton ? (
+          <OrphanSkeleton />
+        ) : isEmpty ? (
+          <div className="v4-empty v4-ai-empty">
+            Все issues распределены по milestones.
+          </div>
+        ) : (
+          <svg
+            ref={svgRef}
+            viewBox={`0 0 ${W} ${H}`}
+            preserveAspectRatio="none"
+            onMouseMove={onMove}
+            onMouseLeave={() => setHover(null)}
+            style={{ display: "block", cursor: "crosshair" }}
+          >
+            {/* gridlines (3 dotted + 1 solid baseline) */}
+            {grid.map((y, i) => (
+              <line
+                key={i}
+                x1={PAD_L}
+                x2={W - PAD_R}
+                y1={y}
+                y2={y}
+                stroke="var(--v4-line-soft)"
+                strokeWidth="1"
+                strokeDasharray={i === grid.length - 1 ? "0" : "2 4"}
+              />
+            ))}
+
+            {/* hover full-height column highlight */}
+            {hover !== null && (
+              <line
+                x1={xOf(hover)}
+                x2={xOf(hover)}
+                y1={PAD_T - 4}
+                y2={PAD_T + INNER_H}
+                stroke="var(--v4-accent-700)"
+                strokeWidth="1"
+                strokeDasharray="2 3"
+                opacity="0.55"
+              />
+            )}
+
+            {/* area fill — opacity ramps with `t` so it fades in cleanly */}
+            {areaD && (
+              <path
+                d={areaD}
+                fill="var(--v4-accent-100)"
+                opacity={t * 0.6}
+              />
+            )}
+
+            {/* trend line — animated dash-reveal */}
+            {lineD && (
+              <path
+                ref={pathRef}
+                d={lineD}
+                fill="none"
+                stroke="var(--v4-accent-500)"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeDasharray={lineLen ? `${lineLen} ${lineLen}` : undefined}
+                strokeDashoffset={lineLen ? lineLen * (1 - t) : 0}
+              />
+            )}
+
+            {/* hover dot */}
+            {hover !== null && (
+              <circle
+                cx={xOf(hover)}
+                cy={yOf(buckets[hover].count)}
+                r="4"
+                fill="var(--v4-accent-700)"
+                stroke="var(--v4-paper)"
+                strokeWidth="2"
+              />
+            )}
+
+            {/* X-axis: every 5th day */}
+            {buckets.map((b, i) =>
+              i % 5 === 0 || i === buckets.length - 1 ? (
+                <text
+                  key={`x-${b.iso}`}
+                  x={xOf(i)}
+                  y={H - 10}
+                  textAnchor="middle"
+                  fontFamily="var(--v4-mono)"
+                  fontSize="10"
+                  fill="var(--v4-ink-400)"
+                >
+                  {new Date(b.iso).getUTCDate()}
+                </text>
+              ) : null,
+            )}
+          </svg>
+        )}
+
+        {/* Tooltip card on hover — flips to the left of cursor near the
+            right edge so it can't clip out of the panel. */}
+        {!showSkeleton && !isEmpty && hover !== null && buckets[hover] && (() => {
+          const row = buckets[hover];
+          const date = new Date(row.iso);
+          const xFrac = xOf(hover) / W;
+          const flipLeft = xFrac > TOOLTIP_FLIP_THRESHOLD;
+          // Cap repo breakdown — long lists overflow the card, and the
+          // long tail is rarely meaningful on a per-day count.
+          const TOP_REPOS = 6;
+          const repos = row.byRepo.slice(0, TOP_REPOS);
+          const overflow = Math.max(0, row.byRepo.length - TOP_REPOS);
+          return (
+            <div
+              className="v4-closed-tip"
+              style={{
+                left: `calc(${xFrac * 100}% + ${flipLeft ? "-220px" : "20px"})`,
+              }}
+            >
+              <div className="v4-closed-tip-l">
+                {ruDow(date)}, {date.getUTCDate()} {ruMonthShort(date)}.{" "}
+                {date.getUTCFullYear()}
+              </div>
+              <div className="v4-closed-tip-row">
+                <span className="v4-closed-tip-v">{row.count}</span>
+                <span className="v4-closed-tip-u">
+                  {row.count === 1 ? "orphan-issue" : "orphan-issues"}
+                </span>
+              </div>
+              {repos.length > 0 && (
+                <div className="v4-orphan-tip-list">
+                  {repos.map((r) => (
+                    <div key={r.repo} className="v4-orphan-tip-row">
+                      <span className="v4-mono">{r.repo}</span>
+                      <span className="v4-orphan-tip-c">{r.count}</span>
+                    </div>
+                  ))}
+                  {overflow > 0 && (
+                    <div className="v4-orphan-tip-more">
+                      и ещё {overflow} {overflow === 1 ? "репо" : "репо"}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })()}
+      </div>
+
+      {!showSkeleton && !isEmpty && (
+        <div className="v4-cc-legend">
+          <span className="v4-cc-lg">
+            <span
+              className="v4-cc-sw"
+              style={{ background: "var(--v4-accent-500)" }}
+            />
+            Orphan-issues (open, без milestone)
+          </span>
+          <span className="v4-cc-peak">
+            пик за 30 дн.: <b>{peak}</b>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OrphanSkeleton() {
+  // Light shimmer placeholder — uses the existing v4-ai-skel keyframe so we
+  // don't ship a second animation. Bars climb in a faux trend so the
+  // placeholder reads as a chart, not a flat strip.
+  return (
+    <div className="v4-orphan-skel" aria-hidden>
+      {Array.from({ length: SKELETON_BARS }).map((_, i) => {
+        const h = 20 + Math.round(60 * (0.4 + 0.6 * (i / SKELETON_BARS)));
+        return (
+          <div
+            key={i}
+            className="v4-orphan-skel-bar"
+            style={{ height: `${h}%` }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/v4/OrphanIssuesPanel.tsx
+++ b/src/components/v4/OrphanIssuesPanel.tsx
@@ -336,7 +336,7 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated }: Props) {
                   ))}
                   {overflow > 0 && (
                     <div className="v4-orphan-tip-more">
-                      и ещё {overflow} {overflow === 1 ? "репо" : "репо"}
+                      и ещё {overflow} репо
                     </div>
                   )}
                 </div>

--- a/src/hooks/usePortfolioOrphans.ts
+++ b/src/hooks/usePortfolioOrphans.ts
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { DEFAULT_PROJECTS, getToken } from "../utils/config";
+import { listOrphanIssuesWithMeta, type OrphanIssueMeta } from "../utils/github-actions";
+
+// Bumped suffix when the cache shape changes incompatibly.
+const CACHE_KEY = "makeit_portfolio_orphans_v1";
+// 30 minutes — same envelope as usePortfolioHealth so the two panels
+// refresh in lockstep on a tab re-open.
+const CACHE_TTL_MS = 30 * 60 * 1000;
+// 3 parallel REST scans. Each repo touches ~1-5 pages of /issues, so 3
+// concurrent ≈ 15 in-flight requests at peak — well under GitHub's
+// secondary rate-limit threshold.
+const SCAN_CONCURRENCY = 3;
+// Defer the very first scan so the dashboard's GraphQL warm-up finishes
+// before we hammer REST.
+const INITIAL_DELAY_MS = 1500;
+
+interface CacheShape {
+  generated_at: string;
+  items: OrphanIssueMeta[];
+}
+
+interface State {
+  items: OrphanIssueMeta[];
+  loading: boolean;
+  error: string | null;
+  lastUpdated: string | null;
+}
+
+const IDLE_STATE: State = {
+  items: [],
+  loading: false,
+  error: null,
+  lastUpdated: null,
+};
+
+function readCache(): CacheShape | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CacheShape;
+    if (!parsed.generated_at || !Array.isArray(parsed.items)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(items: OrphanIssueMeta[], generatedAt: string): void {
+  try {
+    const payload: CacheShape = { generated_at: generatedAt, items };
+    localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
+  } catch {
+    // Quota exceeded — drop silently. Next refresh retries.
+  }
+}
+
+function isCacheFresh(cache: CacheShape): boolean {
+  const age = Date.now() - new Date(cache.generated_at).getTime();
+  return Number.isFinite(age) && age >= 0 && age < CACHE_TTL_MS;
+}
+
+// Bounded-concurrency runner — same shape as the helper inside
+// usePortfolioHealth. Kept inline (not extracted) because the two callers
+// are the only consumers and a shared module would force a generics
+// signature with no other benefit.
+async function runWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      results[i] = await mapper(items[i], i);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+// Loads orphan-issue metadata across the full portfolio with caching and
+// per-repo failure isolation. Mirrors the usePortfolioHealth contract so
+// downstream panels can switch between the two without surprise.
+export function usePortfolioOrphans(): State & { refresh: () => void } {
+  const [state, setState] = useState<State>(IDLE_STATE);
+  // Monotonic request id — discriminates between in-flight scans so a
+  // stale run can't overwrite a fresher one's state.
+  const requestId = useRef(0);
+  const isMounted = useRef(true);
+
+  const run = useCallback(async (force: boolean, withInitialDelay: boolean) => {
+    const token = getToken();
+    if (!token) {
+      if (isMounted.current) {
+        setState({
+          items: [],
+          loading: false,
+          error: "Нужен GitHub-токен",
+          lastUpdated: null,
+        });
+      }
+      return;
+    }
+
+    if (!force) {
+      const cached = readCache();
+      if (cached && isCacheFresh(cached)) {
+        if (isMounted.current) {
+          setState({
+            items: cached.items,
+            loading: false,
+            error: null,
+            lastUpdated: cached.generated_at,
+          });
+        }
+        return;
+      }
+    }
+
+    // Bump request id BEFORE any await so cleanup can invalidate this run
+    // while it's parked in the initial delay.
+    const myReq = ++requestId.current;
+
+    if (withInitialDelay) {
+      await new Promise((r) => setTimeout(r, INITIAL_DELAY_MS));
+      if (myReq !== requestId.current || !isMounted.current) return;
+    }
+
+    if (isMounted.current) {
+      setState((s) => ({ ...s, loading: true, error: null }));
+    }
+
+    const settled = await runWithConcurrency(DEFAULT_PROJECTS, SCAN_CONCURRENCY, async (proj) => {
+      try {
+        const meta = await listOrphanIssuesWithMeta(token, proj.owner, proj.repo);
+        return { ok: true as const, meta };
+      } catch (err) {
+        // Per-repo isolation: a 404 / rate-limit on one project mustn't
+        // wipe the whole scan.
+        const msg = err instanceof Error ? err.message : "scan failed";
+        return { ok: false as const, repo: proj.repo, error: msg };
+      }
+    });
+
+    if (myReq !== requestId.current || !isMounted.current) return;
+
+    const items = settled
+      .filter((r): r is { ok: true; meta: OrphanIssueMeta[] } => r.ok)
+      .flatMap((r) => r.meta);
+    const failedAll = settled.every((r) => !r.ok);
+    const generatedAt = new Date().toISOString();
+    writeCache(items, generatedAt);
+
+    setState({
+      items,
+      loading: false,
+      // Surface error only when *every* repo failed — partial success is the
+      // common rate-limit case and shouldn't block the chart.
+      error: failedAll && DEFAULT_PROJECTS.length > 0
+        ? "Не удалось загрузить orphan-issues ни для одного репозитория"
+        : null,
+      lastUpdated: generatedAt,
+    });
+  }, []);
+
+  useEffect(() => {
+    isMounted.current = true;
+    void run(false, true);
+    return () => {
+      isMounted.current = false;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      requestId.current++;
+    };
+  }, [run]);
+
+  const refresh = useCallback(() => {
+    try {
+      localStorage.removeItem(CACHE_KEY);
+    } catch {
+      // Ignore — readCache will treat a malformed entry as a miss.
+    }
+    void run(true, false);
+  }, [run]);
+
+  return { ...state, refresh };
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -1405,6 +1405,62 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 .v4-cc-peak b { color: var(--v4-ink-900); }
 
 /* ────────────────────────────────────────
+   ORPHAN ISSUES PANEL
+   ──────────────────────────────────────── */
+.v4-orphan-tip-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 8px;
+  margin-top: 4px;
+  border-top: 1px solid var(--v4-line-soft);
+  max-height: 160px;
+  overflow-y: auto;
+}
+.v4-orphan-tip-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  font-size: 11px;
+  color: var(--v4-ink-700);
+}
+.v4-orphan-tip-c {
+  font-family: var(--v4-mono);
+  font-weight: 700;
+  color: var(--v4-ink-900);
+  font-variant-numeric: tabular-nums;
+}
+.v4-orphan-tip-more {
+  font-size: 10px;
+  color: var(--v4-ink-500);
+  padding-top: 2px;
+}
+.v4-orphan-skel {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  padding: 10px 20px 14px;
+  flex: 1;
+  min-height: 220px;
+}
+.v4-orphan-skel-bar {
+  flex: 1;
+  background: linear-gradient(
+    90deg,
+    var(--v4-line-soft) 0%,
+    var(--v4-surface-2, #f4f5f9) 50%,
+    var(--v4-line-soft) 100%
+  );
+  background-size: 200% 100%;
+  border-radius: 3px;
+  animation: v4-ai-skel-shimmer 1.4s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .v4-orphan-skel-bar { animation: none; }
+}
+
+/* ────────────────────────────────────────
    MILESTONES STRIP
    ──────────────────────────────────────── */
 .v4-ms-grid {

--- a/src/utils/github-actions.ts
+++ b/src/utils/github-actions.ts
@@ -688,3 +688,51 @@ export async function listIssuesWithoutMilestone(
   return out;
 }
 
+// Same query as listIssuesWithoutMilestone, but returns the metadata callers
+// need to plot a 30-day orphan trend (created_at + originating repo). Kept as
+// a separate function so existing call-sites keep their compact `number[]`
+// shape.
+//
+// Pagination caps at 5 pages × 100 = 500 orphans per repo — same envelope as
+// findOpenIssueByTitle. If a project ever exceeds that, the chart will
+// undercount but never crash.
+export interface OrphanIssueMeta {
+  number: number;
+  created_at: string;
+  repo: string;
+}
+
+export async function listOrphanIssuesWithMeta(
+  token: string,
+  owner: string,
+  repo: string,
+): Promise<OrphanIssueMeta[]> {
+  const PER_PAGE = 100;
+  const MAX_PAGES = 5;
+  const out: OrphanIssueMeta[] = [];
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const data = await rest(
+      token,
+      `/repos/${owner}/${repo}/issues?state=open&milestone=none&per_page=${PER_PAGE}&page=${page}`,
+    );
+    if (!Array.isArray(data) || data.length === 0) break;
+    for (const i of data as Array<{
+      number: number;
+      pull_request?: unknown;
+      milestone: unknown;
+      created_at: string;
+    }>) {
+      // The /issues endpoint returns PRs interleaved — drop them or the
+      // count balloons with merged-but-milestone-less PRs.
+      if (i.pull_request) continue;
+      // GitHub's `milestone=none` filter is server-side, but we re-check on
+      // the client too: defence-in-depth against an API quirk where the
+      // filter occasionally ships an issue with a stale milestone object.
+      if (i.milestone != null) continue;
+      out.push({ number: i.number, created_at: i.created_at, repo });
+    }
+    if (data.length < PER_PAGE) break;
+  }
+  return out;
+}
+


### PR DESCRIPTION
Closes #143

## Что сделано
- `listOrphanIssuesWithMeta` в `github-actions.ts` (5×100 пагинация + PR filter + client-side milestone re-check)
- `usePortfolioOrphans` хук (concurrency=3, 30-min localStorage cache, per-repo failure isolation, requestId/AbortController-style cleanup)
- `OrphanIssuesPanel` — 30-day chart по портфелю с UTC-midnight buckets, tooltip с разбивкой `repo: count`, skeleton/empty/refreshing states (паттерн как `AIInsightsPanel`)
- Подключён в `DashboardView` под `AIInsightsPanel`, full-width

## Архитектурные решения
- UTC midnight для bucket-ов — стабильно при DST, совпадает с GitHub `created_at`
- Tooltip flip при `xFrac > 0.7` — не выезжает за viewport
- Отдельный хук (а не загрузка inline в компоненте) — кэш переживает unmount, можно переиспользовать в других панелях
- Все magic-числа (TTL, concurrency, days, skeleton bars, flip threshold) вынесены в const на верх файлов

## Проверки
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean (240 modules, 201ms)