### PR TITLE
feat(health): BulkCreateModal — batch create issues from health-findings

### DIFF
--- a/src/components/v4/health/BulkCreateModal.tsx
+++ b/src/components/v4/health/BulkCreateModal.tsx
@@ -349,7 +349,9 @@ export function BulkCreateModal({ report, repo, onClose, onActionStateChange }: 
   // ─── Render ──────────────────────────────────────────────────────────
   const selectedCount = selected.size;
   const showWarning = selectedCount > WARNING_THRESHOLD;
-  const projectedSeconds = selectedCount; // 1 req/sec ⇒ N findings ≈ N seconds.
+  // 1 req/sec ⇒ N findings ≈ N seconds. Cap by MAX_BATCH_SIZE because the
+  // submit loop itself caps the slice at MAX_BATCH_SIZE (line 206).
+  const projectedSeconds = Math.min(selectedCount, MAX_BATCH_SIZE);
   const submitDisabled = submitting || selectedCount === 0 || !hasToken;
   const progressPct =
     progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 0;

--- a/src/components/v4/health/BulkCreateModal.tsx
+++ b/src/components/v4/health/BulkCreateModal.tsx
@@ -1,0 +1,593 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { HealthFinding, HealthReport, HealthSeverity } from "../../../types/health";
+import { GITHUB_OWNER, GITHUB_PROJECT_NUMBER, getToken } from "../../../utils/config";
+import {
+  addIssueToProject,
+  createIssue,
+  findOpenIssueByTitle,
+} from "../../../utils/github-actions";
+import {
+  buildIssueBody,
+  buildIssueLabels,
+  buildIssueTitle,
+} from "../../../utils/health-issue";
+import { useToast } from "../toastContext";
+import type { FindingActionState } from "./FindingsBoard";
+import { Icon } from "./Icon";
+
+// ── Tunables ─────────────────────────────────────────────────────────
+// GitHub's secondary rate limit is the practical ceiling for write bursts;
+// 1 req/sec sequential is the documented safe rate.
+const RATE_LIMIT_DELAY_MS = 1000;
+// Above this many selected findings we warn the user about the projected
+// wall-clock cost (LIMIT * 1s per request). 30 keeps the hint relevant
+// without being noisy for typical fail-counts (most repos have ≤10).
+const WARNING_THRESHOLD = 30;
+// Hard cap on how many findings we'll create per submit. Prevents the
+// modal turning into a multi-minute operation by accident; if a repo
+// somehow has more, the user can submit a second batch.
+const MAX_BATCH_SIZE = 100;
+
+const SEVERITY_ORDER: readonly HealthSeverity[] = ["critical", "high", "medium", "low"];
+// Default include-set — anything `medium` or worse. `low` findings still
+// appear in the list but are unchecked by default so the user opts-in.
+const DEFAULT_SEVERITY_FILTER: ReadonlySet<HealthSeverity> = new Set(["critical", "high", "medium"]);
+
+interface BulkCreateModalProps {
+  report: HealthReport;
+  /** Simple repo name (no owner/). The modal pairs it with GITHUB_OWNER. */
+  repo: string;
+  onClose: () => void;
+  /**
+   * Optional sync hook — when provided, every per-finding state transition
+   * is mirrored to the parent so the per-row «→ issue» buttons in
+   * FindingsBoard reflect the bulk-created state immediately on close.
+   */
+  onActionStateChange?: (ruleId: string, state: FindingActionState) => void;
+}
+
+type LogEntry =
+  | { ruleId: string; status: "created"; number: number; url: string }
+  | { ruleId: string; status: "duplicate"; number: number; url: string }
+  | { ruleId: string; status: "error"; detail: string };
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+const friendlyError = (err: unknown): string => {
+  if (err instanceof Error) return err.message;
+  return "Неизвестная ошибка";
+};
+
+/**
+ * Bulk-create GitHub issues from the failing health-findings of a single
+ * repository. Lifecycle:
+ *
+ *  1. User picks a subset (severity-filter chips + per-row checkboxes).
+ *  2. Submit kicks off a *sequential* loop — one issue per second to stay
+ *     well under GitHub's secondary rate limit. Each iteration: dedupe by
+ *     title → POST /issues → best-effort add-to-project.
+ *  3. Closing the modal flips an abort ref the loop checks at the top of
+ *     every iteration, so a half-finished batch stops cleanly without
+ *     orphaning in-flight requests (the current request still completes).
+ *  4. On finish (or abort) we push a sticky toast with the totals and a
+ *     deep-link to the repo's tech-debt filter.
+ */
+export function BulkCreateModal({ report, repo, onClose, onActionStateChange }: BulkCreateModalProps) {
+  const toast = useToast();
+  const hasToken = !!getToken();
+
+  // Findings that are eligible for bulk-create — only `fail`. unknown / pass /
+  // skipped never become tech-debt issues, no matter what the user does.
+  const fails = useMemo(
+    () => report.findings.filter((f) => f.status === "fail"),
+    [report.findings],
+  );
+
+  // Severity counts drive the chip badges and the "is the chip fully selected?"
+  // logic. Computed once per fails list since findings don't change while the
+  // modal is open.
+  const severityCounts = useMemo(() => {
+    const counts: Record<HealthSeverity, number> = { critical: 0, high: 0, medium: 0, low: 0 };
+    for (const f of fails) counts[f.severity]++;
+    return counts;
+  }, [fails]);
+
+  // ─── Selection state ─────────────────────────────────────────────────
+  // Set<rule_id> for O(1) membership checks in the row render loop.
+  const [selected, setSelected] = useState<Set<string>>(() => {
+    const init = new Set<string>();
+    for (const f of fails) {
+      if (DEFAULT_SEVERITY_FILTER.has(f.severity)) init.add(f.rule_id);
+    }
+    return init;
+  });
+
+  // ─── Submission state ────────────────────────────────────────────────
+  const [submitting, setSubmitting] = useState(false);
+  const [progress, setProgress] = useState({ done: 0, total: 0 });
+  const [log, setLog] = useState<LogEntry[]>([]);
+  // Ref (not state) so flipping it from the close-handler doesn't cause
+  // the in-flight loop to re-render and lose its closure over `current`.
+  const abortRef = useRef(false);
+
+  // ─── Esc + scroll lock ───────────────────────────────────────────────
+  // Closing while submitting would leave the loop running but unmount the
+  // modal — we keep the modal mounted but accept the close intent by
+  // setting the abort flag, which the loop then notices.
+  const handleClose = useCallback(() => {
+    if (submitting) {
+      // Mark abort and wait for the loop to drain. The completion handler
+      // calls onClose() itself once it has finalised totals.
+      abortRef.current = true;
+      return;
+    }
+    onClose();
+  }, [submitting, onClose]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") handleClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [handleClose]);
+
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  // ─── Selection helpers ───────────────────────────────────────────────
+  const toggleRow = useCallback((ruleId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(ruleId)) next.delete(ruleId);
+      else next.add(ruleId);
+      return next;
+    });
+  }, []);
+
+  // Severity chip is "all-or-nothing": clicking it adds every finding of
+  // that severity if any is missing from `selected`, otherwise removes them
+  // all. Mirrors typical "select-all" UX in tabular UIs.
+  const toggleSeverity = useCallback(
+    (sev: HealthSeverity) => {
+      const ruleIds = fails.filter((f) => f.severity === sev).map((f) => f.rule_id);
+      if (ruleIds.length === 0) return;
+      setSelected((prev) => {
+        const next = new Set(prev);
+        const allSelected = ruleIds.every((id) => next.has(id));
+        if (allSelected) {
+          for (const id of ruleIds) next.delete(id);
+        } else {
+          for (const id of ruleIds) next.add(id);
+        }
+        return next;
+      });
+    },
+    [fails],
+  );
+
+  const severityChipState = useCallback(
+    (sev: HealthSeverity): "all" | "some" | "none" => {
+      const ruleIds = fails.filter((f) => f.severity === sev).map((f) => f.rule_id);
+      if (ruleIds.length === 0) return "none";
+      const inCount = ruleIds.filter((id) => selected.has(id)).length;
+      if (inCount === 0) return "none";
+      if (inCount === ruleIds.length) return "all";
+      return "some";
+    },
+    [fails, selected],
+  );
+
+  // ─── Submit ──────────────────────────────────────────────────────────
+  const handleSubmit = useCallback(async () => {
+    const token = getToken();
+    if (!token) {
+      // Defence in depth — submit button is disabled in this case.
+      toast.push({
+        kind: "error",
+        title: "Нет GitHub токена",
+        description: "Добавьте токен в настройках, чтобы создавать issues.",
+      });
+      return;
+    }
+    if (selected.size === 0 || submitting) return;
+
+    // Build a stable, severity-ordered work list. Sorting by severity means
+    // the most painful items get filed first — useful when the user aborts
+    // mid-batch.
+    const workList = fails
+      .filter((f) => selected.has(f.rule_id))
+      .slice(0, MAX_BATCH_SIZE)
+      .sort(
+        (a, b) =>
+          SEVERITY_ORDER.indexOf(a.severity) - SEVERITY_ORDER.indexOf(b.severity),
+      );
+
+    abortRef.current = false;
+    setSubmitting(true);
+    setProgress({ done: 0, total: workList.length });
+    setLog([]);
+
+    let created = 0;
+    let dups = 0;
+    let errors = 0;
+    let aborted = false;
+
+    for (let i = 0; i < workList.length; i++) {
+      // Abort check at the TOP of the loop, before any network call. If the
+      // user clicked × mid-batch we stop immediately rather than burning
+      // another request.
+      if (abortRef.current) {
+        aborted = true;
+        break;
+      }
+
+      // Polite spacing between requests — but only AFTER the first one,
+      // otherwise we add a needless 1s lag to single-issue submits.
+      if (i > 0) {
+        await sleep(RATE_LIMIT_DELAY_MS);
+        if (abortRef.current) {
+          aborted = true;
+          break;
+        }
+      }
+
+      const finding = workList[i];
+      const title = buildIssueTitle(finding);
+      const labels = buildIssueLabels(finding);
+      const body = buildIssueBody(
+        finding,
+        repo,
+        report.classification,
+        report.generated_at,
+      );
+
+      try {
+        const existing = await findOpenIssueByTitle(token, GITHUB_OWNER, repo, title);
+        if (existing) {
+          dups++;
+          setLog((prev) => [
+            ...prev,
+            { ruleId: finding.rule_id, status: "duplicate", number: existing.number, url: existing.url },
+          ]);
+          onActionStateChange?.(finding.rule_id, {
+            kind: "duplicate",
+            number: existing.number,
+            url: existing.url,
+          });
+        } else {
+          const createdIssue = await createIssue(
+            token,
+            GITHUB_OWNER,
+            repo,
+            title,
+            body,
+            labels,
+          );
+          // Best-effort project add — don't let a Project v2 hiccup mark the
+          // whole row as failed; the issue is already on GitHub.
+          try {
+            await addIssueToProject(
+              token,
+              GITHUB_OWNER,
+              repo,
+              createdIssue.number,
+              GITHUB_PROJECT_NUMBER,
+            );
+          } catch (projErr) {
+            if (import.meta.env.DEV) {
+              console.warn("[bulk-create] addIssueToProject failed:", projErr);
+            }
+          }
+          created++;
+          setLog((prev) => [
+            ...prev,
+            { ruleId: finding.rule_id, status: "created", number: createdIssue.number, url: createdIssue.url },
+          ]);
+          onActionStateChange?.(finding.rule_id, {
+            kind: "created",
+            number: createdIssue.number,
+            url: createdIssue.url,
+          });
+        }
+      } catch (err) {
+        errors++;
+        const detail = friendlyError(err);
+        setLog((prev) => [...prev, { ruleId: finding.rule_id, status: "error", detail }]);
+        onActionStateChange?.(finding.rule_id, { kind: "error", message: detail });
+      }
+      setProgress({ done: i + 1, total: workList.length });
+    }
+
+    setSubmitting(false);
+
+    // Sticky toast (duration: 0 → user dismisses manually). Link goes to the
+    // repo's tech-debt filter so the user lands directly on the freshly
+    // filed issues.
+    const filterUrl = `https://github.com/${GITHUB_OWNER}/${repo}/issues?q=${encodeURIComponent(
+      "is:issue is:open label:tech-debt",
+    )}`;
+    if (aborted) {
+      const remaining = workList.length - (created + dups + errors);
+      toast.push({
+        kind: "info",
+        title: `Создание прервано: ${created} created, ${remaining} skipped`,
+        description: `Дублей: ${dups}, ошибок: ${errors}. ${filterUrl}`,
+        duration: 0,
+      });
+    } else {
+      toast.push({
+        kind: errors > 0 ? "info" : "success",
+        title: `Создано ${created}, дублей ${dups}, ошибок ${errors}`,
+        description: filterUrl,
+        duration: 0,
+      });
+    }
+
+    // Auto-close the modal once the batch finished (or fully aborted) so the
+    // user sees the outcome via the toast and the underlying findings board
+    // (whose action-state map is already in sync).
+    onClose();
+  }, [
+    selected,
+    submitting,
+    fails,
+    repo,
+    report.classification,
+    report.generated_at,
+    toast,
+    onActionStateChange,
+    onClose,
+  ]);
+
+  // ─── Render ──────────────────────────────────────────────────────────
+  const selectedCount = selected.size;
+  const showWarning = selectedCount > WARNING_THRESHOLD;
+  const projectedSeconds = selectedCount; // 1 req/sec ⇒ N findings ≈ N seconds.
+  const submitDisabled = submitting || selectedCount === 0 || !hasToken;
+  const progressPct =
+    progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 0;
+
+  // Group log entries by rule_id for fast lookup when rendering rows.
+  const logByRule = useMemo(() => {
+    const m = new Map<string, LogEntry>();
+    for (const entry of log) m.set(entry.ruleId, entry);
+    return m;
+  }, [log]);
+
+  return createPortal(
+    <div
+      className="v4-mspopup-bd ph-bulk-bd"
+      onClick={(e) => {
+        // Click outside closes — but during submit we ignore the click on
+        // the backdrop entirely (use the × button to abort). Avoids the user
+        // accidentally aborting a batch they wanted to finish.
+        if (e.target === e.currentTarget && !submitting) onClose();
+      }}
+    >
+      <div
+        className="v4-mspopup ph-bulk"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ph-bulk-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="v4-mspopup-h ph-bulk-h">
+          <div className="v4-mspopup-h-text">
+            <div className="v4-mspopup-repo">{repo}</div>
+            <h2 id="ph-bulk-title" className="v4-mspopup-title">
+              Создать issues для {fails.length} нарушений в {repo}
+            </h2>
+          </div>
+          <button
+            type="button"
+            className="v4-mspopup-close"
+            aria-label={submitting ? "Прервать создание" : "Закрыть"}
+            onClick={handleClose}
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="ph-bulk-filters">
+          {SEVERITY_ORDER.map((sev) => {
+            const count = severityCounts[sev];
+            const state = severityChipState(sev);
+            const dim = count === 0;
+            return (
+              <button
+                key={sev}
+                type="button"
+                className={`ph-bulk-chip ph-bulk-chip--${sev} is-${state} ${dim ? "is-dim" : ""}`}
+                onClick={() => toggleSeverity(sev)}
+                disabled={submitting || count === 0}
+                aria-pressed={state !== "none"}
+              >
+                <span className="ph-bulk-chip-dot" />
+                {sev}
+                <span className="ph-bulk-chip-count">{count}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="ph-bulk-body">
+          {fails.length === 0 ? (
+            <div className="v4-mspopup-empty">Нарушений нет — всё зелёное.</div>
+          ) : (
+            <ul className="ph-bulk-list">
+              {fails.map((f) => {
+                const isSelected = selected.has(f.rule_id);
+                const entry = logByRule.get(f.rule_id);
+                return (
+                  <BulkRow
+                    key={f.rule_id}
+                    finding={f}
+                    selected={isSelected}
+                    onToggle={() => toggleRow(f.rule_id)}
+                    disabled={submitting}
+                    repo={repo}
+                    report={report}
+                    logEntry={entry}
+                  />
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        {submitting && (
+          <div className="ph-bulk-progress">
+            <div className="ph-bulk-progress-bar">
+              <div className="ph-bulk-progress-fill" style={{ width: `${progressPct}%` }} />
+            </div>
+            <span className="num">
+              {progress.done}/{progress.total}
+            </span>
+          </div>
+        )}
+
+        {showWarning && !submitting && (
+          <div className="ph-bulk-warning">
+            <Icon name="alert" />
+            <span>
+              Это много issues, создание займёт ~{projectedSeconds} сек
+              {selectedCount > MAX_BATCH_SIZE && (
+                <> (будут обработаны первые {MAX_BATCH_SIZE})</>
+              )}
+              .
+            </span>
+          </div>
+        )}
+
+        {!hasToken && (
+          <div className="ph-bulk-warning ph-bulk-warning--err">
+            <Icon name="alert" />
+            <span>Нет GitHub токена — добавьте его в настройках, чтобы создавать issues.</span>
+          </div>
+        )}
+
+        <footer className="ph-bulk-footer">
+          <span className="ph-bulk-count">
+            Выбрано <b>{selectedCount}</b> из {fails.length}
+          </span>
+          <div className="ph-bulk-footer-btns">
+            <button
+              type="button"
+              className="v4-btn"
+              onClick={handleClose}
+            >
+              {submitting ? "Прервать" : "Отмена"}
+            </button>
+            <button
+              type="button"
+              className="v4-btn v4-btn--pri"
+              onClick={handleSubmit}
+              disabled={submitDisabled}
+              title={!hasToken ? "Нужен GitHub токен" : undefined}
+            >
+              <Icon name="git-branch" />
+              {submitting ? "Создаю…" : `Создать ${selectedCount} issues`}
+            </button>
+          </div>
+        </footer>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+interface BulkRowProps {
+  finding: HealthFinding;
+  selected: boolean;
+  onToggle: () => void;
+  disabled: boolean;
+  repo: string;
+  report: HealthReport;
+  logEntry: LogEntry | undefined;
+}
+
+// One row in the findings list — checkbox + severity badge + identifying text,
+// with an expandable preview of the GitHub issue body that *would* be sent.
+// Preview body is built lazily on expand to avoid running buildIssueBody for
+// every row on first render.
+function BulkRow({ finding, selected, onToggle, disabled, repo, report, logEntry }: BulkRowProps) {
+  const [open, setOpen] = useState(false);
+  const detail = finding.detail ?? "";
+  const truncated = detail.length > 90 ? `${detail.slice(0, 90).trimEnd()}…` : detail;
+
+  const previewBody = useMemo(() => {
+    if (!open) return "";
+    return buildIssueBody(finding, repo, report.classification, report.generated_at);
+  }, [open, finding, repo, report.classification, report.generated_at]);
+
+  return (
+    <li className={`ph-bulk-row ph-bulk-row--sev-${finding.severity} ${selected ? "is-selected" : ""}`}>
+      <label className="ph-bulk-row-main">
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={onToggle}
+          disabled={disabled}
+          className="ph-bulk-row-cb"
+        />
+        <span className={`ph-sev ph-sev--${finding.severity}`}>
+          <span className="ph-sev-dot" />
+          {finding.severity}
+        </span>
+        <span className="ph-bulk-row-text">
+          <span className="ph-bulk-row-title">
+            <span className="v4-mono ph-bulk-row-rule">{finding.rule_id}</span>
+            <span>{finding.title}</span>
+          </span>
+          {detail && <span className="ph-bulk-row-detail">{truncated}</span>}
+        </span>
+        {logEntry && (
+          <span className={`ph-bulk-row-status ph-bulk-row-status--${logEntry.status}`}>
+            {logEntry.status === "created" && (
+              <a href={logEntry.url} target="_blank" rel="noreferrer noopener">
+                <Icon name="check" /> #{logEntry.number} created
+              </a>
+            )}
+            {logEntry.status === "duplicate" && (
+              <a href={logEntry.url} target="_blank" rel="noreferrer noopener">
+                <Icon name="check" /> #{logEntry.number} exists
+              </a>
+            )}
+            {logEntry.status === "error" && (
+              <span title={logEntry.detail}>
+                <Icon name="alert" /> error
+              </span>
+            )}
+          </span>
+        )}
+        <button
+          type="button"
+          className="ph-bulk-row-toggle"
+          onClick={(e) => {
+            e.preventDefault();
+            setOpen(!open);
+          }}
+          aria-label={open ? "Скрыть превью" : "Показать превью"}
+          disabled={disabled}
+        >
+          <Icon name={open ? "chev-up" : "chev"} />
+        </button>
+      </label>
+      {open && (
+        <div className="ph-bulk-row-preview">
+          <div className="ph-bulk-row-preview-h">
+            <Icon name="lightbulb" /> Превью body
+          </div>
+          <pre>{previewBody}</pre>
+        </div>
+      )}
+    </li>
+  );
+}

--- a/src/components/v4/health/Hero.tsx
+++ b/src/components/v4/health/Hero.tsx
@@ -8,14 +8,20 @@ interface Props {
   onRescan: () => void;
   refreshing: boolean;
   rulesCount: number;
+  /** Optional — wired from ProjectHealthPage to open the BulkCreateModal. */
+  onBulkCreate?: () => void;
 }
 
 // Header of the report — repo name with classification chips, sub-row with
 // scan time and rules-version link, action buttons (drift scan placeholder
 // + rescan), and the 3-tile KPI row. Navigation back to the projects list
 // happens via the topbar breadcrumb.
-export function Hero({ report, onRescan, refreshing, rulesCount }: Props) {
+export function Hero({ report, onRescan, refreshing, rulesCount, onBulkCreate }: Props) {
   const cls = report.classification;
+  // Bulk-create only makes sense when there's something to file. Hiding the
+  // button (rather than disabling) keeps the toolbar visually clean for
+  // healthy projects.
+  const hasFails = report.findings.some((f) => f.status === "fail");
   return (
     <section className="ph-hero-block">
       <div className="ph-hero-top">
@@ -54,6 +60,16 @@ export function Hero({ report, onRescan, refreshing, rulesCount }: Props) {
           </div>
         </div>
         <div className="ph-hero-actions">
+          {hasFails && onBulkCreate && (
+            <button
+              type="button"
+              className="v4-btn"
+              onClick={onBulkCreate}
+              title="Массово создать GitHub issues для всех нарушений"
+            >
+              <Icon name="git-branch" /> Создать issues по всем
+            </button>
+          )}
           <button type="button" className="v4-btn" disabled title="Layer 4 — следующая итерация">
             <Icon name="zap" /> Просканировать drift
           </button>

--- a/src/components/v4/health/ProjectHealthPage.tsx
+++ b/src/components/v4/health/ProjectHealthPage.tsx
@@ -15,6 +15,7 @@ import {
   buildIssueTitle,
 } from "../../../utils/health-issue";
 import { useToast } from "../toastContext";
+import { BulkCreateModal } from "./BulkCreateModal";
 import { Hero } from "./Hero";
 import { LayerStrip } from "./LayerStrip";
 import { FindingsBoard, type FindingActionState } from "./FindingsBoard";
@@ -72,6 +73,11 @@ export function ProjectHealthPage({ repo, project }: Props) {
       return m;
     });
   }, []);
+
+  // ─── Bulk-create modal toggle ──────────────────────────────────────
+  // Lives here (not in Hero) so the modal can read `report` and write into
+  // the shared `actionStates` map.
+  const [bulkOpen, setBulkOpen] = useState(false);
 
   // Friendly text for the most common failure modes. The raw error message
   // from rest() is intentionally short ("GitHub API 422") because we don't
@@ -249,6 +255,7 @@ export function ProjectHealthPage({ repo, project }: Props) {
         onRescan={refresh}
         refreshing={refreshing}
         rulesCount={rulesCount}
+        onBulkCreate={() => setBulkOpen(true)}
       />
       <div className="ph-page">
         <div className="ph-main">
@@ -282,6 +289,14 @@ export function ProjectHealthPage({ repo, project }: Props) {
         </div>
         <Sidebar report={report} project={project} />
       </div>
+      {bulkOpen && (
+        <BulkCreateModal
+          report={report}
+          repo={repo}
+          onClose={() => setBulkOpen(false)}
+          onActionStateChange={setActionState}
+        />
+      )}
     </div>
   );
 }

--- a/src/styles/v4-health.css
+++ b/src/styles/v4-health.css
@@ -1026,3 +1026,233 @@
   .ph-fi-rem { margin-left: 0; }
   .ph-layer-row { grid-template-columns: 130px 1fr 90px; }
 }
+
+/* ──────────────────────────────────────────────────────────────────
+ * Bulk-create modal (BulkCreateModal.tsx)
+ * Reuses .v4-mspopup-bd / .v4-mspopup container styles from v4.css
+ * for the overlay + card; everything below is bulk-specific layout.
+ * ────────────────────────────────────────────────────────────────── */
+.ph-bulk { max-width: 880px; }
+.ph-bulk-h { grid-template-columns: 1fr auto; }
+.ph-bulk-filters {
+  display: flex; gap: 6px; flex-wrap: wrap;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--v4-line-soft);
+}
+.ph-bulk-chip {
+  appearance: none;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--v4-mono);
+  font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.04em;
+  padding: 5px 10px;
+  border-radius: 99px;
+  border: 1px solid var(--v4-line);
+  background: var(--v4-paper);
+  color: var(--v4-ink-700);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, color .15s, opacity .15s;
+}
+.ph-bulk-chip:hover:not(:disabled) {
+  border-color: var(--v4-line-strong);
+}
+.ph-bulk-chip:disabled { opacity: .45; cursor: not-allowed; }
+.ph-bulk-chip.is-dim { opacity: .4; }
+.ph-bulk-chip-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--v4-ink-400);
+  display: inline-block;
+}
+.ph-bulk-chip-count {
+  font-size: 10.5px; font-weight: 600;
+  padding: 1px 6px; border-radius: 99px;
+  background: var(--v4-surface-2); color: var(--v4-ink-600);
+}
+
+.ph-bulk-chip--critical .ph-bulk-chip-dot { background: var(--v4-danger-700); }
+.ph-bulk-chip--high     .ph-bulk-chip-dot { background: var(--v4-danger-500); }
+.ph-bulk-chip--medium   .ph-bulk-chip-dot { background: var(--v4-warn-500); }
+.ph-bulk-chip--low      .ph-bulk-chip-dot { background: var(--v4-ink-400); }
+
+.ph-bulk-chip.is-all {
+  border-color: var(--v4-accent-500);
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
+}
+.ph-bulk-chip.is-some {
+  border-color: var(--v4-accent-500);
+  background: var(--v4-paper);
+  color: var(--v4-accent-700);
+  border-style: dashed;
+}
+
+.ph-bulk-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 20px 8px;
+  min-height: 200px;
+}
+.ph-bulk-list {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.ph-bulk-row {
+  border: 1px solid var(--v4-line-soft);
+  border-radius: 10px;
+  background: var(--v4-paper);
+  transition: border-color .15s, background .15s;
+}
+.ph-bulk-row.is-selected {
+  border-color: var(--v4-accent-300, var(--v4-accent-500));
+  background: var(--v4-accent-50);
+}
+.ph-bulk-row-main {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+.ph-bulk-row-cb {
+  width: 16px; height: 16px;
+  cursor: pointer;
+  accent-color: var(--v4-accent-600);
+}
+.ph-bulk-row-cb:disabled { cursor: not-allowed; }
+.ph-bulk-row-text {
+  display: flex; flex-direction: column; gap: 2px;
+  min-width: 0;
+}
+.ph-bulk-row-title {
+  display: inline-flex; align-items: baseline; gap: 8px;
+  font-size: 13px; color: var(--v4-ink-900); font-weight: 500;
+  flex-wrap: wrap;
+}
+.ph-bulk-row-rule {
+  font-size: 10.5px; color: var(--v4-ink-500);
+  font-weight: 600;
+}
+.ph-bulk-row-detail {
+  font-size: 11.5px; color: var(--v4-ink-500);
+  line-height: 1.4;
+}
+.ph-bulk-row-status {
+  font-family: var(--v4-mono);
+  font-size: 11px; font-weight: 600;
+  display: inline-flex; align-items: center; gap: 4px;
+  white-space: nowrap;
+}
+.ph-bulk-row-status svg { width: 12px; height: 12px; }
+.ph-bulk-row-status a {
+  color: var(--v4-accent-600);
+  text-decoration: none;
+  display: inline-flex; align-items: center; gap: 4px;
+}
+.ph-bulk-row-status a:hover { text-decoration: underline; }
+.ph-bulk-row-status--created a,
+.ph-bulk-row-status--duplicate a { color: var(--v4-success-700, var(--v4-accent-600)); }
+.ph-bulk-row-status--error { color: var(--v4-danger-700); }
+.ph-bulk-row-toggle {
+  appearance: none;
+  border: 0; background: transparent;
+  width: 28px; height: 28px;
+  border-radius: 6px;
+  color: var(--v4-ink-500);
+  cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background .15s, color .15s;
+}
+.ph-bulk-row-toggle:hover:not(:disabled) {
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
+}
+.ph-bulk-row-toggle svg { width: 14px; height: 14px; }
+.ph-bulk-row-preview {
+  border-top: 1px solid var(--v4-line-soft);
+  padding: 10px 14px 12px;
+  background: var(--v4-surface-1, var(--v4-surface-2));
+  border-radius: 0 0 10px 10px;
+}
+.ph-bulk-row-preview-h {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 10.5px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--v4-ink-500);
+  margin-bottom: 6px;
+}
+.ph-bulk-row-preview-h svg { width: 12px; height: 12px; }
+.ph-bulk-row-preview pre {
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  margin: 0;
+  padding: 8px 10px;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line-soft);
+  border-radius: 6px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.ph-bulk-progress {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 20px;
+  border-top: 1px solid var(--v4-line-soft);
+}
+.ph-bulk-progress-bar {
+  flex: 1;
+  height: 6px;
+  background: var(--v4-surface-3, var(--v4-surface-2));
+  border-radius: 99px;
+  overflow: hidden;
+}
+.ph-bulk-progress-fill {
+  height: 100%;
+  background: var(--v4-accent-500);
+  border-radius: 99px;
+  transition: width .3s ease-out;
+}
+.ph-bulk-progress .num {
+  font-family: var(--v4-mono);
+  font-size: 12px; font-weight: 600;
+  color: var(--v4-ink-700);
+}
+
+.ph-bulk-warning {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 20px;
+  font-size: 12px;
+  color: var(--v4-warn-700);
+  background: var(--v4-warn-50);
+  border-top: 1px solid var(--v4-warn-100);
+}
+.ph-bulk-warning svg { width: 14px; height: 14px; flex-shrink: 0; }
+.ph-bulk-warning--err {
+  color: var(--v4-danger-700);
+  background: var(--v4-danger-50);
+  border-top-color: var(--v4-danger-100);
+}
+
+.ph-bulk-footer {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--v4-line-soft);
+}
+.ph-bulk-count {
+  font-size: 12px;
+  color: var(--v4-ink-700);
+}
+.ph-bulk-count b { color: var(--v4-ink-900); }
+.ph-bulk-footer-btns {
+  margin-left: auto;
+  display: flex; gap: 8px;
+}
+
+@media (max-width: 760px) {
+  .ph-bulk-row-main { grid-template-columns: auto 1fr auto; }
+  .ph-bulk-row-main .ph-sev { grid-column: 1 / -1; }
+  .ph-bulk-row-status { grid-column: 1 / -1; }
+}


### PR DESCRIPTION
Closes #148

## Что сделано
- Новый компонент `BulkCreateModal` (`src/components/v4/health/BulkCreateModal.tsx`) с severity-фильтрами (chips), checkboxes, прогресс-баром и preview body
- Кнопка «Создать issues по всем» в `Hero.tsx` (показывается только при наличии fails)
- Sequential создание с `RATE_LIMIT_DELAY_MS = 1000` (защита от secondary rate-limit GitHub)
- Abort при закрытии модалки во время submit — флаг проверяется в каждой итерации (до и после sleep)
- Sync с `ProjectHealthPage` action states через optional `onActionStateChange` — после bulk-create per-row кнопки `→ issue` сразу показывают `#N ✓`
- Sticky toast по завершению со ссылкой на GitHub-фильтр `is:issue is:open label:tech-debt`
- Warning при `selectedCount > WARNING_THRESHOLD` (30) с прогнозом времени
- Hard cap `MAX_BATCH_SIZE = 100`
- CSS — стили вписаны в `v4-health.css` (~230 строк), переиспользует `.v4-mspopup-bd/.v4-mspopup` overlay из `v4.css`

## Архитектурные решения
1. **Abort flag — `useRef`, не state** — флипается из close-handler без re-render внутри loop
2. **Severity chips ↔ checkboxes — двусторонняя связь** через `severityChipState()`: `all`/`some`/`none`. Клик по chip toggle всю severity-группу
3. **Sync с parent — optional callback** `onActionStateChange?` вызывается на каждом success/duplicate/error чтобы `FindingsBoard` мгновенно отразил bulk-результаты после закрытия модалки
4. **Backdrop click во время submit игнорируется** — × button становится Abort кнопкой; защита от случайного прерывания

## Проверки
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — 181ms, успешно