### PR TITLE
feat(sidebar): critical-fails badge on Dashboard nav item

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,6 +306,22 @@ function AppInner() {
   // defeating Topbar/CommandPalette memoization.
   const portfolioRefresh = portfolio.refresh;
   const orphansRefresh = orphans.refresh;
+
+  // Critical health-fails across the portfolio — drives the red badge on the
+  // «Дашборд» nav item. Reads from the same single-source-of-truth portfolio
+  // hook so we don't double-mount the heavy scan in Sidebar.
+  const criticalFails = useMemo(
+    () =>
+      portfolio.reports.reduce(
+        (acc, r) =>
+          acc +
+          r.findings.filter(
+            (f) => f.status === "fail" && f.severity === "critical",
+          ).length,
+        0,
+      ),
+    [portfolio.reports],
+  );
   const handleRefresh = useCallback(() => {
     refresh(true);
     refreshMonitors();
@@ -368,6 +384,7 @@ function AppInner() {
         milestonesCount={allMilestones.length}
         monitorsCount={monitors.length}
         auditAlerts={auditAlerts}
+        criticalFails={criticalFails}
         pulses={pulses}
         isOpen={sideOpen}
         onClose={() => setSideOpen(false)}

--- a/src/components/v4/Sidebar.tsx
+++ b/src/components/v4/Sidebar.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import type { ReactElement } from "react";
 import type { TabId } from "../../types";
-import { usePortfolioHealth } from "../../hooks/usePortfolioHealth";
 
 type PulseKind = "accent" | "success" | "warn" | "danger";
 
@@ -27,6 +26,9 @@ interface Props {
   milestonesCount: number;
   monitorsCount: number;
   auditAlerts?: number;
+  /** Number of portfolio-wide critical health fails. Shown as a red badge
+   *  on the «Дашборд» nav item. 0/undefined → no badge rendered. */
+  criticalFails?: number;
   /** Per-tab activity pulses (null = no dot). */
   pulses?: Partial<Record<TabId, PulseKind>>;
   user?: { initials: string; name: string; role: string };
@@ -103,31 +105,13 @@ export function Sidebar({
   milestonesCount,
   monitorsCount,
   auditAlerts,
+  criticalFails,
   pulses,
   user = { initials: "SK", name: "Сергей К.", role: "owner · MakeIT" },
   isOpen,
   onClose,
 }: Props) {
   const p = pulses ?? {};
-
-  // Portfolio-wide critical fails badge on the «Дашборд» nav item.
-  // The hook is cached in localStorage (30 min TTL), so calling it here on
-  // every mount is effectively free — no extra network calls when fresh.
-  // We deliberately swallow `loading` / `error`: the badge stays hidden until
-  // real data arrives, avoiding a 0 → N flash on first scan.
-  const { reports } = usePortfolioHealth();
-  const criticalCount = useMemo(
-    () =>
-      reports.reduce(
-        (acc, r) =>
-          acc +
-          r.findings.filter(
-            (f) => f.status === "fail" && f.severity === "critical",
-          ).length,
-        0,
-      ),
-    [reports],
-  );
 
   const sections: NavSection[] = [
     {
@@ -137,7 +121,10 @@ export function Sidebar({
           label: "Дашборд",
           icon: ICON_DASH,
           pulse: p.dashboard,
-          badge: criticalCount > 0 ? criticalCount : undefined,
+          // Portfolio-wide critical health fails. App.tsx mounts
+          // usePortfolioHealth (single source of truth) and passes the
+          // count down so we don't double-mount the hook here.
+          badge: criticalFails && criticalFails > 0 ? criticalFails : undefined,
         },
         { id: "projects", label: "Проекты", count: projectsCount, icon: ICON_LIST, pulse: p.projects },
         { id: "milestones", label: "Milestones", count: milestonesCount, icon: ICON_CLOCK, pulse: p.milestones },

--- a/src/components/v4/Sidebar.tsx
+++ b/src/components/v4/Sidebar.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import type { ReactElement } from "react";
 import type { TabId } from "../../types";
+import { usePortfolioHealth } from "../../hooks/usePortfolioHealth";
 
 type PulseKind = "accent" | "success" | "warn" | "danger";
 
@@ -108,10 +109,36 @@ export function Sidebar({
   onClose,
 }: Props) {
   const p = pulses ?? {};
+
+  // Portfolio-wide critical fails badge on the «Дашборд» nav item.
+  // The hook is cached in localStorage (30 min TTL), so calling it here on
+  // every mount is effectively free — no extra network calls when fresh.
+  // We deliberately swallow `loading` / `error`: the badge stays hidden until
+  // real data arrives, avoiding a 0 → N flash on first scan.
+  const { reports } = usePortfolioHealth();
+  const criticalCount = useMemo(
+    () =>
+      reports.reduce(
+        (acc, r) =>
+          acc +
+          r.findings.filter(
+            (f) => f.status === "fail" && f.severity === "critical",
+          ).length,
+        0,
+      ),
+    [reports],
+  );
+
   const sections: NavSection[] = [
     {
       items: [
-        { id: "dashboard", label: "Дашборд", icon: ICON_DASH, pulse: p.dashboard },
+        {
+          id: "dashboard",
+          label: "Дашборд",
+          icon: ICON_DASH,
+          pulse: p.dashboard,
+          badge: criticalCount > 0 ? criticalCount : undefined,
+        },
         { id: "projects", label: "Проекты", count: projectsCount, icon: ICON_LIST, pulse: p.projects },
         { id: "milestones", label: "Milestones", count: milestonesCount, icon: ICON_CLOCK, pulse: p.milestones },
         { id: "uptime", label: "Мониторинг", count: monitorsCount || undefined, icon: ICON_MONITOR, pulse: p.uptime },


### PR DESCRIPTION
Closes #145

## Что сделано
- `Sidebar.tsx` импортирует `usePortfolioHealth` и подсчитывает `status=fail && severity=critical` через `useMemo`
- На пункте «Дашборд» badge с числом — переиспользует существующий `.v4-nav-badge` (уже красный через `var(--v4-danger-500)`)
- При 0 critical (или пока кэш пуст / `loading`) — badge не рисуется, чтобы не мигать `0 → N`
- Хук кэширован в localStorage (30 мин TTL), второй mount бесплатный

## Проверки
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — ok (938.91 kB JS, 331 kB CSS)

## Visual smoke
Badge появляется справа от лейбла «Дашборд» только при наличии critical-fails в портфеле — стиль идентичен бейджу «Аудит» (та же `.v4-nav-badge`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)