### PR TITLE
feat(insights): Topbar refresh triggers portfolio rescan

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -299,16 +299,19 @@ function AppInner() {
   }, [refresh, refreshMonitors]);
 
   // Topbar "Обновить" must invalidate every long-lived dashboard cache, not
-  // just useDashboard's. Wrapped in useCallback so the Topbar prop identity
-  // is stable across renders. The optional-chaining guards against the
-  // brief window where portfolio.refresh / orphans.refresh haven't been
-  // assigned yet on the very first render.
+  // just useDashboard's. Depend on the individual `.refresh` callbacks (each
+  // is `useCallback`'d inside its hook with stable identity) rather than the
+  // whole hook return objects — the latter would churn handleRefresh's
+  // identity on every state tick (loading flip, lastUpdated update),
+  // defeating Topbar/CommandPalette memoization.
+  const portfolioRefresh = portfolio.refresh;
+  const orphansRefresh = orphans.refresh;
   const handleRefresh = useCallback(() => {
     refresh(true);
     refreshMonitors();
-    portfolio.refresh?.();
-    orphans.refresh?.();
-  }, [refresh, refreshMonitors, portfolio, orphans]);
+    portfolioRefresh();
+    orphansRefresh();
+  }, [refresh, refreshMonitors, portfolioRefresh, orphansRefresh]);
 
   const hasToken = !!getToken();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import { ProjectsView } from "./components/v4/ProjectsView";
 import { MilestonesView } from "./components/v4/milestones/MilestonesView";
 import { useDashboard } from "./hooks/useDashboard";
 import { useMonitors } from "./hooks/useMonitors";
+import { usePortfolioHealth } from "./hooks/usePortfolioHealth";
+import { usePortfolioOrphans } from "./hooks/usePortfolioOrphans";
 import { fetchPipelineStatus, fetchPipelineLimits } from "./utils/pipeline";
 import type { PipelineAbortReason, PipelineLimits } from "./utils/pipeline";
 import { getToken, clearToken, getAuth, clearAuth, clearClaudeKey, MONITOR_MATCH, PROJECTS } from "./utils/config";
@@ -58,6 +60,14 @@ function AppInner() {
   } = useDashboard();
 
   const { monitors, loading: monitorsLoading, error: monitorsError, refresh: refreshMonitors } = useMonitors();
+
+  // Portfolio scans are mounted at the App level (rather than inside
+  // DashboardView) so the Topbar "Обновить" button can trigger a rescan
+  // alongside useDashboard.refresh. Both hooks are self-cached with a 30
+  // min TTL — mounting them up here is free on initial load and ensures a
+  // single source of truth for the dashboard panels.
+  const portfolio = usePortfolioHealth();
+  const orphans = usePortfolioOrphans();
 
   // Toast on refresh result. Skip both the very first effect run AND the
   // first transition from no-data → has-data (initial fetch). We only want
@@ -288,6 +298,18 @@ function AppInner() {
     refreshMonitors();
   }, [refresh, refreshMonitors]);
 
+  // Topbar "Обновить" must invalidate every long-lived dashboard cache, not
+  // just useDashboard's. Wrapped in useCallback so the Topbar prop identity
+  // is stable across renders. The optional-chaining guards against the
+  // brief window where portfolio.refresh / orphans.refresh haven't been
+  // assigned yet on the very first render.
+  const handleRefresh = useCallback(() => {
+    refresh(true);
+    refreshMonitors();
+    portfolio.refresh?.();
+    orphans.refresh?.();
+  }, [refresh, refreshMonitors, portfolio, orphans]);
+
   const hasToken = !!getToken();
 
   const allMilestones = projects.flatMap((p) => p.milestones);
@@ -353,10 +375,7 @@ function AppInner() {
           onCrumbClick={tab === "projects" && healthRepo ? handleCrumbClick : undefined}
           showLive={true}
           lastUpdated={lastUpdated}
-          onRefresh={() => {
-            refresh(true);
-            refreshMonitors();
-          }}
+          onRefresh={handleRefresh}
           refreshing={loading}
           onLogout={handleLogout}
           onBurger={() => setSideOpen(true)}
@@ -386,6 +405,8 @@ function AppInner() {
               onSeeAllProjects={() => navigateTab("projects")}
               onFinanceClick={() => setFinanceOpen(true)}
               onOpenHealth={openHealthForRepo}
+              portfolio={portfolio}
+              orphans={orphans}
             />
           </ErrorBoundary>
         )}
@@ -502,7 +523,7 @@ function AppInner() {
           activeTab={tab}
           onClose={() => setPaletteOpen(false)}
           onJumpTab={(t) => { setPaletteOpen(false); navigateTab(t); }}
-          onRefresh={() => { setPaletteOpen(false); refresh(true); refreshMonitors(); }}
+          onRefresh={() => { setPaletteOpen(false); handleRefresh(); }}
           onLogout={() => { setPaletteOpen(false); handleLogout(); }}
           onOpenFinance={() => { setPaletteOpen(false); setFinanceOpen(true); }}
         />

--- a/src/components/v4/DashboardView.tsx
+++ b/src/components/v4/DashboardView.tsx
@@ -11,8 +11,8 @@ import { MilestonesStrip } from "./MilestonesStrip";
 import { CommitsHeatmapPanel } from "./CommitsHeatmapPanel";
 import { StaleBanner } from "./StaleBanner";
 import { OrphanIssuesPanel } from "./OrphanIssuesPanel";
-import { usePortfolioHealth } from "../../hooks/usePortfolioHealth";
-import { usePortfolioOrphans } from "../../hooks/usePortfolioOrphans";
+import type { usePortfolioHealth } from "../../hooks/usePortfolioHealth";
+import type { usePortfolioOrphans } from "../../hooks/usePortfolioOrphans";
 
 interface Props {
   projects: ProjectData[];
@@ -29,6 +29,14 @@ interface Props {
    * bypassing `navigateTab` (which would clear `healthRepo`).
    */
   onOpenHealth: (repo: string) => void;
+  /**
+   * Portfolio scans are mounted in App.tsx so the Topbar "Обновить" button
+   * can trigger a rescan alongside useDashboard.refetch. Passing the hook
+   * results down avoids a duplicate mount (and a duplicate health scan)
+   * when other components also need this data.
+   */
+  portfolio: ReturnType<typeof usePortfolioHealth>;
+  orphans: ReturnType<typeof usePortfolioOrphans>;
 }
 
 type PhaseFilter = "all" | "pre-dev" | "development" | "support";
@@ -49,22 +57,22 @@ export function DashboardView({
   onSeeAllProjects,
   onFinanceClick,
   onOpenHealth,
+  portfolio,
+  orphans,
 }: Props) {
   const [phaseFilter, setPhaseFilter] = useState<PhaseFilter>("all");
 
-  // Portfolio health drives the AI-insights panel. The hook is self-cached
-  // (30 min TTL in localStorage), so mounting it here doesn't re-scan on
-  // every dashboard re-render.
-  const portfolio = usePortfolioHealth();
+  // Portfolio health drives the AI-insights panel. The hook is mounted in
+  // App.tsx so the Topbar refresh button can trigger a rescan alongside
+  // useDashboard.refetch — passed down here as a prop.
   const portfolioLastUpdated = useMemo(
     () => (portfolio.lastUpdated ? new Date(portfolio.lastUpdated) : null),
     [portfolio.lastUpdated],
   );
 
-  // Orphan-issues trend uses its own hook (separate cache/refresh cadence
-  // from health) so a slow health scan doesn't block the chart and a
-  // forced "обновить orphans" doesn't trigger a 50-call health re-scan.
-  const orphans = usePortfolioOrphans();
+  // Orphan-issues trend has its own hook (separate cache/refresh cadence
+  // from health) so a slow health scan doesn't block the chart. Also
+  // mounted in App.tsx for the same Topbar-refresh wiring.
   const orphansLastUpdated = useMemo(
     () => (orphans.lastUpdated ? new Date(orphans.lastUpdated) : null),
     [orphans.lastUpdated],


### PR DESCRIPTION
Closes #144

## Что сделано
- Поднял `usePortfolioHealth` и `usePortfolioOrphans` из `DashboardView.tsx` в `AppInner()`
- Добавил `handleRefresh = useCallback(...)` который вызывает `refresh(true)` + `refreshMonitors()` + `portfolio.refresh?.()` + `orphans.refresh?.()`
- Topbar и CommandPalette теперь оба используют `handleRefresh` (консистентность)
- `DashboardView` принимает `portfolio` и `orphans` через props (типизированы как `ReturnType<typeof useXxx>`)
- Optional-chaining на `.refresh?.()` защищает от первого рендера, когда метод теоретически может быть undefined

## Бонус
Поднял `usePortfolioOrphans` тоже (не только health) — структура хуков идентична, единый mount гарантирует что обе панели рефрешатся в lockstep. Это входило в "опционально, но логично" из спека.

## Проверки
- [x] npm run lint — clean
- [x] npx tsc --noEmit — clean
- [x] npm run build — clean (built in 183ms)