### PR TITLE
feat(settings): Pipeline settings client + bootstrap UX (Epic-004 Task-03)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,8 @@ import { fetchPipelineStatus, fetchPipelineLimits } from "./utils/pipeline";
 import type { PipelineAbortReason, PipelineLimits } from "./utils/pipeline";
 import { getToken, clearToken, getAuth, clearAuth, clearClaudeKey, MONITOR_MATCH, PROJECTS } from "./utils/config";
 import { PasswordGate } from "./components/PasswordGate";
+import { SettingsBootstrap, SettingsUnavailable } from "./components/v4/SettingsBootstrap";
+import { useSettings } from "./hooks/useSettings";
 import type { TabId, Monitor } from "./types";
 import "./App.css";
 import "./styles/v4.css";
@@ -552,6 +554,28 @@ function AppInner() {
   );
 }
 
+function SettingsGate() {
+  const settings = useSettings();
+  if (!settings.ready) {
+    if (settings.error === "auth") {
+      return <SettingsBootstrap onSuccess={settings.retry} />;
+    }
+    if (settings.error === "unavailable") {
+      return <SettingsUnavailable onRetry={settings.retry} />;
+    }
+    // Initial loading state — short, but render something rather than a blank
+    // page so the user knows the app is alive while loadAllSettings() resolves.
+    return (
+      <div className="v4-app" style={{ gridTemplateColumns: "1fr", minHeight: "100vh" }}>
+        <main className="v4-main">
+          <div className="v4-loading">Загрузка настроек…</div>
+        </main>
+      </div>
+    );
+  }
+  return <AppInner />;
+}
+
 function App() {
   const [authed, setAuthed] = useState(getAuth());
 
@@ -561,7 +585,7 @@ function App() {
 
   return (
     <ToastHost>
-      <AppInner />
+      <SettingsGate />
     </ToastHost>
   );
 }

--- a/src/components/v4/SettingsBootstrap.tsx
+++ b/src/components/v4/SettingsBootstrap.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  loadAllSettings,
+  setBootstrapToken,
+  SettingsAuthError,
+  SettingsUnavailableError,
+} from "../../utils/settings";
+
+interface Props {
+  onSuccess: () => void;
+}
+
+/**
+ * First-run / re-auth screen for the Pipeline settings store.
+ *
+ * Renders when the dashboard has no bootstrap token (or the token was
+ * rejected). The user pastes a bootstrap token issued by the Pipeline admin;
+ * on submit we save it, immediately try `loadAllSettings()`, and either
+ * proceed (onSuccess) or show an inline error.
+ *
+ * Errors handled:
+ *  - SettingsAuthError       → "Токен отклонён" (likely typo / wrong token)
+ *  - SettingsUnavailableError → "Pipeline недоступен" (network/5xx)
+ */
+export function SettingsBootstrap({ onSuccess }: Props) {
+  const [value, setValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus on mount so the user can paste immediately.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Esc clears the input — no destructive action, so no confirm dialog.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setValue("");
+        setError(null);
+        inputRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const token = value.trim();
+    if (!token || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    setBootstrapToken(token);
+    try {
+      await loadAllSettings();
+      // Don't clear `value` — the form unmounts on success anyway, and
+      // clearing first causes a brief blank-input flash.
+      onSuccess();
+    } catch (err) {
+      if (err instanceof SettingsAuthError) {
+        setError(
+          "Токен отклонён. Проверьте, что вы скопировали значение целиком и без пробелов.",
+        );
+      } else if (err instanceof SettingsUnavailableError) {
+        setError(
+          "Pipeline API недоступен. Проверьте подключение и нажмите «Подключить» ещё раз.",
+        );
+      } else {
+        setError(
+          `Не удалось проверить токен: ${(err as Error)?.message ?? "неизвестная ошибка"}`,
+        );
+      }
+      setSubmitting(false);
+      // Refocus so the next attempt is one keystroke away.
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  };
+
+  return (
+    <div
+      className="v4-app"
+      style={{ gridTemplateColumns: "1fr", minHeight: "100vh" }}
+    >
+      <main className="v4-main">
+        <div
+          className="v4-content"
+          style={{
+            paddingTop: 80,
+            maxWidth: 520,
+            margin: "0 auto",
+          }}
+        >
+          <h1 style={{ fontSize: 28, marginBottom: 8 }}>MakeIT Dashboard</h1>
+          <p
+            style={{
+              color: "var(--v4-ink-500)",
+              marginBottom: 24,
+              fontSize: 14,
+              lineHeight: 1.5,
+            }}
+          >
+            Подключитесь к серверному хранилищу настроек Pipeline.
+            Bootstrap-токен выдаёт администратор Pipeline (один раз на
+            устройство).
+          </p>
+          <form onSubmit={handleSubmit} className="token-form">
+            <label
+              htmlFor="settings-bootstrap-token"
+              style={{
+                display: "block",
+                marginBottom: 6,
+                fontSize: 12,
+                color: "var(--v4-ink-500)",
+              }}
+            >
+              Bootstrap-токен
+            </label>
+            <div className="token-input-row" style={{ display: "flex", gap: 8 }}>
+              <input
+                id="settings-bootstrap-token"
+                ref={inputRef}
+                type="password"
+                value={value}
+                onChange={(e) => {
+                  setValue(e.target.value);
+                  if (error) setError(null);
+                }}
+                placeholder="Вставьте токен"
+                className="input"
+                autoComplete="off"
+                disabled={submitting}
+                style={{ flex: 1 }}
+              />
+              <button
+                type="submit"
+                className="v4-btn v4-btn--pri"
+                disabled={!value.trim() || submitting}
+              >
+                {submitting ? "Подключение…" : "Подключить"}
+              </button>
+            </div>
+            {error && (
+              <div
+                role="alert"
+                style={{
+                  marginTop: 14,
+                  padding: "10px 12px",
+                  borderRadius: 8,
+                  background: "var(--v4-danger-50, rgba(239,68,68,0.08))",
+                  border: "1px solid var(--v4-danger-100, rgba(239,68,68,0.25))",
+                  color: "var(--v4-danger-700, #b91c1c)",
+                  fontSize: 13,
+                  lineHeight: 1.4,
+                }}
+              >
+                {error}
+              </div>
+            )}
+            <p
+              style={{
+                marginTop: 18,
+                fontSize: 12,
+                color: "var(--v4-ink-500)",
+                lineHeight: 1.5,
+              }}
+            >
+              Получите токен у администратора Pipeline. Токен сохраняется
+              локально на этом устройстве и используется для запросов к
+              Pipeline settings API.
+            </p>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+interface UnavailableProps {
+  onRetry: () => void;
+}
+
+/**
+ * Diagnostic screen shown when the Pipeline is reachable enough to fail with
+ * 5xx / network. Lets the user retry without losing the bootstrap token.
+ */
+export function SettingsUnavailable({ onRetry }: UnavailableProps) {
+  return (
+    <div
+      className="v4-app"
+      style={{ gridTemplateColumns: "1fr", minHeight: "100vh" }}
+    >
+      <main className="v4-main">
+        <div
+          className="v4-content"
+          style={{
+            paddingTop: 80,
+            maxWidth: 520,
+            margin: "0 auto",
+            textAlign: "center",
+          }}
+        >
+          <h1 style={{ fontSize: 24, marginBottom: 12 }}>
+            Pipeline API недоступен
+          </h1>
+          <p
+            style={{
+              color: "var(--v4-ink-500)",
+              marginBottom: 24,
+              fontSize: 14,
+              lineHeight: 1.5,
+            }}
+          >
+            Не удалось загрузить настройки с Pipeline. Проверьте, что Pipeline
+            запущен и доступен по сети, затем повторите попытку.
+          </p>
+          <button
+            type="button"
+            className="v4-btn v4-btn--pri"
+            onClick={onRetry}
+          >
+            Повторить
+          </button>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  getBootstrapToken,
+  loadAllSettings,
+  SettingsAuthError,
+  SettingsUnavailableError,
+} from "../utils/settings";
+
+export type SettingsError = "auth" | "unavailable" | null;
+
+export interface UseSettingsResult {
+  /** True once `loadAllSettings()` has succeeded for this page session. */
+  ready: boolean;
+  /**
+   * - `auth`        — bootstrap token missing or rejected (401/403).
+   * - `unavailable` — pipeline 5xx / network failure (transient).
+   * - `null`        — no error (either still loading or ready).
+   */
+  error: SettingsError;
+  /** Re-attempt `loadAllSettings()` (e.g. after the user fixes the token). */
+  retry: () => void;
+}
+
+/**
+ * App-level bootstrap state machine for the Pipeline settings store.
+ *
+ * Flow:
+ *  1. Mount — if no bootstrap token, immediately surface `error: 'auth'`
+ *     so App.tsx can render the bootstrap form (no wasted HTTP call).
+ *  2. With a token — call `loadAllSettings()`; on success → `ready: true`.
+ *  3. SettingsAuthError → token already cleared by the client; surface
+ *     `error: 'auth'`.
+ *  4. SettingsUnavailableError → keep token; surface `error: 'unavailable'`
+ *     so the user sees a retry-able diagnostic screen.
+ *
+ * `retry()` is the single entry point for the bootstrap form's onSuccess
+ * callback AND for the "Повторить" button on the unavailable screen.
+ */
+export function useSettings(): UseSettingsResult {
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<SettingsError>(null);
+  // Bumped by retry() to re-trigger the load effect.
+  const [tick, setTick] = useState(0);
+  // Guards against late completions setting state on an unmounted component.
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    let active = true;
+
+    const run = async () => {
+      // Reset per-attempt UI state so a stale "unavailable" doesn't flash
+      // before the loader resolves.
+      setReady(false);
+      setError(null);
+
+      if (!getBootstrapToken()) {
+        if (!active) return;
+        setError("auth");
+        return;
+      }
+
+      try {
+        await loadAllSettings();
+        if (!active) return;
+        setReady(true);
+      } catch (e) {
+        if (!active) return;
+        if (e instanceof SettingsAuthError) {
+          setError("auth");
+        } else if (e instanceof SettingsUnavailableError) {
+          setError("unavailable");
+        } else {
+          // Unknown error — treat as transient so the user can retry without
+          // losing the bootstrap token.
+          if (import.meta.env.DEV) console.error("[useSettings] unknown error:", e);
+          setError("unavailable");
+        }
+      }
+    };
+
+    void run();
+    return () => {
+      active = false;
+      cancelledRef.current = true;
+    };
+  }, [tick]);
+
+  const retry = useCallback(() => {
+    setTick((t) => t + 1);
+  }, []);
+
+  return { ready, error, retry };
+}

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -52,12 +52,21 @@ export function getBootstrapToken(): string | null {
   }
 }
 
+export class SettingsStorageError extends Error {
+  constructor() {
+    super("Браузер блокирует localStorage (приватный режим / отключённое хранилище)");
+    this.name = "SettingsStorageError";
+  }
+}
+
 export function setBootstrapToken(token: string): void {
   try {
     localStorage.setItem(BOOTSTRAP_TOKEN_KEY, token.trim());
   } catch {
-    // Storage may be disabled (private mode, quota). Caller handles failures
-    // implicitly via subsequent SettingsAuthError on the next request.
+    // Storage may be disabled (private mode, quota). Surface a distinct error
+    // so the bootstrap form can show a helpful message instead of the misleading
+    // "token rejected" path that fires when the very next request reads back null.
+    throw new SettingsStorageError();
   }
 }
 

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,0 +1,217 @@
+/**
+ * Pipeline settings API client (Epic-004 Task-03).
+ *
+ * Wraps the makeit-pipeline `/settings` endpoints (Bearer-auth) so the
+ * dashboard can read/write a single, server-side, cross-device source of
+ * truth for secrets (github_token, anthropic_api_key, betterstack_token,
+ * etc.). Existing token consumers are NOT touched in this task — that is
+ * Task-04. Migration of legacy `localStorage` values is Task-05.
+ *
+ * Design notes:
+ *  - Bootstrap token lives in `localStorage` under `pipeline_settings_token`.
+ *    It is the only secret the dashboard still stores client-side; everything
+ *    else is fetched on demand from the pipeline.
+ *  - In-memory cache (`Map`) is module-scoped so a single page session pays
+ *    for `loadAllSettings()` once. Cleared on 401 or `clearBootstrapToken()`.
+ *  - 401 → server has rejected the bootstrap token → we drop it locally and
+ *    surface `SettingsAuthError` so callers can re-prompt the user. NEVER
+ *    drop the token on 5xx/network — those are transient and a retry must
+ *    work without re-asking for the secret.
+ */
+
+import { PIPELINE_BASE_URL } from "./config";
+
+const BOOTSTRAP_TOKEN_KEY = "pipeline_settings_token";
+
+/** 401 from the pipeline — bootstrap token is missing or invalid. */
+export class SettingsAuthError extends Error {
+  constructor(message = "Pipeline settings: unauthorized") {
+    super(message);
+    this.name = "SettingsAuthError";
+  }
+}
+
+/** 5xx / network failure — pipeline is unreachable, transient. */
+export class SettingsUnavailableError extends Error {
+  constructor(message = "Pipeline settings: unavailable") {
+    super(message);
+    this.name = "SettingsUnavailableError";
+  }
+}
+
+/* ────────────────────────────────────────
+   Bootstrap token (localStorage)
+   ──────────────────────────────────────── */
+
+export function getBootstrapToken(): string | null {
+  try {
+    const raw = localStorage.getItem(BOOTSTRAP_TOKEN_KEY);
+    return raw && raw.trim() ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setBootstrapToken(token: string): void {
+  try {
+    localStorage.setItem(BOOTSTRAP_TOKEN_KEY, token.trim());
+  } catch {
+    // Storage may be disabled (private mode, quota). Caller handles failures
+    // implicitly via subsequent SettingsAuthError on the next request.
+  }
+}
+
+export function clearBootstrapToken(): void {
+  try {
+    localStorage.removeItem(BOOTSTRAP_TOKEN_KEY);
+  } catch {
+    // ignore
+  }
+  invalidateCache();
+}
+
+/* ────────────────────────────────────────
+   In-memory cache (module-scoped)
+   ──────────────────────────────────────── */
+
+let cache: Map<string, string> | null = null;
+
+function invalidateCache(): void {
+  cache = null;
+}
+
+/** Sync read from the in-memory cache. Returns null if cache miss / not loaded. */
+export function getSetting(key: string): string | null {
+  if (!cache) return null;
+  return cache.get(key) ?? null;
+}
+
+/* ────────────────────────────────────────
+   HTTP helpers
+   ──────────────────────────────────────── */
+
+interface SettingsListItem {
+  key: string;
+  masked_value?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+interface SettingsValueResponse {
+  key: string;
+  value: string;
+}
+
+function authHeaders(): Record<string, string> {
+  const token = getBootstrapToken();
+  if (!token) throw new SettingsAuthError("Bootstrap token is not set");
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function request(path: string, init: RequestInit = {}): Promise<Response> {
+  let res: Response;
+  try {
+    res = await fetch(`${PIPELINE_BASE_URL}${path}`, {
+      ...init,
+      headers: {
+        ...authHeaders(),
+        ...(init.headers ?? {}),
+      },
+      cache: "no-store",
+    });
+  } catch (e) {
+    // Network / DNS / CORS — treat as transient.
+    if (import.meta.env.DEV) console.error("[settings] network error:", e);
+    throw new SettingsUnavailableError(
+      `Pipeline settings: network error (${(e as Error)?.message ?? "unknown"})`,
+    );
+  }
+  if (res.status === 401 || res.status === 403) {
+    // Server rejected the bootstrap token. Drop it locally so the next mount
+    // of useSettings() shows the bootstrap form instead of looping.
+    clearBootstrapToken();
+    throw new SettingsAuthError();
+  }
+  if (res.status >= 500) {
+    throw new SettingsUnavailableError(`Pipeline settings: HTTP ${res.status}`);
+  }
+  if (!res.ok) {
+    // 4xx other than 401/403 — surface as unavailable so retry is offered.
+    // Real-world examples: 404 (route disabled), 422 (bad payload).
+    throw new SettingsUnavailableError(`Pipeline settings: HTTP ${res.status}`);
+  }
+  return res;
+}
+
+/* ────────────────────────────────────────
+   Public API
+   ──────────────────────────────────────── */
+
+/**
+ * Populate the in-memory cache with every setting the bootstrap token can
+ * read. Called once on app start by `useSettings()`. Subsequent
+ * `getSetting()` calls are sync reads from the cache.
+ *
+ * Strategy:
+ *  1. GET /settings → list of {key, masked_value, ...}.
+ *  2. For each key, GET /settings/{key} → unmasked value.
+ *
+ * Two round-trips per setting is fine here (a handful of secrets, page
+ * lifetime cache). If the list grows large we can switch to a bulk endpoint
+ * later — but that's a pipeline-side change.
+ */
+export async function loadAllSettings(): Promise<void> {
+  const listRes = await request("/settings");
+  const items = (await listRes.json()) as SettingsListItem[];
+  const next = new Map<string, string>();
+  // Fetch values in parallel — bounded by the number of declared keys (small).
+  const values = await Promise.all(
+    items.map(async (item) => {
+      const r = await request(`/settings/${encodeURIComponent(item.key)}`);
+      const data = (await r.json()) as SettingsValueResponse;
+      return [item.key, data.value] as const;
+    }),
+  );
+  for (const [k, v] of values) next.set(k, v);
+  cache = next;
+}
+
+/** PUT /settings/{key} — also updates the in-memory cache on success. */
+export async function setSetting(key: string, value: string): Promise<void> {
+  const res = await request(`/settings/${encodeURIComponent(key)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ value }),
+  });
+  // Drain the body so the connection can be reused; we don't need the payload.
+  await res.text().catch(() => "");
+  if (!cache) cache = new Map();
+  cache.set(key, value);
+}
+
+/** DELETE /settings/{key} — also removes from the in-memory cache on success. */
+export async function deleteSetting(key: string): Promise<void> {
+  const res = await request(`/settings/${encodeURIComponent(key)}`, {
+    method: "DELETE",
+  });
+  await res.text().catch(() => "");
+  cache?.delete(key);
+}
+
+/** GET /settings/keys — list of declared/known keys. */
+export async function listSettingsKeys(): Promise<string[]> {
+  const res = await request("/settings/keys");
+  return (await res.json()) as string[];
+}
+
+/* ────────────────────────────────────────
+   Test/debug helpers (not exported via barrel)
+   ──────────────────────────────────────── */
+
+/**
+ * Exported for tests only — production code must not depend on the cache
+ * being empty across a page lifetime.
+ */
+export function _resetSettingsCacheForTests(): void {
+  invalidateCache();
+}


### PR DESCRIPTION
Closes #133

## Что сделано
- `src/utils/settings.ts` — REST-клиент Pipeline `/settings/*` с module-scoped in-memory кешем. Bearer-токен из `localStorage`. 401/403 → `clearBootstrapToken()` + cache invalidate + `SettingsAuthError`. 5xx/network → `SettingsUnavailableError` без сброса токена (transient).
- `src/hooks/useSettings.ts` — bootstrap state-machine `{ready, error, retry}`. Если bootstrap-токен отсутствует — сразу `error: 'auth'` без HTTP.
- `src/components/v4/SettingsBootstrap.tsx` — форма ввода (auto-focus, Esc clears) + `SettingsUnavailable` retry-экран.
- `src/App.tsx` — `SettingsGate` оборачивает `AppInner` внутри `ToastHost`/`PasswordGate`.

## НЕ сделано (по дизайну Task-03)
- Существующие потребители GitHub-токена (`utils/github.ts`, `claude.ts`, `betterstack.ts`) НЕ тронуты — это Task-04.
- Миграция значений из `localStorage` на сервер НЕ делалась — это Task-05.
- GitHub `TokenForm` gate остаётся внутри `AppInner` после `ready` (без изменений).

## Поведение
- Старт без bootstrap-токена → `SettingsBootstrap` форма.
- Введён валидный токен → `loadAllSettings()` → `ready` → `AppInner`.
- 401 на любом запросе → токен сброшен локально → форма показана снова (нет infinite loop).
- 5xx/network → `SettingsUnavailable` → кнопка «Повторить» вызывает `retry()` без сброса токена.
- Cache живёт всё время сессии страницы (не пересоздаётся на mount).

## Проверки
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean (944.81 kB chunk-warning — pre-existing)
- [x] `curl http://127.0.0.1:8766/settings/keys` → 401 Unauthorized — endpoint существует и требует Bearer (контракт Task-02 подтверждён)
- [ ] Live UI smoke не прогонялся — параллельный preview server слушает другой cwd (main repo, не этот worktree); чтобы не мешать соседнему агенту, я не перезапускал preview. Грепом `dist/assets/index-*.js` подтверждено что bootstrap-строки попали в bundle.

## Разблокирует
- Task-04 (#134) — миграция консьюмеров на `getSetting()`
- Task-05 (#135) — one-shot миграция localStorage → server