### PR TITLE
refactor(hooks): extract shared portfolio-scan utilities

### DIFF
--- a/src/hooks/usePortfolioHealth.ts
+++ b/src/hooks/usePortfolioHealth.ts
@@ -1,88 +1,24 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { GITHUB_OWNER, getToken } from "../utils/config";
+import { useCallback } from "react";
+import { GITHUB_OWNER } from "../utils/config";
 import { loadChecklist } from "../utils/checklist";
 import { runHealthCheck } from "../utils/health-engine";
-import type { HealthReport } from "../types/health";
+import type { ChecklistDocument, HealthReport } from "../types/health";
+import { usePortfolioScan, type PortfolioScanState } from "./usePortfolioScan";
 
 // Cache key for the persisted portfolio scan. Bump the suffix when the
 // HealthReport shape changes incompatibly.
 const CACHE_KEY = "makeit_portfolio_health_v1";
-// 30 minutes — long enough to feel "free" on tab re-open, short enough that
-// a missing finding gets re-evaluated within the working hour.
-const CACHE_TTL_MS = 30 * 60 * 1000;
-// Concurrent health-checks. Each scan fans out ~50 GitHub calls internally
-// (see health-engine), so 3 parallel repos ≈ 150 in-flight requests at peak.
-// Higher concurrency tripped GitHub secondary rate limits in testing.
-const SCAN_CONCURRENCY = 3;
-// Defer the very first scan a bit so the rest of the dashboard finishes its
-// own GraphQL warm-up before we hammer the REST API. Also keeps the initial
-// render snappy.
-const INITIAL_DELAY_MS = 1500;
 
-interface CacheShape {
-  generated_at: string;
+// Each enumerated item carries the repo name plus a reference to the
+// already-loaded checklist so `scanItem` doesn't have to re-fetch it per
+// repo. The doc is loaded once per scan inside `enumerate`.
+interface HealthScanItem {
+  repo: string;
+  doc: ChecklistDocument;
+}
+
+interface UsePortfolioHealthResult extends Omit<PortfolioScanState<HealthReport>, "items"> {
   reports: HealthReport[];
-}
-
-interface State {
-  reports: HealthReport[];
-  loading: boolean;
-  error: string | null;
-  lastUpdated: string | null;
-}
-
-const IDLE_STATE: State = {
-  reports: [],
-  loading: false,
-  error: null,
-  lastUpdated: null,
-};
-
-function readCache(): CacheShape | null {
-  try {
-    const raw = localStorage.getItem(CACHE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as CacheShape;
-    if (!parsed.generated_at || !Array.isArray(parsed.reports)) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-
-function writeCache(reports: HealthReport[], generatedAt: string): void {
-  try {
-    const payload: CacheShape = { generated_at: generatedAt, reports };
-    localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
-  } catch {
-    // Quota exceeded — drop silently. The next refresh will retry.
-  }
-}
-
-function isCacheFresh(cache: CacheShape): boolean {
-  const age = Date.now() - new Date(cache.generated_at).getTime();
-  return Number.isFinite(age) && age >= 0 && age < CACHE_TTL_MS;
-}
-
-// Bounded-concurrency runner. Mapper is called eagerly with `index`, so the
-// caller can stash partial results in a fixed slot if needed; here we just
-// collect them into an array preserving input order.
-async function runWithConcurrency<T, R>(
-  items: T[],
-  limit: number,
-  mapper: (item: T, index: number) => Promise<R>,
-): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let cursor = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (true) {
-      const i = cursor++;
-      if (i >= items.length) return;
-      results[i] = await mapper(items[i], i);
-    }
-  });
-  await Promise.all(workers);
-  return results;
 }
 
 // Hook that runs the health pipeline for every repo classified in the
@@ -90,133 +26,28 @@ async function runWithConcurrency<T, R>(
 // is effectively free. Per-repo failures are isolated: a rate-limit on one
 // project does not abort the rest — failed repos are simply omitted from
 // `reports`, the rest are persisted as a partial result.
-export function usePortfolioHealth(): State & { refresh: () => void } {
-  const [state, setState] = useState<State>(IDLE_STATE);
-  // Monotonic request id — discriminates between in-flight scans so a stale
-  // run can't overwrite a fresher one's state.
-  const requestId = useRef(0);
-  // Prevents setState after unmount; the in-flight GitHub calls themselves
-  // will complete in the background but their results are dropped.
-  const isMounted = useRef(true);
-
-  const run = useCallback(async (force: boolean, withInitialDelay: boolean) => {
-    const token = getToken();
-    if (!token) {
-      if (isMounted.current) {
-        setState({
-          reports: [],
-          loading: false,
-          error: "Нужен GitHub-токен",
-          lastUpdated: null,
-        });
-      }
-      return;
-    }
-
-    // Cache-first path. On a fresh cache we never flip `loading` — the UI
-    // stays calm and renders instantly.
-    if (!force) {
-      const cached = readCache();
-      if (cached && isCacheFresh(cached)) {
-        if (isMounted.current) {
-          setState({
-            reports: cached.reports,
-            loading: false,
-            error: null,
-            lastUpdated: cached.generated_at,
-          });
-        }
-        return;
-      }
-    }
-
-    // Bump the request id BEFORE any await so the cleanup path (which also
-    // bumps requestId) can invalidate this run while it's parked in the
-    // initial delay. Without this, a StrictMode double-mount can let the
-    // first run's setTimeout resolve under the second mount's `isMounted=true`
-    // and write stale state.
-    const myReq = ++requestId.current;
-
-    if (withInitialDelay) {
-      await new Promise((r) => setTimeout(r, INITIAL_DELAY_MS));
-      if (myReq !== requestId.current || !isMounted.current) return;
-    }
-
-    if (isMounted.current) {
-      setState((s) => ({ ...s, loading: true, error: null }));
-    }
-
-    let doc;
-    try {
-      doc = await loadChecklist(token, force);
-    } catch (err) {
-      if (myReq !== requestId.current || !isMounted.current) return;
-      const msg = err instanceof Error ? err.message : "Не удалось загрузить чеклист";
-      setState((s) => ({ ...s, loading: false, error: msg }));
-      return;
-    }
-
-    if (myReq !== requestId.current || !isMounted.current) return;
-
-    const repos = Object.keys(doc.project_classification);
-    const settled = await runWithConcurrency(repos, SCAN_CONCURRENCY, async (repo) => {
-      try {
-        const report = await runHealthCheck(token, GITHUB_OWNER, repo, doc);
-        return { ok: true as const, report };
-      } catch (err) {
-        // Per-repo isolation: capture and keep going. ClassificationMissing
-        // can't realistically fire here (we iterate the classification keys),
-        // but rate-limit / network / 404 errors absolutely can.
-        const msg = err instanceof Error ? err.message : "scan failed";
-        return { ok: false as const, repo, error: msg };
-      }
-    });
-
-    if (myReq !== requestId.current || !isMounted.current) return;
-
-    const reports = settled
-      .filter((r): r is { ok: true; report: HealthReport } => r.ok)
-      .map((r) => r.report);
-    const failed = settled.filter((r) => !r.ok);
-    const generatedAt = new Date().toISOString();
-    writeCache(reports, generatedAt);
-
-    setState({
-      reports,
-      loading: false,
-      // Surface failures only when the entire scan was wiped — partial
-      // success is the common "one repo rate-limited" case and shouldn't
-      // block the UI.
-      error: reports.length === 0 && failed.length > 0
-        ? "Не удалось просканировать ни один репозиторий"
-        : null,
-      lastUpdated: generatedAt,
-    });
+//
+// Thin wrapper around `usePortfolioScan` (see issue #170) — the cache,
+// concurrency, race-protection, and initial-delay machinery lives there.
+export function usePortfolioHealth(): UsePortfolioHealthResult {
+  const enumerate = useCallback(async (token: string, force: boolean): Promise<HealthScanItem[]> => {
+    const doc = await loadChecklist(token, force);
+    return Object.keys(doc.project_classification).map((repo) => ({ repo, doc }));
   }, []);
 
-  useEffect(() => {
-    isMounted.current = true;
-    // Kick off on mount with the initial delay; cache hit short-circuits
-    // before the timer fires.
-    void run(false, true);
-    return () => {
-      isMounted.current = false;
-      // Bump the request id so any in-flight handlers see a stale id and
-      // skip their setState calls. We deliberately mutate the live ref —
-      // the "snapshot ref before cleanup" advice doesn't apply.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      requestId.current++;
-    };
-  }, [run]);
+  const scanItem = useCallback(
+    (token: string, item: HealthScanItem): Promise<HealthReport> =>
+      runHealthCheck(token, GITHUB_OWNER, item.repo, item.doc),
+    [],
+  );
 
-  const refresh = useCallback(() => {
-    try {
-      localStorage.removeItem(CACHE_KEY);
-    } catch {
-      // Ignore — readCache will still treat a malformed entry as a miss.
-    }
-    void run(true, false);
-  }, [run]);
+  const { items, ...rest } = usePortfolioScan<HealthScanItem, HealthReport>({
+    cacheKey: CACHE_KEY,
+    enumerate,
+    scanItem,
+    enumerateErrorFallback: "Не удалось загрузить чеклист",
+    allFailedError: "Не удалось просканировать ни один репозиторий",
+  });
 
-  return { ...state, refresh };
+  return { reports: items, ...rest };
 }

--- a/src/hooks/usePortfolioOrphans.ts
+++ b/src/hooks/usePortfolioOrphans.ts
@@ -1,190 +1,45 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { DEFAULT_PROJECTS, getToken } from "../utils/config";
+import { useCallback, useMemo } from "react";
+import { DEFAULT_PROJECTS } from "../utils/config";
 import { listOrphanIssuesWithMeta, type OrphanIssueMeta } from "../utils/github-actions";
+import { usePortfolioScan, type PortfolioScanState } from "./usePortfolioScan";
 
 // Bumped suffix when the cache shape changes incompatibly.
 const CACHE_KEY = "makeit_portfolio_orphans_v1";
-// 30 minutes — same envelope as usePortfolioHealth so the two panels
-// refresh in lockstep on a tab re-open.
-const CACHE_TTL_MS = 30 * 60 * 1000;
-// 3 parallel REST scans. Each repo touches ~1-5 pages of /issues, so 3
-// concurrent ≈ 15 in-flight requests at peak — well under GitHub's
-// secondary rate-limit threshold.
-const SCAN_CONCURRENCY = 3;
-// Defer the very first scan so the dashboard's GraphQL warm-up finishes
-// before we hammer REST.
-const INITIAL_DELAY_MS = 1500;
 
-interface CacheShape {
-  generated_at: string;
+// Per-project scan returns an array of orphans; the wrapper flattens these
+// into one list so consumers (OrphanIssuesPanel) get a flat `items` array.
+type OrphansPerRepo = OrphanIssueMeta[];
+
+interface UsePortfolioOrphansResult extends Omit<PortfolioScanState<OrphansPerRepo>, "items"> {
   items: OrphanIssueMeta[];
-}
-
-interface State {
-  items: OrphanIssueMeta[];
-  loading: boolean;
-  error: string | null;
-  lastUpdated: string | null;
-}
-
-const IDLE_STATE: State = {
-  items: [],
-  loading: false,
-  error: null,
-  lastUpdated: null,
-};
-
-function readCache(): CacheShape | null {
-  try {
-    const raw = localStorage.getItem(CACHE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as CacheShape;
-    if (!parsed.generated_at || !Array.isArray(parsed.items)) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-
-function writeCache(items: OrphanIssueMeta[], generatedAt: string): void {
-  try {
-    const payload: CacheShape = { generated_at: generatedAt, items };
-    localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
-  } catch {
-    // Quota exceeded — drop silently. Next refresh retries.
-  }
-}
-
-function isCacheFresh(cache: CacheShape): boolean {
-  const age = Date.now() - new Date(cache.generated_at).getTime();
-  return Number.isFinite(age) && age >= 0 && age < CACHE_TTL_MS;
-}
-
-// Bounded-concurrency runner — same shape as the helper inside
-// usePortfolioHealth. Kept inline (not extracted) because the two callers
-// are the only consumers and a shared module would force a generics
-// signature with no other benefit.
-async function runWithConcurrency<T, R>(
-  items: T[],
-  limit: number,
-  mapper: (item: T, index: number) => Promise<R>,
-): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let cursor = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (true) {
-      const i = cursor++;
-      if (i >= items.length) return;
-      results[i] = await mapper(items[i], i);
-    }
-  });
-  await Promise.all(workers);
-  return results;
 }
 
 // Loads orphan-issue metadata across the full portfolio with caching and
 // per-repo failure isolation. Mirrors the usePortfolioHealth contract so
 // downstream panels can switch between the two without surprise.
-export function usePortfolioOrphans(): State & { refresh: () => void } {
-  const [state, setState] = useState<State>(IDLE_STATE);
-  // Monotonic request id — discriminates between in-flight scans so a
-  // stale run can't overwrite a fresher one's state.
-  const requestId = useRef(0);
-  const isMounted = useRef(true);
+//
+// Thin wrapper around `usePortfolioScan` (see issue #170) — the cache,
+// concurrency, race-protection, and initial-delay machinery lives there.
+export function usePortfolioOrphans(): UsePortfolioOrphansResult {
+  const enumerate = useCallback(async () => DEFAULT_PROJECTS, []);
 
-  const run = useCallback(async (force: boolean, withInitialDelay: boolean) => {
-    const token = getToken();
-    if (!token) {
-      if (isMounted.current) {
-        setState({
-          items: [],
-          loading: false,
-          error: "Нужен GitHub-токен",
-          lastUpdated: null,
-        });
-      }
-      return;
-    }
+  const scanItem = useCallback(
+    (token: string, proj: typeof DEFAULT_PROJECTS[number]): Promise<OrphansPerRepo> =>
+      listOrphanIssuesWithMeta(token, proj.owner, proj.repo),
+    [],
+  );
 
-    if (!force) {
-      const cached = readCache();
-      if (cached && isCacheFresh(cached)) {
-        if (isMounted.current) {
-          setState({
-            items: cached.items,
-            loading: false,
-            error: null,
-            lastUpdated: cached.generated_at,
-          });
-        }
-        return;
-      }
-    }
+  const { items: perRepo, ...rest } = usePortfolioScan<typeof DEFAULT_PROJECTS[number], OrphansPerRepo>({
+    cacheKey: CACHE_KEY,
+    enumerate,
+    scanItem,
+    allFailedError: "Не удалось загрузить orphan-issues ни для одного репозитория",
+  });
 
-    // Bump request id BEFORE any await so cleanup can invalidate this run
-    // while it's parked in the initial delay.
-    const myReq = ++requestId.current;
+  // Flatten N×M (N repos × M orphans each) → single list. Memoised so the
+  // reference is stable when `perRepo` is unchanged — keeps downstream
+  // useMemo deps from re-firing on every render.
+  const items = useMemo(() => perRepo.flat(), [perRepo]);
 
-    if (withInitialDelay) {
-      await new Promise((r) => setTimeout(r, INITIAL_DELAY_MS));
-      if (myReq !== requestId.current || !isMounted.current) return;
-    }
-
-    if (isMounted.current) {
-      setState((s) => ({ ...s, loading: true, error: null }));
-    }
-
-    const settled = await runWithConcurrency(DEFAULT_PROJECTS, SCAN_CONCURRENCY, async (proj) => {
-      try {
-        const meta = await listOrphanIssuesWithMeta(token, proj.owner, proj.repo);
-        return { ok: true as const, meta };
-      } catch (err) {
-        // Per-repo isolation: a 404 / rate-limit on one project mustn't
-        // wipe the whole scan.
-        const msg = err instanceof Error ? err.message : "scan failed";
-        return { ok: false as const, repo: proj.repo, error: msg };
-      }
-    });
-
-    if (myReq !== requestId.current || !isMounted.current) return;
-
-    const items = settled
-      .filter((r): r is { ok: true; meta: OrphanIssueMeta[] } => r.ok)
-      .flatMap((r) => r.meta);
-    const failedAll = settled.every((r) => !r.ok);
-    const generatedAt = new Date().toISOString();
-    writeCache(items, generatedAt);
-
-    setState({
-      items,
-      loading: false,
-      // Surface error only when *every* repo failed — partial success is the
-      // common rate-limit case and shouldn't block the chart.
-      error: failedAll && DEFAULT_PROJECTS.length > 0
-        ? "Не удалось загрузить orphan-issues ни для одного репозитория"
-        : null,
-      lastUpdated: generatedAt,
-    });
-  }, []);
-
-  useEffect(() => {
-    isMounted.current = true;
-    void run(false, true);
-    return () => {
-      isMounted.current = false;
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      requestId.current++;
-    };
-  }, [run]);
-
-  const refresh = useCallback(() => {
-    try {
-      localStorage.removeItem(CACHE_KEY);
-    } catch {
-      // Ignore — readCache will treat a malformed entry as a miss.
-    }
-    void run(true, false);
-  }, [run]);
-
-  return { ...state, refresh };
+  return { items, ...rest };
 }

--- a/src/hooks/usePortfolioScan.ts
+++ b/src/hooks/usePortfolioScan.ts
@@ -1,0 +1,223 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getToken } from "../utils/config";
+import {
+  DEFAULT_CACHE_TTL_MS,
+  DEFAULT_INITIAL_DELAY_MS,
+  DEFAULT_SCAN_CONCURRENCY,
+  createPortfolioCache,
+  isCacheFresh,
+  runWithConcurrency,
+} from "../utils/portfolio-scan";
+
+// Generic portfolio-scan hook. Concrete consumers (usePortfolioHealth,
+// usePortfolioOrphans) wrap this with a cache key, an enumerator that lists
+// the items to scan, and a per-item scanner. The hook owns:
+//
+// - Cache-first read with TTL freshness check (no `loading=true` on a fresh
+//   cache hit, so the UI renders instantly on tab re-open).
+// - Initial-delay-then-scan kickoff on mount to let the dashboard's GraphQL
+//   warm-up finish before we hammer REST.
+// - Bounded-concurrency fan-out via `runWithConcurrency`.
+// - Per-item error isolation: a single repo failing does not abort the rest;
+//   the partial result is persisted as the new cache.
+// - Race protection via a monotonic `requestId` ref + `isMounted` ref so a
+//   stale in-flight scan can't overwrite a fresher run's state (matters under
+//   StrictMode double-mount).
+//
+// `TItem` is whatever the enumerator returns (a repo name string for health,
+// a project descriptor for orphans). `TResult` is the per-item scan output;
+// the hook surfaces `TResult[]` (one entry per *successful* item, in input
+// order). If the consumer needs to flatten (e.g. each item produces an array
+// and they want a single flat list), do it in the wrapper.
+
+export interface PortfolioScanOptions<TItem, TResult> {
+  // Namespaces the localStorage entry. Bump the suffix when TResult shape
+  // changes incompatibly (existing entries will fail the shape check and be
+  // treated as a cache miss).
+  cacheKey: string;
+  // Lists the items to scan. Called once per scan, after the token check
+  // passes and (on a non-fresh cache) before the bump-then-await sequence.
+  // The `force` flag is forwarded so the enumerator can bypass its own
+  // caches on a manual refresh — health uses this for the checklist load.
+  enumerate: (token: string, force: boolean) => Promise<TItem[]>;
+  // Per-item scanner. Called inside a try/catch by the runner — throw freely
+  // for per-item failures, the runner will log it and keep going.
+  scanItem: (token: string, item: TItem) => Promise<TResult>;
+  // Russian message shown when `enumerate` throws and there is no item to
+  // scan. The error's own message is preferred when available; this is the
+  // generic fallback.
+  enumerateErrorFallback?: string;
+  // Russian message shown when at least one item failed and zero succeeded.
+  // Partial success is silent (the panel just shows fewer rows).
+  allFailedError: string;
+  ttlMs?: number;
+  concurrency?: number;
+  initialDelayMs?: number;
+}
+
+export interface PortfolioScanState<TResult> {
+  items: TResult[];
+  loading: boolean;
+  error: string | null;
+  lastUpdated: string | null;
+  refresh: () => void;
+}
+
+interface InternalState<TResult> {
+  items: TResult[];
+  loading: boolean;
+  error: string | null;
+  lastUpdated: string | null;
+}
+
+const TOKEN_MISSING_ERROR = "Нужен GitHub-токен";
+
+export function usePortfolioScan<TItem, TResult>(
+  opts: PortfolioScanOptions<TItem, TResult>,
+): PortfolioScanState<TResult> {
+  const {
+    cacheKey,
+    enumerate,
+    scanItem,
+    enumerateErrorFallback = "Не удалось подготовить список репозиториев",
+    allFailedError,
+    ttlMs = DEFAULT_CACHE_TTL_MS,
+    concurrency = DEFAULT_SCAN_CONCURRENCY,
+    initialDelayMs = DEFAULT_INITIAL_DELAY_MS,
+  } = opts;
+
+  // Cache instance is keyed off `cacheKey`. Callers pass a static literal so
+  // we only build it once; if a future caller ever varies the key at runtime,
+  // they'll need to remount the hook to swap stores.
+  const cacheRef = useRef(createPortfolioCache<TResult[]>(cacheKey));
+
+  const [state, setState] = useState<InternalState<TResult>>({
+    items: [],
+    loading: false,
+    error: null,
+    lastUpdated: null,
+  });
+
+  // Monotonic request id — discriminates between in-flight scans so a stale
+  // run can't overwrite a fresher one's state.
+  const requestId = useRef(0);
+  // Prevents setState after unmount. The in-flight GitHub calls will complete
+  // in the background but their results are dropped.
+  const isMounted = useRef(true);
+
+  const run = useCallback(
+    async (force: boolean, withInitialDelay: boolean) => {
+      const token = getToken();
+      if (!token) {
+        if (isMounted.current) {
+          setState({
+            items: [],
+            loading: false,
+            error: TOKEN_MISSING_ERROR,
+            lastUpdated: null,
+          });
+        }
+        return;
+      }
+
+      // Cache-first path. On a fresh cache we never flip `loading` — the UI
+      // stays calm and renders instantly.
+      if (!force) {
+        const cached = cacheRef.current.read();
+        if (cached && isCacheFresh(cached, ttlMs)) {
+          if (isMounted.current) {
+            setState({
+              items: cached.payload,
+              loading: false,
+              error: null,
+              lastUpdated: cached.generated_at,
+            });
+          }
+          return;
+        }
+      }
+
+      // Bump the request id BEFORE any await so the cleanup path (which also
+      // bumps requestId) can invalidate this run while it's parked in the
+      // initial delay. Without this, a StrictMode double-mount can let the
+      // first run's setTimeout resolve under the second mount's
+      // `isMounted=true` and write stale state.
+      const myReq = ++requestId.current;
+
+      if (withInitialDelay) {
+        await new Promise((r) => setTimeout(r, initialDelayMs));
+        if (myReq !== requestId.current || !isMounted.current) return;
+      }
+
+      if (isMounted.current) {
+        setState((s) => ({ ...s, loading: true, error: null }));
+      }
+
+      let items: TItem[];
+      try {
+        items = await enumerate(token, force);
+      } catch (err) {
+        if (myReq !== requestId.current || !isMounted.current) return;
+        const msg = err instanceof Error ? err.message : enumerateErrorFallback;
+        setState((s) => ({ ...s, loading: false, error: msg }));
+        return;
+      }
+
+      if (myReq !== requestId.current || !isMounted.current) return;
+
+      type Settled = { ok: true; result: TResult } | { ok: false; error: string };
+      const settled = await runWithConcurrency<TItem, Settled>(items, concurrency, async (item) => {
+        try {
+          const result = await scanItem(token, item);
+          return { ok: true, result };
+        } catch (err) {
+          // Per-item isolation: a 404 / rate-limit on one item mustn't wipe
+          // the whole scan.
+          const msg = err instanceof Error ? err.message : "scan failed";
+          return { ok: false, error: msg };
+        }
+      });
+
+      if (myReq !== requestId.current || !isMounted.current) return;
+
+      const successes = settled
+        .filter((r): r is { ok: true; result: TResult } => r.ok)
+        .map((r) => r.result);
+      const failedCount = settled.length - successes.length;
+      const generatedAt = cacheRef.current.write(successes);
+
+      setState({
+        items: successes,
+        loading: false,
+        // Surface failures only when the entire scan was wiped — partial
+        // success is the common "one repo rate-limited" case and shouldn't
+        // block the UI.
+        error: successes.length === 0 && failedCount > 0 ? allFailedError : null,
+        lastUpdated: generatedAt,
+      });
+    },
+    [enumerate, scanItem, ttlMs, concurrency, initialDelayMs, allFailedError, enumerateErrorFallback],
+  );
+
+  useEffect(() => {
+    isMounted.current = true;
+    // Kick off on mount with the initial delay; cache hit short-circuits
+    // before the timer fires.
+    void run(false, true);
+    return () => {
+      isMounted.current = false;
+      // Bump the request id so any in-flight handlers see a stale id and
+      // skip their setState calls. We deliberately mutate the live ref —
+      // the "snapshot ref before cleanup" advice doesn't apply.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      requestId.current++;
+    };
+  }, [run]);
+
+  const refresh = useCallback(() => {
+    cacheRef.current.clear();
+    void run(true, false);
+  }, [run]);
+
+  return { ...state, refresh };
+}

--- a/src/utils/portfolio-scan.ts
+++ b/src/utils/portfolio-scan.ts
@@ -1,0 +1,111 @@
+// Shared primitives for portfolio-wide scanners (health, orphans, future
+// insights panels). Extracted from the duplicated bodies of usePortfolioHealth
+// and usePortfolioOrphans — see issue #170.
+
+// 30 minutes — long enough to feel "free" on tab re-open, short enough that
+// a missing finding gets re-evaluated within the working hour.
+export const DEFAULT_CACHE_TTL_MS = 30 * 60 * 1000;
+
+// 3 parallel scans. Each repo touches ~1-50 GitHub calls internally; 3
+// concurrent kept us under the secondary rate-limit threshold in testing.
+// Bumping this requires re-validating against secondary limits.
+export const DEFAULT_SCAN_CONCURRENCY = 3;
+
+// Defer the very first scan a bit so the rest of the dashboard finishes its
+// own GraphQL warm-up before we hammer the REST API. Also keeps the initial
+// render snappy.
+export const DEFAULT_INITIAL_DELAY_MS = 1500;
+
+// Bounded-concurrency runner. Mapper is called eagerly with `index`, so the
+// caller can stash partial results in a fixed slot if needed; here we just
+// collect them into an array preserving input order. Caller is responsible
+// for try/catch inside the mapper if they want per-item error isolation —
+// an unhandled rejection here will short-circuit the whole batch.
+export async function runWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      results[i] = await mapper(items[i], i);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+// Persisted-cache envelope. `generated_at` is the ISO timestamp of the write
+// and is also re-used as `lastUpdated` in the hook state so the UI can show
+// "обновлено N минут назад".
+export interface PortfolioCacheEntry<T> {
+  generated_at: string;
+  payload: T;
+}
+
+export interface PortfolioCache<T> {
+  // Returns the cached entry if present and parseable. Returns null on miss,
+  // malformed JSON, missing fields, or storage exceptions. Freshness is the
+  // caller's responsibility — see `isCacheFresh`.
+  read(): PortfolioCacheEntry<T> | null;
+  // Persists the payload with a fresh timestamp. Returns the timestamp it
+  // wrote (callers use it for `lastUpdated`). Quota-exceeded / serialization
+  // errors are swallowed — the next refresh will retry — and in that case the
+  // returned timestamp is still valid (the in-memory state still gets the
+  // current moment).
+  write(payload: T): string;
+  // Clears the cache. Used by the manual "Refresh" path to force a re-scan.
+  clear(): void;
+}
+
+// Factory for a typed localStorage-backed cache. The key namespaces the
+// payload; bump the suffix in the cache key when the payload shape changes
+// incompatibly.
+export function createPortfolioCache<T>(key: string): PortfolioCache<T> {
+  return {
+    read() {
+      try {
+        const raw = localStorage.getItem(key);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as PortfolioCacheEntry<T>;
+        // Minimal shape check — turns "Cannot read properties of undefined"
+        // crashes into a clean cache miss after a manual edit / version skew.
+        if (!parsed || typeof parsed !== "object") return null;
+        if (typeof parsed.generated_at !== "string" || !parsed.generated_at) return null;
+        if (!("payload" in parsed)) return null;
+        return parsed;
+      } catch {
+        return null;
+      }
+    },
+    write(payload: T) {
+      const generatedAt = new Date().toISOString();
+      try {
+        const entry: PortfolioCacheEntry<T> = { generated_at: generatedAt, payload };
+        localStorage.setItem(key, JSON.stringify(entry));
+      } catch {
+        // Quota exceeded / serialization error — drop silently. The next
+        // refresh will retry and the in-memory state already has the data.
+      }
+      return generatedAt;
+    },
+    clear() {
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        // Ignore — read() will treat any malformed entry as a miss anyway.
+      }
+    },
+  };
+}
+
+// Freshness check for a cache entry. Defends against a clock skew or hand-
+// edited timestamp by requiring a finite, non-negative age.
+export function isCacheFresh<T>(entry: PortfolioCacheEntry<T>, ttlMs: number): boolean {
+  const age = Date.now() - new Date(entry.generated_at).getTime();
+  return Number.isFinite(age) && age >= 0 && age < ttlMs;
+}


### PR DESCRIPTION
Closes #170

## Что сделано

Разнёс дублированный код portfolio-scan между `usePortfolioHealth` и `usePortfolioOrphans` (выявлено в code review PR #168).

- **`src/utils/portfolio-scan.ts`** — generic утилиты:
  - `runWithConcurrency<T, R>` — bounded-concurrency runner
  - `createPortfolioCache<T>` — shape-validated localStorage обёртка (read/write/clear)
  - `isCacheFresh<T>` — проверка TTL с защитой от битого `generated_at`
  - Константы: `DEFAULT_CACHE_TTL_MS` (30 мин), `DEFAULT_SCAN_CONCURRENCY` (3), `DEFAULT_INITIAL_DELAY_MS` (1500)

- **`src/hooks/usePortfolioScan.ts`** — generic хук `<TItem, TResult>`:
  - cache-first read (без `loading=true` на свежем кеше)
  - initial-delay → enumerate → bounded fan-out → write cache
  - per-item error isolation, partial result сохраняется
  - race-protection через `requestId` + `isMounted` refs (++requestId BEFORE await — фикс stale-write window)
  - конфигурируемые сообщения об ошибках (token-missing, enumerate fallback, all-failed)

- **`usePortfolioHealth`** и **`usePortfolioOrphans`** теперь тонкие обёртки (~30-50 строк каждая):
  - health enumerate грузит checklist + возвращает `{repo, doc}[]`, scanItem вызывает `runHealthCheck`
  - orphans enumerate возвращает `DEFAULT_PROJECTS`, scanItem вызывает `listOrphanIssuesWithMeta`, обёртка `flat()`-ит результат

## Дизайн generic'а

Выбрал `enumerate(token, force) → TItem[]` + `scanItem(token, item) → TResult` (вместо хардкода `(token, owner, repo, doc)`):

- health не таскает unused `owner`, orphans не платит за load checklist
- доменно-специфическую логику (классификация репо для health, фильтр проектов для orphans) можно расширять без изменения generic'а
- `force` пробрасывается в enumerate, чтобы health мог сбросить чеклист-кеш на manual refresh

Hook возвращает `TResult[]` (1 элемент на успешный item, в порядке input). Если consumer хочет flat-list — делает `.flat()` сам (orphans).

## Контракт consumers сохранён

`App.tsx`, `DashboardView.tsx`, `Sidebar.tsx` используют `portfolio.reports`, `orphans.items`, `.refresh`, `.loading`, `.error`, `.lastUpdated` — все эти поля остались.

## Cache compatibility

Cache key оставлен `v1` — внутренняя shape поменялась с `{generated_at, reports/items}` на `{generated_at, payload}`, но `read()` валидирует наличие `payload` и возвращает null на старых записях. Старый кеш транспарентно перезапишется при следующем скане.

## Проверки

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean (prod bundle собирается)

## Self-review

- Контракт consumers НЕ сломан
- Cache key — параметр generic'а
- Generic `<TItem, TResult>` строго типизирован, без `any`
- Per-item error isolation сохранена (try/catch внутри runWithConcurrency mapper)
- Cleanup / requestId / isMounted паттерн перенесён 1-к-1
- localStorage write try/catch вокруг JSON.stringify (QuotaExceeded безопасен)
- TTL fresh check включает Number.isFinite + age >= 0

## Test plan

- [ ] Открыть превью, дождаться инициализации
- [ ] Проверить что AIInsightsPanel (health) показывает данные
- [ ] Проверить что OrphanIssuesPanel показывает данные
- [ ] Нажать «Обновить» в Topbar → оба хука должны рескан-нуть
- [ ] Проверить что `localStorage.makeit_portfolio_health_v1` и `makeit_portfolio_orphans_v1` обновлены с новой shape (`payload` вместо `reports`/`items`)