### PR TITLE
fix(settings): notify consumers on mid-session 401 via window event

### DIFF
--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   getBootstrapToken,
   loadAllSettings,
+  SETTINGS_AUTH_LOST_EVENT,
   SettingsAuthError,
   SettingsUnavailableError,
 } from "../utils/settings";
@@ -85,6 +86,19 @@ export function useSettings(): UseSettingsResult {
       cancelledRef.current = true;
     };
   }, [tick]);
+
+  // Listen for mid-session auth loss (settings.ts dispatches on 401/403 from
+  // any setSetting/deleteSetting/loadAllSettings call). Flip back to the
+  // auth screen so consumers reading sync `getSetting()` aren't stranded
+  // with a silently-wiped cache.
+  useEffect(() => {
+    const onAuthLost = () => {
+      setReady(false);
+      setError("auth");
+    };
+    window.addEventListener(SETTINGS_AUTH_LOST_EVENT, onAuthLost);
+    return () => window.removeEventListener(SETTINGS_AUTH_LOST_EVENT, onAuthLost);
+  }, []);
 
   const retry = useCallback(() => {
     setTick((t) => t + 1);

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -23,6 +23,17 @@ import { PIPELINE_BASE_URL } from "./config";
 
 const BOOTSTRAP_TOKEN_KEY = "pipeline_settings_token";
 
+/**
+ * Fired when a Pipeline request returns 401/403 mid-session — the bootstrap
+ * token has been rejected by the server. `useSettings()` listens for this and
+ * transitions the app back into the bootstrap UI so consumers calling sync
+ * `getSetting()` aren't stuck reading `null` mid-render.
+ *
+ * Use a global window event (rather than a React-side pub/sub) so this works
+ * from utils that aren't part of the component tree, with zero prop-drilling.
+ */
+export const SETTINGS_AUTH_LOST_EVENT = "settings:auth-lost";
+
 /** 401 from the pipeline — bootstrap token is missing or invalid. */
 export class SettingsAuthError extends Error {
   constructor(message = "Pipeline settings: unauthorized") {
@@ -137,8 +148,15 @@ async function request(path: string, init: RequestInit = {}): Promise<Response> 
   }
   if (res.status === 401 || res.status === 403) {
     // Server rejected the bootstrap token. Drop it locally so the next mount
-    // of useSettings() shows the bootstrap form instead of looping.
+    // of useSettings() shows the bootstrap form instead of looping. Fire a
+    // global event so any in-flight `useSettings()` instance can re-transition
+    // to the auth-lost screen mid-session — without this, sync `getSetting()`
+    // consumers (Task-04 wiring) would silently read `null` from the wiped
+    // cache without any UI signal.
     clearBootstrapToken();
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event(SETTINGS_AUTH_LOST_EVENT));
+    }
     throw new SettingsAuthError();
   }
   if (res.status >= 500) {


### PR DESCRIPTION
Closes #176

## Что сделано
- `src/utils/settings.ts`: dispatch `window` event `settings:auth-lost` on 401/403 from `request()`
- `src/hooks/useSettings.ts`: слушает событие → `setReady(false); setError("auth")` → возвращает на bootstrap-форму

## Зачем
До этого `request()` уже чистил bootstrap-токен и кэш на 401, но in-flight `AppInner` оставался смонтирован и рендерил с пустыми данными. Sync `getSetting()` consumers (которых добавит Task-04 #134 для `utils/github.ts`, `claude.ts`, `betterstack.ts`) тихо получали бы `null` без UI-сигнала.

## Дизайн
Window event вместо React Context — потому что `utils/settings.ts` находится вне дерева компонентов и не должен знать о React. `useSettings()` — единственная точка реакции.

## Проверки
- [x] npm run lint
- [x] npx tsc --noEmit
- [x] npm run build
- [x] preview: dispatch вручную не падает, listener установлен (event-string в bundle)