### PR TITLE
refactor(health): Semaphore вместо batched-loop в runHealthCheck (Epic-008 Task-05)

### DIFF
--- a/src/utils/health-engine.ts
+++ b/src/utils/health-engine.ts
@@ -25,6 +25,7 @@ import {
   listMergedPRsInWindow,
   getPRFiles,
 } from "./github-actions";
+import { Semaphore } from "./semaphore";
 
 // Helper: read a typed param from a check object with a fallback.
 function param<T>(obj: Record<string, unknown>, key: string, fallback: T): T {
@@ -744,14 +745,13 @@ export async function runHealthCheck(
 
   // Apply applicable rules. We run with limited concurrency so a single repo
   // doesn't fan out 50 GitHub calls in parallel and trip secondary rate limits.
+  // Semaphore gives smooth concurrency — a new rule starts as soon as a slot
+  // frees, instead of waiting for the whole batch to finish.
   const applicable = doc.rules.filter((r) => ruleApplies(r, cls));
-  const findings: HealthFinding[] = [];
-  const concurrency = 5;
-  for (let i = 0; i < applicable.length; i += concurrency) {
-    const batch = applicable.slice(i, i + concurrency);
-    const results = await Promise.all(batch.map((r) => executeCheck(r, ctx)));
-    findings.push(...results);
-  }
+  const sem = new Semaphore(5);
+  const findings: HealthFinding[] = await Promise.all(
+    applicable.map((rule) => sem.run(() => executeCheck(rule, ctx))),
+  );
 
   // Surface skipped (not-applicable) rules so the UI can show coverage too.
   for (const r of doc.rules) {

--- a/src/utils/health-engine.ts
+++ b/src/utils/health-engine.ts
@@ -748,7 +748,10 @@ export async function runHealthCheck(
   // Semaphore gives smooth concurrency — a new rule starts as soon as a slot
   // frees, instead of waiting for the whole batch to finish.
   const applicable = doc.rules.filter((r) => ruleApplies(r, cls));
-  const sem = new Semaphore(5);
+  const RULE_CONCURRENCY = 5;
+  const sem = new Semaphore(RULE_CONCURRENCY);
+  // executeCheck is total — its global try/catch maps any throw to an
+  // `unknown` finding — so this Promise.all never rejects in practice.
   const findings: HealthFinding[] = await Promise.all(
     applicable.map((rule) => sem.run(() => executeCheck(rule, ctx))),
   );

--- a/src/utils/semaphore.ts
+++ b/src/utils/semaphore.ts
@@ -1,0 +1,24 @@
+// Concurrency limiter with FIFO queue: at most `max` tasks run at once.
+export class Semaphore {
+  private active = 0;
+  private queue: Array<() => void> = [];
+  private readonly max: number;
+
+  constructor(max: number) {
+    this.max = max;
+  }
+
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.active >= this.max) {
+      await new Promise<void>((resolve) => this.queue.push(resolve));
+    }
+    this.active++;
+    try {
+      return await fn();
+    } finally {
+      this.active--;
+      const next = this.queue.shift();
+      if (next) next();
+    }
+  }
+}

--- a/src/utils/semaphore.ts
+++ b/src/utils/semaphore.ts
@@ -1,24 +1,42 @@
 // Concurrency limiter with FIFO queue: at most `max` tasks run at once.
+//
+// Slot ownership uses a handoff pattern: when a task finishes, it either
+// transfers its slot directly to the next queued waiter (active stays the
+// same) or, if the queue is empty, decrements active. This eliminates a
+// theoretical race where a synchronous caller could observe `active < max`
+// in the window between resolving a waiter's promise and that waiter's
+// `await` continuation actually running.
 export class Semaphore {
   private active = 0;
   private queue: Array<() => void> = [];
   private readonly max: number;
 
   constructor(max: number) {
+    if (!Number.isInteger(max) || max < 1) {
+      throw new RangeError(`Semaphore max must be a positive integer, got ${max}`);
+    }
     this.max = max;
   }
 
   async run<T>(fn: () => Promise<T>): Promise<T> {
     if (this.active >= this.max) {
+      // Queue and wait — when our resolver fires, the slot has already
+      // been handed to us; do NOT increment active.
       await new Promise<void>((resolve) => this.queue.push(resolve));
+    } else {
+      this.active++;
     }
-    this.active++;
     try {
       return await fn();
     } finally {
-      this.active--;
       const next = this.queue.shift();
-      if (next) next();
+      if (next) {
+        // Hand off our slot directly — no decrement, no transient gap
+        // where active < max while a waker is mid-flight.
+        next();
+      } else {
+        this.active--;
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #160

## Что сделано
- `src/utils/semaphore.ts` — простой Semaphore с FIFO очередью (`active`/`queue`, метод `run<T>(fn)`)
- `runHealthCheck` использует `Semaphore(5)` вместо batched for-loop, что даёт smooth concurrency: новые правила стартуют сразу как освобождается слот, без 5-up barrier (раньше ждали самого медленного из 5)

## Корректность
- `try/finally` гарантирует `active--` + `next()` даже при rejection — нет утечки слотов
- `Promise.all` сохраняет порядок результатов независимо от порядка резолва — регрессии findings нет
- `Promise.all([])` → `[]` для пустого `applicable`
- `next()` вызывается ровно один раз на одно завершение, шифтится один waiter — переподписки слотов невозможны

## Тесты
- `npm run lint` — чисто
- `npx tsc --noEmit` — чисто
- `npm run build` — чисто (была заминка с `erasableSyntaxOnly` для parameter property `constructor(private max)` — переписал на explicit field; spec-код адаптирован под tsconfig проекта)

## Самопроверка
- [x] type-check / lint / build зелёные
- [x] Senior review проведён
- [x] P1: 0