### PR TITLE
feat(health): pathExists поддерживает case_insensitive (Epic-008 Task-03)

### DIFF
--- a/src/utils/health-engine.ts
+++ b/src/utils/health-engine.ts
@@ -168,6 +168,11 @@ function splitPath(path: string): { dir: string; name: string } {
   return { dir: path.slice(0, idx), name: path.slice(idx + 1) };
 }
 
+// `caseInsensitive` only normalizes the basename — the directory portion is
+// passed verbatim to GitHub's `/contents/{dir}` endpoint, which is
+// case-sensitive. For YAML rules currently using the flag (root-level docs
+// like README.md / CHANGELOG.md) this is sufficient; nested paths with
+// uncertain dir casing would need a per-segment walk.
 async function pathExists(
   token: string,
   owner: string,
@@ -179,10 +184,9 @@ async function pathExists(
 ): Promise<boolean> {
   const { dir, name } = splitPath(path);
   const items = await listDirCached(token, owner, repo, dir, cache);
-  const target = caseInsensitive ? name.toLowerCase() : name;
-  const found = items.find((i) =>
-    caseInsensitive ? i.name.toLowerCase() === target : i.name === target,
-  );
+  const found = caseInsensitive
+    ? items.find((i) => i.name.toLowerCase() === name.toLowerCase())
+    : items.find((i) => i.name === name);
   if (!found) return false;
   if (expect === "file" && found.type !== "file") return false;
   if (expect === "dir" && found.type !== "dir") return false;

--- a/src/utils/health-engine.ts
+++ b/src/utils/health-engine.ts
@@ -175,10 +175,14 @@ async function pathExists(
   path: string,
   cache: DirCache,
   expect?: "file" | "dir",
+  caseInsensitive: boolean = false,
 ): Promise<boolean> {
   const { dir, name } = splitPath(path);
   const items = await listDirCached(token, owner, repo, dir, cache);
-  const found = items.find((i) => i.name === name);
+  const target = caseInsensitive ? name.toLowerCase() : name;
+  const found = items.find((i) =>
+    caseInsensitive ? i.name.toLowerCase() === target : i.name === target,
+  );
   if (!found) return false;
   if (expect === "file" && found.type !== "file") return false;
   if (expect === "dir" && found.type !== "dir") return false;
@@ -243,7 +247,8 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
     switch (c.type) {
       case "file_exists": {
         const path = param(c, "path", "");
-        const ok = await pathExists(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, "file");
+        const caseInsensitive = param<boolean>(c, "case_insensitive", false);
+        const ok = await pathExists(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, "file", caseInsensitive);
         return { ...base, status: ok ? "pass" : "fail", detail: ok ? path : `Нет файла ${path}` };
       }
 
@@ -265,7 +270,8 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
         const path = param(c, "path", "");
         const contains = param<string | undefined>(c, "contains", undefined);
         const containsAny = param<string[] | undefined>(c, "contains_any", undefined);
-        if (!(await pathExists(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, "file"))) {
+        const caseInsensitive = param<boolean>(c, "case_insensitive", false);
+        if (!(await pathExists(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, "file", caseInsensitive))) {
           return { ...base, status: "fail", detail: `Нет файла ${path}` };
         }
         try {


### PR DESCRIPTION
Closes #158

Разблокирован после мержа Sergio1990-1/makeit-knowledge#7 (YAML флаг `case_insensitive: true` для `hygiene.readme`).

## Что сделано
- `pathExists`: добавлен опциональный параметр `caseInsensitive` (default false), нормализующий имена через `toLowerCase` при сравнении. Существующие 5 вызовов не затронуты — параметр опциональный.
- `executeCheck`: case `file_exists` и `file_contains` читают `case_insensitive` из YAML checklist через `param<boolean>` и пробрасывают в pathExists.

## Тесты
- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm run build` — clean

## Самопроверка
- [x] type-check / lint / build зелёные
- [x] Senior review проведён: при default `false` → точное совпадение (как было). При `true` оба operand'а нормализуются.
- [x] P1: 0