### PR TITLE
feat(drift): LLM-инфраструктура — tool-use wrapper, tree-sha, drift-cache (Epic-007 Task-01)

### DIFF
--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -679,7 +679,9 @@ export async function callClaudeWithTool<T>(
       return block.input as T;
     }
   }
-  throw new Error("model did not call tool");
+  throw new Error(
+    `model did not call tool "${toolDef.name}" (model=${model})`,
+  );
 }
 
 // ── Chat with tool use loop ──

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -639,6 +639,49 @@ export async function generateIssuesFromFindings(
   return allIssues;
 }
 
+// ── Generic tool-use wrapper (single forced tool call) ──
+
+/**
+ * Call Claude with `tool_choice` forcing exactly one tool invocation and return
+ * the parsed `input` of that tool, typed as `T`.
+ *
+ * Used by drift-checks and other features that want structured output without
+ * JSON-string parsing — Anthropic validates the input against `toolDef.input_schema`,
+ * so the returned value already conforms to the declared shape.
+ *
+ * Throws `Error("model did not call tool")` if no `tool_use` block is present.
+ */
+export async function callClaudeWithTool<T>(
+  apiKey: string,
+  systemPrompt: string,
+  userMessage: string,
+  toolDef: { name: string; description: string; input_schema: object },
+  model: "claude-haiku-4-5-20251001" | "claude-opus-4-7",
+  maxTokens = 1024,
+): Promise<T> {
+  const client = new Anthropic({ apiKey, dangerouslyAllowBrowser: true });
+
+  const response = await client.messages
+    .create({
+      model,
+      max_tokens: maxTokens,
+      system: systemPrompt,
+      messages: [{ role: "user", content: userMessage }],
+      tools: [toolDef as Anthropic.Tool],
+      tool_choice: { type: "tool", name: toolDef.name },
+    })
+    .catch((e) => {
+      throw maybeDispatchAuthLostFromError("claude", e);
+    });
+
+  for (const block of response.content) {
+    if (block.type === "tool_use" && block.name === toolDef.name) {
+      return block.input as T;
+    }
+  }
+  throw new Error("model did not call tool");
+}
+
 // ── Chat with tool use loop ──
 
 export interface ClaudeMessage {

--- a/src/utils/github-actions.ts
+++ b/src/utils/github-actions.ts
@@ -475,7 +475,11 @@ export async function getRepoTreeSha(
     const meta = await getRepoMeta(token, owner, repo);
     ref = meta.default_branch || "main";
   }
-  const refData = await rest(token, `/repos/${owner}/${repo}/git/refs/heads/${ref}`);
+  // Encode each path segment so branch names with reserved chars (e.g. `#`)
+  // don't break the URL. Slash-separated branch names like `feat/x` keep their
+  // slashes — GitHub's git/refs/heads endpoint accepts the suffix as a path.
+  const refPath = ref.split("/").map(encodeURIComponent).join("/");
+  const refData = await rest(token, `/repos/${owner}/${repo}/git/refs/heads/${refPath}`);
   const commitSha: string | undefined = refData?.object?.sha;
   if (!commitSha) throw new Error(`getRepoTreeSha: missing object.sha for ${owner}/${repo}@${ref}`);
   const commitData = await rest(token, `/repos/${owner}/${repo}/git/commits/${commitSha}`);

--- a/src/utils/github-actions.ts
+++ b/src/utils/github-actions.ts
@@ -463,6 +463,27 @@ export async function getRepoMeta(token: string, owner: string, repo: string): P
   };
 }
 
+/** Resolve `{commitSha, treeSha}` for a branch. Falls back to `default_branch` when omitted. */
+export async function getRepoTreeSha(
+  token: string,
+  owner: string,
+  repo: string,
+  branch?: string,
+): Promise<{ commitSha: string; treeSha: string }> {
+  let ref = branch;
+  if (!ref) {
+    const meta = await getRepoMeta(token, owner, repo);
+    ref = meta.default_branch || "main";
+  }
+  const refData = await rest(token, `/repos/${owner}/${repo}/git/refs/heads/${ref}`);
+  const commitSha: string | undefined = refData?.object?.sha;
+  if (!commitSha) throw new Error(`getRepoTreeSha: missing object.sha for ${owner}/${repo}@${ref}`);
+  const commitData = await rest(token, `/repos/${owner}/${repo}/git/commits/${commitSha}`);
+  const treeSha: string | undefined = commitData?.tree?.sha;
+  if (!treeSha) throw new Error(`getRepoTreeSha: missing tree.sha for commit ${commitSha}`);
+  return { commitSha, treeSha };
+}
+
 export async function listRepoLabels(token: string, owner: string, repo: string): Promise<string[]> {
   const out: string[] = [];
   for (let page = 1; page <= 5; page++) {

--- a/src/utils/health-llm-cache.ts
+++ b/src/utils/health-llm-cache.ts
@@ -1,0 +1,56 @@
+// localStorage-backed cache for LLM-driven drift findings (Epic-007).
+// Key format: `makeit_drift_cache:{repo}:{treeSha}:{ruleId}` — the treeSha
+// component invalidates entries automatically when the repo's tree changes.
+
+import type { HealthFinding } from "../types/health";
+
+const KEY_PREFIX = "makeit_drift_cache";
+
+function buildKey(repo: string, treeSha: string, ruleId: string): string {
+  return `${KEY_PREFIX}:${repo}:${treeSha}:${ruleId}`;
+}
+
+/** Read a cached finding. Returns `null` on miss or corrupted entry. */
+export function getCached(
+  repo: string,
+  treeSha: string,
+  ruleId: string,
+): HealthFinding | null {
+  try {
+    const raw = localStorage.getItem(buildKey(repo, treeSha, ruleId));
+    if (raw == null) return null;
+    return JSON.parse(raw) as HealthFinding;
+  } catch {
+    return null;
+  }
+}
+
+/** Store a finding. Silently swallows quota/serialization errors — cache is best-effort. */
+export function setCached(
+  repo: string,
+  treeSha: string,
+  ruleId: string,
+  finding: HealthFinding,
+): void {
+  try {
+    localStorage.setItem(buildKey(repo, treeSha, ruleId), JSON.stringify(finding));
+  } catch {
+    // QuotaExceededError or serialization failure — cache writes are non-critical.
+  }
+}
+
+/** Drop all cached entries for `repo` (any treeSha, any ruleId). */
+export function clearCacheForRepo(repo: string): void {
+  const prefix = `${KEY_PREFIX}:${repo}:`;
+  // Collect keys first — removeItem during iteration shifts indices.
+  const toRemove: string[] = [];
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && k.startsWith(prefix)) toRemove.push(k);
+    }
+    for (const k of toRemove) localStorage.removeItem(k);
+  } catch {
+    // localStorage unavailable (private mode quirks) — nothing to clear.
+  }
+}


### PR DESCRIPTION
Closes #149

Базовый слой Epic-007. Открывает путь Task-02..Task-07.

## Что сделано
- `claude.ts`: `callClaudeWithTool<T>` — Messages API + tool_use, форсированный вызов одного tool через `tool_choice`, типизированный input. Использует существующий `@anthropic-ai/sdk` с `dangerouslyAllowBrowser: true` (как остальные браузерные вызовы Claude в проекте). Auth-lost интегрирован через `maybeDispatchAuthLostFromError`.
- `github-actions.ts`: `getRepoTreeSha(token, owner, repo, branch?)` — возвращает `{commitSha, treeSha}` через 2 REST вызова (`/git/refs/heads/{branch}` + `/git/commits/{sha}`). Без указания `branch` берёт `default_branch` из `getRepoMeta`, дефолт-фоллбек `main`.
- `health-llm-cache.ts` (new): `getCached` / `setCached` / `clearCacheForRepo` поверх localStorage с key `makeit_drift_cache:{repo}:{treeSha}:{ruleId}`. `setCached` глотает `QuotaExceededError`, `getCached` возвращает `null` на corrupted entries, `clearCacheForRepo` собирает ключи в массив до удаления (защита от сдвига индексов).

## Тесты
- type-check + lint + build чистые
- Smoke (вручную не запускался — нужен браузерный контекст с `localStorage` и валидный API key, проверим в Task-02 при первом реальном вызове)

## Самопроверка
- [x] type-check / lint / build зелёные
- [x] Senior review проведён (P1 чеклист: API key не утекает, HTTP errors throw'ятся с осмысленными сообщениями, localStorage обёрнут try/catch, key collection до удаления, JSON parse безопасный, branch fallback корректный, tool_choice имя совпадает с toolDef, type narrowing на `tool_use` корректный)
- [x] P1: 0