### PR TITLE
feat(drift): runDriftScan orchestrator + Hero кнопка с прогрессом (Epic-007 Task-02)

### DIFF
--- a/src/components/v4/health/Hero.tsx
+++ b/src/components/v4/health/Hero.tsx
@@ -49,7 +49,9 @@ export function Hero({
     ? "Нужен Claude API key — настрой в шапке"
     : driftScanning
       ? "Drift-скан в процессе…"
-      : "Layer 4 — AI drift-проверки";
+      : !onScanDrift
+        ? "Drift-скан недоступен на этой странице"
+        : "Layer 4 — AI drift-проверки";
 
   return (
     <section className="ph-hero-block">

--- a/src/components/v4/health/Hero.tsx
+++ b/src/components/v4/health/Hero.tsx
@@ -10,18 +10,47 @@ interface Props {
   rulesCount: number;
   /** Optional — wired from ProjectHealthPage to open the BulkCreateModal. */
   onBulkCreate?: () => void;
+  /** Drift scan handler (Layer 4). When omitted the button is hidden. */
+  onScanDrift?: () => void;
+  /** True while a drift scan is in flight — disables the button + shows progress. */
+  driftScanning?: boolean;
+  /** Progress emitted by `runDriftScan`. null when idle. */
+  driftProgress?: { done: number; total: number; currentRule?: string } | null;
+  /** True when a Claude API key is configured. Drives disabled-with-tooltip. */
+  hasClaudeKey?: boolean;
 }
 
 // Header of the report — repo name with classification chips, sub-row with
 // scan time and rules-version link, action buttons (drift scan placeholder
 // + rescan), and the 3-tile KPI row. Navigation back to the projects list
 // happens via the topbar breadcrumb.
-export function Hero({ report, onRescan, refreshing, rulesCount, onBulkCreate }: Props) {
+export function Hero({
+  report,
+  onRescan,
+  refreshing,
+  rulesCount,
+  onBulkCreate,
+  onScanDrift,
+  driftScanning = false,
+  driftProgress = null,
+  hasClaudeKey = false,
+}: Props) {
   const cls = report.classification;
   // Bulk-create only makes sense when there's something to file. Hiding the
   // button (rather than disabling) keeps the toolbar visually clean for
   // healthy projects.
   const hasFails = report.findings.some((f) => f.status === "fail");
+
+  // Drift button label / progress logic. We render the same button whether
+  // we're idle, scanning, or disabled-without-key — only the title attribute
+  // and the inner content change.
+  const driftDisabled = !hasClaudeKey || driftScanning || !onScanDrift;
+  const driftTitle = !hasClaudeKey
+    ? "Нужен Claude API key — настрой в шапке"
+    : driftScanning
+      ? "Drift-скан в процессе…"
+      : "Layer 4 — AI drift-проверки";
+
   return (
     <section className="ph-hero-block">
       <div className="ph-hero-top">
@@ -70,8 +99,24 @@ export function Hero({ report, onRescan, refreshing, rulesCount, onBulkCreate }:
               <Icon name="git-branch" /> Создать issues по всем
             </button>
           )}
-          <button type="button" className="v4-btn" disabled title="Layer 4 — следующая итерация">
-            <Icon name="zap" /> Просканировать drift
+          <button
+            type="button"
+            className={`v4-btn ${driftScanning ? "is-spin" : ""}`}
+            disabled={driftDisabled}
+            onClick={driftDisabled ? undefined : onScanDrift}
+            title={driftTitle}
+            aria-label={
+              driftScanning && driftProgress
+                ? `Drift ${driftProgress.done}/${driftProgress.total}${
+                    driftProgress.currentRule ? ` · ${driftProgress.currentRule}` : ""
+                  }`
+                : "Просканировать drift"
+            }
+          >
+            <Icon name="zap" />
+            {driftScanning && driftProgress
+              ? `Drift ${driftProgress.done}/${driftProgress.total}`
+              : "Просканировать drift"}
           </button>
           <button
             type="button"

--- a/src/components/v4/health/ProjectHealthPage.tsx
+++ b/src/components/v4/health/ProjectHealthPage.tsx
@@ -3,7 +3,7 @@ import type { ProjectData } from "../../../types";
 import type { HealthFinding } from "../../../types/health";
 import { useProjectHealth } from "../../../hooks/useProjectHealth";
 import { loadChecklist } from "../../../utils/checklist";
-import { GITHUB_OWNER, GITHUB_PROJECT_NUMBER, getToken } from "../../../utils/config";
+import { GITHUB_OWNER, GITHUB_PROJECT_NUMBER, getClaudeKey, getToken } from "../../../utils/config";
 import {
   addIssueToProject,
   createIssue,
@@ -35,8 +35,72 @@ interface Props {
 // Most of these collapse to "render the report with banners on top".
 
 export function ProjectHealthPage({ repo, project }: Props) {
-  const { report, loading, error, classificationMissing, refresh } = useProjectHealth(repo);
+  const {
+    report,
+    loading,
+    error,
+    classificationMissing,
+    refresh,
+    scanDrift,
+    driftScanning,
+    driftProgress,
+  } = useProjectHealth(repo);
   const toast = useToast();
+
+  // Re-read Claude key on each render — settings may change mid-session
+  // (SettingsPanel emits an event but we don't subscribe here; the simplest
+  // correct behaviour is "ask localStorage every time we render Hero").
+  const hasClaudeKey = !!getClaudeKey();
+
+  const handleScanDrift = useCallback(async () => {
+    const outcome = await scanDrift();
+    switch (outcome.kind) {
+      case "ok": {
+        if (outcome.total === 0) {
+          toast.push({
+            kind: "info",
+            title: "Drift-скан: нечего проверять",
+            description: "Для этого проекта нет применимых Layer-4 правил.",
+          });
+        } else {
+          toast.push({
+            kind: "success",
+            title: `Drift-скан: +${outcome.addedFails} fails, ${outcome.cachedHits} cached`,
+            description: `Проверено ${outcome.total} правил.`,
+          });
+        }
+        break;
+      }
+      case "no-key":
+        toast.push({
+          kind: "error",
+          title: "Нет Claude API key",
+          description: "Настрой ключ в шапке, чтобы запускать drift-сканы.",
+        });
+        break;
+      case "no-token":
+        toast.push({
+          kind: "error",
+          title: "Нет GitHub токена",
+          description: "Добавьте токен в настройках.",
+        });
+        break;
+      case "no-report":
+        toast.push({
+          kind: "error",
+          title: "Нет отчёта",
+          description: "Сначала запусти базовый скан.",
+        });
+        break;
+      case "error":
+        toast.push({
+          kind: "error",
+          title: "Drift-скан упал",
+          description: outcome.message,
+        });
+        break;
+    }
+  }, [scanDrift, toast]);
 
   // Load the rules count for the hero "N правил · makeit-knowledge" link.
   // Fire once when the page opens; the value is cached by loadChecklist.
@@ -256,6 +320,10 @@ export function ProjectHealthPage({ repo, project }: Props) {
         refreshing={refreshing}
         rulesCount={rulesCount}
         onBulkCreate={() => setBulkOpen(true)}
+        onScanDrift={handleScanDrift}
+        driftScanning={driftScanning}
+        driftProgress={driftProgress}
+        hasClaudeKey={hasClaudeKey}
       />
       <div className="ph-page">
         <div className="ph-main">

--- a/src/hooks/useProjectHealth.ts
+++ b/src/hooks/useProjectHealth.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { GITHUB_OWNER, getToken } from "../utils/config";
+import { GITHUB_OWNER, getClaudeKey, getToken } from "../utils/config";
 import { loadChecklist } from "../utils/checklist";
 import { ClassificationMissingError, runHealthCheck } from "../utils/health-engine";
-import type { HealthReport } from "../types/health";
+import { runDriftScan } from "../utils/health-llm";
+import type { HealthFinding, HealthLayer, HealthLayerSummary, HealthReport } from "../types/health";
 
 const SESSION_PREFIX = "makeit_health_";
 
@@ -13,25 +14,91 @@ interface State {
   // Set when the engine raised a typed ClassificationMissingError —
   // the UI uses this instead of substring-matching the error message.
   classificationMissing: boolean;
+  // Layer-4 (drift) scan progress. `driftScanning` gates the Hero button so
+  // double-clicks can't fan out parallel scans; `driftProgress` drives the
+  // progress UI when set.
+  driftScanning: boolean;
+  driftProgress: { done: number; total: number; currentRule?: string } | null;
+}
+
+// Outcome of a drift scan, surfaced to callers so the UI can toast a
+// summary («+N fails, M cached»). Resolves even on no-op (no key, no
+// applicable rules) so the caller has uniform handling.
+export type DriftScanOutcome =
+  | { kind: "ok"; addedFails: number; cachedHits: number; total: number }
+  | { kind: "no-key" }
+  | { kind: "no-token" }
+  | { kind: "no-report" }
+  | { kind: "error"; message: string };
+
+// Recompute by_layer summary after we swap Layer-4 findings — keeping this
+// in sync with health-engine.ts is critical so the UI's layer chips don't
+// drift after a partial scan.
+function summarizeByLayer(
+  findings: HealthFinding[],
+): Record<HealthLayer, HealthLayerSummary> {
+  const empty: HealthLayerSummary = {
+    total: 0,
+    pass: 0,
+    fail: 0,
+    unknown: 0,
+    skipped: 0,
+  };
+  const out: Record<HealthLayer, HealthLayerSummary> = {
+    1: { ...empty },
+    2: { ...empty },
+    3: { ...empty },
+    4: { ...empty },
+  };
+  for (const f of findings) {
+    const s = out[f.layer];
+    s.total++;
+    s[f.status]++;
+  }
+  return out;
 }
 
 // Hook that runs the health pipeline for one repo. Caches the last report in
 // sessionStorage keyed by repo so navigating between projects doesn't re-scan
 // every time. Cache survives only the current tab session.
-export function useProjectHealth(repo: string | null): State & { refresh: () => void } {
+export function useProjectHealth(
+  repo: string | null,
+): State & { refresh: () => void; scanDrift: () => Promise<DriftScanOutcome> } {
   const [state, setState] = useState<State>({
     report: null,
     loading: false,
     error: null,
     classificationMissing: false,
+    driftScanning: false,
+    driftProgress: null,
   });
   const requestId = useRef(0);
+  // Mounted-flag so async scanDrift() callbacks don't setState after the
+  // hook unmounts (project navigation, page tear-down).
+  const mounted = useRef(true);
+  // Synchronous reentrancy guard. `state.driftScanning` can't be used for
+  // double-click protection because setState is async — two clicks in the
+  // same tick both read the same false snapshot. The ref flips immediately.
+  const driftRunning = useRef(false);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
 
   const run = useCallback(
     async (currentRepo: string, force: boolean) => {
       const token = getToken();
       if (!token) {
-        setState({ report: null, loading: false, error: "Нужен GitHub-токен", classificationMissing: false });
+        setState({
+          report: null,
+          loading: false,
+          error: "Нужен GitHub-токен",
+          classificationMissing: false,
+          driftScanning: false,
+          driftProgress: null,
+        });
         return;
       }
 
@@ -45,7 +112,14 @@ export function useProjectHealth(repo: string | null): State & { refresh: () => 
             const parsed = JSON.parse(cached) as HealthReport;
             const myReq = ++requestId.current;
             void myReq;
-            setState({ report: parsed, loading: false, error: null, classificationMissing: false });
+            setState({
+              report: parsed,
+              loading: false,
+              error: null,
+              classificationMissing: false,
+              driftScanning: false,
+              driftProgress: null,
+            });
             return;
           } catch {
             sessionStorage.removeItem(SESSION_PREFIX + currentRepo);
@@ -65,15 +139,36 @@ export function useProjectHealth(repo: string | null): State & { refresh: () => 
         } catch {
           // Quota exceeded — drop silently, the next render will recompute.
         }
-        setState({ report, loading: false, error: null, classificationMissing: false });
+        setState({
+          report,
+          loading: false,
+          error: null,
+          classificationMissing: false,
+          driftScanning: false,
+          driftProgress: null,
+        });
       } catch (err) {
         if (myReq !== requestId.current) return;
         if (err instanceof ClassificationMissingError) {
-          setState({ report: null, loading: false, error: null, classificationMissing: true });
+          setState({
+            report: null,
+            loading: false,
+            error: null,
+            classificationMissing: true,
+            driftScanning: false,
+            driftProgress: null,
+          });
           return;
         }
         const msg = err instanceof Error ? err.message : "Не удалось выполнить health-чек";
-        setState({ report: null, loading: false, error: msg, classificationMissing: false });
+        setState({
+          report: null,
+          loading: false,
+          error: msg,
+          classificationMissing: false,
+          driftScanning: false,
+          driftProgress: null,
+        });
       }
     },
     [],
@@ -81,10 +176,9 @@ export function useProjectHealth(repo: string | null): State & { refresh: () => 
 
   useEffect(() => {
     // Fetch-on-prop-change. setState inside `run` is intentional —
-    // discriminates loading/error/cache-hit. The lint rule errs on any
-    // setState reachable from an effect, but here it's the canonical
-    // "kick off async work when input changes" pattern.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // discriminates loading/error/cache-hit. The lint rule (when active)
+    // errs on any setState reachable from an effect, but here it's the
+    // canonical "kick off async work when input changes" pattern.
     if (repo) run(repo, false);
   }, [repo, run]);
 
@@ -95,11 +189,137 @@ export function useProjectHealth(repo: string | null): State & { refresh: () => 
     }
   }, [repo, run]);
 
+  // Run the Layer-4 (drift / AI) scan. Reads classification from the current
+  // report — so it requires a successful sync scan first; otherwise we have
+  // no anchor for what's applicable. Merges new findings into the existing
+  // report (replaces all Layer-4 entries) and persists to sessionStorage.
+  const scanDrift = useCallback(async (): Promise<DriftScanOutcome> => {
+    if (!repo) return { kind: "no-report" };
+    const token = getToken();
+    if (!token) return { kind: "no-token" };
+    const claudeKey = getClaudeKey();
+    if (!claudeKey) return { kind: "no-key" };
+
+    // Snapshot the current report — we need its classification and we'll
+    // merge new findings into it. Reading from `state` here captures the
+    // latest sync via the closure update on each render.
+    const currentReport = state.report;
+    if (!currentReport) return { kind: "no-report" };
+
+    // Re-entrancy guard via ref so double-clicks within the same render tick
+    // can't both pass — setState's async nature makes a state-read insufficient.
+    if (driftRunning.current) {
+      return { kind: "ok", addedFails: 0, cachedHits: 0, total: 0 };
+    }
+    driftRunning.current = true;
+
+    setState((s) => ({
+      ...s,
+      driftScanning: true,
+      driftProgress: { done: 0, total: 0 },
+    }));
+
+    try {
+      const doc = await loadChecklist(token);
+      const result = await runDriftScan(
+        token,
+        GITHUB_OWNER,
+        repo,
+        doc,
+        currentReport.classification,
+        claudeKey,
+        (p) => {
+          if (!mounted.current) return;
+          setState((s) => {
+            // Stale-progress guard: if a newer scan started, drop this update.
+            if (!s.driftScanning) return s;
+            return {
+              ...s,
+              driftProgress: { done: p.done, total: p.total, currentRule: p.currentRule },
+            };
+          });
+        },
+      );
+
+      if (!mounted.current) {
+        return { kind: "ok", addedFails: 0, cachedHits: 0, total: 0 };
+      }
+
+      // Track cache hits BEFORE the merge — by counting how many findings
+      // were already present (with non-`unknown` status) in the previous
+      // Layer-4 set. Approximate but useful for the toast.
+      const prevLayer4 = currentReport.findings.filter((f) => f.layer === 4);
+      const prevCachedIds = new Set(
+        prevLayer4.filter((f) => f.status !== "unknown").map((f) => f.rule_id),
+      );
+      const cachedHits = result.findings.filter(
+        (f) => prevCachedIds.has(f.rule_id) && f.status !== "unknown",
+      ).length;
+      const addedFails = result.findings.filter((f) => f.status === "fail").length;
+
+      // Merge: drop ALL existing Layer-4 findings (incl. "skipped" placeholders)
+      // and append the freshly-scanned set. This keeps the per-layer counters
+      // honest after the swap.
+      const nonLayer4 = currentReport.findings.filter((f) => f.layer !== 4);
+      const mergedFindings = [...nonLayer4, ...result.findings];
+      const merged: HealthReport = {
+        ...currentReport,
+        findings: mergedFindings,
+        by_layer: summarizeByLayer(mergedFindings),
+        // Note: we deliberately don't re-compute `score` here — drift checks
+        // are advisory and shouldn't impact the score until task-08 wires
+        // them in. `generated_at` likewise stays anchored to the sync scan.
+      };
+
+      try {
+        sessionStorage.setItem(SESSION_PREFIX + repo, JSON.stringify(merged));
+      } catch {
+        // Quota exceeded — non-fatal.
+      }
+
+      setState((s) => ({
+        ...s,
+        report: merged,
+        driftScanning: false,
+        driftProgress: null,
+      }));
+
+      return {
+        kind: "ok",
+        addedFails,
+        cachedHits,
+        total: result.findings.length,
+      };
+    } catch (err) {
+      if (!mounted.current) {
+        return { kind: "error", message: "unmounted" };
+      }
+      // Always reset the scanning flag — otherwise the button stays disabled
+      // forever after a transient failure.
+      setState((s) => ({ ...s, driftScanning: false, driftProgress: null }));
+      const msg = err instanceof Error ? err.message : "Не удалось запустить drift-скан";
+      return { kind: "error", message: msg };
+    } finally {
+      // Release the reentrancy ref no matter what — the button must become
+      // clickable again on success, error, AND unmount-mid-scan.
+      driftRunning.current = false;
+    }
+  }, [repo, state.report]);
+
   // When `repo` is null we expose an empty/idle state without touching the
   // internal store — keeps state-from-effect linting happy and avoids extra
   // renders on null transitions.
   if (!repo) {
-    return { report: null, loading: false, error: null, classificationMissing: false, refresh };
+    return {
+      report: null,
+      loading: false,
+      error: null,
+      classificationMissing: false,
+      driftScanning: false,
+      driftProgress: null,
+      refresh,
+      scanDrift,
+    };
   }
-  return { ...state, refresh };
+  return { ...state, refresh, scanDrift };
 }

--- a/src/hooks/useProjectHealth.ts
+++ b/src/hooks/useProjectHealth.ts
@@ -80,6 +80,13 @@ export function useProjectHealth(
   // double-click protection because setState is async — two clicks in the
   // same tick both read the same false snapshot. The ref flips immediately.
   const driftRunning = useRef(false);
+  // Current `repo` mirrored as a ref so scanDrift can detect the user
+  // navigating to a different project mid-scan (in which case we must NOT
+  // commit drift findings into the new report).
+  const repoRef = useRef(repo);
+  useEffect(() => {
+    repoRef.current = repo;
+  }, [repo]);
   useEffect(() => {
     mounted.current = true;
     return () => {
@@ -200,11 +207,16 @@ export function useProjectHealth(
     const claudeKey = getClaudeKey();
     if (!claudeKey) return { kind: "no-key" };
 
-    // Snapshot the current report — we need its classification and we'll
-    // merge new findings into it. Reading from `state` here captures the
-    // latest sync via the closure update on each render.
-    const currentReport = state.report;
-    if (!currentReport) return { kind: "no-report" };
+    // Capture the repo we're scanning so the post-await merge can detect
+    // a navigation away (`repoRef.current !== scanRepo`) and abandon.
+    const scanRepo = repo;
+
+    // Snapshot the current report ONLY for read-only inputs to runDriftScan
+    // (classification). The merge at the end reads `s.report` from setState
+    // so it picks up any fresher report written by Refresh while we awaited.
+    const initialReport = state.report;
+    if (!initialReport) return { kind: "no-report" };
+    const classification = initialReport.classification;
 
     // Re-entrancy guard via ref so double-clicks within the same render tick
     // can't both pass — setState's async nature makes a state-read insufficient.
@@ -224,12 +236,12 @@ export function useProjectHealth(
       const result = await runDriftScan(
         token,
         GITHUB_OWNER,
-        repo,
+        scanRepo,
         doc,
-        currentReport.classification,
+        classification,
         claudeKey,
         (p) => {
-          if (!mounted.current) return;
+          if (!mounted.current || repoRef.current !== scanRepo) return;
           setState((s) => {
             // Stale-progress guard: if a newer scan started, drop this update.
             if (!s.driftScanning) return s;
@@ -241,48 +253,53 @@ export function useProjectHealth(
         },
       );
 
-      if (!mounted.current) {
-        return { kind: "ok", addedFails: 0, cachedHits: 0, total: 0 };
+      if (!mounted.current || repoRef.current !== scanRepo) {
+        // Component unmounted or user navigated away — drop the result.
+        // Findings are already in the localStorage drift cache (keyed by
+        // treeSha) and will be picked up on the next scan.
+        return { kind: "ok", addedFails: 0, cachedHits: result.cachedRuleIds.size, total: result.findings.length };
       }
 
-      // Track cache hits BEFORE the merge — by counting how many findings
-      // were already present (with non-`unknown` status) in the previous
-      // Layer-4 set. Approximate but useful for the toast.
-      const prevLayer4 = currentReport.findings.filter((f) => f.layer === 4);
-      const prevCachedIds = new Set(
-        prevLayer4.filter((f) => f.status !== "unknown").map((f) => f.rule_id),
-      );
-      const cachedHits = result.findings.filter(
-        (f) => prevCachedIds.has(f.rule_id) && f.status !== "unknown",
-      ).length;
+      // Real cache-hit count comes from `runDriftScan` directly — this counts
+      // entries served via `getCached`, not heuristics over previous findings.
+      const cachedHits = result.cachedRuleIds.size;
       const addedFails = result.findings.filter((f) => f.status === "fail").length;
 
-      // Merge: drop ALL existing Layer-4 findings (incl. "skipped" placeholders)
-      // and append the freshly-scanned set. This keeps the per-layer counters
-      // honest after the swap.
-      const nonLayer4 = currentReport.findings.filter((f) => f.layer !== 4);
-      const mergedFindings = [...nonLayer4, ...result.findings];
-      const merged: HealthReport = {
-        ...currentReport,
-        findings: mergedFindings,
-        by_layer: summarizeByLayer(mergedFindings),
-        // Note: we deliberately don't re-compute `score` here — drift checks
-        // are advisory and shouldn't impact the score until task-08 wires
-        // them in. `generated_at` likewise stays anchored to the sync scan.
-      };
+      // Merge against the LATEST report — Refresh may have written a fresher
+      // sync result while drift was running; merging against `initialReport`
+      // would silently overwrite it. We commit only if a base report still
+      // exists (Refresh-then-error could leave it null).
+      let mergedFindings: HealthFinding[] | null = null;
+      let merged: HealthReport | null = null;
+      setState((s) => {
+        if (!s.report) {
+          // No base to merge into — drop drift findings (they're cached on
+          // disk; next scan picks them up). Just clear the scanning flag.
+          return { ...s, driftScanning: false, driftProgress: null };
+        }
+        const nonLayer4 = s.report.findings.filter((f) => f.layer !== 4);
+        mergedFindings = [...nonLayer4, ...result.findings];
+        merged = {
+          ...s.report,
+          findings: mergedFindings,
+          by_layer: summarizeByLayer(mergedFindings),
+          // Note: we deliberately don't re-compute `score` here — drift checks
+          // are advisory and shouldn't impact the score until task-08 wires
+          // them in. `generated_at` likewise stays anchored to the sync scan.
+        };
+        return { ...s, report: merged, driftScanning: false, driftProgress: null };
+      });
 
-      try {
-        sessionStorage.setItem(SESSION_PREFIX + repo, JSON.stringify(merged));
-      } catch {
-        // Quota exceeded — non-fatal.
+      // Persist the merged report iff we actually merged. Reading the
+      // closed-over `merged` after the setState is safe because React invokes
+      // the updater synchronously during dispatch.
+      if (merged) {
+        try {
+          sessionStorage.setItem(SESSION_PREFIX + scanRepo, JSON.stringify(merged));
+        } catch {
+          // Quota exceeded — non-fatal.
+        }
       }
-
-      setState((s) => ({
-        ...s,
-        report: merged,
-        driftScanning: false,
-        driftProgress: null,
-      }));
 
       return {
         kind: "ok",

--- a/src/utils/health-llm.ts
+++ b/src/utils/health-llm.ts
@@ -27,6 +27,8 @@ export interface DriftScanResult {
   scannedAt: string;
   /** Cumulative cost (USD) — populated once detectors track real LLM spend. */
   costEstimate?: number;
+  /** Rule ids that were served from cache (no detector invocation). */
+  cachedRuleIds: Set<string>;
 }
 
 // Mirror health-engine.ts:ruleApplies — duplicated rather than exported to
@@ -150,7 +152,7 @@ export async function runDriftScan(
 
   // Graceful no-op when the repo has no Layer-4 surface area.
   if (applicable.length === 0) {
-    return { findings: [], scannedAt: new Date().toISOString() };
+    return { findings: [], scannedAt: new Date().toISOString(), cachedRuleIds: new Set() };
   }
 
   // Resolve the tree sha once per scan — drives the cache key and lets
@@ -168,13 +170,14 @@ export async function runDriftScan(
 
   const total = applicable.length;
   let done = 0;
-  // Mutex over the progress counter — Semaphore parallelism means callbacks
-  // can fire from concurrent slots; we still want monotonic `done` reads.
+  // JS is single-threaded — `done += 1` is atomic. Ordering is by completion,
+  // not by rule index, so `currentRule` reflects the rule that just finished.
   const reportProgress = (currentRule: string) => {
     done += 1;
     onProgress?.({ done, total, currentRule });
   };
 
+  const cachedRuleIds = new Set<string>();
   const sem = new Semaphore(DRIFT_CONCURRENCY);
   const findings: HealthFinding[] = await Promise.all(
     applicable.map((rule) =>
@@ -183,12 +186,19 @@ export async function runDriftScan(
         // Skip entirely when treeSha couldn't be resolved (uncached run).
         const cached = treeSha ? getCached(repo, treeSha, rule.id) : null;
         if (cached) {
+          cachedRuleIds.add(rule.id);
           reportProgress(rule.id);
           return cached;
         }
 
         const detector = detectorFor(rule);
+        // We only cache findings produced by a successful detector call.
+        // Stub-routing failures (`detector === null`) and detector throws are
+        // transient configuration / environmental problems — caching them
+        // would leave the rule wedged on `unknown` until the target repo's
+        // tree changes, even after the YAML or LLM service is fixed.
         let finding: HealthFinding;
+        let cacheable = false;
         if (!detector) {
           // Layer-4 rule with an unknown check.type — surface as unknown so
           // missing routes don't silently disappear. This is the same
@@ -209,6 +219,7 @@ export async function runDriftScan(
               classification,
               claudeKey,
             });
+            cacheable = true;
           } catch (err) {
             const msg = err instanceof Error ? err.message : "ошибка";
             finding = {
@@ -219,15 +230,17 @@ export async function runDriftScan(
           }
         }
 
-        // Persist to cache only when we have a real tree sha — otherwise
-        // a cache entry would survive the repo-change it was supposed to
-        // be invalidated by. setCached swallows storage errors internally.
-        if (treeSha) setCached(repo, treeSha, rule.id, finding);
+        // Persist to cache only when:
+        //  - we have a real tree sha (otherwise the cache entry would survive
+        //    the repo-change it was supposed to be invalidated by), and
+        //  - the finding came from a successful detector run.
+        // setCached swallows storage errors internally.
+        if (treeSha && cacheable) setCached(repo, treeSha, rule.id, finding);
         reportProgress(rule.id);
         return finding;
       }),
     ),
   );
 
-  return { findings, scannedAt: new Date().toISOString() };
+  return { findings, scannedAt: new Date().toISOString(), cachedRuleIds };
 }

--- a/src/utils/health-llm.ts
+++ b/src/utils/health-llm.ts
@@ -1,0 +1,233 @@
+// Layer 4 (drift / AI) orchestrator. Runs LLM-driven checks with limited
+// concurrency, tree-sha-keyed cache, and progress callback for the UI.
+//
+// In task-02 all detectors are stubs that return `unknown` — the real
+// implementations land in task-03..07. The orchestrator and routing are
+// stable so swapping each stub is a one-line change.
+
+import type {
+  ChecklistDocument,
+  ChecklistRule,
+  HealthFinding,
+  ProjectClassification,
+} from "../types/health";
+import { getRepoTreeSha } from "./github-actions";
+import { getCached, setCached } from "./health-llm-cache";
+import { Semaphore } from "./semaphore";
+
+export interface DriftScanProgress {
+  done: number;
+  total: number;
+  currentRule: string;
+}
+
+export interface DriftScanResult {
+  findings: HealthFinding[];
+  /** ISO timestamp the scan finished. */
+  scannedAt: string;
+  /** Cumulative cost (USD) — populated once detectors track real LLM spend. */
+  costEstimate?: number;
+}
+
+// Mirror health-engine.ts:ruleApplies — duplicated rather than exported to
+// keep health-engine surface area stable. If this diverges in the future
+// we'll lift it into a shared util.
+function ruleApplies(rule: ChecklistRule, cls: ProjectClassification): boolean {
+  const a = rule.applies_to ?? {};
+  if (a.tiers && !a.tiers.includes(cls.tier)) return false;
+  if (a.complex !== undefined && a.complex !== cls.complex) return false;
+  if (a.client !== undefined && a.client !== cls.client) return false;
+  return true;
+}
+
+// Anthropic's per-key concurrency on the Messages API is generous, but the
+// sonnet/opus tiers see secondary rate-limit headers around 5 in-flight.
+// 2 keeps comfortable headroom and is plenty for ~5 Layer-4 rules per repo.
+const DRIFT_CONCURRENCY = 2;
+
+// Build the no-status/no-detail base of a finding — so each detector
+// stub (and future real impl) only fills in `status` and `detail`.
+function findingBase(rule: ChecklistRule): Omit<HealthFinding, "status" | "detail"> {
+  return {
+    rule_id: rule.id,
+    title: rule.title,
+    layer: rule.layer,
+    severity: rule.severity,
+    remediation: rule.remediation,
+    source: rule.source,
+  };
+}
+
+// ── Detector stubs (task-03..07 will replace these) ───────────────────
+// Each TBD detector accepts the same signature as a real one will so the
+// switchboard below doesn't need to change when a real impl lands.
+
+// Common stub helpers — keep `claudeKey` typed even though we don't use it
+// yet, so swapping in the real impl doesn't change the signature.
+type DetectorArgs = {
+  rule: ChecklistRule;
+  token: string;
+  owner: string;
+  repo: string;
+  doc: ChecklistDocument;
+  classification: ProjectClassification;
+  claudeKey: string;
+};
+
+async function checkTemplateFilled_TBD(args: DetectorArgs): Promise<HealthFinding> {
+  return { ...findingBase(args.rule), status: "unknown", detail: "Будет реализовано в task-03" };
+}
+
+async function checkContractMilestonesSync_TBD(args: DetectorArgs): Promise<HealthFinding> {
+  return { ...findingBase(args.rule), status: "unknown", detail: "Будет реализовано в task-04" };
+}
+
+async function checkDocCodeSync_TBD(args: DetectorArgs): Promise<HealthFinding> {
+  return { ...findingBase(args.rule), status: "unknown", detail: "Будет реализовано в task-05" };
+}
+
+async function checkKnowledgeCoverage_TBD(args: DetectorArgs): Promise<HealthFinding> {
+  return { ...findingBase(args.rule), status: "unknown", detail: "Будет реализовано в task-06" };
+}
+
+async function checkClaudeMdFreshness_TBD(args: DetectorArgs): Promise<HealthFinding> {
+  return { ...findingBase(args.rule), status: "unknown", detail: "Будет реализовано в task-07" };
+}
+
+// Routing: rule → detector. We dispatch on `rule.check.type` because that's
+// the existing convention used by health-engine.ts for the synchronous layers
+// — the YAML rule sets `check.type: ai_template_filled` etc., regardless of
+// the rule's id (which is a human label like `drift.brief_template_filled`).
+type Detector = (args: DetectorArgs) => Promise<HealthFinding>;
+
+function detectorFor(rule: ChecklistRule): Detector | null {
+  const checkType = String(rule.check?.type ?? "");
+  switch (checkType) {
+    case "ai_template_filled":
+      return checkTemplateFilled_TBD;
+    case "ai_contract_milestones_sync":
+      return checkContractMilestonesSync_TBD;
+    case "ai_doc_code_sync":
+      return checkDocCodeSync_TBD;
+    case "ai_knowledge_coverage":
+      return checkKnowledgeCoverage_TBD;
+    case "ai_claude_md_freshness":
+      return checkClaudeMdFreshness_TBD;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Run all applicable Layer-4 (drift / AI) checks for `repo`.
+ *
+ * Behaviour:
+ * - Filters `doc.rules` by `layer === 4` AND `ruleApplies(rule, classification)`.
+ * - Looks up each rule in the localStorage cache keyed by repo tree-sha;
+ *   on hit, reuses the cached finding without invoking the detector.
+ * - Otherwise runs the detector with `DRIFT_CONCURRENCY` parallelism via
+ *   Semaphore — keeps Anthropic rate-limits comfortable.
+ * - Reports progress via `onProgress` after each rule completes (cache hit
+ *   or miss). Counter is monotonic and total reflects the filtered set.
+ *
+ * The orchestrator is total — detector throws are caught and surfaced as
+ * `unknown` findings so a single bad rule can't abort the scan.
+ */
+export async function runDriftScan(
+  token: string,
+  owner: string,
+  repo: string,
+  doc: ChecklistDocument,
+  classification: ProjectClassification,
+  claudeKey: string,
+  onProgress?: (p: DriftScanProgress) => void,
+): Promise<DriftScanResult> {
+  // Filter to applicable Layer-4 rules. The applies_to gate prevents drift
+  // checks for client-only rules from running on internal projects.
+  const applicable = doc.rules.filter(
+    (r) => r.layer === 4 && ruleApplies(r, classification),
+  );
+
+  // Graceful no-op when the repo has no Layer-4 surface area.
+  if (applicable.length === 0) {
+    return { findings: [], scannedAt: new Date().toISOString() };
+  }
+
+  // Resolve the tree sha once per scan — drives the cache key and lets
+  // every cache hit share invalidation when the repo changes. If the lookup
+  // fails we run the scan uncached rather than aborting; using a sentinel
+  // string would risk polluting the cache with stale entries that survive
+  // the actual repo change.
+  let treeSha: string | null = null;
+  try {
+    const { treeSha: resolved } = await getRepoTreeSha(token, owner, repo);
+    treeSha = resolved;
+  } catch (err) {
+    if (import.meta.env.DEV) console.warn("[drift] getRepoTreeSha failed:", err);
+  }
+
+  const total = applicable.length;
+  let done = 0;
+  // Mutex over the progress counter — Semaphore parallelism means callbacks
+  // can fire from concurrent slots; we still want monotonic `done` reads.
+  const reportProgress = (currentRule: string) => {
+    done += 1;
+    onProgress?.({ done, total, currentRule });
+  };
+
+  const sem = new Semaphore(DRIFT_CONCURRENCY);
+  const findings: HealthFinding[] = await Promise.all(
+    applicable.map((rule) =>
+      sem.run(async () => {
+        // Cache lookup first — avoids both LLM and GitHub calls on hit.
+        // Skip entirely when treeSha couldn't be resolved (uncached run).
+        const cached = treeSha ? getCached(repo, treeSha, rule.id) : null;
+        if (cached) {
+          reportProgress(rule.id);
+          return cached;
+        }
+
+        const detector = detectorFor(rule);
+        let finding: HealthFinding;
+        if (!detector) {
+          // Layer-4 rule with an unknown check.type — surface as unknown so
+          // missing routes don't silently disappear. This is the same
+          // pattern health-engine.ts uses for unknown sync types.
+          finding = {
+            ...findingBase(rule),
+            status: "unknown",
+            detail: `Неизвестный тип drift-проверки: ${String(rule.check?.type ?? "—")}`,
+          };
+        } else {
+          try {
+            finding = await detector({
+              rule,
+              token,
+              owner,
+              repo,
+              doc,
+              classification,
+              claudeKey,
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : "ошибка";
+            finding = {
+              ...findingBase(rule),
+              status: "unknown",
+              detail: `Ошибка drift-проверки: ${msg}`,
+            };
+          }
+        }
+
+        // Persist to cache only when we have a real tree sha — otherwise
+        // a cache entry would survive the repo-change it was supposed to
+        // be invalidated by. setCached swallows storage errors internally.
+        if (treeSha) setCached(repo, treeSha, rule.id, finding);
+        reportProgress(rule.id);
+        return finding;
+      }),
+    ),
+  );
+
+  return { findings, scannedAt: new Date().toISOString() };
+}


### PR DESCRIPTION
Closes #150

Базовый orchestrator для Layer-4 drift checks. Все 5 detector'ов — заглушки, реальные impl придут в Task-03..07.

## Что сделано
- `src/utils/health-llm.ts` (new): `runDriftScan(token, owner, repo, doc, classification, claudeKey, onProgress)` с Semaphore-concurrency=2, кэшем по treeSha (skip cache if treeSha lookup fails), progress callback, total/done монотонно растёт.
- `useProjectHealth`: state `driftScanning` / `driftProgress` (с `currentRule`), новый метод `scanDrift(): Promise<DriftScanOutcome>`. Reentrancy guard через ref (защита от double-click). Merge: drop все Layer-4 findings → append новые → recompute `by_layer`. Persist в sessionStorage.
- `Hero.tsx`: drift-кнопка active с прогрессом «Drift {done}/{total}». Disabled when `!hasClaudeKey || driftScanning`. Tooltip без ключа: «Нужен Claude API key — настрой в шапке».
- `ProjectHealthPage.tsx`: wires Hero к hook'у; toast «Drift-скан: +N fails, M cached» on success / per-error toasts (no-key, no-token, no-report, error).

## Самопроверка
- [x] type-check / lint / build зелёные
- [x] Senior review: race-condition (ref guard fixed), memory leak (mounted ref), cache key correct (`{repo}:{treeSha}:{ruleId}`), progress monotonic, error handling resets driftScanning, no key leak in logs, graceful empty case (total=0)
- [x] Layer-4 без правил → no-op с info-toast «нечего проверять»
- [x] Повторный скан в рамках того же treeSha → cache hits

## Тесты
- type-check: `npx tsc --noEmit` — clean
- lint: `npm run lint` — clean
- build: `npm run build` — clean (только pre-existing warnings про chunk size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)