### PR TITLE
fix(portfolio-health): AbortController в usePortfolioHealth

### DIFF
--- a/src/hooks/usePortfolioHealth.ts
+++ b/src/hooks/usePortfolioHealth.ts
@@ -30,14 +30,17 @@ interface UsePortfolioHealthResult extends Omit<PortfolioScanState<HealthReport>
 // Thin wrapper around `usePortfolioScan` (see issue #170) — the cache,
 // concurrency, race-protection, and initial-delay machinery lives there.
 export function usePortfolioHealth(): UsePortfolioHealthResult {
-  const enumerate = useCallback(async (token: string, force: boolean): Promise<HealthScanItem[]> => {
-    const doc = await loadChecklist(token, force);
-    return Object.keys(doc.project_classification).map((repo) => ({ repo, doc }));
-  }, []);
+  const enumerate = useCallback(
+    async (token: string, force: boolean, signal: AbortSignal): Promise<HealthScanItem[]> => {
+      const doc = await loadChecklist(token, force, signal);
+      return Object.keys(doc.project_classification).map((repo) => ({ repo, doc }));
+    },
+    [],
+  );
 
   const scanItem = useCallback(
-    (token: string, item: HealthScanItem): Promise<HealthReport> =>
-      runHealthCheck(token, GITHUB_OWNER, item.repo, item.doc),
+    (token: string, item: HealthScanItem, signal: AbortSignal): Promise<HealthReport> =>
+      runHealthCheck(token, GITHUB_OWNER, item.repo, item.doc, signal),
     [],
   );
 

--- a/src/hooks/usePortfolioOrphans.ts
+++ b/src/hooks/usePortfolioOrphans.ts
@@ -24,8 +24,8 @@ export function usePortfolioOrphans(): UsePortfolioOrphansResult {
   const enumerate = useCallback(async () => DEFAULT_PROJECTS, []);
 
   const scanItem = useCallback(
-    (token: string, proj: typeof DEFAULT_PROJECTS[number]): Promise<OrphansPerRepo> =>
-      listOrphanIssuesWithMeta(token, proj.owner, proj.repo),
+    (token: string, proj: typeof DEFAULT_PROJECTS[number], signal: AbortSignal): Promise<OrphansPerRepo> =>
+      listOrphanIssuesWithMeta(token, proj.owner, proj.repo, signal),
     [],
   );
 

--- a/src/hooks/usePortfolioScan.ts
+++ b/src/hooks/usePortfolioScan.ts
@@ -39,10 +39,13 @@ export interface PortfolioScanOptions<TItem, TResult> {
   // passes and (on a non-fresh cache) before the bump-then-await sequence.
   // The `force` flag is forwarded so the enumerator can bypass its own
   // caches on a manual refresh — health uses this for the checklist load.
-  enumerate: (token: string, force: boolean) => Promise<TItem[]>;
+  // `signal` is the current scan's AbortSignal — wire it through to fetch
+  // helpers so refresh()/unmount can cancel in-flight requests.
+  enumerate: (token: string, force: boolean, signal: AbortSignal) => Promise<TItem[]>;
   // Per-item scanner. Called inside a try/catch by the runner — throw freely
   // for per-item failures, the runner will log it and keep going.
-  scanItem: (token: string, item: TItem) => Promise<TResult>;
+  // `signal` aborts when refresh() runs again or the hook unmounts.
+  scanItem: (token: string, item: TItem, signal: AbortSignal) => Promise<TResult>;
   // Russian message shown when `enumerate` throws and there is no item to
   // scan. The error's own message is preferred when available; this is the
   // generic fallback.
@@ -99,11 +102,18 @@ export function usePortfolioScan<TItem, TResult>(
   });
 
   // Monotonic request id — discriminates between in-flight scans so a stale
-  // run can't overwrite a fresher one's state.
+  // run can't overwrite a fresher one's state. Kept as a defensive layer on
+  // top of AbortController: if a fetch helper drops the signal somewhere or
+  // a synchronous cache write races setState, the id guard still fires.
   const requestId = useRef(0);
   // Prevents setState after unmount. The in-flight GitHub calls will complete
   // in the background but their results are dropped.
   const isMounted = useRef(true);
+  // Cancels in-flight fetches on refresh()/unmount. A typical health scan
+  // fans out ~50 GitHub REST calls × 12 repos; without this, hitting Refresh
+  // twice in a row sends ~1200 requests against the rate limit while the
+  // first run's results get silently discarded by the requestId guard.
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const run = useCallback(
     async (force: boolean, withInitialDelay: boolean) => {
@@ -137,6 +147,15 @@ export function usePortfolioScan<TItem, TResult>(
         }
       }
 
+      // Cancel any in-flight scan from a previous refresh()/mount before
+      // starting a new one. Old fetches reject with AbortError → the
+      // per-item runner converts to {ok:false}, but the requestId guard
+      // below also short-circuits the setState anyway.
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      const signal = controller.signal;
+
       // Bump the request id BEFORE any await so the cleanup path (which also
       // bumps requestId) can invalidate this run while it's parked in the
       // initial delay. Without this, a StrictMode double-mount can let the
@@ -155,9 +174,12 @@ export function usePortfolioScan<TItem, TResult>(
 
       let items: TItem[];
       try {
-        items = await enumerate(token, force);
+        items = await enumerate(token, force, signal);
       } catch (err) {
         if (myReq !== requestId.current || !isMounted.current) return;
+        // AbortError from a superseded scan: stay silent. The fresh scan
+        // already bumped requestId and will own the next setState.
+        if (err instanceof Error && err.name === "AbortError") return;
         const msg = err instanceof Error ? err.message : enumerateErrorFallback;
         setState((s) => ({ ...s, loading: false, error: msg }));
         return;
@@ -168,11 +190,13 @@ export function usePortfolioScan<TItem, TResult>(
       type Settled = { ok: true; result: TResult } | { ok: false; error: string };
       const settled = await runWithConcurrency<TItem, Settled>(items, concurrency, async (item) => {
         try {
-          const result = await scanItem(token, item);
+          const result = await scanItem(token, item, signal);
           return { ok: true, result };
         } catch (err) {
           // Per-item isolation: a 404 / rate-limit on one item mustn't wipe
-          // the whole scan.
+          // the whole scan. AbortError flows through here too — the
+          // requestId guard below catches the stale-scan case before any
+          // setState lands.
           const msg = err instanceof Error ? err.message : "scan failed";
           return { ok: false, error: msg };
         }
@@ -206,6 +230,9 @@ export function usePortfolioScan<TItem, TResult>(
     void run(false, true);
     return () => {
       isMounted.current = false;
+      // Abort in-flight fetches so they don't keep burning rate limit
+      // budget after the component goes away.
+      abortControllerRef.current?.abort();
       // Bump the request id so any in-flight handlers see a stale id and
       // skip their setState calls. We deliberately mutate the live ref —
       // the "snapshot ref before cleanup" advice doesn't apply.

--- a/src/utils/checklist.ts
+++ b/src/utils/checklist.ts
@@ -34,9 +34,13 @@ function validate(parsed: unknown): asserts parsed is ChecklistDocument {
   }
 }
 
-export async function loadChecklist(token: string, force = false): Promise<ChecklistDocument> {
+export async function loadChecklist(
+  token: string,
+  force = false,
+  signal?: AbortSignal,
+): Promise<ChecklistDocument> {
   if (!force && cached) return cached.doc;
-  const text = await readRepoFile(token, KNOWLEDGE_OWNER, KNOWLEDGE_REPO, CHECKLIST_PATH);
+  const text = await readRepoFile(token, KNOWLEDGE_OWNER, KNOWLEDGE_REPO, CHECKLIST_PATH, signal);
   const parsed = yaml.load(text);
   validate(parsed);
   cached = { doc: parsed, loaded_at: Date.now() };

--- a/src/utils/github-actions.ts
+++ b/src/utils/github-actions.ts
@@ -1,11 +1,17 @@
 const GITHUB_GRAPHQL = "https://api.github.com/graphql";
 const GITHUB_REST = "https://api.github.com";
 
-async function graphql<T>(token: string, query: string, variables: Record<string, unknown> = {}): Promise<T> {
+async function graphql<T>(
+  token: string,
+  query: string,
+  variables: Record<string, unknown> = {},
+  signal?: AbortSignal,
+): Promise<T> {
   const res = await fetch(GITHUB_GRAPHQL, {
     method: "POST",
     headers: { Authorization: `bearer ${token}`, "Content-Type": "application/json" },
     body: JSON.stringify({ query, variables }),
+    signal,
   });
   if (res.status === 401 || res.status === 403) {
     throw new Error("GitHub token истёк или недостаточно прав. Сбросьте токен и введите новый.");
@@ -16,7 +22,7 @@ async function graphql<T>(token: string, query: string, variables: Record<string
   return json.data as T;
 }
 
-async function rest(token: string, path: string, method = "GET", body?: unknown) {
+async function rest(token: string, path: string, method = "GET", body?: unknown, signal?: AbortSignal) {
   const res = await fetch(`${GITHUB_REST}${path}`, {
     method,
     headers: {
@@ -25,6 +31,7 @@ async function rest(token: string, path: string, method = "GET", body?: unknown)
       Accept: "application/vnd.github.v3+json",
     },
     body: body ? JSON.stringify(body) : undefined,
+    signal,
   });
   if (res.status === 401 || res.status === 403) {
     throw new Error("GitHub token истёк или недостаточно прав. Сбросьте токен и введите новый.");
@@ -49,9 +56,10 @@ export async function listRepoFiles(
   token: string,
   owner: string,
   repo: string,
-  path = ""
+  path = "",
+  signal?: AbortSignal,
 ): Promise<{ name: string; type: string; path: string }[]> {
-  const data = await rest(token, `/repos/${owner}/${repo}/contents/${path}`);
+  const data = await rest(token, `/repos/${owner}/${repo}/contents/${path}`, "GET", undefined, signal);
   if (!Array.isArray(data)) return [];
   return data.map((f: { name: string; type: string; path: string }) => ({
     name: f.name,
@@ -64,9 +72,10 @@ export async function readRepoFile(
   token: string,
   owner: string,
   repo: string,
-  path: string
+  path: string,
+  signal?: AbortSignal,
 ): Promise<string> {
-  const data = await rest(token, `/repos/${owner}/${repo}/contents/${path}`);
+  const data = await rest(token, `/repos/${owner}/${repo}/contents/${path}`, "GET", undefined, signal);
   if (data.encoding === "base64" && data.content) {
     const bytes = Uint8Array.from(atob(data.content.replace(/\s/g, "")), (c) => c.charCodeAt(0));
     return new TextDecoder().decode(bytes);
@@ -286,9 +295,10 @@ export async function addComment(
 export async function listMilestones(
   token: string,
   owner: string,
-  repo: string
+  repo: string,
+  signal?: AbortSignal,
 ): Promise<{ number: number; title: string; state: string; due_on: string | null; open_issues: number; closed_issues: number }[]> {
-  const data = await rest(token, `/repos/${owner}/${repo}/milestones?state=all&per_page=100`);
+  const data = await rest(token, `/repos/${owner}/${repo}/milestones?state=all&per_page=100`, "GET", undefined, signal);
   return data.map((m: { number: number; title: string; state: string; due_on: string | null; open_issues: number; closed_issues: number }) => ({
     number: m.number,
     title: m.title,
@@ -453,8 +463,8 @@ export interface RepoMeta {
   open_issues_count: number;
 }
 
-export async function getRepoMeta(token: string, owner: string, repo: string): Promise<RepoMeta> {
-  const data = await rest(token, `/repos/${owner}/${repo}`);
+export async function getRepoMeta(token: string, owner: string, repo: string, signal?: AbortSignal): Promise<RepoMeta> {
+  const data = await rest(token, `/repos/${owner}/${repo}`, "GET", undefined, signal);
   return {
     created_at: data.created_at,
     pushed_at: data.pushed_at,
@@ -488,10 +498,10 @@ export async function getRepoTreeSha(
   return { commitSha, treeSha };
 }
 
-export async function listRepoLabels(token: string, owner: string, repo: string): Promise<string[]> {
+export async function listRepoLabels(token: string, owner: string, repo: string, signal?: AbortSignal): Promise<string[]> {
   const out: string[] = [];
   for (let page = 1; page <= 5; page++) {
-    const data = await rest(token, `/repos/${owner}/${repo}/labels?per_page=100&page=${page}`);
+    const data = await rest(token, `/repos/${owner}/${repo}/labels?per_page=100&page=${page}`, "GET", undefined, signal);
     if (!Array.isArray(data) || data.length === 0) break;
     out.push(...data.map((l: { name: string }) => l.name));
     if (data.length < 100) break;
@@ -506,11 +516,16 @@ export interface Workflow {
   state: string;
 }
 
-export async function listWorkflows(token: string, owner: string, repo: string): Promise<Workflow[]> {
+export async function listWorkflows(token: string, owner: string, repo: string, signal?: AbortSignal): Promise<Workflow[]> {
   try {
-    const data = await rest(token, `/repos/${owner}/${repo}/actions/workflows?per_page=100`);
+    const data = await rest(token, `/repos/${owner}/${repo}/actions/workflows?per_page=100`, "GET", undefined, signal);
     return Array.isArray(data.workflows) ? data.workflows : [];
-  } catch {
+  } catch (err) {
+    // Re-throw AbortError so callers higher up the stack can distinguish a
+    // cancelled scan from a transient API failure (which is what the broad
+    // `catch → []` was designed for). DOMException with `name === "AbortError"`
+    // is what fetch raises when its signal aborts.
+    if (err instanceof Error && err.name === "AbortError") throw err;
     return [];
   }
 }
@@ -527,15 +542,20 @@ export async function getLatestWorkflowRun(
   owner: string,
   repo: string,
   workflowId: number,
+  signal?: AbortSignal,
 ): Promise<WorkflowRun | null> {
   try {
     const data = await rest(
       token,
       `/repos/${owner}/${repo}/actions/workflows/${workflowId}/runs?per_page=1`,
+      "GET",
+      undefined,
+      signal,
     );
     const runs = Array.isArray(data.workflow_runs) ? data.workflow_runs : [];
     return runs[0] ?? null;
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
     return null;
   }
 }
@@ -548,16 +568,21 @@ export async function getLatestCommitForPath(
   owner: string,
   repo: string,
   path: string,
+  signal?: AbortSignal,
 ): Promise<{ sha: string; date: string } | null> {
   try {
     const data = await rest(
       token,
       `/repos/${owner}/${repo}/commits?path=${encodeURIComponent(path)}&per_page=1`,
+      "GET",
+      undefined,
+      signal,
     );
     const commit = Array.isArray(data) ? data[0] : null;
     if (!commit) return null;
     return { sha: commit.sha, date: commit.commit.author?.date ?? commit.commit.committer?.date };
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
     return null;
   }
 }
@@ -568,12 +593,16 @@ export async function countClosedIssuesSince(
   owner: string,
   repo: string,
   since: string,
+  signal?: AbortSignal,
 ): Promise<number> {
   let count = 0;
   for (let page = 1; page <= 10; page++) {
     const data = await rest(
       token,
       `/repos/${owner}/${repo}/issues?state=closed&since=${encodeURIComponent(since)}&per_page=100&page=${page}`,
+      "GET",
+      undefined,
+      signal,
     );
     if (!Array.isArray(data) || data.length === 0) break;
     for (const i of data as Array<{ pull_request?: unknown; closed_at: string | null }>) {
@@ -593,9 +622,10 @@ export async function getCommitFiles(
   owner: string,
   repo: string,
   sha: string,
+  signal?: AbortSignal,
 ): Promise<Array<{ filename: string; additions: number; deletions: number }>> {
   try {
-    const data = await rest(token, `/repos/${owner}/${repo}/commits/${sha}`);
+    const data = await rest(token, `/repos/${owner}/${repo}/commits/${sha}`, "GET", undefined, signal);
     return Array.isArray(data.files)
       ? data.files.map((f: { filename: string; additions: number; deletions: number }) => ({
           filename: f.filename,
@@ -603,7 +633,8 @@ export async function getCommitFiles(
           deletions: f.deletions,
         }))
       : [];
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
     return [];
   }
 }
@@ -615,18 +646,23 @@ export async function listCommitsForPath(
   repo: string,
   path: string,
   limit = 10,
+  signal?: AbortSignal,
 ): Promise<Array<{ sha: string; date: string }>> {
   try {
     const data = await rest(
       token,
       `/repos/${owner}/${repo}/commits?path=${encodeURIComponent(path)}&per_page=${limit}`,
+      "GET",
+      undefined,
+      signal,
     );
     if (!Array.isArray(data)) return [];
     return data.map((c: { sha: string; commit: { author?: { date?: string }; committer?: { date?: string } } }) => ({
       sha: c.sha,
       date: c.commit.author?.date ?? c.commit.committer?.date ?? "",
     })).filter((c) => c.date);
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
     return [];
   }
 }
@@ -643,6 +679,7 @@ export async function listMergedPRsInWindow(
   repo: string,
   windowDays: number,
   hardLimit = 50,
+  signal?: AbortSignal,
 ): Promise<MergedPR[]> {
   const cutoff = Date.now() - windowDays * 86400000;
   const out: MergedPR[] = [];
@@ -650,6 +687,9 @@ export async function listMergedPRsInWindow(
     const data = await rest(
       token,
       `/repos/${owner}/${repo}/pulls?state=closed&per_page=30&page=${page}&sort=updated&direction=desc`,
+      "GET",
+      undefined,
+      signal,
     );
     if (!Array.isArray(data) || data.length === 0) break;
     let any = false;
@@ -677,16 +717,21 @@ export async function getPRFiles(
   owner: string,
   repo: string,
   number: number,
+  signal?: AbortSignal,
 ): Promise<string[]> {
   try {
     const data = await rest(
       token,
       `/repos/${owner}/${repo}/pulls/${number}/files?per_page=300`,
+      "GET",
+      undefined,
+      signal,
     );
     return Array.isArray(data)
       ? data.map((f: { filename: string }) => f.filename)
       : [];
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
     return [];
   }
 }
@@ -696,12 +741,16 @@ export async function listIssuesWithoutMilestone(
   token: string,
   owner: string,
   repo: string,
+  signal?: AbortSignal,
 ): Promise<number[]> {
   const out: number[] = [];
   for (let page = 1; page <= 10; page++) {
     const data = await rest(
       token,
       `/repos/${owner}/${repo}/issues?state=open&milestone=none&per_page=100&page=${page}`,
+      "GET",
+      undefined,
+      signal,
     );
     if (!Array.isArray(data) || data.length === 0) break;
     for (const i of data as Array<{ number: number; pull_request?: unknown; milestone: unknown }>) {
@@ -731,6 +780,7 @@ export async function listOrphanIssuesWithMeta(
   token: string,
   owner: string,
   repo: string,
+  signal?: AbortSignal,
 ): Promise<OrphanIssueMeta[]> {
   const PER_PAGE = 100;
   const MAX_PAGES = 5;
@@ -739,6 +789,9 @@ export async function listOrphanIssuesWithMeta(
     const data = await rest(
       token,
       `/repos/${owner}/${repo}/issues?state=open&milestone=none&per_page=${PER_PAGE}&page=${page}`,
+      "GET",
+      undefined,
+      signal,
     );
     if (!Array.isArray(data) || data.length === 0) break;
     for (const i of data as Array<{

--- a/src/utils/health-engine.ts
+++ b/src/utils/health-engine.ts
@@ -36,14 +36,18 @@ function param<T>(obj: Record<string, unknown>, key: string, fallback: T): T {
 // (shields.io) where transient 5xx / network blips are common. Last attempt's
 // response is returned as-is so the caller can decide what to do with non-OK
 // statuses; only thrown errors propagate after retries are exhausted.
+//
+// AbortError short-circuits the retry loop — once a scan is cancelled there is
+// no point burning the backoff timer.
 async function fetchWithRetry(
   url: string,
   retries = 1,
   baseDelay = 250,
+  signal?: AbortSignal,
 ): Promise<Response> {
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
-      const r = await fetch(url);
+      const r = await fetch(url, { signal });
       if (r.ok) return r;
       if (attempt < retries) {
         await new Promise((res) => setTimeout(res, baseDelay * Math.pow(4, attempt)));
@@ -51,6 +55,7 @@ async function fetchWithRetry(
       }
       return r;
     } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") throw err;
       if (attempt < retries) {
         await new Promise((res) => setTimeout(res, baseDelay * Math.pow(4, attempt)));
         continue;
@@ -143,6 +148,7 @@ async function listDirCached(
   repo: string,
   dir: string,
   cache: DirCache,
+  signal?: AbortSignal,
 ): Promise<{ name: string; type: string; path: string }[]> {
   const key = `${owner}/${repo}`;
   let m = cache.get(key);
@@ -153,10 +159,13 @@ async function listDirCached(
   const hit = m.get(dir);
   if (hit) return hit;
   try {
-    const items = await listRepoFiles(token, owner, repo, dir);
+    const items = await listRepoFiles(token, owner, repo, dir, signal);
     m.set(dir, items);
     return items;
-  } catch {
+  } catch (err) {
+    // AbortError must propagate — caching `[]` for a cancelled scan would
+    // poison the cache for any subsequent scan that tries to reuse it.
+    if (err instanceof Error && err.name === "AbortError") throw err;
     m.set(dir, []);
     return [];
   }
@@ -181,9 +190,10 @@ async function pathExists(
   cache: DirCache,
   expect?: "file" | "dir",
   caseInsensitive: boolean = false,
+  signal?: AbortSignal,
 ): Promise<boolean> {
   const { dir, name } = splitPath(path);
-  const items = await listDirCached(token, owner, repo, dir, cache);
+  const items = await listDirCached(token, owner, repo, dir, cache, signal);
   const found = caseInsensitive
     ? items.find((i) => i.name.toLowerCase() === name.toLowerCase())
     : items.find((i) => i.name === name);
@@ -229,6 +239,9 @@ interface RunCtx {
   doc: ChecklistDocument;
   dirCache: DirCache;
   inGrace: boolean;
+  // Forwarded to every fetch helper. When this aborts, all in-flight rule
+  // checks reject with AbortError and the top-level Promise.all reflects it.
+  signal?: AbortSignal;
 }
 
 async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFinding> {
@@ -252,20 +265,21 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
       case "file_exists": {
         const path = param(c, "path", "");
         const caseInsensitive = param<boolean>(c, "case_insensitive", false);
-        const ok = await pathExists(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, "file", caseInsensitive);
+        const ok = await pathExists(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, "file", caseInsensitive, ctx.signal);
         return { ...base, status: ok ? "pass" : "fail", detail: ok ? path : `Нет файла ${path}` };
       }
 
       case "file_not_empty": {
         const path = param(c, "path", "");
         const minBytes = param<number>(c, "min_bytes", 1);
-        const ok = await pathExists(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, "file");
+        const ok = await pathExists(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, "file", false, ctx.signal);
         if (!ok) return { ...base, status: "fail", detail: `Нет файла ${path}` };
         try {
-          const text = await readRepoFile(ctx.token, ctx.owner, ctx.repo, path);
+          const text = await readRepoFile(ctx.token, ctx.owner, ctx.repo, path, ctx.signal);
           const isOk = text.length >= minBytes;
           return { ...base, status: isOk ? "pass" : "fail", detail: isOk ? path : `${path}: ${text.length} байт` };
-        } catch {
+        } catch (err) {
+          if (err instanceof Error && err.name === "AbortError") throw err;
           return { ...base, status: "unknown", detail: `Не удалось прочитать ${path}` };
         }
       }
@@ -275,11 +289,11 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
         const contains = param<string | undefined>(c, "contains", undefined);
         const containsAny = param<string[] | undefined>(c, "contains_any", undefined);
         const caseInsensitive = param<boolean>(c, "case_insensitive", false);
-        if (!(await pathExists(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, "file", caseInsensitive))) {
+        if (!(await pathExists(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, "file", caseInsensitive, ctx.signal))) {
           return { ...base, status: "fail", detail: `Нет файла ${path}` };
         }
         try {
-          const text = await readRepoFile(ctx.token, ctx.owner, ctx.repo, path);
+          const text = await readRepoFile(ctx.token, ctx.owner, ctx.repo, path, ctx.signal);
           const ok = contains
             ? text.includes(contains)
             : Array.isArray(containsAny) && containsAny.some((s) => text.includes(s));
@@ -288,7 +302,8 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
             status: ok ? "pass" : "fail",
             detail: ok ? `${path} ✓` : `${path} не содержит «${contains ?? containsAny?.join(" / ")}»`,
           };
-        } catch {
+        } catch (err) {
+          if (err instanceof Error && err.name === "AbortError") throw err;
           return { ...base, status: "unknown", detail: `Не удалось прочитать ${path}` };
         }
       }
@@ -298,7 +313,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
         // на уровне корня + поиск по всему дереву через GitHub git tree, если
         // нужно). MVP — проверяем только корень репо.
         const globAny = param<string[]>(c, "glob_any", [param<string>(c, "glob", "")]);
-        const items = await listDirCached(ctx.token, ctx.owner, ctx.repo, "", ctx.dirCache);
+        const items = await listDirCached(ctx.token, ctx.owner, ctx.repo, "", ctx.dirCache, ctx.signal);
         const found = items.find((i) => globAny.includes(i.name));
         return {
           ...base,
@@ -309,7 +324,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
 
       case "dir_not_empty": {
         const path = param(c, "path", "");
-        const items = await listDirCached(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache);
+        const items = await listDirCached(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, ctx.signal);
         const ok = items.length > 0;
         return {
           ...base,
@@ -320,7 +335,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
 
       case "repo_label_present": {
         const required = param<string[]>(c, "names_all_of", []);
-        const labels = await listRepoLabels(ctx.token, ctx.owner, ctx.repo);
+        const labels = await listRepoLabels(ctx.token, ctx.owner, ctx.repo, ctx.signal);
         const set = new Set(labels);
         const missing = required.filter((n) => !set.has(n));
         return {
@@ -332,7 +347,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
 
       case "repo_label_absent": {
         const forbidden = param<string[]>(c, "names_any_of", []);
-        const labels = await listRepoLabels(ctx.token, ctx.owner, ctx.repo);
+        const labels = await listRepoLabels(ctx.token, ctx.owner, ctx.repo, ctx.signal);
         const set = new Set(labels);
         const found = forbidden.filter((n) => set.has(n));
         return {
@@ -344,7 +359,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
 
       case "workflow_with_tests": {
         const matches = param<string[]>(c, "filename_match", ["test", "ci"]);
-        const workflows = await listWorkflows(ctx.token, ctx.owner, ctx.repo);
+        const workflows = await listWorkflows(ctx.token, ctx.owner, ctx.repo, ctx.signal);
         const hit = workflows.find((w) => {
           const haystack = `${w.name} ${w.path}`.toLowerCase();
           return matches.some((m) => haystack.includes(m.toLowerCase()));
@@ -359,13 +374,13 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
       case "workflow_recent_run_status": {
         const matches = param<string[]>(c, "workflow_match", ["test", "ci"]);
         const wantStatus = param<string>(c, "status", "success");
-        const workflows = await listWorkflows(ctx.token, ctx.owner, ctx.repo);
+        const workflows = await listWorkflows(ctx.token, ctx.owner, ctx.repo, ctx.signal);
         const wf = workflows.find((w) => {
           const haystack = `${w.name} ${w.path}`.toLowerCase();
           return matches.some((m) => haystack.includes(m.toLowerCase()));
         });
         if (!wf) return { ...base, status: "fail", detail: "Нет workflow с тестами" };
-        const run = await getLatestWorkflowRun(ctx.token, ctx.owner, ctx.repo, wf.id);
+        const run = await getLatestWorkflowRun(ctx.token, ctx.owner, ctx.repo, wf.id, ctx.signal);
         if (!run) return { ...base, status: "unknown", detail: `Нет запусков ${wf.name}` };
         const ok = run.conclusion === wantStatus;
         return {
@@ -381,7 +396,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
           ctx.doc.settings,
           ctx.doc.settings.issues_no_milestone_threshold,
         );
-        const numbers = await listIssuesWithoutMilestone(ctx.token, ctx.owner, ctx.repo);
+        const numbers = await listIssuesWithoutMilestone(ctx.token, ctx.owner, ctx.repo, ctx.signal);
         const ok = numbers.length <= max;
         return {
           ...base,
@@ -394,7 +409,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
 
       case "stale_milestones": {
         const max = param<number>(c, "max_count", 0);
-        const ms = await listMilestones(ctx.token, ctx.owner, ctx.repo);
+        const ms = await listMilestones(ctx.token, ctx.owner, ctx.repo, ctx.signal);
         const today = new Date().toISOString().slice(0, 10);
         const stale = ms.filter(
           (m) => m.state === "open" && m.due_on && m.due_on.slice(0, 10) < today,
@@ -415,7 +430,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
         const path = resolveExternalPath(externalRepo, pathTpl, ctx.classification, ctx.repo);
         const [extOwner, extRepoName] = externalRepo.split("/");
         if (!extOwner || !extRepoName) return { ...base, status: "unknown", detail: "Bad external repo" };
-        const ok = await pathExists(ctx.token, extOwner, extRepoName, path, ctx.dirCache, "file");
+        const ok = await pathExists(ctx.token, extOwner, extRepoName, path, ctx.dirCache, "file", false, ctx.signal);
         return {
           ...base,
           status: ok ? "pass" : "fail",
@@ -428,14 +443,14 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
         const pathTpl = param<string>(c, "path_template", "");
         const ageMin = param<number>(c, "project_age_days_min", 7);
         const path = resolveExternalPath(externalRepo, pathTpl, ctx.classification, ctx.repo);
-        const meta = await getRepoMeta(ctx.token, ctx.owner, ctx.repo);
+        const meta = await getRepoMeta(ctx.token, ctx.owner, ctx.repo, ctx.signal);
         const ageDays = (Date.now() - new Date(meta.created_at).getTime()) / 86400000;
         if (ageDays < ageMin) {
           return { ...base, status: "skipped", detail: `Проект ${Math.floor(ageDays)} дн., grace ${ageMin}` };
         }
         const [extOwner, extRepoName] = externalRepo.split("/");
         if (!extOwner || !extRepoName) return { ...base, status: "unknown", detail: "Bad external repo" };
-        const ok = await pathExists(ctx.token, extOwner, extRepoName, path, ctx.dirCache, "file");
+        const ok = await pathExists(ctx.token, extOwner, extRepoName, path, ctx.dirCache, "file", false, ctx.signal);
         return {
           ...base,
           status: ok ? "pass" : "fail",
@@ -478,7 +493,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
           0,
         );
 
-        const commits = await listCommitsForPath(ctx.token, owner, repo, path, 10);
+        const commits = await listCommitsForPath(ctx.token, owner, repo, path, 10, ctx.signal);
         if (commits.length === 0) {
           // Без коммитов нельзя ни о чём судить — file_exists ловит реальное
           // отсутствие файла, здесь возвращаем unknown.
@@ -493,7 +508,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
           meaningfulDate = commits[0].date;
         } else {
           for (const cm of commits) {
-            const files = await getCommitFiles(ctx.token, owner, repo, cm.sha);
+            const files = await getCommitFiles(ctx.token, owner, repo, cm.sha, ctx.signal);
             const f = files.find((x) => x.filename === path);
             if (f) cumulative += f.additions + f.deletions;
             if (cumulative >= minLines) {
@@ -528,6 +543,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
             ctx.owner,
             ctx.repo,
             refDate,
+            ctx.signal,
           );
           if (closedCount >= maxClosedSince) {
             reasons.push(`закрыто ${closedCount} issues с правки (порог ${maxClosedSince})`);
@@ -546,11 +562,11 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
 
       case "coverage_badge_present": {
         const path = param<string>(c, "path", "README.md");
-        if (!(await pathExists(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, "file"))) {
+        if (!(await pathExists(ctx.token, ctx.owner, ctx.repo, path, ctx.dirCache, "file", false, ctx.signal))) {
           return { ...base, status: "fail", detail: `Нет ${path}` };
         }
         try {
-          const text = await readRepoFile(ctx.token, ctx.owner, ctx.repo, path);
+          const text = await readRepoFile(ctx.token, ctx.owner, ctx.repo, path, ctx.signal);
           const re = /(codecov|coveralls)\.io|shields\.io\/(codecov|coveralls)|img\.shields\.io\/codecov/i;
           const ok = re.test(text);
           return {
@@ -558,7 +574,8 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
             status: ok ? "pass" : "fail",
             detail: ok ? "Coverage badge найден в README" : "В README нет coverage-бейджа (codecov/coveralls)",
           };
-        } catch {
+        } catch (err) {
+          if (err instanceof Error && err.name === "AbortError") throw err;
           return { ...base, status: "unknown", detail: `Не удалось прочитать ${path}` };
         }
       }
@@ -582,7 +599,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
         // exponential backoff before giving up as `unknown`.
         const url = `https://img.shields.io/codecov/c/github/${ctx.owner}/${ctx.repo}.json`;
         try {
-          const r = await fetchWithRetry(url);
+          const r = await fetchWithRetry(url, 1, 250, ctx.signal);
           if (!r.ok) {
             return { ...base, status: "unknown", detail: `coverage сервис недоступен (HTTP ${r.status})` };
           }
@@ -600,6 +617,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
             detail: `${pct}% (порог tier ${tier}${ctx.classification.complex ? " complex" : ""}: ${threshold}%)`,
           };
         } catch (err) {
+          if (err instanceof Error && err.name === "AbortError") throw err;
           const msg = err instanceof Error ? err.message : "fetch error";
           return { ...base, status: "unknown", detail: `coverage сервис недоступен: ${msg}` };
         }
@@ -610,14 +628,14 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
         const maxCount = resolveRef<number>(c.max_count, ctx.doc.settings, 3);
         const codeGlobs = param<string[]>(c, "code_globs", ["app/**", "src/**"]);
         const docGlobs = param<string[]>(c, "doc_globs", ["docs/**", "README.md", "CLAUDE.md"]);
-        const prs = await listMergedPRsInWindow(ctx.token, ctx.owner, ctx.repo, windowDays, 30);
+        const prs = await listMergedPRsInWindow(ctx.token, ctx.owner, ctx.repo, windowDays, 30, ctx.signal);
         if (prs.length === 0) {
           return { ...base, status: "pass", detail: `Нет смерженных PR за ${windowDays} дн.` };
         }
         let driftCount = 0;
         const driftPrs: number[] = [];
         for (const pr of prs) {
-          const files = await getPRFiles(ctx.token, ctx.owner, ctx.repo, pr.number);
+          const files = await getPRFiles(ctx.token, ctx.owner, ctx.repo, pr.number, ctx.signal);
           const touchesCode = files.some((f) => pathMatchesAny(f, codeGlobs));
           const touchesDocs = files.some((f) => pathMatchesAny(f, docGlobs));
           if (touchesCode && !touchesDocs) {
@@ -647,6 +665,10 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
         return { ...base, status: "unknown", detail: `Неизвестный тип проверки ${c.type}` };
     }
   } catch (err) {
+    // AbortError must propagate up to runHealthCheck → the consumer hook,
+    // otherwise a cancelled scan looks like a successful run with N "Ошибка
+    // проверки: aborted" findings and gets persisted to cache.
+    if (err instanceof Error && err.name === "AbortError") throw err;
     const msg = err instanceof Error ? err.message : "ошибка";
     return { ...base, status: "unknown", detail: `Ошибка проверки: ${msg}` };
   }
@@ -727,6 +749,7 @@ export async function runHealthCheck(
   owner: string,
   repo: string,
   doc: ChecklistDocument,
+  signal?: AbortSignal,
 ): Promise<HealthReport> {
   const cls = resolveClassification(doc, repo);
   if (!cls) {
@@ -736,10 +759,13 @@ export async function runHealthCheck(
   // Grace check — uses repo creation date.
   let inGrace = false;
   try {
-    const meta = await getRepoMeta(token, owner, repo);
+    const meta = await getRepoMeta(token, owner, repo, signal);
     const ageDays = (Date.now() - new Date(meta.created_at).getTime()) / 86400000;
     inGrace = ageDays < doc.settings.grace_period_days;
-  } catch {
+  } catch (err) {
+    // Cancellation must abort the whole scan, not silently flip into a
+    // non-grace run that fans out N more rule fetches before failing.
+    if (err instanceof Error && err.name === "AbortError") throw err;
     inGrace = false;
   }
 
@@ -751,6 +777,7 @@ export async function runHealthCheck(
     doc,
     dirCache: new Map(),
     inGrace,
+    signal,
   };
 
   // Apply applicable rules. We run with limited concurrency so a single repo


### PR DESCRIPTION
Closes #164

## Что сделано
- `runHealthCheck` (`src/utils/health-engine.ts`) и `loadChecklist` (`src/utils/checklist.ts`) принимают опциональный `signal: AbortSignal` — последний параметр, default `undefined`, backward-compat сохранён.
- Сигнал пробрасывается через `RunCtx` во все fetch-helper'ы health-engine: `listRepoFiles/readRepoFile/listRepoLabels/listWorkflows/getLatestWorkflowRun/listMilestones/listIssuesWithoutMilestone/countClosedIssuesSince/listCommitsForPath/getCommitFiles/listMergedPRsInWindow/getPRFiles/getRepoMeta` (`src/utils/github-actions.ts`), плюс `fetchWithRetry` для shields.io.
- `usePortfolioScan` (общий хук, на нём построен `usePortfolioHealth`) держит `abortControllerRef`. На каждом `refresh()` — abort старого + new controller; на unmount — abort. Сигнал прокидывается в `enumerate(token, force, signal)` и `scanItem(token, item, signal)`.
- `usePortfolioOrphans.scanItem` тоже принимает signal и пробрасывает в `listOrphanIssuesWithMeta` — get parity for free.
- AbortError специально различается через `err.name === "AbortError"` и не маппится в `unknown` finding и не в `{ok: false}` псевдо-ошибку: пробрасывается до `usePortfolioScan`, где гасится тихо (стало быть, больше не пишется в state).
- Существующий `requestId` guard сохранён как defensive layer — если abort где-то не сработает, стейл-rезультат всё равно не попадёт в state.
- `useProjectHealth` (single-repo) НЕ тронут — оба хелпера принимают signal опционально, существующий вызов без signal продолжает работать.

## Тесты
- `npm run lint` — green
- `npx tsc --noEmit` — green
- `npm run build` — green

## Самопроверка
- [x] type-check / lint / build зелёные
- [x] Senior review проведён
- [x] P1: 0
- [x] Backward compat: `useProjectHealth` и `ProjectHealthPage` продолжают работать без signal
- [x] AbortError не глушит generic ошибки (только AbortError silent)
- [x] requestId guard сохранён (defensive layer)
- [x] dirCache не «отравляется» `[]` на abort'е (re-throw перед cache.set)