### PR TITLE
fix(toast): clickable link in description (#171)

### DIFF
--- a/src/components/v4/ToastHost.tsx
+++ b/src/components/v4/ToastHost.tsx
@@ -16,6 +16,40 @@ interface Toast extends Required<Omit<ToastInput, "description" | "action">> {
   leaving: boolean;
 }
 
+function safeHttpUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.href;
+    }
+  } catch {
+    // ignore — URL constructor throws on malformed input
+  }
+  return null;
+}
+
+function ToastDescription({
+  description,
+}: {
+  description: string | { text: string; url: string };
+}) {
+  if (typeof description === "string") {
+    return <span>{description}</span>;
+  }
+  const safeUrl = safeHttpUrl(description.url);
+  if (!safeUrl) {
+    // Block javascript: / data: / other non-http schemes — render plain text.
+    return <span>{description.text}</span>;
+  }
+  return (
+    <span>
+      <a href={safeUrl} target="_blank" rel="noreferrer noopener">
+        {description.text}
+      </a>
+    </span>
+  );
+}
+
 const ICONS: Record<ToastKind, ReactNode> = {
   success: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
@@ -102,20 +136,7 @@ export function ToastHost({ children }: { children: ReactNode }) {
             <span className="wow-toast-ic">{ICONS[t.kind]}</span>
             <div className="wow-toast-body">
               <b>{t.title}</b>
-              {t.description &&
-                (typeof t.description === "string" ? (
-                  <span>{t.description}</span>
-                ) : (
-                  <span>
-                    <a
-                      href={t.description.url}
-                      target="_blank"
-                      rel="noreferrer noopener"
-                    >
-                      {t.description.text}
-                    </a>
-                  </span>
-                ))}
+              {t.description && <ToastDescription description={t.description} />}
               {t.action && (
                 <button
                   type="button"

--- a/src/components/v4/ToastHost.tsx
+++ b/src/components/v4/ToastHost.tsx
@@ -11,7 +11,7 @@ import type { ToastAction, ToastContextValue, ToastInput, ToastKind } from "./to
 
 interface Toast extends Required<Omit<ToastInput, "description" | "action">> {
   id: number;
-  description?: string;
+  description?: string | { text: string; url: string };
   action?: ToastAction;
   leaving: boolean;
 }
@@ -102,7 +102,20 @@ export function ToastHost({ children }: { children: ReactNode }) {
             <span className="wow-toast-ic">{ICONS[t.kind]}</span>
             <div className="wow-toast-body">
               <b>{t.title}</b>
-              {t.description && <span>{t.description}</span>}
+              {t.description &&
+                (typeof t.description === "string" ? (
+                  <span>{t.description}</span>
+                ) : (
+                  <span>
+                    <a
+                      href={t.description.url}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                    >
+                      {t.description.text}
+                    </a>
+                  </span>
+                ))}
               {t.action && (
                 <button
                   type="button"

--- a/src/components/v4/health/BulkCreateModal.tsx
+++ b/src/components/v4/health/BulkCreateModal.tsx
@@ -317,15 +317,15 @@ export function BulkCreateModal({ report, repo, onClose, onActionStateChange }: 
       const remaining = workList.length - (created + dups + errors);
       toast.push({
         kind: "info",
-        title: `Создание прервано: ${created} created, ${remaining} skipped`,
-        description: `Дублей: ${dups}, ошибок: ${errors}. ${filterUrl}`,
+        title: `Создание прервано: ${created} created, ${remaining} skipped (дублей ${dups}, ошибок ${errors})`,
+        description: { text: "Открыть в трекере", url: filterUrl },
         duration: 0,
       });
     } else {
       toast.push({
         kind: errors > 0 ? "info" : "success",
         title: `Создано ${created}, дублей ${dups}, ошибок ${errors}`,
-        description: filterUrl,
+        description: { text: "Открыть в трекере", url: filterUrl },
         duration: 0,
       });
     }

--- a/src/components/v4/toastContext.ts
+++ b/src/components/v4/toastContext.ts
@@ -9,7 +9,7 @@ export interface ToastAction {
 
 export interface ToastInput {
   title: string;
-  description?: string;
+  description?: string | { text: string; url: string };
   kind?: ToastKind;
   /** Auto-dismiss delay in ms; 0 disables. Defaults to 3500. */
   duration?: number;


### PR DESCRIPTION
Closes #171

## Summary
- Extend `ToastInput.description` to `string | { text, url }`.
- `ToastHost` renders the object form as `<a href target=_blank rel=noreferrer noopener>`.
- `BulkCreateModal` uses the new shape for the GitHub-filter link in success and aborted toasts.

## Verification
- [x] type-check chистый
- [x] lint chистый
- [x] build chистый