### PR TITLE
fix(portfolio-scan): log localStorage write failures under DEV (#165)

### DIFF
--- a/src/utils/portfolio-scan.ts
+++ b/src/utils/portfolio-scan.ts
@@ -87,9 +87,14 @@ export function createPortfolioCache<T>(key: string): PortfolioCache<T> {
       try {
         const entry: PortfolioCacheEntry<T> = { generated_at: generatedAt, payload };
         localStorage.setItem(key, JSON.stringify(entry));
-      } catch {
-        // Quota exceeded / serialization error — drop silently. The next
-        // refresh will retry and the in-memory state already has the data.
+      } catch (err) {
+        // Quota exceeded / serialization error — drop silently in production:
+        // the next refresh will retry and the in-memory state already has the
+        // data. In DEV we log so a developer notices when the cache budget is
+        // chronically exceeded (issue #165).
+        if (import.meta.env.DEV) {
+          console.warn(`[portfolio-scan] localStorage write failed for "${key}":`, err);
+        }
       }
       return generatedAt;
     },


### PR DESCRIPTION
Closes #165

## Summary
- writeCache now logs the underlying error and cache key via `console.warn` under `import.meta.env.DEV`.
- Production silent-drop behaviour unchanged.
- Fix moved from the issue body's stale path (usePortfolioHealth.ts:50) to the actual call-site in portfolio-scan.ts after the #170 refactor — covers every usePortfolioScan consumer.

## Verification
- [x] type-check чистый
- [x] lint чистый
- [x] build чистый