### PR TITLE
fix(toast): clickable issue URLs in ProjectHealthPage (#194)

### DIFF
--- a/src/components/v4/health/ProjectHealthPage.tsx
+++ b/src/components/v4/health/ProjectHealthPage.tsx
@@ -207,7 +207,7 @@ export function ProjectHealthPage({ repo, project }: Props) {
           toast.push({
             kind: "info",
             title: `Уже есть #${existing.number}`,
-            description: existing.url,
+            description: { text: "Открыть issue", url: existing.url },
           });
           return;
         }
@@ -239,7 +239,7 @@ export function ProjectHealthPage({ repo, project }: Props) {
         toast.push({
           kind: "success",
           title: `Создан #${created.number}`,
-          description: created.url,
+          description: { text: "Открыть issue", url: created.url },
         });
       } catch (err) {
         const message = friendlyError(err);


### PR DESCRIPTION
Closes #194

## Summary
- Two existing toast.push call-sites in ProjectHealthPage moved to the new `description: {text, url}` shape introduced in #171.
- Result: "Открыть issue" link is now clickable in both toasts.

## Verification
- [x] type-check чистый
- [x] lint чистый
- [x] build чистый