### PR TITLE
feat(pipeline): IssueContext panel for active tasks (refs #111)

### DIFF
--- a/src/components/v4/ToastHost.tsx
+++ b/src/components/v4/ToastHost.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from "react";
 import type { ReactNode } from "react";
+import { safeHttpUrl } from "../../utils/url";
 import { ToastCtx } from "./toastContext";
 import type { ToastAction, ToastContextValue, ToastInput, ToastKind } from "./toastContext";
 
@@ -14,18 +15,6 @@ interface Toast extends Required<Omit<ToastInput, "description" | "action">> {
   description?: string | { text: string; url: string };
   action?: ToastAction;
   leaving: boolean;
-}
-
-function safeHttpUrl(url: string): string | null {
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-      return parsed.href;
-    }
-  } catch {
-    // ignore — URL constructor throws on malformed input
-  }
-  return null;
 }
 
 function ToastDescription({

--- a/src/components/v4/pipeline/IssueContextPanel.tsx
+++ b/src/components/v4/pipeline/IssueContextPanel.tsx
@@ -1,0 +1,296 @@
+// Modal panel showing the full IssueContext for one pipeline task —
+// status, retry budget, phase history, artifacts. Triggered from the
+// active-tasks list by clicking a row. epic-027 / issue #111.
+
+import { useEffect, useState } from "react";
+import {
+  fetchIssueContext,
+  type IssueContext,
+  type IssueContextPhaseEntry,
+} from "../../../utils/pipeline";
+import { safeHttpUrl } from "../../../utils/url";
+import { formatDuration } from "./utils";
+
+interface Props {
+  open: boolean;
+  /** "owner/name" — passed straight to the pipeline API path. */
+  repo: string | null;
+  issueNumber: number | null;
+  onClose: () => void;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  queued: "В очереди",
+  in_dev: "В разработке",
+  reviewing: "Ревью",
+  resolving: "Резолюшн",
+  qa_verifying: "QA",
+  polishing: "Полировка",
+  ready_to_merge: "К мержу",
+  ci_verifying: "CI",
+  merged: "Замержен",
+  needs_human: "Нужен человек",
+  failed: "Провален",
+};
+
+const PHASE_STATUS_LABEL: Record<string, string> = {
+  running: "идёт",
+  success: "успех",
+  partial: "частично",
+  failure: "ошибка",
+  terminal_failure: "критично",
+};
+
+function formatTimestamp(iso: string): string {
+  // Tolerate malformed timestamps — show raw rather than crash.
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return iso;
+  return new Date(t).toLocaleString("ru-RU", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function PhaseRow({ entry }: { entry: IssueContextPhaseEntry }) {
+  const statusLabel = PHASE_STATUS_LABEL[entry.status] ?? entry.status;
+  // Treat any non-success phase status as "bad" for the indicator dot. Keeps
+  // the UI useful even when the pipeline adds a new status value we haven't
+  // labelled yet.
+  const isOk = entry.status === "success";
+  const dotClass = isOk
+    ? "v4-pl-ctx-phase-ok"
+    : entry.status === "running"
+      ? "v4-pl-ctx-phase-run"
+      : "v4-pl-ctx-phase-bad";
+  return (
+    <li className="v4-pl-ctx-phase">
+      <div className="v4-pl-ctx-phase-head">
+        <span className={`v4-pl-ctx-phase-dot ${dotClass}`} />
+        <span className="v4-pl-ctx-phase-name">{entry.phase}</span>
+        <span className="v4-pl-ctx-phase-status">{statusLabel}</span>
+        {entry.event && (
+          <span className="v4-pl-ctx-phase-event v4-pl-mono">{entry.event}</span>
+        )}
+        <span className="v4-pl-ctx-phase-meta v4-pl-mono">
+          {formatTimestamp(entry.started_at)}
+          {entry.duration_seconds > 0 && (
+            <> · {formatDuration(Math.round(entry.duration_seconds))}</>
+          )}
+          {entry.cost_usd > 0 && <> · ${entry.cost_usd.toFixed(2)}</>}
+        </span>
+      </div>
+      {entry.error && (
+        <div className="v4-pl-ctx-phase-err">{entry.error}</div>
+      )}
+    </li>
+  );
+}
+
+function ArtifactRow({ k, value }: { k: string; value: unknown }) {
+  // Prefer rendering URLs as anchors so users can click through. The pipeline
+  // store is local and trusted today, but the type allows any string — go
+  // through safeHttpUrl so a future http(s)-impostor scheme can't slip in.
+  const text =
+    typeof value === "string"
+      ? value
+      : value === null || value === undefined
+        ? "—"
+        : JSON.stringify(value);
+  const safeUrl = typeof value === "string" ? safeHttpUrl(value) : null;
+  return (
+    <div className="v4-pl-ctx-art-row">
+      <span className="v4-pl-ctx-art-key v4-pl-mono">{k}</span>
+      {safeUrl ? (
+        <a
+          className="v4-pl-ctx-art-val"
+          href={safeUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          {text}
+        </a>
+      ) : (
+        <span className="v4-pl-ctx-art-val v4-pl-mono">{text}</span>
+      )}
+    </div>
+  );
+}
+
+export function IssueContextPanel({ open, repo, issueNumber, onClose }: Props) {
+  // Single state machine — 'idle' before/while loading, then 'success' or
+  // 'error'. Avoids the React 19 set-state-in-effect lint complaint about
+  // multiple direct setX calls in the effect body, and means stale data
+  // can't render: caller adds `key={issueNumber}` so this state resets on
+  // every issue switch.
+  const [state, setState] = useState<
+    | { kind: "loading" }
+    | { kind: "success"; data: IssueContext }
+    | { kind: "error"; message: string }
+  >({ kind: "loading" });
+
+  // Fetch context whenever the modal is open for a valid (repo, issueNumber).
+  // Caller's `key` ensures we mount fresh on each open, so this effect runs
+  // exactly once per modal lifetime in practice; the abort still guards
+  // against unmount-during-flight.
+  useEffect(() => {
+    if (!open || repo == null || issueNumber == null) return;
+    const controller = new AbortController();
+    fetchIssueContext(repo, issueNumber, controller.signal)
+      .then((data) => {
+        if (!controller.signal.aborted) {
+          setState({ kind: "success", data });
+        }
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        setState({
+          kind: "error",
+          message: err instanceof Error ? err.message : "Ошибка",
+        });
+      });
+    return () => controller.abort();
+  }, [open, repo, issueNumber]);
+
+  // Close on Escape — same UX contract as ClassifyDialog.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open || repo == null || issueNumber == null) return null;
+
+  const ctx = state.kind === "success" ? state.data : null;
+  const statusLabel = ctx ? (STATUS_LABEL[ctx.status] ?? ctx.status) : "";
+
+  return (
+    <div
+      className="v4-modal-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="v4-modal v4-pl-ctx-modal" role="dialog" aria-modal="true">
+        <div className="v4-modal-h">
+          <h3 className="v4-modal-t">
+            Issue Context — <span className="v4-pl-mono">#{issueNumber}</span>
+            {ctx && (
+              <span className="v4-pl-ctx-status">{statusLabel}</span>
+            )}
+          </h3>
+          <button
+            type="button"
+            className="v4-modal-close"
+            onClick={onClose}
+            aria-label="Закрыть"
+          >
+            ×
+          </button>
+        </div>
+        <div className="v4-modal-body v4-pl-ctx-body">
+          {state.kind === "loading" && (
+            <div className="v4-empty">Загрузка контекста…</div>
+          )}
+          {state.kind === "error" && (
+            <div className="v4-pl-ctx-err">
+              <b>Не удалось загрузить:</b> {state.message}
+            </div>
+          )}
+          {ctx && (
+            <>
+              <section className="v4-pl-ctx-section">
+                <div className="v4-pl-ctx-grid">
+                  <div>
+                    <span className="v4-pl-ctx-lbl">Repo</span>
+                    <span className="v4-pl-mono">{ctx.repo}</span>
+                  </div>
+                  <div>
+                    <span className="v4-pl-ctx-lbl">Попытки</span>
+                    <span className="v4-pl-mono">
+                      {ctx.retry_budget.attempts} / {ctx.retry_budget.max_attempts}
+                      {ctx.retry_budget.exhausted && (
+                        <> · исчерпаны</>
+                      )}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="v4-pl-ctx-lbl">Бюджет</span>
+                    <span className="v4-pl-mono">
+                      ${ctx.retry_budget.cost_usd.toFixed(2)} / $
+                      {ctx.retry_budget.max_cost_usd.toFixed(2)}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="v4-pl-ctx-lbl">Обновлён</span>
+                    <span className="v4-pl-mono">
+                      {formatTimestamp(ctx.updated_at)}
+                    </span>
+                  </div>
+                  {ctx.pr_url && (() => {
+                    const safe = safeHttpUrl(ctx.pr_url);
+                    return (
+                      <div>
+                        <span className="v4-pl-ctx-lbl">PR</span>
+                        {safe ? (
+                          <a
+                            className="v4-pl-ctx-val"
+                            href={safe}
+                            target="_blank"
+                            rel="noreferrer noopener"
+                          >
+                            {ctx.pr_url}
+                          </a>
+                        ) : (
+                          <span className="v4-pl-ctx-val v4-pl-mono">
+                            {ctx.pr_url}
+                          </span>
+                        )}
+                      </div>
+                    );
+                  })()}
+                  {ctx.branch && (
+                    <div>
+                      <span className="v4-pl-ctx-lbl">Ветка</span>
+                      <span className="v4-pl-mono">{ctx.branch}</span>
+                    </div>
+                  )}
+                </div>
+              </section>
+
+              <section className="v4-pl-ctx-section">
+                <h4 className="v4-pl-ctx-h">
+                  История фаз ({ctx.phase_history.length})
+                </h4>
+                {ctx.phase_history.length === 0 ? (
+                  <div className="v4-empty">Нет записей</div>
+                ) : (
+                  <ol className="v4-pl-ctx-phases">
+                    {ctx.phase_history.map((entry, i) => (
+                      <PhaseRow key={i} entry={entry} />
+                    ))}
+                  </ol>
+                )}
+              </section>
+
+              {Object.keys(ctx.artifacts).length > 0 && (
+                <section className="v4-pl-ctx-section">
+                  <h4 className="v4-pl-ctx-h">Артефакты</h4>
+                  <div className="v4-pl-ctx-artifacts">
+                    {Object.entries(ctx.artifacts).map(([k, v]) => (
+                      <ArtifactRow key={k} k={k} value={v} />
+                    ))}
+                  </div>
+                </section>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/pipeline/IssueContextPanel.tsx
+++ b/src/components/v4/pipeline/IssueContextPanel.tsx
@@ -88,6 +88,17 @@ function PhaseRow({ entry }: { entry: IssueContextPhaseEntry }) {
   );
 }
 
+function stringifySafe(value: unknown): string {
+  // Pydantic JSON is acyclic so JSON.stringify never realistically throws on
+  // pipeline payloads, but defending against a circular ref keeps the modal
+  // from crashing on unexpected upstream changes.
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
 function ArtifactRow({ k, value }: { k: string; value: unknown }) {
   // Prefer rendering URLs as anchors so users can click through. The pipeline
   // store is local and trusted today, but the type allows any string — go
@@ -97,7 +108,7 @@ function ArtifactRow({ k, value }: { k: string; value: unknown }) {
       ? value
       : value === null || value === undefined
         ? "—"
-        : JSON.stringify(value);
+        : stringifySafe(value);
   const safeUrl = typeof value === "string" ? safeHttpUrl(value) : null;
   return (
     <div className="v4-pl-ctx-art-row">

--- a/src/components/v4/pipeline/PipelineActiveTasks.tsx
+++ b/src/components/v4/pipeline/PipelineActiveTasks.tsx
@@ -137,6 +137,11 @@ export function PipelineActiveTasks({ status, runEpoch }: Props) {
                 className="v4-pl-active-row v4-pl-active-row-btn"
                 onClick={() => setOpenIssue(item.number)}
                 disabled={!repoForContext}
+                title={
+                  repoForContext
+                    ? "Открыть контекст задачи"
+                    : "Нет активного проекта pipeline — контекст недоступен"
+                }
                 aria-label={`Контекст задачи #${item.number}: ${item.title}`}
               >
                 <span className="v4-pl-mono v4-pl-active-num">#{item.number}</span>

--- a/src/components/v4/pipeline/PipelineActiveTasks.tsx
+++ b/src/components/v4/pipeline/PipelineActiveTasks.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from "react";
+import { GITHUB_OWNER } from "../../../utils/config";
 import type {
   PipelineQueueItem,
   PipelineStageEntry,
   PipelineStatus,
 } from "../../../utils/pipeline";
+import { IssueContextPanel } from "./IssueContextPanel";
 import { PhaseDots } from "./PhaseDots";
 import { RiskDot } from "./badges";
 import { formatDuration } from "./utils";
@@ -42,11 +44,21 @@ function LiveTimer({ startMs }: { startMs?: number }) {
 
 export function PipelineActiveTasks({ status, runEpoch }: Props) {
   const taskSeenAtRef = useRef<Map<number, number>>(new Map());
+  // Issue number whose context modal is currently open. `null` = closed.
+  const [openIssue, setOpenIssue] = useState<number | null>(null);
 
   // Reset on new run
   useEffect(() => {
     taskSeenAtRef.current = new Map();
   }, [runEpoch]);
+
+  // pipeline `current_project` is a bare repo slug ("Sewing-ERP"); the
+  // IssueContext API needs "owner/name". Compose against the dashboard's
+  // single GitHub owner. Returns null when no project is active so the panel
+  // never opens against a stale repo.
+  const repoForContext = status?.current_project
+    ? `${GITHUB_OWNER}/${status.current_project}`
+    : null;
 
   // Derive active items first (pure computation), then sync the seen-map in
   // an effect — avoids calling Date.now() during render.
@@ -114,8 +126,19 @@ export function PipelineActiveTasks({ status, runEpoch }: Props) {
           allItems.slice(0, 10).map((item) => {
             const liveStages = issueStages[item.number];
             const fallbackStartMs = seen.get(item.number);
+            // Each row is a button so keyboard users can open the context
+            // panel via Enter/Space — matches the click-to-inspect contract.
+            // Disabled when there's no active project (the panel needs an
+            // owner/name to fetch).
             return (
-              <div key={item.number} className="v4-pl-active-row">
+              <button
+                key={item.number}
+                type="button"
+                className="v4-pl-active-row v4-pl-active-row-btn"
+                onClick={() => setOpenIssue(item.number)}
+                disabled={!repoForContext}
+                aria-label={`Контекст задачи #${item.number}: ${item.title}`}
+              >
                 <span className="v4-pl-mono v4-pl-active-num">#{item.number}</span>
                 <RiskDot riskLevel={item.risk_level} />
                 <span className="v4-pl-active-title">{item.title}</span>
@@ -127,11 +150,20 @@ export function PipelineActiveTasks({ status, runEpoch }: Props) {
                   </span>
                 )}
                 <LiveTimer startMs={fallbackStartMs} />
-              </div>
+              </button>
             );
           })
         )}
       </div>
+      {/* `key` resets the panel's state on every issue switch — keeps the
+          fetch effect simple (no manual reset) and prevents stale data flashes. */}
+      <IssueContextPanel
+        key={openIssue ?? "closed"}
+        open={openIssue !== null}
+        repo={repoForContext}
+        issueNumber={openIssue}
+        onClose={() => setOpenIssue(null)}
+      />
     </div>
   );
 }

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -2415,6 +2415,169 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   text-align: right;
 }
 
+/* Active-tasks rows are <button> for click-to-inspect — strip the default
+   button chrome and keep the row layout identical to the prior <div>. */
+.v4-pl-active-row-btn {
+  width: 100%;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--v4-line-soft);
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+.v4-pl-active-row-btn:hover:not(:disabled) {
+  background: var(--v4-bg-soft);
+}
+.v4-pl-active-row-btn:focus-visible {
+  outline: 2px solid var(--v4-accent-500);
+  outline-offset: -2px;
+}
+.v4-pl-active-row-btn:disabled {
+  cursor: default;
+}
+
+/* Issue Context modal (epic-027) */
+.v4-pl-ctx-modal { max-width: 720px; width: 92vw; }
+.v4-pl-ctx-body { padding: 16px 20px; max-height: 70vh; overflow-y: auto; }
+.v4-pl-ctx-section + .v4-pl-ctx-section {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--v4-line-soft);
+}
+.v4-pl-ctx-h {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v4-ink-700);
+  margin: 0 0 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.v4-pl-ctx-status {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--v4-ink-500);
+  margin-left: 10px;
+  padding: 2px 8px;
+  border: 1px solid var(--v4-line);
+  border-radius: 99px;
+  font-family: var(--v4-mono);
+}
+.v4-pl-ctx-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 24px;
+  font-size: 12px;
+}
+.v4-pl-ctx-grid > div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.v4-pl-ctx-lbl {
+  font-size: 10px;
+  text-transform: uppercase;
+  color: var(--v4-ink-500);
+  letter-spacing: 0.04em;
+}
+.v4-pl-ctx-val,
+.v4-pl-ctx-grid a {
+  color: var(--v4-accent-600);
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.v4-pl-ctx-grid a:hover { text-decoration: underline; }
+.v4-pl-ctx-phases {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v4-pl-ctx-phase {
+  padding: 6px 0;
+  border-bottom: 1px solid var(--v4-line-soft);
+}
+.v4-pl-ctx-phase:last-child { border-bottom: 0; }
+.v4-pl-ctx-phase-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+.v4-pl-ctx-phase-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.v4-pl-ctx-phase-ok { background: var(--v4-success-500); }
+.v4-pl-ctx-phase-bad { background: var(--v4-danger-500); }
+.v4-pl-ctx-phase-run { background: var(--v4-accent-500); }
+.v4-pl-ctx-phase-name {
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+.v4-pl-ctx-phase-status {
+  font-size: 11px;
+  color: var(--v4-ink-500);
+}
+.v4-pl-ctx-phase-event {
+  font-size: 11px;
+  color: var(--v4-ink-500);
+}
+.v4-pl-ctx-phase-meta {
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  margin-left: auto;
+  white-space: nowrap;
+}
+.v4-pl-ctx-phase-err {
+  margin-top: 4px;
+  margin-left: 16px;
+  font-size: 11px;
+  color: var(--v4-danger-700);
+  font-family: var(--v4-mono);
+  word-break: break-word;
+}
+.v4-pl-ctx-artifacts {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v4-pl-ctx-art-row {
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  align-items: baseline;
+}
+.v4-pl-ctx-art-key {
+  color: var(--v4-ink-500);
+  min-width: 100px;
+  flex: 0 0 auto;
+}
+.v4-pl-ctx-art-val {
+  color: var(--v4-ink-900);
+  word-break: break-all;
+  min-width: 0;
+  flex: 1;
+}
+a.v4-pl-ctx-art-val { color: var(--v4-accent-600); text-decoration: none; }
+a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
+.v4-pl-ctx-err {
+  padding: 12px 16px;
+  background: var(--v4-bg-soft);
+  border: 1px solid var(--v4-line);
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--v4-danger-700);
+}
+
 /* Phase dots (stage progress) */
 .v4-pl-phases {
   display: flex;

--- a/src/utils/pipeline.ts
+++ b/src/utils/pipeline.ts
@@ -230,6 +230,111 @@ export const STAGE_LABEL: Record<string, string> = {
   ci_monitor: "CI",
 };
 
+/* ══════════════════════════════════════════
+   ISSUE CONTEXT (epic-027)
+   ══════════════════════════════════════════ */
+
+// Issue lifecycle status — kept loose (string) so a new pipeline-side enum
+// value renders as raw text rather than crashing the panel. The known values
+// at the time of writing are listed in IssueStatus on the pipeline side.
+export type IssueLifecycleStatus =
+  | "queued"
+  | "in_dev"
+  | "reviewing"
+  | "resolving"
+  | "qa_verifying"
+  | "polishing"
+  | "ready_to_merge"
+  | "ci_verifying"
+  | "merged"
+  | "needs_human"
+  | "failed"
+  | (string & {}); // tolerate unknown enum values added later
+
+export interface IssueContextRetryBudget {
+  attempts: number;
+  max_attempts: number;
+  cost_usd: number;
+  max_cost_usd: number;
+  exhausted?: boolean;
+}
+
+// `structured_result` is a discriminated envelope on the pipeline side
+// (DevResult / ReviewResult / QAResult). The dashboard renders it tolerantly,
+// so we keep the type open and key off `kind`.
+export interface IssueContextStructuredResult {
+  kind: string;
+  [k: string]: unknown;
+}
+
+export interface IssueContextPhaseEntry {
+  phase: string;
+  status: PhaseStatus | string;
+  started_at: string; // ISO 8601
+  duration_seconds: number;
+  cost_usd: number;
+  event: string;
+  error?: string | null;
+  artifacts?: Record<string, unknown>;
+  structured_result?: IssueContextStructuredResult | null;
+}
+
+export interface IssueContext {
+  repo: string;
+  issue_number: number;
+  status: IssueLifecycleStatus;
+  attempts: number;
+  cost_usd: number;
+  phase_history: IssueContextPhaseEntry[];
+  artifacts: Record<string, unknown>;
+  retry_budget: IssueContextRetryBudget;
+  created_at: string;
+  updated_at: string;
+  pr_url?: string | null;
+  branch?: string | null;
+}
+
+/**
+ * Fetch the full IssueContext (phase history, retry budget, status, FSM
+ * artifacts) for a given pipeline issue.
+ *
+ * @param repo "owner/name" — must contain exactly one `/`. The pipeline API
+ *   route uses `{repo:path}` so the slash is fine to pass through; we still
+ *   validate before sending so a malformed value gets a useful client-side
+ *   error instead of a confusing 400 from the server.
+ *
+ * Throws on HTTP error / network failure; callers should surface the message
+ * to the user.
+ */
+export async function fetchIssueContext(
+  repo: string,
+  issueNumber: number,
+  signal?: AbortSignal,
+): Promise<IssueContext> {
+  if (!repo.includes("/")) {
+    throw new Error(`Invalid repo "${repo}" — expected "owner/name"`);
+  }
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    throw new Error(`Invalid issue number ${issueNumber} — must be a positive integer`);
+  }
+  // The repo path may include reserved characters in either segment; encode
+  // each owner / name part separately to keep the slash that the pipeline
+  // route's `{repo:path}` converter expects.
+  const [owner, name] = repo.split("/", 2);
+  const encodedRepo = `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+  const res = await fetch(
+    `${PIPELINE_BASE_URL}/issue/${encodedRepo}/${issueNumber}/context`,
+    { cache: "no-store", signal },
+  );
+  if (!res.ok) {
+    if (res.status === 404) throw new Error("Контекст не найден");
+    if (res.status === 400) throw new Error("Неверный формат repo / номера");
+    if (res.status === 500) throw new Error("Хранилище контекстов недоступно");
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return res.json() as Promise<IssueContext>;
+}
+
 export async function isPipelineRunning(): Promise<boolean> {
   try {
     const controller = new AbortController();

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,18 @@
+// Tiny helper for rendering external URLs safely. React does NOT block
+// `javascript:` / `data:` schemes in `href` — it warns, but still renders,
+// and clicking executes the script. Wrap any user / API-controlled string
+// before binding it to an anchor.
+//
+// Returns the normalised URL string when scheme is http(s), else `null`.
+// Callers fall back to plain text in the null case.
+export function safeHttpUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.href;
+    }
+  } catch {
+    // ignore — URL constructor throws on malformed input
+  }
+  return null;
+}


### PR DESCRIPTION
Refs #111 — Issue Context Panel sub-task (epic-027). Замыкает один из 4 пунктов чек-листа в #111; Replay / MCP health / Analytics отдельно.

## Что сделано

Клик по любой active-task row в Pipeline-вкладке → модал с полным IssueContext-ом из \`GET /issue/{repo}/{issue}/context\`: статус, retry-бюджет, история фаз, артефакты. Закрывает gap «доступно только через curl».

## Файлы

- \`src/utils/pipeline.ts\` — типы \`IssueContext\`, \`IssueContextPhaseEntry\`, \`IssueContextRetryBudget\` и \`fetchIssueContext()\`. Repo-аргумент \`owner/name\` валидируется на клиенте; обе части URL-encoded, slash сохранён (pipeline-роут: \`{repo:path}\`).
- \`src/utils/url.ts\` (new) — \`safeHttpUrl()\` helper. Принимает только http(s) — fallback на null. Используется ToastHost и IssueContextPanel.
- \`src/components/v4/ToastHost.tsx\` — убрана inline-копия \`safeHttpUrl\` (была добавлена в #192), импорт из \`utils/url\`. Поведение неизменно.
- \`src/components/v4/pipeline/IssueContextPanel.tsx\` (new) — модал, Esc-to-close, abortable fetch, единый state machine \`loading | success | error\`. Phase-rows: event, duration, cost. PR URL + artifact-URL через \`safeHttpUrl\`.
- \`src/components/v4/pipeline/PipelineActiveTasks.tsx\` — rows стали \`<button>\` (keyboard-accessible), родитель держит \`openIssue\`, панель ключена по \`issueNumber\` для чистого state-reset на каждое открытие.
- \`src/styles/v4.css\` — стили модала, status-pills, phase-rows, artifacts. Reuse \`.v4-modal-*\`.

## Архитектурные решения

- \`current_project\` из \`/pipeline/status\` — это bare repo slug (\`Sewing-ERP\`), pipeline-API требует \`owner/name\`. Композируем с \`GITHUB_OWNER\`. Кнопка disabled когда нет активного проекта — панель не открывается против stale repo.
- Single-state machine вместо нескольких \`useState\` — уходит React 19 lint \`set-state-in-effect\`, без \`useReducer\`.
- \`key={issueNumber}\` на панели — компонент пересоздаётся при смене issue, без manual reset state.
- XSS-defence: \`safeHttpUrl\` проверяет protocol через \`new URL()\`, отсекает \`javascript:\` / \`data:\`. Reuse решение из #192.

## Верификация

- [x] type-check чистый
- [x] lint чистый
- [x] build чистый
- [x] Senior review: P1 XSS-риск через \`pr_url\` / artifact-URL — закрыт через \`safeHttpUrl\`
- [ ] Smoke-тест с реальным pipeline (нужен запущенный pipeline-API + активная задача)

## Не входит в scope

Issue #111 — большой эпик. Этот PR закрывает 1 из 4 пунктов:
- ✅ Issue Context panel — этот PR
- ⏳ Replay tab (epic-030)
- ⏳ MCP Health badge (epic-026)
- ⏳ Analytics tab — опционально

Issue остаётся открытым для оставшихся sub-tasks.