### PR TITLE
fix(pipeline): IssueContext panel review nits (post-#196)

### DIFF
--- a/src/components/v4/pipeline/IssueContextPanel.tsx
+++ b/src/components/v4/pipeline/IssueContextPanel.tsx
@@ -244,23 +244,22 @@ export function IssueContextPanel({ open, repo, issueNumber, onClose }: Props) {
                   </div>
                   {ctx.pr_url && (() => {
                     const safe = safeHttpUrl(ctx.pr_url);
+                    // When the URL fails the http(s) scheme check, hide it
+                    // entirely instead of rendering raw garbage — keeps the
+                    // grid clean and signals "no actionable PR link" rather
+                    // than dumping a `javascript:`-style string into the UI.
+                    if (!safe) return null;
                     return (
                       <div>
                         <span className="v4-pl-ctx-lbl">PR</span>
-                        {safe ? (
-                          <a
-                            className="v4-pl-ctx-val"
-                            href={safe}
-                            target="_blank"
-                            rel="noreferrer noopener"
-                          >
-                            {ctx.pr_url}
-                          </a>
-                        ) : (
-                          <span className="v4-pl-ctx-val v4-pl-mono">
-                            {ctx.pr_url}
-                          </span>
-                        )}
+                        <a
+                          className="v4-pl-ctx-val"
+                          href={safe}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                        >
+                          {safe}
+                        </a>
                       </div>
                     );
                   })()}

--- a/src/utils/pipeline.ts
+++ b/src/utils/pipeline.ts
@@ -311,16 +311,21 @@ export async function fetchIssueContext(
   issueNumber: number,
   signal?: AbortSignal,
 ): Promise<IssueContext> {
-  if (!repo.includes("/")) {
+  // Reject anything that's not exactly "owner/name" — the prior loose
+  // `includes("/")` check accepted "a/b/c" and silently dropped the tail
+  // via split, so the request landed on /issue/a/b/.../context. Today's
+  // only caller is `${GITHUB_OWNER}/${current_project}` so this is
+  // defence-in-depth, not a live bug.
+  const repoParts = repo.split("/");
+  if (repoParts.length !== 2 || !repoParts[0] || !repoParts[1]) {
     throw new Error(`Invalid repo "${repo}" — expected "owner/name"`);
   }
   if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
     throw new Error(`Invalid issue number ${issueNumber} — must be a positive integer`);
   }
-  // The repo path may include reserved characters in either segment; encode
-  // each owner / name part separately to keep the slash that the pipeline
+  const [owner, name] = repoParts;
+  // Encode each segment separately to keep the slash that the pipeline
   // route's `{repo:path}` converter expects.
-  const [owner, name] = repo.split("/", 2);
   const encodedRepo = `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
   const res = await fetch(
     `${PIPELINE_BASE_URL}/issue/${encodedRepo}/${issueNumber}/context`,


### PR DESCRIPTION
Post-merge review of #196 нашёл 3 Low-находки. Здесь чиню 2 из 3 — третья требует визуального spot-check.

## Что сделано

**1. \`fetchIssueContext\` — tighter repo validator** (\`src/utils/pipeline.ts\`)

Прежний \`repo.includes(\"/\")\` принимал \`\"a/b/c\"\` и тихо отбрасывал хвост через \`split(\"/\", 2)\` — запрос летел на \`/issue/a/b/...\`. Заменил на length-2 split с непустыми сегментами. Defence-in-depth — реальные вызовы идут только через \`\${GITHUB_OWNER}/\${current_project}\`.

**2. \`IssueContextPanel\` — hide invalid pr_url** (\`src/components/v4/pipeline/IssueContextPanel.tsx\`)

Когда \`safeHttpUrl()\` отверг scheme (например \`javascript:\`), панель раньше выводила сырую строку в \`<span>\`. XSS-surface был уже закрыт (без \`href\`), но в гриде появлялся мусор. Теперь — поле скрывается полностью.

## Не сделано (вне scope)

3. CSS spot-check (\`v4-pl-active-row-btn\` поверх \`v4-pl-active-row\`) — нужен живой preview, отложил.

## Верификация

- [x] type-check чистый
- [x] lint чистый
- [x] build чистый