### PR TITLE
chore: add .pre-commit-config.yaml with detect-private-key (#202)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# Pre-commit hooks for makeit-dashboard.
+#
+# Install once per clone:
+#   pip install pre-commit && pre-commit install
+#
+# Required by MakeIT GLOBAL_CLAUDE.md (Security): detect-private-key.
+# Other hooks are safety-only (no automatic re-formatting) so the config can
+# land cleanly without churning unrelated files. Style/formatting hooks
+# (end-of-file-fixer, trailing-whitespace) tracked separately.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: detect-private-key
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: check-merge-conflict
+      - id: check-yaml


### PR DESCRIPTION
Closes #202.

## Что сделано
Добавлен `.pre-commit-config.yaml` с обязательным по [GLOBAL_CLAUDE.md](Security) хуком `detect-private-key` + safety-хуки (large files cap 1 MB, merge-conflict, yaml).

## Тесты
`pre-commit run --all-files` — все 4 хука проходят без модификаций файлов.

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён
- [x] P1 issues: 0

Style/formatting хуки (`end-of-file-fixer`, `trailing-whitespace`) специально не включены — они тронули бы 7+ unrelated файлов; вынесено в отдельный tech-debt #204.