### PR TITLE
chore(pre-commit): full hygiene set + repo-wide sweep (#203, #204)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,15 +4,24 @@
 #   pip install pre-commit && pre-commit install
 #
 # Required by MakeIT GLOBAL_CLAUDE.md (Security): detect-private-key.
-# Other hooks are safety-only (no automatic re-formatting) so the config can
-# land cleanly without churning unrelated files. Style/formatting hooks
-# (end-of-file-fixer, trailing-whitespace) tracked separately.
+# `ruff` from the canonical Init.md list is intentionally omitted — this is
+# a JS/TS-only project, no Python sources to lint.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
+      # Security
       - id: detect-private-key
+      # Safety
       - id: check-added-large-files
         args: ["--maxkb=1024"]
       - id: check-merge-conflict
       - id: check-yaml
+      - id: check-json
+        # tsconfig*.json files are JSON-with-comments (TypeScript convention),
+        # not strict JSON — exclude them from this strict-JSON check.
+        exclude: ^tsconfig.*\.json$
+      - id: no-commit-to-branch  # default: blocks commits on main/master
+      # Hygiene (auto-fix)
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/PROCESS_MAP.md
+++ b/PROCESS_MAP.md
@@ -130,8 +130,8 @@ Knowledge (makeit-knowledge):
 
 ### Процесс 1: Автоматическая разработка (Pipeline)
 
-**Статус:** ✅ Реализован  
-**Компоненты:** Pipeline (orchestrator), Dashboard (UI), GitHub (Issues/PRs)  
+**Статус:** ✅ Реализован
+**Компоненты:** Pipeline (orchestrator), Dashboard (UI), GitHub (Issues/PRs)
 **Ключевые файлы:**
 - Pipeline: `simple_orchestrator.py`, `workflow.py`, `phase_machine.py`, `dev_agent.py`, `review_agent.py`, `git_ops.py`, `qa_client.py`
 - Dashboard: `PipelineControlPanel.tsx`, `usePipeline.ts`, `pipeline.ts`
@@ -191,8 +191,8 @@ Knowledge (makeit-knowledge):
 
 ### Процесс 2: Code Audit
 
-**Статус:** ✅ Реализован  
-**Компоненты:** Auditor (backend), Dashboard (UI), GitHub (код + issues)  
+**Статус:** ✅ Реализован
+**Компоненты:** Auditor (backend), Dashboard (UI), GitHub (код + issues)
 **Ключевые файлы:**
 - Auditor: `pipeline.py`, `runners/`, `indexer/`, `llm/`, `report/`, `api.py`
 - Dashboard: `AuditTab.tsx`, `AuditVerifyDialog.tsx`, `useAudit.ts`, `auditor.ts`, `verify-agent.ts`, `claude.ts`
@@ -253,8 +253,8 @@ Knowledge (makeit-knowledge):
 
 ### Процесс 3: Транскрипция и обработка встреч
 
-**Статус:** ✅ Реализован  
-**Компоненты:** Pipeline (backend), Dashboard (UI)  
+**Статус:** ✅ Реализован
+**Компоненты:** Pipeline (backend), Dashboard (UI)
 **Ключевые файлы:**
 - Pipeline: `transcription_engine.py`, `transcript_processor.py`, `domain_dictionary.py`, `manifest.py`, `api.py`
 - Dashboard: `TranscriptsTab.tsx`, `TranscriptEditor.tsx`, `TranscriptProgress.tsx`, `transcript.ts`
@@ -292,8 +292,8 @@ Knowledge (makeit-knowledge):
 
 ### Процесс 4: Research & Discovery
 
-**Статус:** ✅ Реализован  
-**Компоненты:** Pipeline (agents), Dashboard (UI), GitHub (RESEARCH.md, DISCOVERY.md)  
+**Статус:** ✅ Реализован
+**Компоненты:** Pipeline (agents), Dashboard (UI), GitHub (RESEARCH.md, DISCOVERY.md)
 **Ключевые файлы:**
 - Pipeline: `research.py`, `discovery.py`, `api.py`
 - Dashboard: `ResearchTab.tsx`, `StartResearchModal.tsx`, `useResearch.ts`, `research-parser.ts`
@@ -323,8 +323,8 @@ Knowledge (makeit-knowledge):
 
 ### Процесс 5: Quality Management
 
-**Статус:** ✅ Реализован  
-**Компоненты:** Pipeline (metrics, retro, autotuner), Dashboard (UI)  
+**Статус:** ✅ Реализован
+**Компоненты:** Pipeline (metrics, retro, autotuner), Dashboard (UI)
 **Ключевые файлы:**
 - Pipeline: `quality_metrics.py`, `retro_agent.py`, `auto_tuning.py`, `quality_gate.py`, `quality_signals.py`
 - Dashboard: `QualityTab.tsx`, `QualityPanel.tsx`, `QualityBarCharts.tsx`, `QualityTrendsChart.tsx`, `QualityPendingChanges.tsx`, `QualityRetros.tsx`, `quality.ts`
@@ -363,8 +363,8 @@ Tier 3 (manual review):   config.yaml, major changes → ожидает чело
 
 ### Процесс 6: Debate Engine
 
-**Статус:** ✅ Реализован  
-**Компоненты:** Pipeline (debate/), Dashboard (UI)  
+**Статус:** ✅ Реализован
+**Компоненты:** Pipeline (debate/), Dashboard (UI)
 **Ключевые файлы:**
 - Pipeline: `debate/engine.py`, `debate/providers.py`, `debate/adr.py`, `debate/context_gatherer.py`
 - Dashboard: `DebateTab.tsx`, `StartDebateModal.tsx`, `debate.ts`, `useDebate.ts`
@@ -399,8 +399,8 @@ Tier 3 (manual review):   config.yaml, major changes → ожидает чело
 
 ### Процесс 7: Specs Tracking (PRD → Epic → Tasks)
 
-**Статус:** ✅ Реализован  
-**Компоненты:** Dashboard (UI), Pipeline (docs/), Knowledge (шаблоны)  
+**Статус:** ✅ Реализован
+**Компоненты:** Dashboard (UI), Pipeline (docs/), Knowledge (шаблоны)
 **Ключевые файлы:**
 - Dashboard: `SpecsTab.tsx`, `useSpecs.ts`, `specs-parser.ts`
 - Pipeline: `docs/prds/PRD-*.md`, `docs/epics/epic-*/`
@@ -425,8 +425,8 @@ Tier 3 (manual review):   config.yaml, major changes → ожидает чело
 
 ### Процесс 8: Мониторинг и наблюдаемость
 
-**Статус:** ✅ Реализован  
-**Компоненты:** Dashboard (UI), BetterStack (uptime), GitHub (activity)  
+**Статус:** ✅ Реализован
+**Компоненты:** Dashboard (UI), BetterStack (uptime), GitHub (activity)
 **Ключевые файлы:**
 - Dashboard: `UptimeBar.tsx`, `CommitHeatmap.tsx`, `StaleAlert.tsx`, `MilestoneCard.tsx`, `UrgentDeadlines.tsx`, `betterstack.ts`, `useMonitors.ts`
 
@@ -452,8 +452,8 @@ Tier 3 (manual review):   config.yaml, major changes → ожидает чело
 
 ### Процесс 9: UX Audit
 
-**Статус:** ✅ Реализован  
-**Компоненты:** Auditor (UX runners + Vision LLM), Dashboard (UI)  
+**Статус:** ✅ Реализован
+**Компоненты:** Auditor (UX runners + Vision LLM), Dashboard (UI)
 **Ключевые файлы:**
 - Auditor: `runners/ux_orchestrator.py`, `runners/lighthouse.py`, `runners/axe_core.py`, `llm/ux_auditor.py`, `llm/vision_client.py`, `screenshotter.py`
 - Dashboard: `UXAuditTab.tsx`, `ux-auditor.ts`
@@ -471,8 +471,8 @@ Tier 3 (manual review):   config.yaml, major changes → ожидает чело
 
 ### Процесс 10: Chat / Project Manager Agent
 
-**Статус:** ✅ Реализован  
-**Компоненты:** Dashboard (ChatPanel + Claude API)  
+**Статус:** ✅ Реализован
+**Компоненты:** Dashboard (ChatPanel + Claude API)
 **Ключевые файлы:**
 - Dashboard: `ChatPanel.tsx`, `ChatButton.tsx`, `useChat.ts`, `claude.ts`
 
@@ -494,8 +494,8 @@ Tier 3 (manual review):   config.yaml, major changes → ожидает чело
 
 ### Процесс 11: Complexity Classification
 
-**Статус:** ✅ Реализован  
-**Компоненты:** Pipeline (classifier), Dashboard (UI)  
+**Статус:** ✅ Реализован
+**Компоненты:** Pipeline (classifier), Dashboard (UI)
 **Ключевые файлы:**
 - Pipeline: `complexity_classifier.py`, `api.py`
 - Dashboard: `pipeline.ts` (classify endpoint), `PipelineControlPanel.tsx`

--- a/docs/epics/epic-003/task-01.md
+++ b/docs/epics/epic-003/task-01.md
@@ -34,12 +34,12 @@
      quality: "pass" | "warning" | "needs_review" | null;  // NEW
      quality_report: QualityReport | null;                   // NEW
    }
-   
+
    export interface QualityReport {
      checks: QualityCheck[];
      score: number;
    }
-   
+
    export interface QualityCheck {
      name: string;
      status: "pass" | "warning" | "fail";

--- a/src/App.css
+++ b/src/App.css
@@ -148,7 +148,7 @@
     --shadow-sm: 0 2px 4px rgba(0,0,0,0.02);
     --shadow-md: 0 8px 20px rgba(0,0,0,0.04);
     --shadow-lg: 0 16px 32px rgba(15, 23, 42, 0.08); /* slight blue tint shadow */
-    
+
     --bg-pattern: radial-gradient(circle, rgba(0,0,0,0.05) 1px, transparent 1px);
   }
 }
@@ -303,12 +303,12 @@ body::after {
   font-weight: 700;
   color: var(--color-text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.06em; 
+  letter-spacing: 0.06em;
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin: 0 0 var(--sp-4) 0;
-  height: 20px; 
+  height: 20px;
   line-height: 1;
 }
 
@@ -354,8 +354,8 @@ body::after {
   border-radius: 50%;
   /* Apple-style Blue to Cyan gradient */
   background: conic-gradient(
-    #3b82f6 0%, 
-    #06b6d4 var(--pct, 0%), 
+    #3b82f6 0%,
+    #06b6d4 var(--pct, 0%),
     var(--color-neutral-tint-4) 0
   );
   display: flex;
@@ -1433,7 +1433,7 @@ body::after {
   padding: var(--sp-1) var(--sp-2);
   margin-top: 0; /* Margin managed by group flex */
   border-radius: var(--radius-sm);
-  background: var(--color-neutral-tint-2); 
+  background: var(--color-neutral-tint-2);
   flex-wrap: nowrap; /* Force 1 line as requested before */
 }
 .pc-stat {
@@ -1878,9 +1878,9 @@ body::after {
   min-width: 0;
 }
 
-.blocked-repo { 
-  font-size: 11px; 
-  color: var(--color-text-muted); 
+.blocked-repo {
+  font-size: 11px;
+  color: var(--color-text-muted);
   font-family: var(--font-mono);
   margin-bottom: 1px;
 }

--- a/src/components/v4/health/FindingsBoard.tsx
+++ b/src/components/v4/health/FindingsBoard.tsx
@@ -414,4 +414,3 @@ function CleanCelebration({ repo, count }: { repo: string; count: number }) {
     </div>
   );
 }
-

--- a/src/components/v4/milestones/MilestoneIssuesPopup.tsx
+++ b/src/components/v4/milestones/MilestoneIssuesPopup.tsx
@@ -321,4 +321,3 @@ export function MilestoneIssuesPopup({ milestone, onClose, onEdited }: Props) {
     document.body,
   );
 }
-

--- a/src/utils/auditor.ts
+++ b/src/utils/auditor.ts
@@ -27,12 +27,12 @@ export async function isAuditorRunning(): Promise<boolean> {
     // Timeout applied via AbortController to avoid hanging on connection refused
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000);
-    
+
     const res = await fetch(`${AUDITOR_BASE_URL}/api/projects`, {
       signal: controller.signal,
       cache: "no-store",
     });
-    
+
     clearTimeout(timeoutId);
     return res.ok;
   } catch {

--- a/src/utils/github-actions.ts
+++ b/src/utils/github-actions.ts
@@ -845,4 +845,3 @@ export async function listOrphanIssuesWithMeta(
   }
   return out;
 }
-


### PR DESCRIPTION
Closes #203. Closes #204.

⚠️ **Stacked on top of #205** — base is `fix/issue-202-precommit-detect-private-key`, not `main`. Merge #205 first, then this rebases cleanly onto `main`.

## Что сделано
1. Добавлены недостающие хуки из канонического Init.md hygiene-набора:
   - `end-of-file-fixer`, `trailing-whitespace` (sweep — закрывает #204)
   - `check-json` (с исключением для `tsconfig*.json` — там JSON-with-comments)
   - `no-commit-to-branch` (блокирует прямые коммиты в main/master)
2. `ruff` из списка пропущен — это Python-линтер, в JS-only проекте не применим.
3. Прогнан `pre-commit run --all-files` — отсюда правки в `src/`, `docs/`, `PROCESS_MAP.md`. Механика, без семантических изменений.
4. `pre-commit install` выполнен локально — хук теперь срабатывает на каждый коммит.

## Тесты
- `pre-commit run --all-files` — все 8 хуков зелёные
- `npx tsc --noEmit` — чисто

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён
- [x] P1 issues: 0

После мерджа: новые коммиты автоматически держат стиль; нельзя случайно закоммитить в main без PR.