### PR TITLE
infra(deploy): nginx -t pre-check + retry/backoff health checks

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# VPS deploy script for makeit-stack (89.167.17.79).
+# Source of truth: this file. On the server it lives at
+# /opt/apps/makeit-stack/deploy.sh and is updated by copying from this repo.
+set -euo pipefail
+cd /opt/apps/makeit-stack
+
+echo "=== Pulling dashboard ==="
+cd makeit-dashboard
+git fetch origin main
+git reset --hard origin/main
+git log -1 --oneline
+cd ..
+
+echo "=== Pulling auditor ==="
+cd makeit-auditor
+git fetch origin main
+git reset --hard origin/main
+git log -1 --oneline
+cd ..
+
+echo "=== Building and starting ==="
+docker compose build
+docker compose up -d
+
+# Validate every conf.d/*.conf BEFORE touching the running nginx. A sibling
+# stack's broken config (missing cert, bad upstream) would otherwise crash
+# the whole proxy on restart and take every site on this host down.
+echo "=== Validating nginx config ==="
+if ! docker exec nginx_proxy nginx -t; then
+  echo "❌ nginx config invalid — НЕ перезагружаю прокси."
+  echo "Дамп conf.d:"
+  docker exec nginx_proxy ls -la /etc/nginx/conf.d/
+  exit 1
+fi
+
+# Graceful reload — no downtime. `docker restart` is only needed when
+# docker-compose itself changed, not for conf.d edits.
+echo "=== Reloading nginx proxy ==="
+docker exec nginx_proxy nginx -s reload
+
+# Containers may be Up but still booting (cache, dashboard) — retry instead
+# of one-shot curl so a slow start doesn't surface as a false FAIL.
+check_with_retry() {
+  local name="$1"
+  local cmd="$2"
+  local max_tries=6
+  local delay=5
+  for i in $(seq 1 $max_tries); do
+    if eval "$cmd" >/dev/null 2>&1; then
+      echo "$name: OK (try $i)"
+      return 0
+    fi
+    sleep $delay
+  done
+  echo "$name: FAIL after $max_tries tries"
+  return 1
+}
+
+echo "=== Verifying ==="
+EXIT=0
+check_with_retry "Dashboard"       "docker exec nginx_proxy curl -sf http://makeit_dashboard:80/" || EXIT=1
+check_with_retry "Auditor"         "docker exec makeit_auditor curl -sf http://localhost:8765/api/projects" || EXIT=1
+check_with_retry "Cache"           "docker exec nginx_proxy curl -sf http://makeit_cache:8767/health" || EXIT=1
+check_with_retry "Pipeline tunnel" "curl -sf http://127.0.0.1:8766/health" || EXIT=1
+
+echo "=== Done ==="
+docker ps --filter name=makeit --format "table {{.Names}}\t{{.Status}}"
+
+exit $EXIT


### PR DESCRIPTION
## Summary
- Adds versioned copy of `deploy.sh` at `infra/deploy.sh` — previously unversioned on the VPS (`/opt/apps/makeit-stack/deploy.sh`).
- **nginx -t before reload** (closes #198): validates every `conf.d/*.conf` so a sibling stack's broken config can't crash the proxy. Also switches `docker restart nginx_proxy` → `nginx -s reload` (graceful, no downtime).
- **Retry/backoff for health checks** (closes #199): 6 tries × 5s per service, eliminates false FAILs on cold starts. Final exit code reflects real status (CI-usable).

## Test plan
- [ ] Bash syntax: `bash -n infra/deploy.sh` — passes locally
- [ ] After merge: copy to VPS (`scp infra/deploy.sh root@89.167.17.79:/opt/apps/makeit-stack/deploy.sh`)
- [ ] Run a deploy and verify: `nginx -t` step appears, `nginx -s reload` used (not restart), each service prints `OK (try N)` or `FAIL after 6 tries`
- [ ] Negative path: temporarily break a `conf.d` cert path → confirm script exits before touching nginx

## Notes
- Source of truth is now this file. Future edits to `deploy.sh` should land in this repo, then be copied to VPS.
- `.bak` of the previous version remains on the VPS (`deploy.sh.bak.20260425`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)