### PR TITLE
fix(sidebar): correct owner initials to Сергей М. (SM)

### DIFF
--- a/src/components/v4/Sidebar.tsx
+++ b/src/components/v4/Sidebar.tsx
@@ -107,7 +107,7 @@ export function Sidebar({
   auditAlerts,
   criticalFails,
   pulses,
-  user = { initials: "SK", name: "Сергей К.", role: "owner · MakeIT" },
+  user = { initials: "SM", name: "Сергей М.", role: "owner · MakeIT" },
   isOpen,
   onClose,
 }: Props) {


### PR DESCRIPTION
## Summary
- Hardcoded дефолт `user` пропа в `Sidebar.tsx` показывал «Сергей К.» / «SK». Владелец — Сергей **М**акаров, исправлено на `SM` / «Сергей М.».

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] Визуально проверить нижний левый угол сайдбара после деплоя