### PR TITLE
fix(pipeline): isFail whitelist of terminal failure statuses

### DIFF
--- a/src/components/v4/pipeline/PipelineResults.tsx
+++ b/src/components/v4/pipeline/PipelineResults.tsx
@@ -26,6 +26,9 @@ const STATUS_LABEL: Record<string, string> = {
   done: "Готово",
   needs_human: "Нужен человек",
   rolled_back: "Откат",
+  failed: "Ошибка",
+  cancelled: "Отменено",
+  error: "Ошибка",
 };
 
 type StatusFilter = "all" | "done" | "needs_human" | "failed";
@@ -37,11 +40,29 @@ const FILTER_LABELS: Record<StatusFilter, string> = {
   failed: "Failed",
 };
 
+/**
+ * Terminal failure statuses for a PipelineResult. Whitelist (not blacklist):
+ * intermediate states like `pr_open`, `in_review`, `retry`, `queued`,
+ * `in_progress` are still active work and must NOT be treated as failures
+ * (issue #217). Unknown future statuses also default to "not failed" — they
+ * fall through to the in-progress styling instead of being misclassified.
+ */
+const TERMINAL_FAILURE_STATUSES: ReadonlySet<string> = new Set([
+  "failed",
+  "cancelled",
+  "error",
+  "rolled_back",
+]);
+
+function isTerminalFailure(status: string): boolean {
+  return TERMINAL_FAILURE_STATUSES.has(status);
+}
+
 function matchesFilter(r: PipelineResult, f: StatusFilter): boolean {
   if (f === "all") return true;
   if (f === "done") return r.status === "done";
   if (f === "needs_human") return r.status === "needs_human";
-  if (f === "failed") return r.status !== "done" && r.status !== "needs_human" && r.status !== "queued" && r.status !== "in_progress";
+  if (f === "failed") return isTerminalFailure(r.status);
   return true;
 }
 
@@ -55,14 +76,19 @@ function ResultRow({
   const [whyOpen, setWhyOpen] = useState(false);
   const isDone = r.status === "done";
   const isNeedsHuman = r.status === "needs_human";
+  // Issue #217: only terminal-failure statuses get failure styling, the
+  // `Why?` affordance and contribute to the `Failed` filter. Intermediate
+  // states (`pr_open`, `in_review`, `retry`, …) are still in progress.
+  const isFail = isTerminalFailure(r.status);
   const rowCls = isDone
     ? "v4-pl-result--ok"
     : isNeedsHuman
     ? "v4-pl-result--warn"
-    : "v4-pl-result--err";
+    : isFail
+    ? "v4-pl-result--err"
+    : "v4-pl-result--inprog";
 
   const hasWhy = !!(r.human_summary || r.error || r.escalation_reason);
-  const isFail = r.status !== "done" && r.status !== "queued" && r.status !== "in_progress";
   const showWhyToggle = isFail && hasWhy;
 
   // Attempts warning
@@ -182,7 +208,7 @@ export function PipelineResults({
     for (const r of results) {
       if (r.status === "done") c.done++;
       else if (r.status === "needs_human") c.needs_human++;
-      else if (r.status !== "queued" && r.status !== "in_progress") c.failed++;
+      else if (isTerminalFailure(r.status)) c.failed++;
     }
     return c;
   }, [results]);

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -2792,6 +2792,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-pl-result--ok { border-left-color: var(--v4-success-500); }
 .v4-pl-result--warn { border-left-color: var(--v4-warn-500); background: rgba(247, 144, 9, 0.04); }
 .v4-pl-result--err { border-left-color: var(--v4-danger-500); background: rgba(239, 68, 68, 0.04); }
+/* Issue #217: in-progress non-terminal statuses (pr_open, in_review, retry, …)
+   share the accent palette used by the in-progress status badge. */
+.v4-pl-result--inprog { border-left-color: var(--v4-accent-500); }
 .v4-pl-result-main {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- `isFail` in `PipelineResults` previously used a blacklist (`!== done && !== queued && !== in_progress`), which incorrectly labeled active intermediate statuses `pr_open`, `in_review`, `retry` as failures — they got failure styling, the `Why?` affordance, and contributed to the `Failed` filter / counts even though work was still in progress.
- Replaced with a whitelist of terminal-failure statuses (`failed`, `cancelled`, `error`, `rolled_back`) shared by the row class, the `Why?` toggle, the `Failed` filter, and the counts.
- Added a new `.v4-pl-result--inprog` row modifier (accent palette) so non-terminal / unknown future statuses fall through to in-progress styling instead of being painted as errors.
- Filled in missing Russian labels for `failed` / `cancelled` / `error` in `STATUS_LABEL`.

Closes #217

## Test plan
- [ ] `npm run lint` — clean
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run build` — clean
- [ ] Manual: with a `pr_open` / `in_review` / `retry` result, row no longer renders with red `--err` border, `Why?` button is hidden, and the result is excluded from the `Failed` filter and count.
- [ ] Manual: a `failed` / `cancelled` / `error` / `rolled_back` result still shows `--err` styling, `Why?` toggle, and is counted under `Failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)