### PR TITLE
fix(milestones): guard MilestoneCardV4 header onKeyDown against bubbled events

### DIFF
--- a/src/components/v4/milestones/MilestoneCardV4.tsx
+++ b/src/components/v4/milestones/MilestoneCardV4.tsx
@@ -108,6 +108,8 @@ export function MilestoneCardV4({ milestone, density, now, onSelect }: Props) {
         } список.`}
         onClick={() => setExpanded((v) => !v)}
         onKeyDown={(e) => {
+          // Skip bubbled events from nested interactive elements (title link, etc.)
+          if (e.target !== e.currentTarget) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             setExpanded((v) => !v);


### PR DESCRIPTION
## Summary
- Header `role=\"button\"` onKeyDown в `MilestoneCardV4` обрабатывал Enter/Space для всей карточки и получал bubbled события от вложенных интерактивных элементов (title `<a>`). При фокусе на ссылке заголовка нажатие Enter вызывало `preventDefault()` и toggle expansion вместо нативной активации ссылки — keyboard navigation ломалась.
- Добавлен early return `if (e.target !== e.currentTarget) return;` — handler срабатывает только когда сам header в фокусе.

## Test plan
- [ ] Tab до title link внутри milestone card → Enter открывает ссылку (а не toggle expansion)
- [ ] Tab до самого header → Enter/Space toggle expansion как раньше
- [ ] Mouse click на header — toggle expansion работает
- [ ] Mouse click на title link — открывает milestone (через onSelect/native)
- [ ] `npm run lint` clean
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run build` clean

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)