### PR TITLE
fix(migration): set MIGRATION_FLAG only when failed.length === 0 (spec)

### DIFF
--- a/docs/epics/epic-004/task-05.md
+++ b/docs/epics/epic-004/task-05.md
@@ -40,7 +40,7 @@
      - Если `localStorage.getItem(legacyKey)` пустой → skip
      - Если уже на сервере → skip + удалить из localStorage
      - Иначе → `setSetting(settingsKey, value)`, при успехе → `localStorage.removeItem(legacyKey)`
-   - В конце ставим `localStorage.setItem(MIGRATION_FLAG, 'true')`
+   - В конце ставим `localStorage.setItem(MIGRATION_FLAG, 'true')` ТОЛЬКО если `failed.length === 0`. При partial failure флаг НЕ ставим — на следующем page load миграция повторится для оставшихся keys (transient network/5xx не должен permanently suppress retries).
    - При любой ошибке для конкретного ключа — записать в `failed[]`, не прерывать общий процесс
 
 3. **Запуск:**


### PR DESCRIPTION
## Summary

- Aligns `docs/epics/epic-004/task-05.md:43` with the actual runtime behavior in `src/utils/settings-migration.ts`.
- Spec previously said «В конце ставим `localStorage.setItem(MIGRATION_FLAG, 'true')`» without a `failed.length === 0` guard.
- In a transient network / 5xx scenario this would permanently suppress retries and leave a subset of secrets unsynced until the user clears storage or v2 migration ships.
- Implementation already guards correctly (`settings-migration.ts:177-179`); this PR only updates the spec to match.

## Test plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Re-read `runOneTimeMigration()` — flag write is gated on `result.failed.length === 0`; per-key failures keep the value in `localStorage` so the next mount retries.
- [x] Re-read `App.tsx:371-389` caller — toast surfaces partial failures; module is invoked on every mount, so unset flag means automatic retry next load.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)