### PR TITLE
fix(a11y): apply target===currentTarget guard to 4 onKeyDown handlers

### DIFF
--- a/src/components/DebateTab.tsx
+++ b/src/components/DebateTab.tsx
@@ -159,7 +159,13 @@ export function DebateTab() {
                   key={d.id}
                   className="debate-row debate-row--clickable"
                   onClick={() => { setManualBack(false); setSelectedId(d.id); }}
-                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setSelectedId(d.id); } }}
+                  onKeyDown={(e) => {
+                    if (e.target !== e.currentTarget) return;
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setSelectedId(d.id);
+                    }
+                  }}
                   tabIndex={0}
                   role="button"
                   aria-label={`Open debate: ${d.topic}`}

--- a/src/components/MilestoneCard.tsx
+++ b/src/components/MilestoneCard.tsx
@@ -27,6 +27,7 @@ export function MilestoneCard({ milestone }: Props) {
       aria-label={`Milestone ${milestone.title}, ${milestone.closedIssues} из ${total} задач закрыто. ${expanded ? "Свернуть" : "Раскрыть"} список.`}
       onClick={() => setExpanded(!expanded)}
       onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return;
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           setExpanded(!expanded);

--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -693,7 +693,13 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
                     tabIndex={0}
                     aria-label={`Таймлайн issue #${r.issue_number}`}
                     onClick={() => setTimelineIssue(r.issue_number)}
-                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setTimelineIssue(r.issue_number); }}
+                    onKeyDown={(e) => {
+                      if (e.target !== e.currentTarget) return;
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setTimelineIssue(r.issue_number);
+                      }
+                    }}
                     style={{
                       fontFamily: "var(--font-mono)",
                       fontSize: "var(--text-xs)",

--- a/src/components/v4/quality/AutoTunerConfigCard.tsx
+++ b/src/components/v4/quality/AutoTunerConfigCard.tsx
@@ -67,6 +67,7 @@ export function AutoTunerConfigCard({ config, onSave }: Props) {
         tabIndex={0}
         onClick={() => setOpen((v) => !v)}
         onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             setOpen((v) => !v);


### PR DESCRIPTION
Closes #257

## Что сделано
Добавлен `if (e.target !== e.currentTarget) return;` guard в начало `onKeyDown` хендлеров на role="button" контейнерах в 4 файлах. Это аналог уже применённого в #255 фикса для `MilestoneCardV4` — без guard handler ловит bubbled key events от nested interactive элементов и ломает их native activation.

Затронутые места:
- `src/components/MilestoneCard.tsx` (legacy v3) — header `<div role="button">` с expand-toggle
- `src/components/v4/quality/AutoTunerConfigCard.tsx` — header панели с open-toggle
- `src/components/PipelineControlPanel.tsx:692` — `<span role="button">` для timeline issue link (заодно добавлен `e.preventDefault()`)
- `src/components/DebateTab.tsx` — `<tr role="button">` для open-debate

## Самопроверка
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] Senior review — паттерн идентичен #255, P1 issues: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)