### PR TITLE
fix(settings): parse object/keys per spec contract

### DIFF
--- a/docs/epics/epic-004/task-02.md
+++ b/docs/epics/epic-004/task-02.md
@@ -22,11 +22,17 @@
    - Возвращает текущее имя пользователя — сейчас всегда `"default"` (TODO-комментарий: «replace with JWT claims at multi-user epic»)
 
 2. **Endpoints в `api.py`:**
-   - `GET /settings` → `get_all(username)` → `{key: value, ...}`
-   - `GET /settings/keys` → `list_keys(username)` → `{"keys": [...]}` (без значений)
-   - `GET /settings/{key}` → `get(username, key)` → `{"value": "..."}`, 404 если ключа нет
+   - `GET /settings` → `get_all(username)` → `[{"key": "...", "masked_value": "..."}, ...]` (raw array, отсортирован по `key`; полные значения только через `GET /settings/{key}`)
+   - `GET /settings/keys` → `list_keys(username)` → `["...", ...]` (raw array, без значений)
+   - `GET /settings/{key}` → `get(username, key)` → `{"key": "...", "value": "..."}`, 404 если ключа нет
    - `PUT /settings/{key}` body `{"value": "..."}` → `put(username, key, value)` → 204
    - `DELETE /settings/{key}` → `delete(username, key)` → 204 если удалили, 404 если не было
+
+   > **Wire-shape note (Phase-1.5, 2026-05-03):** earlier draft использовал
+   > обёртки `{key: value, ...}` для `/settings` и `{"keys": [...]}` для
+   > `/settings/keys`. Эти формы крашили dashboard-loader (`items.map is not
+   > a function`) — backend переведён на raw-array, dashboard
+   > (`src/utils/settings.ts`) парсит именно этот контракт. См. issue #215.
 
 3. **Lifecycle:**
    - `SettingsStore` создаётся в `_lifespan` (см. `create_app` в `api.py`)

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -151,10 +151,16 @@ function isObjectShape(x: unknown): x is Record<string, unknown> {
 export function parseSettingsList(raw: unknown): SettingsListItem[] {
   if (Array.isArray(raw)) {
     // Defensive: drop entries without a string ``key`` rather than crashing.
-    return raw.filter(
-      (item): item is SettingsListItem =>
-        isObjectShape(item) && typeof (item as { key?: unknown }).key === "string",
-    );
+    const isItem = (item: unknown): item is SettingsListItem =>
+      isObjectShape(item) && typeof (item as { key?: unknown }).key === "string";
+    const kept = raw.filter(isItem);
+    const dropped = raw.length - kept.length;
+    if (dropped > 0 && import.meta.env.DEV) {
+      console.warn(
+        `[settings] /settings dropped ${dropped} malformed entr${dropped === 1 ? "y" : "ies"} (missing string \`key\`).`,
+      );
+    }
+    return kept;
   }
   if (isObjectShape(raw)) {
     if (import.meta.env.DEV) {
@@ -177,7 +183,14 @@ export function parseSettingsList(raw: unknown): SettingsListItem[] {
  */
 export function parseSettingsKeys(raw: unknown): string[] {
   if (Array.isArray(raw)) {
-    return raw.filter((k): k is string => typeof k === "string");
+    const kept = raw.filter((k): k is string => typeof k === "string");
+    const dropped = raw.length - kept.length;
+    if (dropped > 0 && import.meta.env.DEV) {
+      console.warn(
+        `[settings] /settings/keys dropped ${dropped} non-string entr${dropped === 1 ? "y" : "ies"}.`,
+      );
+    }
+    return kept;
   }
   if (isObjectShape(raw) && Array.isArray((raw as { keys?: unknown }).keys)) {
     if (import.meta.env.DEV) {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -122,6 +122,95 @@ interface SettingsValueResponse {
   value: string;
 }
 
+/* ────────────────────────────────────────
+   Wire-shape parsers
+   ──────────────────────────────────────────
+   Authoritative contract (makeit-pipeline Phase-1.5, 2026-05-03):
+     GET /settings/keys → list[str]                    (raw array)
+     GET /settings      → list[{key, masked_value?}]   (raw array)
+     GET /settings/{key}→ {key, value}
+
+   The earlier draft spec wrapped these in ``{key: value}`` / ``{"keys": [...]}``
+   — the backend was migrated to raw arrays after that wrapping caused
+   ``items.map is not a function`` here. We now (a) parse the realized
+   contract and (b) keep a defensive fallback for the wrapped shapes so a
+   stale-deploy regression surfaces with an explicit warning instead of an
+   unhandled TypeError that strands ``useSettings()`` in error/retry forever.
+   ──────────────────────────────────────── */
+
+function isObjectShape(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+/**
+ * Parse the response of ``GET /settings``. Authoritative shape is
+ * ``Array<{key, masked_value?, ...}>``. Falls back to the legacy
+ * ``{key: value, ...}`` object shape (with a dev warning) so a stale
+ * backend doesn't crash the loader.
+ */
+export function parseSettingsList(raw: unknown): SettingsListItem[] {
+  if (Array.isArray(raw)) {
+    // Defensive: drop entries without a string ``key`` rather than crashing.
+    return raw.filter(
+      (item): item is SettingsListItem =>
+        isObjectShape(item) && typeof (item as { key?: unknown }).key === "string",
+    );
+  }
+  if (isObjectShape(raw)) {
+    if (import.meta.env.DEV) {
+      console.warn(
+        "[settings] /settings returned legacy object shape; expected array. " +
+          "Falling back to Object.entries — backend should be upgraded to Phase-1.5 wire-shape.",
+      );
+    }
+    return Object.keys(raw).map((key) => ({ key }));
+  }
+  throw new SettingsUnavailableError(
+    "Pipeline settings: /settings returned unexpected shape (expected array)",
+  );
+}
+
+/**
+ * Parse the response of ``GET /settings/keys``. Authoritative shape is a
+ * raw ``string[]``. Falls back to the legacy ``{"keys": [...]}`` wrapper
+ * (with a dev warning).
+ */
+export function parseSettingsKeys(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((k): k is string => typeof k === "string");
+  }
+  if (isObjectShape(raw) && Array.isArray((raw as { keys?: unknown }).keys)) {
+    if (import.meta.env.DEV) {
+      console.warn(
+        "[settings] /settings/keys returned legacy {keys: [...]} shape; expected raw array. " +
+          "Falling back to .keys — backend should be upgraded to Phase-1.5 wire-shape.",
+      );
+    }
+    return (raw as { keys: unknown[] }).keys.filter((k): k is string => typeof k === "string");
+  }
+  throw new SettingsUnavailableError(
+    "Pipeline settings: /settings/keys returned unexpected shape (expected array)",
+  );
+}
+
+/**
+ * Parse the response of ``GET /settings/{key}``. Authoritative shape is
+ * ``{key, value}``; we accept ``{value}`` (key-less) too — the caller already
+ * has the requested key in scope.
+ */
+export function parseSettingsValue(raw: unknown, requestedKey: string): SettingsValueResponse {
+  if (isObjectShape(raw) && typeof (raw as { value?: unknown }).value === "string") {
+    const obj = raw as { key?: unknown; value: string };
+    return {
+      key: typeof obj.key === "string" ? obj.key : requestedKey,
+      value: obj.value,
+    };
+  }
+  throw new SettingsUnavailableError(
+    `Pipeline settings: /settings/${requestedKey} returned unexpected shape (expected {value})`,
+  );
+}
+
 function authHeaders(): Record<string, string> {
   const token = getBootstrapToken();
   if (!token) throw new SettingsAuthError("Bootstrap token is not set");
@@ -189,13 +278,13 @@ async function request(path: string, init: RequestInit = {}): Promise<Response> 
  */
 export async function loadAllSettings(): Promise<void> {
   const listRes = await request("/settings");
-  const items = (await listRes.json()) as SettingsListItem[];
+  const items = parseSettingsList(await listRes.json());
   const next = new Map<string, string>();
   // Fetch values in parallel — bounded by the number of declared keys (small).
   const values = await Promise.all(
     items.map(async (item) => {
       const r = await request(`/settings/${encodeURIComponent(item.key)}`);
-      const data = (await r.json()) as SettingsValueResponse;
+      const data = parseSettingsValue(await r.json(), item.key);
       return [item.key, data.value] as const;
     }),
   );
@@ -228,7 +317,7 @@ export async function deleteSetting(key: string): Promise<void> {
 /** GET /settings/keys — list of declared/known keys. */
 export async function listSettingsKeys(): Promise<string[]> {
   const res = await request("/settings/keys");
-  return (await res.json()) as string[];
+  return parseSettingsKeys(await res.json());
 }
 
 /* ────────────────────────────────────────


### PR DESCRIPTION
Closes #215

## Что сделано

**Diagnosis**: Backend (`makeit-pipeline`) уже на Phase-1.5 wire-shape (raw arrays, 2026-05-03):
- `GET /settings/keys` → `list[str]`
- `GET /settings` → `list[{key, masked_value?}]`
- `GET /settings/{key}` → `{key, value}`

Подтверждено в `makeit-pipeline/src/makeit_pipeline/api.py:2423-2456` и `tests/test_settings_api.py`. Spec-документ был stale-артефактом — комментарий в backend-коде явно отмечает: «Earlier wrapping shapes (`{keys: [...]}`/`{key: value}`) caused the dashboard's loadAllSettings/listSettingsKeys to crash with `e.map is not a function`».

**Fix**:
- `docs/epics/epic-004/task-02.md` — обновлён под реализованный контракт + ссылка на этот issue
- `src/utils/settings.ts` — заменены прямые `as`-касты на explicit shape-guarding парсеры:
  - `parseSettingsList(raw)` — принимает raw array, gracefully fallback на legacy object shape с DEV-warn
  - `parseSettingsKeys(raw)` — принимает raw array, gracefully fallback на `{keys: [...]}` с DEV-warn
  - `parseSettingsValue(raw, requestedKey)` — принимает `{key, value}`, accepts keyless `{value}`
- Невалидный JSON shape теперь бросает типизированный `SettingsUnavailableError` вместо unhandled TypeError, попадает в retry-flow `useSettings()` (raty-able "unavailable" экран) вместо stranded loading

## Тесты

В репо нет test runner (`package.json` без vitest/jest). Verification через:
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run build` — clean

Backend-side tests в `makeit-pipeline/tests/test_settings_api.py` уже фиксируют raw-array shape (assert `r.json() == []`, `assert r.json() == ["k1", "k2"]`, etc.) — frontend контракт теперь к ним привязан.

## Самопроверка

- [x] 13 пунктов: нет хардкода, нет debug `console.log` (только DEV-gated `console.warn`, как существующий pattern в settings.ts:144), типизация через `unknown` + narrowing, error handling typed
- [x] Senior review:
  - **P1**: 0 — no secrets exposed, no race, no data loss, no regression (raw-array path identical to old behavior, just с фильтром malformed entries)
  - **P2**: edge cases — empty array, non-array/non-object, entry без `key` — все purposeful (filter / typed throw / dev-warn fallback)
- [x] P1: 0
- [x] Backward compat: stale-deploy backend (object/wrapped shapes) → DEV-warn + degraded but functional, не крашит