### PR TITLE
fix(orphans): surface error state in OrphanIssuesPanel

### DIFF
--- a/src/components/v4/DashboardView.tsx
+++ b/src/components/v4/DashboardView.tsx
@@ -213,6 +213,7 @@ export function DashboardView({
           items={orphans.items}
           loading={orphans.loading}
           lastUpdated={orphansLastUpdated}
+          error={orphans.error}
         />
       </div>
 

--- a/src/components/v4/OrphanIssuesPanel.tsx
+++ b/src/components/v4/OrphanIssuesPanel.tsx
@@ -7,6 +7,13 @@ interface Props {
   loading: boolean;
   /** Timestamp of the most recent successful scan; null while we have no data yet. */
   lastUpdated: Date | null;
+  /**
+   * Scan failure message (missing token / all repos failed). Shown as a
+   * dedicated state when there's nothing to render, and as a non-blocking
+   * warning chip in the header when stale items are still on screen — so
+   * the user never sees the success-empty copy after a true failure.
+   */
+  error?: string | null;
 }
 
 // SVG viewBox dimensions — match ClosedChart30d so both panels feel like
@@ -103,7 +110,7 @@ function formatRelativeTime(d: Date | null, now: number): string | null {
   return `обновлено ${days} д назад`;
 }
 
-export function OrphanIssuesPanel({ items, loading, lastUpdated }: Props) {
+export function OrphanIssuesPanel({ items, loading, lastUpdated, error = null }: Props) {
   const buckets = useMemo(() => build30DayBuckets(items), [items]);
   const today = buckets[buckets.length - 1] ?? null;
   const totalToday = today?.count ?? 0;
@@ -172,7 +179,14 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated }: Props) {
 
   const showSkeleton = loading && items.length === 0;
   const showRefreshing = loading && items.length > 0;
-  const isEmpty = !loading && items.length === 0;
+  // Dedicated error state takes over when we have nothing to show — keeps the
+  // success-empty copy ("Все issues распределены…") from masking a failed scan.
+  const showError = !loading && items.length === 0 && !!error;
+  const isEmpty = !loading && items.length === 0 && !error;
+  // Recoverable failure: stale items still on screen but the latest scan failed.
+  // The chart stays so the user keeps the data, and a warn chip in the header
+  // signals that what they see may be out of date.
+  const showStaleErrorChip = !loading && items.length > 0 && !!error;
 
   return (
     <div className="v4-panel">
@@ -191,6 +205,11 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated }: Props) {
           Issues без milestone
           <span className="v4-tag">30 дней</span>
           {showRefreshing && <span className="v4-tag">обновляется…</span>}
+          {showStaleErrorChip && (
+            <span className="v4-tag v4-tag--warn" title={error ?? undefined}>
+              данные могут быть устаревшими
+            </span>
+          )}
         </div>
         <div className="v4-panel-meta">
           {totalToday > 0 ? `сейчас ${totalToday}` : meta ?? ""}
@@ -201,6 +220,11 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated }: Props) {
       <div className="v4-closed-chart">
         {showSkeleton ? (
           <OrphanSkeleton />
+        ) : showError ? (
+          <div className="v4-empty v4-ai-empty v4-orphan-error" role="alert">
+            <div className="v4-orphan-error-t">Не удалось загрузить orphan-issues</div>
+            <div className="v4-orphan-error-m">{error}</div>
+          </div>
         ) : isEmpty ? (
           <div className="v4-empty v4-ai-empty">
             Все issues распределены по milestones.
@@ -299,7 +323,7 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated }: Props) {
 
         {/* Tooltip card on hover — flips to the left of cursor near the
             right edge so it can't clip out of the panel. */}
-        {!showSkeleton && !isEmpty && hover !== null && buckets[hover] && (() => {
+        {!showSkeleton && !isEmpty && !showError && hover !== null && buckets[hover] && (() => {
           const row = buckets[hover];
           const date = new Date(row.iso);
           const xFrac = xOf(hover) / W;
@@ -346,7 +370,7 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated }: Props) {
         })()}
       </div>
 
-      {!showSkeleton && !isEmpty && (
+      {!showSkeleton && !isEmpty && !showError && (
         <div className="v4-cc-legend">
           <span className="v4-cc-lg">
             <span

--- a/src/components/v4/OrphanIssuesPanel.tsx
+++ b/src/components/v4/OrphanIssuesPanel.tsx
@@ -206,7 +206,12 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated, error = null }:
           <span className="v4-tag">30 дней</span>
           {showRefreshing && <span className="v4-tag">обновляется…</span>}
           {showStaleErrorChip && (
-            <span className="v4-tag v4-tag--warn" title={error ?? undefined}>
+            <span
+              className="v4-tag v4-tag--warn"
+              role="status"
+              title={error ?? undefined}
+              aria-label={`данные могут быть устаревшими: ${error}`}
+            >
               данные могут быть устаревшими
             </span>
           )}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -1571,6 +1571,7 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 .v4-orphan-error-m {
   font-size: 12px;
   opacity: 0.85;
+  white-space: pre-line;
 }
 
 /* ────────────────────────────────────────

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -1549,6 +1549,29 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 @media (prefers-reduced-motion: reduce) {
   .v4-orphan-skel-bar { animation: none; }
 }
+/* Failure state — overrides .v4-empty's muted look so the user can tell a
+   scan failure apart from "all issues distributed". Mirrors the inline-warn
+   pattern used by other panels (no full v4-error banner — we're inside a
+   panel body). */
+.v4-orphan-error {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--v4-danger-50);
+  color: var(--v4-danger-700);
+  border-radius: var(--v4-r-md);
+  border: 1px solid var(--v4-danger-100);
+  padding: 18px 16px;
+  margin: 8px;
+}
+.v4-orphan-error-t {
+  font-weight: 600;
+  font-size: 13px;
+}
+.v4-orphan-error-m {
+  font-size: 12px;
+  opacity: 0.85;
+}
 
 /* ────────────────────────────────────────
    MILESTONES STRIP


### PR DESCRIPTION
Closes #213

## Что сделано
- `OrphanIssuesPanel` получает новый опциональный prop `error?: string | null`.
- Render order внутри панели: `skeleton (cold load) → error → empty → chart`.
- Когда есть items и одновременно прилетел error (recoverable refresh failure) — чарт остаётся, но в шапке показывается warn-чип «данные могут быть устаревшими» с полным текстом ошибки в `title`.
- `DashboardView` теперь форвардит `error={orphans.error}` наряду с остальными полями хука.
- Добавлены CSS-классы `.v4-orphan-error{,-t,-m}` (danger-палитра, inline-блок внутри панели — без полноценного `.v4-error` баннера, мы внутри панели).

Это устраняет misleading-кейс из PR #168 review: при отсутствии токена или при провале сканов всех репо пользователю показывали success-empty копию «Все issues распределены по milestones», скрывая реальную проблему.

## Тесты
- `npx tsc --noEmit` — green
- `npm run lint` — green
- `npm run build` — green (vite build)

JS test runner в репо нет (см. CLAUDE.md), верификация через type-check + lint + prod build.

## Самопроверка
- [x] 13 пунктов makeit-dev (нет хардкода, TODO, console.log; типы строгие; error handling — error optional и default null; copy на русском)
- [x] Senior review:
  - **P1 регресс**: при `error=null` все новые ветки (`showError`, `showStaleErrorChip`, расширенные guards у легенды/тултипа) collapse в старое поведение. Prop опциональный — другие call-site (если появятся) не сломаются. ✓
  - **P2 copy**: «Не удалось загрузить orphan-issues» + текст ошибки из хука; чип «данные могут быть устаревшими». ✓
  - **P2 edge case (recoverable error + items)**: chart + warn-чип; ошибка не перетирает данные. ✓
- [x] P1: 0