### PR TITLE
fix(github-actions): paginate getPRFiles

### DIFF
--- a/src/utils/github-actions.ts
+++ b/src/utils/github-actions.ts
@@ -744,6 +744,20 @@ export async function listMergedPRsInWindow(
   return out;
 }
 
+// Returns the full list of changed file paths for a PR.
+//
+// Pagination: GitHub silently caps `per_page` at 100 for the
+// `/pulls/{n}/files` endpoint, and the REST API itself returns at most 3000
+// files per PR. We loop up to MAX_PAGES (30 × 100 = 3000) so PRs touching
+// many files don't get truncated — previously the helper grabbed only the
+// first page, which made `pr_touches_code_not_docs` mis-classify large PRs
+// as "code without docs" when the doc changes happened to land on later
+// pages, skewing the project health score.
+//
+// Error handling: callers treat an empty list as "unknown set of files" and
+// skip the related health check, so on any non-Abort failure mid-stream we
+// return `[]` (NOT a partial list) to preserve that conservative semantic.
+// AbortError is re-thrown so cancellation propagates to the orchestrator.
 export async function getPRFiles(
   token: string,
   owner: string,
@@ -751,17 +765,25 @@ export async function getPRFiles(
   number: number,
   signal?: AbortSignal,
 ): Promise<string[]> {
+  const PER_PAGE = 100;
+  const MAX_PAGES = 30; // 3000 files — GitHub's hard cap for this endpoint
+  const out: string[] = [];
   try {
-    const data = await rest(
-      token,
-      `/repos/${owner}/${repo}/pulls/${number}/files?per_page=300`,
-      "GET",
-      undefined,
-      signal,
-    );
-    return Array.isArray(data)
-      ? data.map((f: { filename: string }) => f.filename)
-      : [];
+    for (let page = 1; page <= MAX_PAGES; page++) {
+      const data = await rest(
+        token,
+        `/repos/${owner}/${repo}/pulls/${number}/files?per_page=${PER_PAGE}&page=${page}`,
+        "GET",
+        undefined,
+        signal,
+      );
+      if (!Array.isArray(data)) return []; // unexpected shape — treat as unknown
+      for (const f of data as Array<{ filename: string }>) {
+        out.push(f.filename);
+      }
+      if (data.length < PER_PAGE) break; // last page reached
+    }
+    return out;
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") throw err;
     return [];


### PR DESCRIPTION
Closes #211

## Что сделано
`getPRFiles` теперь пагинирует `/pulls/{n}/files` через `per_page=100&page=N` цикл (паттерн `listIssuesWithoutMilestone` / `findOpenIssueByTitle`). Cap `MAX_PAGES=30` → 3000 файлов (hard limit GitHub REST API для PR files endpoint).

## Why
PRs с >100 changed files обрезались — `pr_touches_code_not_docs` ложно классифицировал PR как "code without docs", искажая health score. `per_page=300` в старом коде вводил в заблуждение: GitHub silently капает значение до 100.

## Поведение
- Останов на последней странице по `data.length < PER_PAGE`.
- На любой non-Abort ошибке (включая `data` не-массив) возвращаем `[]` — caller трактует это как "unknown set" и пропускает связанный health-чек. Не возвращаем частичный список, чтобы не давать ложно-уверенный сигнал.
- AbortError re-thrown — отмена пробрасывается оркестратору.

## Тесты
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run build` — clean

## Самопроверка
- [x] 13 пунктов пройдены (named constants, no magic numbers, no console.log, AbortError re-thrown, error-handling shape сохранён, no TODO/FIXME)
- [x] Senior review проведён
- [x] P1 issues: 0 (один P1 пойман в self-review — non-array data в середине пагинации возвращал partial; исправлено на `return []`)