### PR TITLE
fix(checks): docCodeSync catch-all returns unknownDetail

### DIFF
--- a/src/utils/checks/docCodeSync.ts
+++ b/src/utils/checks/docCodeSync.ts
@@ -85,7 +85,8 @@ function unknownFinding(
 // graceful `unknown`-finding signals. Returns:
 //  - { hits } on success (possibly empty array)
 //  - { unknownDetail } for rate-limit / not-indexed (caller short-circuits)
-//  - { hits: [] } for any other error (logged in DEV; treated as zero hits)
+//  - { hits: [], unknownDetail } for any other error (logged in DEV; caller
+//    short-circuits to unknown)
 async function safeSymbolSearch(
   token: string,
   owner: string,
@@ -107,7 +108,7 @@ async function safeSymbolSearch(
     if (import.meta.env.DEV) {
       console.warn(`[docCodeSync] code search "${symbol}" failed:`, err);
     }
-    return { hits: [] };
+    return { hits: [], unknownDetail: `Code search недоступен: ${msg}` };
   }
 }
 


### PR DESCRIPTION
## Summary
- The catch-all branch in `safeSymbolSearch` (src/utils/checks/docCodeSync.ts) returned `{ hits: [] }` for any unexpected error (401/403 expired token, 5xx, network failure). The caller then proceeded to LLM comparison as if there were genuinely no code evidence — producing a misleading `pass`/`fail` verdict from incomplete data instead of `unknown`.
- Now the catch-all sets `unknownDetail` so the existing caller short-circuit (line 149) fires and the rule is reported as `unknown` with a useful detail string. DEV-only `console.warn` is preserved.
- Helper docstring updated to reflect the new behavior.

Closes #209

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — passes
- [ ] Manual: simulate a non-rate-limit / non-422 search failure (e.g. expired token → 401) and verify the rule reports `unknown` with the new detail string instead of pass/fail.