### PR TITLE
fix(audit): exclude cancelled audits from notRun filter

### DIFF
--- a/src/components/v4/audit/UXAuditView.tsx
+++ b/src/components/v4/audit/UXAuditView.tsx
@@ -43,7 +43,7 @@ export function UXAuditView() {
       const s = statuses[p.name]?.state;
       if (filter === "completed" && s !== "completed") return false;
       if (filter === "running" && s !== "running") return false;
-      if (filter === "notRun" && (s === "completed" || s === "running" || s === "failed")) return false;
+      if (filter === "notRun" && (s === "completed" || s === "running" || s === "failed" || s === "cancelled")) return false;
       return true;
     });
   }, [projects, statuses, filter, search]);


### PR DESCRIPTION
## Summary
- The `notRun` filter in `UXAuditView` excluded `completed`/`running`/`failed`, but not `cancelled` — so cancelled audits showed up as "never run", misleading users.
- Added `"cancelled"` to the exclude list. `UXAuditRunStatus` (`src/types/index.ts:281`) confirms `cancelled` is a valid state.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [ ] Manual: cancel a UX audit, confirm the project no longer shows under "Не запускались"

Closes #246