### PR TITLE
fix(verify-agent): scan candidate paths when no def-fragment hits

### DIFF
--- a/src/utils/verify-agent.ts
+++ b/src/utils/verify-agent.ts
@@ -454,6 +454,23 @@ async function executeFindSymbolTool(
     rendered.push(renderCodeWindow(file.resolvedPath, file.content, line, 20));
   }
 
+  // Fallback A: no def-fragment hits but raw hits exist — bare-query fallback may
+  // have surfaced files where the first text match is a reference, not the def.
+  // Scan top-3 candidate paths from the raw hits via findDefinitionLine before
+  // falling through to blind path guessing.
+  if (rendered.length === 0 && hits.length > 0) {
+    for (const hit of hits) {
+      if (rendered.length >= 3) break;
+      if (seenPaths.has(hit.path)) continue;
+      seenPaths.add(hit.path);
+      const file = await fetchFileWithCache(githubToken, owner, repo, hit.path, cache);
+      if (!file) continue;
+      const line = findDefinitionLine(file.content, symbol);
+      if (line < 0) continue;
+      rendered.push(renderCodeWindow(file.resolvedPath, file.content, line, 20));
+    }
+  }
+
   // 3. If search returned nothing useful (either unavailable or no definitions),
   //    fall back to sequential path guessing.
   if (rendered.length === 0) {


### PR DESCRIPTION
## Summary
- When code search returned hits but none had a fragment matching `class/def/async def <symbol>`, the agent dropped all hits and fell through to blind path guessing — missing cases where the bare-query fallback surfaced files whose first text match was a reference (import/usage) but the real definition was elsewhere in the same file.
- Added Fallback A between def-fragment rendering and path guessing: when `rendered.length === 0 && hits.length > 0`, iterate up to top-3 candidate paths from raw hits (deduped via `seenPaths`) and try `findDefinitionLine`.
- The shared `seenPaths` Set ensures Fallback A and the existing path-guessing fallback never refetch the same file twice.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [ ] Manual verification next time an audit finding triggers verify-agent on a symbol whose def lives in a file where the search fragment matched an import/usage

Closes #249