### PR TITLE
fix(verify-agent): try snake_case variants in guessSymbolPaths fallback

### DIFF
--- a/src/utils/verify-agent.ts
+++ b/src/utils/verify-agent.ts
@@ -371,23 +371,32 @@ async function executeGrepFileTool(
  */
 function guessSymbolPaths(symbol: string, hintFile?: string): string[] {
   const lower = symbol.toLowerCase();
+  // Python convention: `QueueManager` lives in `queue_manager.py`, not `queuemanager.py`.
+  // Generate a snake_case variant alongside the lowercase one. When the symbol is
+  // already lowercase (e.g. `queue`), `snake === lower` and the Set dedupes.
+  const snake = symbol.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
   const out = new Set<string>();
   if (hintFile) {
     const lastSlash = hintFile.lastIndexOf("/");
     const dir = lastSlash >= 0 ? hintFile.slice(0, lastSlash) : "";
     if (dir) {
       out.add(`${dir}/${lower}.py`);
+      out.add(`${dir}/${snake}.py`);
       // Walk up one directory level too.
       const parentSlash = dir.lastIndexOf("/");
       const parent = parentSlash >= 0 ? dir.slice(0, parentSlash) : "";
       if (parent) {
         out.add(`${parent}/${lower}.py`);
+        out.add(`${parent}/${snake}.py`);
         out.add(`${parent}/${lower}/__init__.py`);
+        out.add(`${parent}/${snake}/__init__.py`);
       }
     }
   }
   out.add(`src/${lower}.py`);
+  out.add(`src/${snake}.py`);
   out.add(`${lower}.py`);
+  out.add(`${snake}.py`);
   return Array.from(out);
 }
 

--- a/src/utils/verify-agent.ts
+++ b/src/utils/verify-agent.ts
@@ -372,9 +372,13 @@ async function executeGrepFileTool(
 function guessSymbolPaths(symbol: string, hintFile?: string): string[] {
   const lower = symbol.toLowerCase();
   // Python convention: `QueueManager` lives in `queue_manager.py`, not `queuemanager.py`.
-  // Generate a snake_case variant alongside the lowercase one. When the symbol is
-  // already lowercase (e.g. `queue`), `snake === lower` and the Set dedupes.
-  const snake = symbol.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+  // Generate a snake_case variant alongside the lowercase one. Two-pass split handles
+  // acronyms followed by another word: `IOError` → `io_error`, `HTTPClient` → `http_client`.
+  // When the symbol is already lowercase (e.g. `queue`), `snake === lower` and the Set dedupes.
+  const snake = symbol
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase();
   const out = new Set<string>();
   if (hintFile) {
     const lastSlash = hintFile.lastIndexOf("/");


### PR DESCRIPTION
## Summary

`guessSymbolPaths` in `src/utils/verify-agent.ts` only generated lowercase candidate paths (e.g. `queuemanager.py` for `QueueManager`). Python convention is snake_case (`queue_manager.py`), so the fallback missed real definitions when GitHub Code Search was unavailable, skewing verification toward UNCERTAIN / FALSE_POSITIVE.

## Change

Generate a snake_case variant alongside the lowercase variant for every candidate path. The `Set` dedupes when `snake === lower`, so already-lowercase symbols produce identical output to before. Snake variants are inserted immediately after the lowercase ones to preserve predictable priority.

For `QueueManager` with hintFile `src/foo/bar.py` the candidates now include `queue_manager.py` alongside `queuemanager.py` at every level.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] Verify on a real audit finding referencing a CamelCase Python class

Closes #248