### PR TITLE
fix(debate): show error state instead of empty when fetch fails

### DIFF
--- a/src/components/v4/debate/DebateView.tsx
+++ b/src/components/v4/debate/DebateView.tsx
@@ -115,7 +115,7 @@ export function DebateView() {
         onOpenActive={(id) => { setManualBack(false); setSelectedId(id); }}
       />
 
-      {error && <div className="v4-error" style={{ marginTop: 14 }}>{error}</div>}
+      {error && debates.length > 0 && <div className="v4-error" style={{ marginTop: 14 }}>{error}</div>}
 
       <DebateKpiStrip debates={debates} />
 

--- a/src/components/v4/debate/DebateView.tsx
+++ b/src/components/v4/debate/DebateView.tsx
@@ -165,6 +165,21 @@ export function DebateView() {
 
       {loading && debates.length === 0 ? (
         <div className="v4-empty" style={{ marginTop: 14 }}>Загрузка…</div>
+      ) : error && debates.length === 0 ? (
+        <div className="v4-panel">
+          <div className="v4-db-empty">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" />
+              <path d="M12 8v4" />
+              <path d="M12 16h.01" />
+            </svg>
+            <h3>Не удалось загрузить дебаты</h3>
+            <p>{error || "Проверьте соединение и попробуйте снова."}</p>
+            <button type="button" className="v4-btn v4-btn--pri" onClick={refresh}>
+              Повторить
+            </button>
+          </div>
+        </div>
       ) : visible.length === 0 && debates.length === 0 ? (
         <div className="v4-panel">
           <div className="v4-db-empty">


### PR DESCRIPTION
## Summary

When `useDebate`'s initial fetch fails (`error` set, `debates` empty), `DebateView` previously fell through to the "Дебатов ещё не было" first-time empty state, making a backend/network failure look like a legitimate clean-slate state.

This adds a dedicated error branch in the ternary chain (placed before the first-time empty state) that:
- Shows a clear "Не удалось загрузить дебаты" headline
- Surfaces the actual `error` message from the hook (with sensible fallback)
- Provides a "Повторить" button that calls `refresh()` from `useDebate`

Reuses existing `v4-panel` / `v4-db-empty` / `v4-btn--pri` styles — no new CSS.

## Test plan

- [ ] Mock `listDebates` to throw on first call; confirm "Не удалось загрузить дебаты" panel shows instead of "Дебатов ещё не было"
- [ ] Click "Повторить" → confirm `useDebate.refresh` re-runs the fetch
- [ ] Successful first fetch with empty list still shows the original "Дебатов ещё не было" CTA
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes

Closes #245