### PR TITLE
fix(debate): drop context_files from payload when no project selected

### DIFF
--- a/src/components/StartDebateModal.tsx
+++ b/src/components/StartDebateModal.tsx
@@ -110,7 +110,7 @@ export function StartDebateModal({ onClose, onStarted }: Props) {
         topic: topic.trim(),
         project: project || undefined,
         brief: brief.trim() || undefined,
-        context_files: contextFilesList.length > 0 ? contextFilesList : undefined,
+        context_files: project && contextFilesList.length > 0 ? contextFilesList : undefined,
         participants,
       });
       setStarting(false);


### PR DESCRIPTION
## Summary
- The "Context files" textarea in `StartDebateModal` is only rendered when a project is selected, but stale `contextFiles` state was still being included in the `startDebate` payload after switching back to "no project".
- This caused abstract debates to run with hidden `context_files` and could trigger backend validation errors.
- Fix: gate `context_files` on `project` so it is only sent when the input is actually visible.

## Files changed
- `src/components/StartDebateModal.tsx` (1-line change in `handleSubmit`)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [ ] Manual: select project → enter context paths → switch back to "Без проекта" → submit → verify `context_files` is not in the payload

Closes #244