### PR TITLE
fix(verify-agent): mark tool call as seen only on success

### DIFF
--- a/src/utils/verify-agent.ts
+++ b/src/utils/verify-agent.ts
@@ -735,6 +735,9 @@ Verify it now.`;
                 break;
               default:
                 result = { text: `ERROR: unknown tool '${block.name}'`, error: true };
+                // Unknown tool name is a deterministic failure — dedupe so the
+                // model can't waste iterations re-calling the same wrong name.
+                seenToolCalls.add(callKey);
             }
             toolResults.push({
               type: "tool_result",

--- a/src/utils/verify-agent.ts
+++ b/src/utils/verify-agent.ts
@@ -703,7 +703,6 @@ Verify it now.`;
               });
               continue;
             }
-            seenToolCalls.add(callKey);
 
             let result: VerifyToolResult;
             switch (block.name) {
@@ -743,6 +742,12 @@ Verify it now.`;
               content: result.text,
               is_error: result.error,
             });
+            // Only mark as "seen" for dedupe when the tool actually succeeded.
+            // Transient failures (e.g. GitHub rate-limiting in
+            // executeFindSymbolTool) must be retryable with the same arguments,
+            // otherwise the verifier drifts to UNCERTAIN even though a retry
+            // could have worked.
+            if (!result.error) seenToolCalls.add(callKey);
           }
           currentMessages = [
             ...currentMessages,


### PR DESCRIPTION
## Summary

The dedupe guard inside the verify-agent loop was adding the tool-call key to `seenToolCalls` *before* the tool executed. When a tool returned a transient error (notably `executeFindSymbolTool` hitting GitHub Code Search rate-limits), any retry with the same arguments was short-circuited by the dedupe stub — so the verifier never got a real result and drifted to `UNCERTAIN`.

This PR moves `seenToolCalls.add(callKey)` to after the tool executes and gates it on `!result.error`. Successful calls are still deduped; transient failures remain retryable.

## Changes

- `src/utils/verify-agent.ts` — moved `seenToolCalls.add(callKey)` from before the switch to after `toolResults.push(...)`, guarded by `!result.error`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [ ] Manually trigger a verify run that hits a transient `find_symbol_definition` failure and confirm the next iteration retries instead of short-circuiting.

Closes #247