### PR TITLE
fix(debate): defer blob URL revoke to avoid Safari download cancellation

### DIFF
--- a/src/components/DebateChat.tsx
+++ b/src/components/DebateChat.tsx
@@ -481,7 +481,7 @@ function AdrPreview({ markdown, topic }: { markdown: string; topic: string }) {
     a.href = url;
     a.download = filename;
     a.click();
-    URL.revokeObjectURL(url);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }, [markdown, topic]);
 
   return (


### PR DESCRIPTION
Closes #243

## Что сделано
Обернул `URL.revokeObjectURL(url)` в `setTimeout(..., 1000)` в DebateChat.tsx:484. Safari и часть Firefox версий могут cancel download если revoke происходит до начала navigation к blob URL.

## Изменения
1 строка в `src/components/DebateChat.tsx`.

## Тесты
Manual verify: `npx tsc --noEmit` чист, `npm run lint` чист по изменению.