### PR TITLE
fix(quality): reset snapshot and error on project change

### DIFF
--- a/src/components/QualityPanel.tsx
+++ b/src/components/QualityPanel.tsx
@@ -58,6 +58,15 @@ export function QualityPanel({ project }: QualityPanelProps) {
 
   useEffect(() => {
     let cancelled = false;
+    // Microtask defer satisfies react-hooks/set-state-in-effect (sync
+    // setState in effect body) while still clearing stale snapshot/error
+    // before the new fetch resolves on project change.
+    Promise.resolve().then(() => {
+      if (!cancelled) {
+        setSnapshot(null);
+        setError(false);
+      }
+    });
     const load = async () => {
       try {
         const data = await fetchQualitySnapshot(project);


### PR DESCRIPTION
Closes #242

## Что сделано
В useEffect с зависимостью `[project]` в `QualityPanel.tsx:59` добавил сброс `setSnapshot(null)` и `setError(false)` в начале — чтобы при смене project панель не показывала кратко KPI предыдущего проекта.

## Изменения
`src/components/QualityPanel.tsx` — сброс через `Promise.resolve().then(...)` (microtask defer), как в `MonitoringView.tsx` / `CodeAuditView.tsx`. Это требуется, чтобы пройти линт `react-hooks/set-state-in-effect` (синхронный setState в теле effect блокируется правилом). Microtask отрабатывает раньше, чем резолвится fetch, поэтому snapshot/error всё равно успевают сброситься до нового результата. Cancellation guard защищает от race при размонтировании.

## Тесты
Manual verify: `npx tsc --noEmit` чист, `npm run lint` чист.