### PR TITLE
fix(pipeline): stop double-counting active run with partial results

### DIFF
--- a/src/components/v4/pipeline/PipelineView.tsx
+++ b/src/components/v4/pipeline/PipelineView.tsx
@@ -156,9 +156,10 @@ export function PipelineView({
   const { sessionCost, sessionRuns } = useMemo(() => {
     if (!status) return { sessionCost: 0, sessionRuns: 0 };
     const cost = sumCost(status.results);
-    const runs = status.results.length > 0 ? 1 : 0;
-    const total = runs + (status.running && runStartedAt ? 1 : 0);
-    return { sessionCost: cost, sessionRuns: total };
+    // A running pipeline is the same run that produced any existing results,
+    // so count "1" when either condition holds — never both.
+    const hasRun = status.results.length > 0 || (status.running && runStartedAt !== null);
+    return { sessionCost: cost, sessionRuns: hasRun ? 1 : 0 };
   }, [status, runStartedAt]);
 
   // Classify dialog


### PR DESCRIPTION
Closes #240

## Что сделано
`PipelineView.tsx:159` — counter `runs + (running ? 1 : 0)` удваивал active run сразу как только появлялись результаты. Теперь run считается как 1 если есть results ИЛИ pipeline running (но не оба раза).

Edge cases:
- `results.length=0 && !running` → 0
- `results.length>0 && !running` → 1
- `results.length>0 && running` → 1 (было 2 — баг)
- `results.length=0 && running && runStartedAt` → 1 (сохранено: показываем 1 для свежего run без результатов)

## Тесты
`npx tsc --noEmit` чист, `npx eslint` на изменённом файле чист.