### PR TITLE
fix(transcripts): reset stale project filter when missing from dataset

### DIFF
--- a/src/components/v4/transcripts/TranscriptHistoryV4.tsx
+++ b/src/components/v4/transcripts/TranscriptHistoryV4.tsx
@@ -245,6 +245,16 @@ export function TranscriptHistoryV4({ onOpen, onResume, onRetry, refreshKey }: P
     [items]
   );
 
+  // If a stale persisted project filter is no longer present in the dataset,
+  // reset it to "" — otherwise the user may see zero rows with no way to clear
+  // the filter (the selector is hidden when projects.length <= 1).
+  useEffect(() => {
+    if (loading) return;
+    if (state.project && !projects.includes(state.project)) {
+      setState((s) => (s.project ? { ...s, project: "" } : s));
+    }
+  }, [projects, state.project, loading]);
+
   const counts = useMemo(() => {
     const c = { all: items.length, active: 0, done: 0, error: 0 };
     for (const i of items) {


### PR DESCRIPTION
Closes #237

## Что сделано
В `TranscriptHistoryV4` добавлен `useEffect`, который после загрузки списка транскрипций проверяет, существует ли persisted `state.project` в текущем `projects[]`. Если значения нет — фильтр сбрасывается в `""`. Это исправляет залипание stale значения, когда `<select>` скрыт (projects.length <= 1) и пользователь не может очистить фильтр через UI.

Поведение `setState((s) => s.project ? { ...s, project: "" } : s)` гарантирует отсутствие лишних обновлений: после сброса повторных рендеров не происходит. Эффект ничего не делает, пока `loading=true`, чтобы не сбрасывать фильтр на старте до загрузки данных.

## Проверка
- `npx tsc --noEmit` — pass
- `npm run lint` — pass
- `npm run build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)