### PR TITLE
fix(quality): distinguish empty scoped_projects from global scope

### DIFF
--- a/src/components/v4/quality/PendingChangePreview.tsx
+++ b/src/components/v4/quality/PendingChangePreview.tsx
@@ -132,10 +132,12 @@ export function PendingChangePreviewV4({ change, loadPreview, onConfirm, onCance
                     </span>
                   )
                 )}
-                {preview.scoped_projects && preview.scoped_projects.length > 0 ? (
-                  <span className="v4-tag">проекты: {preview.scoped_projects.join(", ")}</span>
-                ) : (
+                {preview.scoped_projects == null ? (
                   <span className="v4-tag">все проекты</span>
+                ) : preview.scoped_projects.length === 0 ? (
+                  <span className="v4-tag v4-tag--danger">⚠ Скоуп не разрешён — нет проектов</span>
+                ) : (
+                  <span className="v4-tag">проекты: {preview.scoped_projects.join(", ")}</span>
                 )}
               </div>
 


### PR DESCRIPTION
Closes #234

## Что сделано
В `src/components/v4/quality/PendingChangePreview.tsx` бейдж scope теперь различает три состояния `preview.scoped_projects`:

- `null/undefined` → «все проекты» (global scope, как было)
- `[]` → красный warning-тег «⚠ Скоуп не разрешён — нет проектов» (новое)
- `string[]` непустой → «проекты: a, b, c» (как было)

Раньше пустой массив падал в fallback-ветку и ошибочно метил scope как «все проекты», что вводило reviewer'а в заблуждение.

## Проверка
- `npx tsc --noEmit` — pass
- `npm run lint` — pass
- `npm run build` — pass