### PR TITLE
fix(monitoring): classify all-paused pool as unknown

### DIFF
--- a/src/components/v4/monitoring/utils.ts
+++ b/src/components/v4/monitoring/utils.ts
@@ -33,6 +33,8 @@ export function poolHealth(monitors: Monitor[]): MonitorHealth {
   if (monitors.some((m) => m.status === "down")) return "danger";
   if (monitors.some((m) => m.status === "pending")) return "warn";
   if (monitors.some((m) => m.uptimePct !== null && m.uptimePct < 99)) return "warn";
+  // All monitors paused -> no signal; align with monitorHealth("paused") = "unknown".
+  if (monitors.every((m) => m.status === "paused")) return "unknown";
   return "ok";
 }
 


### PR DESCRIPTION
Closes #232

## Что сделано
В `poolHealth` (src/components/v4/monitoring/utils.ts) добавлена явная ветка для случая, когда все мониторы в статусе `paused`. Раньше такая ситуация падала в fallthrough `return "ok"` -> `MonitoringHero` показывал green state «Все сервисы онлайн», что неверно и противоречило `monitorHealth` (paused -> unknown). Теперь возвращаем `"unknown"`, согласовано с `monitorHealth`.

Возвращаемый тип не менялся — `MonitorHealth` уже включает `"unknown"`. `MonitoringHero` уже корректно обрабатывает `"unknown"` (есть `HEALTH_TITLE.unknown` = "Нет данных", `HEALTH_DESC.unknown`, и CSS класс `v4-mon-hero--unknown` использовался для пустого пула).

## Изменения
- `src/components/v4/monitoring/utils.ts` — +2 строки: проверка `monitors.every((m) => m.status === "paused")` перед `return "ok"`.

## Edge cases
- **Пустой массив**: возвращает `"unknown"` (через ранний `return` на line 32, поведение сохранено).
- **Все paused**: теперь `"unknown"` (было `"ok"` — баг).
- **Mix paused + up**: возвращает `"ok"` (как раньше, корректно).
- **Любой down/pending**: short-circuit раньше paused-проверки, без изменений.

## Тесты
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Senior review — P1 issues: 0
- [x] Edge cases: empty array, all-paused, mixed states

Тестов в проекте нет (нет test runner в package.json), unit-тесты не добавлял.