### PR TITLE
refactor(milestones): pass precomputed days/cls to MilestoneCardV4

### DIFF
--- a/src/components/v4/milestones/MilestoneCardV4.tsx
+++ b/src/components/v4/milestones/MilestoneCardV4.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Milestone } from "../../../types";
-import { daysUntil, formatShortDate } from "../../../utils/date";
-import { classifyMilestone } from "./classifyMilestone";
+import { formatShortDate } from "../../../utils/date";
+import type { MilestoneStatusKind } from "./classifyMilestone";
 import { MilestoneIssueRow } from "./MilestoneIssueRow";
 import {
   countBlocked,
@@ -13,9 +13,14 @@ import {
 interface Props {
   milestone: Milestone;
   density: "comfortable" | "compact";
-  /** Anchor for daysUntil — passed from the view to keep classification
-   *  consistent with the data refresh timestamp. */
-  now: Date;
+  /** Days until due, precomputed by the parent view against the data-refresh
+   *  anchor. `null` when the milestone has no `dueOn`. Passed in so card
+   *  badges/risk strip never drift from group bucket and aggregate counters
+   *  between refreshes (e.g. across midnight). */
+  days: number | null;
+  /** Classification bucket precomputed alongside `days`. Same anchor as
+   *  the parent's grouping/sorting/aggregates. */
+  cls: MilestoneStatusKind;
   onSelect?: (m: Milestone) => void;
 }
 
@@ -34,14 +39,12 @@ const FILL_BY_CLS: Record<string, string> = {
   noeta: "v4-mscv-fill--noeta",
 };
 
-export function MilestoneCardV4({ milestone, density, now, onSelect }: Props) {
+export function MilestoneCardV4({ milestone, density, days, cls, onSelect }: Props) {
   const [expanded, setExpanded] = useState(false);
 
   const total = milestone.openIssues + milestone.closedIssues;
   const pct = total > 0 ? Math.round((milestone.closedIssues / total) * 100) : 0;
   const left = total - milestone.closedIssues;
-  const days = milestone.dueOn ? daysUntil(milestone.dueOn, now) : null;
-  const cls = classifyMilestone(milestone, days);
   const isDone = cls === "done";
 
   const pctClass =

--- a/src/components/v4/milestones/MilestonesView.tsx
+++ b/src/components/v4/milestones/MilestonesView.tsx
@@ -368,7 +368,8 @@ export function MilestonesView({ milestones: rawMilestones, projects, lastUpdate
                       key={e.m.url}
                       milestone={e.m}
                       density={state.density}
-                      now={now}
+                      days={e.days}
+                      cls={e.cls}
                       onSelect={setPopupMs}
                     />
                   ))}


### PR DESCRIPTION
Closes #231

## Что сделано
`MilestoneCardV4` пересчитывал `daysUntil()` и `classifyMilestone()` на каждый render, хотя `MilestonesView` уже precomputes их once per refresh в массиве `enriched` для grouping / sorting / aggregates. Это потенциально приводило к drift между card badges / risk strip и group bucket / aggregate counters между refresh-циклами (например, через полночь или у самого дедлайна).

- Поднял `days: number | null` и `cls: MilestoneStatusKind` в props карточки
- Убрал локальный пересчёт + dead imports (`daysUntil`, `classifyMilestone` значение); оставил только `MilestoneStatusKind` type
- Убрал prop `now` — он больше не нужен карточке (anchor живёт там, где значения вычисляются)
- В `MilestonesView` передаю `e.days` / `e.cls` из enriched item; других callsites нет

Edge case: `e.days === null` уже корректно обрабатывается (милстоун без `dueOn` → `cls === "noeta"`), как и раньше.

## Тесты
- [x] tsc --noEmit — ok
- [x] npm run lint — ok
- [x] npm run build — ok
- [x] Senior review — P1 issues: 0