### PR TITLE
fix(milestones): clamp milestoneStart to dueOn

### DIFF
--- a/src/components/v4/milestones/utils.ts
+++ b/src/components/v4/milestones/utils.ts
@@ -165,9 +165,13 @@ export function clsPriority(cls: MilestoneStatusKind): number {
  * Best-guess milestone start used as the left edge of the Gantt bar.
  *
  * Strategy keeps bars compact within the visible window:
- * - dueOn present: max(createdAt, due − issue-scaled offset). Using the LATER
- *   of the two avoids showing year-long bars when a milestone was created
- *   long before its deadline.
+ * - dueOn present: max(createdAt, due − issue-scaled offset), clamped to due.
+ *   Using the LATER of created vs projected avoids showing year-long bars when
+ *   a milestone was created long before its deadline. The clamp to `due`
+ *   prevents `start > due` for overdue milestones whose createdAt happens to
+ *   be after the deadline (e.g. a milestone updated/repurposed after it
+ *   expired) — without it the Gantt bar gets negative width and renders
+ *   inverted.
  * - dueOn missing: today. The bar projects forward by issue count, so the
  *   chart doesn't get a 28-px stub stuck at the left edge for milestones
  *   created months ago without a deadline.
@@ -178,11 +182,13 @@ export function milestoneStart(m: Milestone, fallbackNow: Date): Date {
     const due = startOfDay(new Date(m.dueOn));
     const total = m.openIssues + m.closedIssues;
     const projected = addDays(due, -Math.max(7, Math.round(total * 1.5)));
+    let candidate = projected;
     if (m.createdAt) {
       const created = startOfDay(new Date(m.createdAt));
-      return created > projected ? created : projected;
+      if (created > projected) candidate = created;
     }
-    return projected;
+    // Clamp to dueOn so the Gantt bar can never have negative width.
+    return candidate > due ? due : candidate;
   }
   return today;
 }


### PR DESCRIPTION
Closes #229

## Что сделано
В `src/components/v4/milestones/utils.ts` функция `milestoneStart` могла возвращать дату позже `dueOn` для overdue milestone, у которого `createdAt > dueOn` (например, milestone обновлён/перенаправлен после истечения дедлайна). Это приводило к тому, что в `MilestonesGantt.tsx` `endIdx - startIdx < 0` и Gantt-бар рендерился с отрицательной шириной (визуально инвертированно, частично закрывался `Math.max(28, ...)` floor).

Добавлен clamp финального кандидата к `due`:
```ts
return candidate > due ? due : candidate;
```
Теперь `milestoneStart(m) <= dueOn` всегда. При совпадении `start === due` Gantt всё равно отрендерит минимальную ширину 28px (существующий floor).

## Тесты
- [x] `npx tsc --noEmit` — ok
- [x] `npm run lint` — ok
- [x] `npm run build` — ok
- [x] Senior review — P1 issues: 0
- [x] Edge cases:
  - `dueOn === null` → возврат `today` (путь не изменён)
  - `createdAt > dueOn` (баг) → clamp к `due`
  - `createdAt === dueOn` → возврат `due` (zero-width, floors to 28px)
  - `createdAt` отсутствует → `projected = due - max(7, total*1.5)d` всегда ≤ due, clamp = no-op
  - empty milestone (`openIssues + closedIssues = 0`) → `projected = due - 7d`, clamp = no-op
- [x] Callsites: единственный потребитель — `MilestonesGantt.tsx:94` (через `milestoneStart(m, now)`); поведение для нормальных milestone не меняется

🤖 Generated with [Claude Code](https://claude.com/claude-code)