### PR TITLE
fix(milestones): include closed count in hero summary

### DIFF
--- a/src/components/v4/milestones/MilestonesHero.tsx
+++ b/src/components/v4/milestones/MilestonesHero.tsx
@@ -6,7 +6,12 @@ import { classifyMilestone } from "./classifyMilestone";
 import { stripEpicPrefix } from "./utils";
 
 interface Props {
-  /** Open milestones — drives portfolio stats, deadlines, status counts. */
+  /**
+   * Full milestone set (open + closed). Hero classifies internally and counts
+   * `done`, `inProgress`, `overdue`, plus the issue rollup ring. Passing only
+   * open milestones makes the «завершено» counter and progress ring miss every
+   * closed milestone — see fix for #230.
+   */
   milestones: Milestone[];
   /**
    * Project data (issues from project boards). Velocity reuses the dashboard's

--- a/src/components/v4/milestones/MilestonesView.tsx
+++ b/src/components/v4/milestones/MilestonesView.tsx
@@ -216,8 +216,11 @@ export function MilestonesView({ milestones: rawMilestones, projects, lastUpdate
         </div>
       </div>
 
-      {/* Hero — three tiles */}
-      <MilestonesHero milestones={openMs} projects={projects} now={now} />
+      {/* Hero — three tiles. Passes full milestone set (open + closed) so
+          «завершено» counter and the progress ring reflect the whole
+          portfolio. Hero classifies internally and filters out `done` for
+          deadline/status calculations. */}
+      <MilestonesHero milestones={milestones} projects={projects} now={now} />
 
       {/* Gantt */}
       <MilestonesGantt


### PR DESCRIPTION
Closes #230

## Проблема
`MilestonesHero` получал только `openMs`, поэтому:
- «завершено» счётчик всегда равен 0,
- progress-ring (issues done %) считался на incomplete set — closed milestones не попадали ни в числитель, ни в знаменатель.

## Fix
Выбран **Variant A** — пробрасываем полный список milestones (open + closed) в Hero.

Hero уже классифицирует milestones внутри (`classifyMilestone`), и все остальные подсчёты (`overdue`, `inProgress`, `upcoming`, `cnt7/30/Far`) уже фильтруют `cls !== "done"`, так что закрытые milestones корректно исключаются откуда нужно. Затронутые семантически метрики:
- **done count** — теперь корректный (был 0).
- **progress ring (`pct`)** — теперь отражает весь портфель, а не только open. Это и есть intended behaviour для tile «Портфель milestones».

Velocity не зависит от `milestones` (использует `projects`) — без изменений.

## Изменённые файлы
- `src/components/v4/milestones/MilestonesView.tsx` — `openMs` → `milestones` в вызове Hero.
- `src/components/v4/milestones/MilestonesHero.tsx` — обновлён JSDoc у `Props.milestones` (контракт «full set»).

## Проверки
- [x] npm run lint — PASS
- [x] npx tsc --noEmit — PASS
- [x] npm run build — PASS
- [x] Senior review: P1 = 0 (проверены все производные подсчёты Hero на регрессию)