### PR TITLE
fix(settings): stop Escape propagation in edit-input

### DIFF
--- a/src/components/v4/SettingsPanel.tsx
+++ b/src/components/v4/SettingsPanel.tsx
@@ -396,7 +396,10 @@ export function SettingsPanel({ onClose, onBootstrapCleared }: Props) {
                         autoComplete="off"
                         onKeyDown={(e) => {
                           if (e.key === "Enter") void handleSave(key);
-                          if (e.key === "Escape") handleCancelEdit(key);
+                          if (e.key === "Escape") {
+                            e.stopPropagation();
+                            handleCancelEdit(key);
+                          }
                         }}
                       />
                       <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>


### PR DESCRIPTION
Closes #227

## Проблема
Escape в inline edit input триггерил handleCancelEdit, но event bubbled в window-level Escape listener и закрывал весь модал.

## Fix
Добавлен e.stopPropagation() в Escape branch input onKeyDown handler.

## Проверки
- [x] npm run lint
- [x] npx tsc --noEmit
- [x] npm run build
- [x] Senior review: P1 = 0