### PR TITLE
chore(ci): artifact between jobs, concurrency, manual deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   lint-and-build:
@@ -19,11 +24,15 @@ jobs:
       - run: npm run lint
       - run: npx tsc --noEmit
       - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          path: dist
 
   deploy:
     runs-on: ubuntu-latest
     needs: lint-and-build
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch'
     permissions:
       pages: write
       id-token: write
@@ -31,15 +40,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Closes #292

## Что сделано
1. **concurrency.cancel-in-progress** — несколько push в одну ветку подряд больше не плодят параллельные runs.
2. **Передача артефакта между jobs** — ${"`upload-pages-artifact`"} в ${"`lint-and-build`"} (под условием ${"`workflow_dispatch`"}); ${"`deploy`"} сжат до одного шага ${"`actions/deploy-pages@v4`"}. Раньше deploy дублировал ${"`npm ci`"} + ${"`npm run build`"} (~40s лишних).
3. **Manual deploy** — auto-deploy на ${"`push: main`"} убран, заменён на ${"`workflow_dispatch`"}. Теперь Pages-деплой консистентен с VPS-деплоем (оба ручные).

## Поведение по триггерам после PR
| Trigger | lint+build | pages artifact | deploy |
|---|---|---|---|
| ${"`pull_request`"} | ✅ | ❌ | ❌ |
| ${"`push: main`"} | ✅ | ❌ | ❌ |
| ${"`workflow_dispatch`"} | ✅ | ✅ | ✅ |

## Как теперь деплоить Pages
- GitHub UI: Actions → CI → Run workflow → main.
- CLI: ${"`gh workflow run ci.yml`"}

## Проверки
- [x] Senior review: P1 = 0
- [x] YAML валидный (проверено локально)
- [x] CI logic не ломает существующий PR/push trigger flow