### PR TITLE
fix(claude-md-freshness): signal scripts truncation in prompt

### DIFF
--- a/src/utils/checks/claudeMdFreshness.ts
+++ b/src/utils/checks/claudeMdFreshness.ts
@@ -93,25 +93,33 @@ function unknownFinding(
   return { ...baseFinding(rule), status: "unknown", detail };
 }
 
-// Read package.json and return a compact JSON of just its `scripts` block.
-// Empty string means "no package.json" or "no scripts" — both are treated
-// equivalently by the prompt. Errors fall through to absent — a failed read
-// shouldn't kill the rule, the LLM still has CLAUDE.md + repo tree.
+// Read package.json and return a compact JSON of just its `scripts` block,
+// plus a flag signalling whether the payload was truncated. Empty json means
+// "no package.json" or "no scripts" — both are treated equivalently by the
+// prompt. Errors fall through to absent — a failed read shouldn't kill the
+// rule, the LLM still has CLAUDE.md + repo tree. The `truncated` flag lets
+// the prompt warn the model so it doesn't flag clipped scripts as missing
+// with high confidence (mirrors the repo_tree truncation note).
 async function readScripts(
   token: string,
   owner: string,
   repo: string,
-): Promise<string> {
+): Promise<{ json: string; truncated: boolean }> {
   try {
     const raw = await readRepoFile(token, owner, repo, "package.json");
     // Bound parse work for adversarial / accidentally-huge files.
-    if (raw.length > MAX_PACKAGE_JSON_CHARS) return "";
+    if (raw.length > MAX_PACKAGE_JSON_CHARS) return { json: "", truncated: false };
     const parsed = JSON.parse(raw) as { scripts?: Record<string, string> };
-    if (!parsed.scripts || typeof parsed.scripts !== "object") return "";
-    const json = JSON.stringify(parsed.scripts);
-    return json.slice(0, MAX_SCRIPTS_CHARS);
+    if (!parsed.scripts || typeof parsed.scripts !== "object") {
+      return { json: "", truncated: false };
+    }
+    const full = JSON.stringify(parsed.scripts);
+    if (full.length > MAX_SCRIPTS_CHARS) {
+      return { json: full.slice(0, MAX_SCRIPTS_CHARS), truncated: true };
+    }
+    return { json: full, truncated: false };
   } catch {
-    return "";
+    return { json: "", truncated: false };
   }
 }
 
@@ -187,10 +195,11 @@ export async function checkClaudeMdFreshness(
   // Step 3 — opportunistically read Makefile and package.json scripts in
   // parallel. Either failing is fine — the LLM gets "(не найден)" for
   // missing surfaces.
-  const [makefile, scripts] = await Promise.all([
+  const [makefile, scriptsResult] = await Promise.all([
     readMakefile(token, owner, repo),
     readScripts(token, owner, repo),
   ]);
+  const { json: scripts, truncated: scriptsTruncated } = scriptsResult;
 
   // Truncate at the last newline before the cap so a path mention straddling
   // the boundary doesn't reach the LLM as a partial token (which would cause
@@ -221,7 +230,7 @@ ${treeText}${truncationNote}
 ${makefile || "(не найден)"}
 </makefile>
 <package_json_scripts>
-${scripts || "(не найден)"}
+${scripts || "(не найден)"}${scriptsTruncated ? "\n[note: scripts обрезаны, часть ключей могут быть скрыты]" : ""}
 </package_json_scripts>
 
 Задача:
@@ -235,7 +244,8 @@ ${scripts || "(не найден)"}
 4. Если есть устаревшие → status fail, detail с конкретными примерами (≤ 200 chars), например «\`./scripts/old-deploy.sh\` не найден; \`npm run prepare\` не в scripts».
 5. Не придирайся к опечаткам или общим описаниям — только к конкретным упоминаниям пути/команды, которые легко проверить.
 6. Если в repo_tree есть note о неполноте, и упомянутый путь не виден в сэмпле — НЕ помечай как fail; снизь confidence (0.4–0.6).
-7. Если в claude_md есть note об обрезке — игнорируй упоминания которые могут быть частично обрезаны на границе.`;
+7. Если в claude_md есть note об обрезке — игнорируй упоминания которые могут быть частично обрезаны на границе.
+8. Если в package_json_scripts есть note об обрезке, и \`npm run X\` не виден среди ключей — НЕ помечай как fail; снизь confidence (0.4–0.6).`;
 
   let result: LLMResult;
   try {

--- a/src/utils/checks/claudeMdFreshness.ts
+++ b/src/utils/checks/claudeMdFreshness.ts
@@ -107,8 +107,10 @@ async function readScripts(
 ): Promise<{ json: string; truncated: boolean }> {
   try {
     const raw = await readRepoFile(token, owner, repo, "package.json");
-    // Bound parse work for adversarial / accidentally-huge files.
-    if (raw.length > MAX_PACKAGE_JSON_CHARS) return { json: "", truncated: false };
+    // Bound parse work for adversarial / accidentally-huge files. The file
+    // exists but we can't see its scripts — flag truncated so the prompt
+    // tells the model not to fail `npm run X` mentions with high confidence.
+    if (raw.length > MAX_PACKAGE_JSON_CHARS) return { json: "", truncated: true };
     const parsed = JSON.parse(raw) as { scripts?: Record<string, string> };
     if (!parsed.scripts || typeof parsed.scripts !== "object") {
       return { json: "", truncated: false };
@@ -200,6 +202,14 @@ export async function checkClaudeMdFreshness(
     readScripts(token, owner, repo),
   ]);
   const { json: scripts, truncated: scriptsTruncated } = scriptsResult;
+  const scriptsBlock = scripts
+    ? scripts +
+      (scriptsTruncated
+        ? "\n[note: scripts обрезаны, часть ключей могут быть скрыты]"
+        : "")
+    : scriptsTruncated
+      ? "(package.json слишком большой, scripts недоступны для проверки)"
+      : "(не найден)";
 
   // Truncate at the last newline before the cap so a path mention straddling
   // the boundary doesn't reach the LLM as a partial token (which would cause
@@ -230,7 +240,7 @@ ${treeText}${truncationNote}
 ${makefile || "(не найден)"}
 </makefile>
 <package_json_scripts>
-${scripts || "(не найден)"}${scriptsTruncated ? "\n[note: scripts обрезаны, часть ключей могут быть скрыты]" : ""}
+${scriptsBlock}
 </package_json_scripts>
 
 Задача:
@@ -245,7 +255,7 @@ ${scripts || "(не найден)"}${scriptsTruncated ? "\n[note: scripts обр
 5. Не придирайся к опечаткам или общим описаниям — только к конкретным упоминаниям пути/команды, которые легко проверить.
 6. Если в repo_tree есть note о неполноте, и упомянутый путь не виден в сэмпле — НЕ помечай как fail; снизь confidence (0.4–0.6).
 7. Если в claude_md есть note об обрезке — игнорируй упоминания которые могут быть частично обрезаны на границе.
-8. Если в package_json_scripts есть note об обрезке, и \`npm run X\` не виден среди ключей — НЕ помечай как fail; снизь confidence (0.4–0.6).`;
+8. Если в package_json_scripts есть note об обрезке ИЛИ сообщение что scripts недоступны (package.json слишком большой), и \`npm run X\` не виден среди ключей — НЕ помечай как fail; снизь confidence (0.4–0.6).`;
 
   let result: LLMResult;
   try {


### PR DESCRIPTION
## Summary
- `readScripts()` теперь возвращает `{ json, truncated }` вместо silently-clipped строки.
- Когда `package.json` scripts JSON > `MAX_SCRIPTS_CHARS` (1000), prompt получает note `[note: scripts обрезаны, часть ключей могут быть скрыты]` — по образцу `repo_tree` truncation.
- Добавлено правило 8: если есть note об обрезке и `npm run X` не виден среди ключей — не fail, confidence 0.4–0.6 (зеркало правила 6 для repo_tree).

Без этого fix валидные команды CLAUDE.md из больших package.json могли incorrectly помечаться как missing с high confidence.

Closes #220

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)