### PR TITLE
chore(ux): batch 2 status/error UX fixes

### DIFF
--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -122,6 +122,42 @@ function isTerminalFailure(status: string): boolean {
   return TERMINAL_FAILURE_STATUSES.has(status);
 }
 
+/**
+ * Visual tokens for the four ladder states (done / terminal-failure /
+ * needs_human / other) used by the row border and the status badge. Kept as
+ * a single helper so the four three-property tuples stay in lockstep — a
+ * mismatch between border and badge colour would be visually jarring.
+ */
+type StatusVisual = { border: string; badgeBg: string; badgeColor: string };
+
+const STATUS_VISUAL_DONE: StatusVisual = {
+  border: "rgba(16,185,129,0.2)",
+  badgeBg: "rgba(16, 185, 129, 0.12)",
+  badgeColor: "var(--green-500)",
+};
+const STATUS_VISUAL_FAILED: StatusVisual = {
+  border: "rgba(239,68,68,0.2)",
+  badgeBg: "rgba(239, 68, 68, 0.12)",
+  badgeColor: "var(--red-500)",
+};
+const STATUS_VISUAL_NEEDS_HUMAN: StatusVisual = {
+  border: "rgba(245,158,11,0.25)",
+  badgeBg: "rgba(245, 158, 11, 0.12)",
+  badgeColor: "var(--orange-500)",
+};
+const STATUS_VISUAL_DEFAULT: StatusVisual = {
+  border: "var(--color-border)",
+  badgeBg: "rgba(76, 141, 255, 0.12)",
+  badgeColor: "var(--blue-500)",
+};
+
+function statusVisual(status: string): StatusVisual {
+  if (status === "done") return STATUS_VISUAL_DONE;
+  if (isTerminalFailure(status)) return STATUS_VISUAL_FAILED;
+  if (status === "needs_human") return STATUS_VISUAL_NEEDS_HUMAN;
+  return STATUS_VISUAL_DEFAULT;
+}
+
 const VERDICT_STYLE: Record<string, { color: string; bg: string }> = {
   APPROVED: { color: "var(--green-500)", bg: "rgba(16, 185, 129, 0.12)" },
   CHANGES_REQUESTED: { color: "var(--orange-500)", bg: "rgba(245, 158, 11, 0.12)" },
@@ -693,11 +729,9 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
             {status.results.map((r) => {
-              const isDone = r.status === "done";
               // Issue #254: distinguish terminal failures (red) from
               // needs_human (warn/amber) — they're semantically different.
-              const isFailed = isTerminalFailure(r.status);
-              const isNeedsHuman = r.status === "needs_human";
+              const visual = statusVisual(r.status);
               return (
                 <div
                   key={r.issue_number}
@@ -708,15 +742,7 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
                     padding: "8px 10px",
                     borderRadius: "var(--radius-sm)",
                     background: "var(--color-bg)",
-                    border: `1px solid ${
-                      isDone
-                        ? "rgba(16,185,129,0.2)"
-                        : isFailed
-                          ? "rgba(239,68,68,0.2)"
-                          : isNeedsHuman
-                            ? "rgba(245,158,11,0.25)"
-                            : "var(--color-border)"
-                    }`,
+                    border: `1px solid ${visual.border}`,
                   }}
                 >
                   <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
@@ -755,20 +781,8 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
                     fontWeight: 600,
                     padding: "1px 8px",
                     borderRadius: 10,
-                    background: isDone
-                      ? "rgba(16, 185, 129, 0.12)"
-                      : isFailed
-                        ? "rgba(239, 68, 68, 0.12)"
-                        : isNeedsHuman
-                          ? "rgba(245, 158, 11, 0.12)"
-                          : "rgba(76, 141, 255, 0.12)",
-                    color: isDone
-                      ? "var(--green-500)"
-                      : isFailed
-                        ? "var(--red-500)"
-                        : isNeedsHuman
-                          ? "var(--orange-500)"
-                          : "var(--blue-500)",
+                    background: visual.badgeBg,
+                    color: visual.badgeColor,
                   }}>
                     {STATUS_LABEL[r.status] ?? r.status}
                   </span>

--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -98,7 +98,29 @@ const STATUS_LABEL: Record<string, string> = {
   done: "Готово",
   needs_human: "Нужен человек",
   rolled_back: "Откат",
+  failed: "Ошибка",
+  cancelled: "Отменено",
+  error: "Ошибка",
 };
+
+/**
+ * Terminal-failure statuses — the pipeline ran and conclusively failed.
+ * Kept in sync with v4/pipeline/PipelineResults.tsx (issue #217). Note that
+ * `needs_human` is intentionally NOT here: it's a triage state (warn), not a
+ * failure. Unknown future statuses default to "not failed".
+ *
+ * TODO: extract to utils/pipeline-status.ts (duplicated across 5 files).
+ */
+const TERMINAL_FAILURE_STATUSES: ReadonlySet<string> = new Set([
+  "failed",
+  "cancelled",
+  "error",
+  "rolled_back",
+]);
+
+function isTerminalFailure(status: string): boolean {
+  return TERMINAL_FAILURE_STATUSES.has(status);
+}
 
 const VERDICT_STYLE: Record<string, { color: string; bg: string }> = {
   APPROVED: { color: "var(--green-500)", bg: "rgba(16, 185, 129, 0.12)" },
@@ -672,7 +694,10 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
             {status.results.map((r) => {
               const isDone = r.status === "done";
-              const isFailed = r.status === "needs_human";
+              // Issue #254: distinguish terminal failures (red) from
+              // needs_human (warn/amber) — they're semantically different.
+              const isFailed = isTerminalFailure(r.status);
+              const isNeedsHuman = r.status === "needs_human";
               return (
                 <div
                   key={r.issue_number}
@@ -683,7 +708,15 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
                     padding: "8px 10px",
                     borderRadius: "var(--radius-sm)",
                     background: "var(--color-bg)",
-                    border: `1px solid ${isDone ? "rgba(16,185,129,0.2)" : isFailed ? "rgba(239,68,68,0.2)" : "var(--color-border)"}`,
+                    border: `1px solid ${
+                      isDone
+                        ? "rgba(16,185,129,0.2)"
+                        : isFailed
+                          ? "rgba(239,68,68,0.2)"
+                          : isNeedsHuman
+                            ? "rgba(245,158,11,0.25)"
+                            : "var(--color-border)"
+                    }`,
                   }}
                 >
                   <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
@@ -726,12 +759,16 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
                       ? "rgba(16, 185, 129, 0.12)"
                       : isFailed
                         ? "rgba(239, 68, 68, 0.12)"
-                        : "rgba(76, 141, 255, 0.12)",
+                        : isNeedsHuman
+                          ? "rgba(245, 158, 11, 0.12)"
+                          : "rgba(76, 141, 255, 0.12)",
                     color: isDone
                       ? "var(--green-500)"
                       : isFailed
                         ? "var(--red-500)"
-                        : "var(--blue-500)",
+                        : isNeedsHuman
+                          ? "var(--orange-500)"
+                          : "var(--blue-500)",
                   }}>
                     {STATUS_LABEL[r.status] ?? r.status}
                   </span>

--- a/src/components/v4/AIInsightsPanel.tsx
+++ b/src/components/v4/AIInsightsPanel.tsx
@@ -8,6 +8,13 @@ interface Props {
   lastUpdated: Date | null;
   /** Switches to the Projects tab and opens the Project Health drilldown for `repo`. */
   onOpenHealth: (repo: string) => void;
+  /**
+   * Scan failure message (missing token / all repos failed). Shown as a
+   * dedicated state when there's nothing to render, and as a non-blocking
+   * warning chip in the header when stale reports are still on screen — so
+   * the user never sees the success-empty copy after a true failure.
+   */
+  error?: string | null;
 }
 
 // Sorting / filtering knobs — single source of truth so a designer tweak is
@@ -120,7 +127,7 @@ function rankFails(reports: HealthReport[], nowMs: number): RankedFail[] {
     .slice(0, MAX_CARDS);
 }
 
-export function AIInsightsPanel({ reports, loading, lastUpdated, onOpenHealth }: Props) {
+export function AIInsightsPanel({ reports, loading, lastUpdated, onOpenHealth, error = null }: Props) {
   // We freeze the "now" used for *scoring* at lastUpdated so cards don't
   // reorder on every parent re-render. Without lastUpdated we fall back to
   // 0 — ageDays then clamps to 0 and ageFactor collapses to 1× uniformly,
@@ -151,6 +158,14 @@ export function AIInsightsPanel({ reports, loading, lastUpdated, onOpenHealth }:
   // with a small "обновляется" indicator so the user knows it isn't stale.
   const showSkeleton = loading && reports.length === 0;
   const showRefreshing = loading && reports.length > 0;
+  // Dedicated error state takes over when we have nothing to show — keeps
+  // the success-empty copy ("Нет данных health-сканирования.") from masking
+  // a failed scan.
+  const showError = !loading && reports.length === 0 && !!error;
+  // Recoverable failure: stale reports still on screen but the latest scan
+  // failed. The list stays so the user keeps the data, and a warn chip in
+  // the header signals that what they see may be out of date.
+  const showStaleErrorChip = !loading && reports.length > 0 && !!error;
 
   return (
     <div className="v4-panel">
@@ -168,6 +183,16 @@ export function AIInsightsPanel({ reports, loading, lastUpdated, onOpenHealth }:
           AI-инсайты по портфелю
           <span className="v4-tag">{top.length}</span>
           {showRefreshing && <span className="v4-tag">обновляется…</span>}
+          {showStaleErrorChip && (
+            <span
+              className="v4-tag v4-tag--warn"
+              role="status"
+              title={error ?? undefined}
+              aria-label={`данные могут быть устаревшими: ${error}`}
+            >
+              данные могут быть устаревшими
+            </span>
+          )}
         </div>
         {meta && <div className="v4-panel-meta">{meta}</div>}
       </div>
@@ -175,6 +200,11 @@ export function AIInsightsPanel({ reports, loading, lastUpdated, onOpenHealth }:
       <div className="v4-ai-list">
         {showSkeleton ? (
           <SkeletonList count={SKELETON_COUNT} />
+        ) : showError ? (
+          <div className="v4-empty v4-ai-empty v4-orphan-error" role="alert">
+            <div className="v4-orphan-error-t">Не удалось загрузить health-сканирование</div>
+            <div className="v4-orphan-error-m">{error}</div>
+          </div>
         ) : top.length === 0 ? (
           <EmptyState hasReports={reports.length > 0} />
         ) : (

--- a/src/components/v4/DashboardView.tsx
+++ b/src/components/v4/DashboardView.tsx
@@ -191,6 +191,7 @@ export function DashboardView({
           loading={portfolio.loading}
           lastUpdated={portfolioLastUpdated}
           onOpenHealth={onOpenHealth}
+          error={portfolio.error}
         />
       </div>
 


### PR DESCRIPTION
Two small UX fixes batched into one PR — separate commits, will be merged with **merge commit (not squash)** to preserve commit boundaries for bisect.

## Closes
- Closes #254 — `PipelineControlPanel`: variable name `isFailed` was checking `needs_human` while real terminal failures (`failed`/`cancelled`/`error`/`rolled_back`) fell through to neutral styling
- Closes #263 — `AIInsightsPanel`: portfolio scan errors were indistinguishable from a true-empty state ("no findings") for the user

## Commits

| # | SHA | Files |
|---|---|---|
| #254 | `6f78a1d` | `src/components/PipelineControlPanel.tsx` |
| #263 | `07e327a` | `src/components/v4/AIInsightsPanel.tsx`, `src/components/v4/DashboardView.tsx` |

## Notes per fix

**#254** — added local `isTerminalFailure(status)` helper + `TERMINAL_FAILURE_STATUSES` Set with the same whitelist as `v4/pipeline/PipelineResults.tsx`. 4-way visual ladder: `done` → green (unchanged), `terminal-failure` → red (was previously **neutral grey** — the actual bug), `needs_human` → amber/warn (was previously **red** as if a failure), other → neutral. Added Russian labels for `failed`/`cancelled`/`error` to `STATUS_LABEL`. **Out of scope**: extracting shared `utils/pipeline-status.ts` (5 files duplicate `STATUS_LABEL`/`isTerminalFailure`) — flagged in issue body as separate work.

**#263** — added `error?: string \| null` prop to `AIInsightsPanel`, plumbed `portfolio.error` through `DashboardView.tsx`. Hybrid UX matches `OrphanIssuesPanel` pattern from #262: `reports.length === 0 && error` → full-panel error block, `reports.length > 0 && error` → warn chip in header (data may be stale), otherwise unchanged. Reuses `.v4-orphan-error*` CSS verbatim — no class rename (kept diff minimal; will rename when a 3rd consumer appears).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build` succeeded
- [ ] Manual visual: load dashboard with invalid token → AIInsightsPanel shows red error block (was: muted empty-state)
- [ ] Manual visual: pipeline tab with a `failed` task → red border + "Ошибка" badge (was: neutral grey)
- [ ] Manual visual: pipeline tab with a `needs_human` task → amber border + "Нужен человек" badge (was: red as if failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)