### PR TITLE
feat(milestones): rename + delete from popup

### DIFF
--- a/src/components/v4/milestones/MilestoneIssuesPopup.tsx
+++ b/src/components/v4/milestones/MilestoneIssuesPopup.tsx
@@ -120,14 +120,29 @@ export function MilestoneIssuesPopup({ milestone, onClose, onEdited }: Props) {
     onClose();
   };
 
-  // ESC to close
+  // ESC to close — but if a sub-form is open (date edit, title edit, delete
+  // confirm), close that form instead so a stray Escape doesn't bin the
+  // whole dialog mid-edit.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key !== "Escape") return;
+      if (editingTitle) {
+        setEditingTitle(false);
+        return;
+      }
+      if (editing) {
+        setEditing(false);
+        return;
+      }
+      if (confirmDelete) {
+        setConfirmDelete(false);
+        return;
+      }
+      onClose();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  }, [onClose, editingTitle, editing, confirmDelete]);
 
   // Lock background scroll while popup is open
   useEffect(() => {
@@ -198,13 +213,6 @@ export function MilestoneIssuesPopup({ milestone, onClose, onEdited }: Props) {
                   onChange={(e) => setDraftTitle(e.target.value)}
                   disabled={savingTitle}
                   autoFocus
-                  onKeyDown={(e) => {
-                    if (e.key === "Escape") {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      setEditingTitle(false);
-                    }
-                  }}
                   aria-label="Название milestone"
                 />
                 <button
@@ -231,9 +239,11 @@ export function MilestoneIssuesPopup({ milestone, onClose, onEdited }: Props) {
                     type="button"
                     className="v4-mspopup-edit-btn"
                     title="Переименовать milestone"
+                    aria-label="Переименовать milestone"
                     onClick={() => {
                       setDraftTitle(milestone.title);
                       setEditingTitle(true);
+                      setConfirmDelete(false);
                     }}
                   >
                     ✎
@@ -366,6 +376,7 @@ export function MilestoneIssuesPopup({ milestone, onClose, onEdited }: Props) {
                       onClick={() => {
                         setDraftDate(dueOnInputValue(milestone.dueOn));
                         setEditing(true);
+                        setConfirmDelete(false);
                       }}
                     >
                       ✎
@@ -388,7 +399,7 @@ export function MilestoneIssuesPopup({ milestone, onClose, onEdited }: Props) {
               </>
             )}
           </div>
-          {canEdit && !editing && (
+          {canEdit && !editing && !editingTitle && (
             <div className="v4-mspopup-danger-row">
               {confirmDelete ? (
                 <>

--- a/src/components/v4/milestones/MilestoneIssuesPopup.tsx
+++ b/src/components/v4/milestones/MilestoneIssuesPopup.tsx
@@ -4,9 +4,13 @@ import type { Milestone } from "../../../types";
 import { formatShortDate } from "../../../utils/date";
 import { getToken } from "../../../utils/config";
 import {
+  deleteMilestone,
   parseMilestoneUrl,
   patchMilestoneDueOn,
+  patchMilestoneTitle,
+  setDeletedOverride,
   setDueOverride,
+  setTitleOverride,
   triggerCacheSync,
 } from "../../../utils/milestoneEdit";
 import { useToast } from "../toastContext";
@@ -39,10 +43,82 @@ export function MilestoneIssuesPopup({ milestone, onClose, onEdited }: Props) {
   const [editing, setEditing] = useState(false);
   const [draftDate, setDraftDate] = useState("");
   const [saving, setSaving] = useState(false);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [draftTitle, setDraftTitle] = useState("");
+  const [savingTitle, setSavingTitle] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const toast = useToast();
 
   const ref = useMemo(() => parseMilestoneUrl(milestone.url), [milestone.url]);
   const canEdit = ref !== null;
+
+  const renameTitle = async () => {
+    if (!ref) return;
+    const trimmed = draftTitle.trim();
+    if (!trimmed || trimmed === milestone.title) {
+      setEditingTitle(false);
+      return;
+    }
+    const token = getToken();
+    if (!token) {
+      toast.push({
+        title: "Нет GitHub-токена",
+        description: "Добавь PAT в настройках, чтобы переименовать milestone.",
+        kind: "error",
+      });
+      return;
+    }
+    setSavingTitle(true);
+    const result = await patchMilestoneTitle(token, ref, trimmed);
+    setSavingTitle(false);
+    if (!result) {
+      toast.push({
+        title: "Не удалось переименовать",
+        description: "GitHub отклонил запрос. Проверь права токена.",
+        kind: "error",
+      });
+      return;
+    }
+    setTitleOverride(milestone.url, trimmed);
+    triggerCacheSync();
+    toast.push({ title: "Milestone переименован", kind: "success" });
+    setEditingTitle(false);
+    onEdited?.();
+  };
+
+  const performDelete = async () => {
+    if (!ref) return;
+    const token = getToken();
+    if (!token) {
+      toast.push({
+        title: "Нет GitHub-токена",
+        description: "Добавь PAT в настройках, чтобы удалить milestone.",
+        kind: "error",
+      });
+      return;
+    }
+    setDeleting(true);
+    const ok = await deleteMilestone(token, ref);
+    setDeleting(false);
+    if (!ok) {
+      toast.push({
+        title: "Не удалось удалить",
+        description: "GitHub отклонил запрос. Проверь права токена.",
+        kind: "error",
+      });
+      return;
+    }
+    setDeletedOverride(milestone.url);
+    triggerCacheSync();
+    toast.push({
+      title: "Milestone удалён",
+      description: "Issues остались в репо — у них просто снят milestone.",
+      kind: "success",
+    });
+    onEdited?.();
+    onClose();
+  };
 
   // ESC to close
   useEffect(() => {
@@ -108,9 +184,63 @@ export function MilestoneIssuesPopup({ milestone, onClose, onEdited }: Props) {
           />
           <div className="v4-mspopup-h-text">
             <div className="v4-mspopup-repo">{milestone.repo}</div>
-            <h2 id="v4-mspopup-title" className="v4-mspopup-title">
-              {stripEpicPrefix(milestone.title) || milestone.title}
-            </h2>
+            {editingTitle ? (
+              <form
+                className="v4-mspopup-title-edit"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  void renameTitle();
+                }}
+              >
+                <input
+                  type="text"
+                  value={draftTitle}
+                  onChange={(e) => setDraftTitle(e.target.value)}
+                  disabled={savingTitle}
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setEditingTitle(false);
+                    }
+                  }}
+                  aria-label="Название milestone"
+                />
+                <button
+                  type="submit"
+                  className="v4-mspopup-edit-save"
+                  disabled={savingTitle || !draftTitle.trim()}
+                >
+                  {savingTitle ? "..." : "OK"}
+                </button>
+                <button
+                  type="button"
+                  className="v4-mspopup-edit-cancel"
+                  disabled={savingTitle}
+                  onClick={() => setEditingTitle(false)}
+                >
+                  Отмена
+                </button>
+              </form>
+            ) : (
+              <h2 id="v4-mspopup-title" className="v4-mspopup-title">
+                {stripEpicPrefix(milestone.title) || milestone.title}
+                {canEdit && (
+                  <button
+                    type="button"
+                    className="v4-mspopup-edit-btn"
+                    title="Переименовать milestone"
+                    onClick={() => {
+                      setDraftTitle(milestone.title);
+                      setEditingTitle(true);
+                    }}
+                  >
+                    ✎
+                  </button>
+                )}
+              </h2>
+            )}
           </div>
           <button
             type="button"
@@ -258,6 +388,43 @@ export function MilestoneIssuesPopup({ milestone, onClose, onEdited }: Props) {
               </>
             )}
           </div>
+          {canEdit && !editing && (
+            <div className="v4-mspopup-danger-row">
+              {confirmDelete ? (
+                <>
+                  <span className="v4-mspopup-danger-prompt">
+                    Удалить milestone «{stripEpicPrefix(milestone.title) || milestone.title}»?
+                    Issues останутся в репо, но потеряют привязку к milestone.
+                  </span>
+                  <button
+                    type="button"
+                    className="v4-mspopup-danger-confirm"
+                    onClick={performDelete}
+                    disabled={deleting}
+                  >
+                    {deleting ? "Удаляю..." : "Да, удалить"}
+                  </button>
+                  <button
+                    type="button"
+                    className="v4-mspopup-edit-cancel"
+                    onClick={() => setConfirmDelete(false)}
+                    disabled={deleting}
+                  >
+                    Отмена
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  className="v4-mspopup-danger-btn"
+                  onClick={() => setConfirmDelete(true)}
+                  title="Удалить milestone на GitHub"
+                >
+                  Удалить milestone
+                </button>
+              )}
+            </div>
+          )}
         </div>
 
         <div className="v4-mspopup-tabs" role="tablist">

--- a/src/components/v4/milestones/MilestonesView.tsx
+++ b/src/components/v4/milestones/MilestonesView.tsx
@@ -13,7 +13,7 @@ import { MilestonesStatusBar } from "./MilestonesStatusBar";
 import { MilestoneIssuesPopup } from "./MilestoneIssuesPopup";
 import { classifyMilestone } from "./classifyMilestone";
 import { deadlineBucket } from "./utils";
-import { applyDueOverrides } from "../../../utils/milestoneEdit";
+import { applyMilestoneOverrides } from "../../../utils/milestoneEdit";
 
 interface Props {
   milestones: Milestone[];
@@ -102,19 +102,21 @@ export function MilestonesView({ milestones: rawMilestones, projects, lastUpdate
     saveState(state);
   }, [state]);
 
-  // Apply local due-date overrides to the milestone array so every downstream
-  // tile (Gantt, Hero, cards, popup) sees the same effective due date.
+  // Apply ALL local milestone overrides (due, title, deletion) so every
+  // downstream tile (Gantt, Hero, cards, popup) sees the same effective list.
   const milestones = useMemo(
-    () => applyDueOverrides(rawMilestones),
+    () => applyMilestoneOverrides(rawMilestones),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [rawMilestones, overrideTick],
   );
 
   // Re-resolve the popup milestone against the latest data so issue counts
   // refresh while the popup is open. Match by URL — stable across refreshes.
+  // If the milestone vanished (deletion), return null so the popup closes
+  // automatically instead of holding onto a stale snapshot.
   const popupMsLive = useMemo(() => {
     if (!popupMs) return null;
-    return milestones.find((m) => m.url === popupMs.url) ?? popupMs;
+    return milestones.find((m) => m.url === popupMs.url) ?? null;
   }, [milestones, popupMs]);
 
   // Anchor "now" to lastUpdated so daysUntil/Gantt today line stay consistent

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -8284,6 +8284,75 @@ ul.v4-rsh-list {
 .v4-mspopup-edit button:disabled,
 .v4-mspopup-edit input:disabled { opacity: 0.55; cursor: not-allowed; }
 
+.v4-mspopup-title-edit {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.v4-mspopup-title-edit input[type="text"] {
+  flex: 1 1 220px;
+  min-width: 180px;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 4px 8px;
+  border: 1px solid var(--v4-line-strong);
+  border-radius: 6px;
+  background: var(--v4-paper);
+  color: var(--v4-ink-900);
+}
+.v4-mspopup-title-edit input[type="text"]:focus {
+  outline: none;
+  border-color: var(--v4-accent-500);
+}
+
+.v4-mspopup-danger-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding-top: 8px;
+  border-top: 1px dashed var(--v4-line-soft);
+  font-family: var(--v4-mono);
+  font-size: 11px;
+}
+.v4-mspopup-danger-prompt {
+  flex: 1 1 240px;
+  color: var(--v4-ink-700);
+}
+.v4-mspopup-danger-btn {
+  appearance: none;
+  border: 1px solid #FCC8C5;
+  background: transparent;
+  color: #B42318;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background .15s, border-color .15s;
+}
+.v4-mspopup-danger-btn:hover {
+  background: #FEE4E2;
+  border-color: #B42318;
+}
+.v4-mspopup-danger-confirm {
+  appearance: none;
+  border: 0;
+  background: #B42318;
+  color: #fff;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 700;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background .15s, opacity .15s;
+}
+.v4-mspopup-danger-confirm:hover:not(:disabled) { background: #912018; }
+.v4-mspopup-danger-confirm:disabled { opacity: 0.55; cursor: not-allowed; }
+
 .v4-mspopup-tabs {
   display: flex;
   gap: 4px;

--- a/src/utils/milestoneEdit.ts
+++ b/src/utils/milestoneEdit.ts
@@ -132,9 +132,10 @@ export async function patchMilestoneTitle(
 }
 
 /**
- * DELETE the milestone on GitHub. Returns true on success (204), false on any
- * failure. The issues attached to the milestone are NOT deleted — GitHub just
- * unsets their milestone field.
+ * DELETE the milestone on GitHub. Returns true on success (204) or if the
+ * milestone is already gone (404 — UI-equivalent to success since it ends up
+ * with the same state). Issues attached to the milestone are NOT deleted —
+ * GitHub just unsets their milestone field.
  */
 export async function deleteMilestone(
   token: string,
@@ -151,7 +152,7 @@ export async function deleteMilestone(
         },
       },
     );
-    return res.ok || res.status === 204;
+    return res.ok || res.status === 404;
   } catch {
     return false;
   }

--- a/src/utils/milestoneEdit.ts
+++ b/src/utils/milestoneEdit.ts
@@ -13,6 +13,8 @@ const GITHUB_REST = "https://api.github.com";
 const OVERRIDE_KEY = "makeit.milestoneOverrides.v1";
 const DUE_OVERRIDE_TTL_MS = 30 * 60 * 1000; // 30 min — long enough for a sync cycle
 const START_OVERRIDE_TTL_MS = 30 * 60 * 1000;
+const TITLE_OVERRIDE_TTL_MS = 30 * 60 * 1000;
+const DELETED_OVERRIDE_TTL_MS = 60 * 60 * 1000; // 1h — deletion is destructive, hide longer
 
 // HTML comment marker in milestone descriptions — invisible in GitHub's
 // rendered Markdown, but parseable for cross-device sync of start dates.
@@ -101,6 +103,61 @@ export async function patchMilestoneDueOn(
 }
 
 /**
+ * PATCH the milestone title on GitHub. Returns the updated payload, or null
+ * on any failure.
+ */
+export async function patchMilestoneTitle(
+  token: string,
+  ref: MilestoneRef,
+  title: string,
+): Promise<unknown | null> {
+  try {
+    const res = await fetch(
+      `${GITHUB_REST}/repos/${ref.owner}/${ref.repo}/milestones/${ref.number}`,
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `bearer ${token}`,
+          Accept: "application/vnd.github.v3+json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ title }),
+      },
+    );
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * DELETE the milestone on GitHub. Returns true on success (204), false on any
+ * failure. The issues attached to the milestone are NOT deleted — GitHub just
+ * unsets their milestone field.
+ */
+export async function deleteMilestone(
+  token: string,
+  ref: MilestoneRef,
+): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `${GITHUB_REST}/repos/${ref.owner}/${ref.repo}/milestones/${ref.number}`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `bearer ${token}`,
+          Accept: "application/vnd.github.v3+json",
+        },
+      },
+    );
+    return res.ok || res.status === 204;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * PATCH the milestone description on GitHub. Used to tunnel the start date
  * via an HTML comment marker — see injectStartIntoDescription().
  */
@@ -159,6 +216,15 @@ interface OverrideEntry {
    *  cache sync pulls the updated description back. */
   start?: string;
   startExpiresAt?: number;
+  /** Optimistic title rename — server is authoritative, this just hides the
+   *  stale value until the cache catches up. */
+  title?: string;
+  titleExpiresAt?: number;
+  /** Marker that the milestone was deleted on GitHub. The cache may keep
+   *  serving it for ~30s after deletion; this hides it from the UI in the
+   *  meantime so it doesn't reappear. */
+  deleted?: boolean;
+  deletedExpiresAt?: number;
 }
 
 type OverrideMap = Record<string, OverrideEntry>;
@@ -187,6 +253,19 @@ function writeAll(map: OverrideMap): void {
  * out without needing a background timer. Both due and start overrides have
  * their own TTL.
  */
+function isEntryEmpty(entry: OverrideEntry): boolean {
+  return (
+    entry.start === undefined &&
+    entry.dueOn === undefined &&
+    entry.dueExpiresAt === undefined &&
+    entry.startExpiresAt === undefined &&
+    entry.title === undefined &&
+    entry.titleExpiresAt === undefined &&
+    entry.deleted === undefined &&
+    entry.deletedExpiresAt === undefined
+  );
+}
+
 function pruneExpired(map: OverrideMap): OverrideMap {
   const now = Date.now();
   let mutated = false;
@@ -201,12 +280,17 @@ function pruneExpired(map: OverrideMap): OverrideMap {
       delete entry.startExpiresAt;
       mutated = true;
     }
-    if (
-      entry.start === undefined &&
-      entry.dueOn === undefined &&
-      entry.dueExpiresAt === undefined &&
-      entry.startExpiresAt === undefined
-    ) {
+    if (entry.titleExpiresAt !== undefined && entry.titleExpiresAt < now) {
+      delete entry.title;
+      delete entry.titleExpiresAt;
+      mutated = true;
+    }
+    if (entry.deletedExpiresAt !== undefined && entry.deletedExpiresAt < now) {
+      delete entry.deleted;
+      delete entry.deletedExpiresAt;
+      mutated = true;
+    }
+    if (isEntryEmpty(entry)) {
       delete map[url];
     }
   }
@@ -256,8 +340,26 @@ export function clearDueOverride(url: string): void {
   if (!entry) return;
   delete entry.dueOn;
   delete entry.dueExpiresAt;
-  if (entry.start === undefined) delete map[url];
+  if (isEntryEmpty(entry)) delete map[url];
   else map[url] = entry;
+  writeAll(map);
+}
+
+export function setTitleOverride(url: string, title: string): void {
+  const map = readAll();
+  const entry = map[url] ?? {};
+  entry.title = title;
+  entry.titleExpiresAt = Date.now() + TITLE_OVERRIDE_TTL_MS;
+  map[url] = entry;
+  writeAll(map);
+}
+
+export function setDeletedOverride(url: string): void {
+  const map = readAll();
+  const entry = map[url] ?? {};
+  entry.deleted = true;
+  entry.deletedExpiresAt = Date.now() + DELETED_OVERRIDE_TTL_MS;
+  map[url] = entry;
   writeAll(map);
 }
 
@@ -275,6 +377,30 @@ export function applyDueOverrides(milestones: Milestone[]): Milestone[] {
     if (!o || o.dueOn === undefined) return m;
     return { ...m, dueOn: o.dueOn };
   });
+}
+
+/**
+ * Apply ALL local milestone overrides (due, title, deletion) in one pass.
+ * Deleted milestones are filtered out entirely. Use this in the milestones
+ * view layer so every downstream tile sees the same effective list.
+ */
+export function applyMilestoneOverrides(milestones: Milestone[]): Milestone[] {
+  const overrides = getMilestoneOverrides();
+  if (Object.keys(overrides).length === 0) return milestones;
+  const out: Milestone[] = [];
+  for (const m of milestones) {
+    const o = overrides[m.url];
+    if (!o) {
+      out.push(m);
+      continue;
+    }
+    if (o.deleted) continue;
+    let next = m;
+    if (o.dueOn !== undefined) next = { ...next, dueOn: o.dueOn };
+    if (o.title !== undefined) next = { ...next, title: o.title };
+    out.push(next);
+  }
+  return out;
 }
 
 export function getStartOverride(url: string): string | undefined {


### PR DESCRIPTION
## Summary
- Inline title rename in `MilestoneIssuesPopup` (✎ next to title)
- Delete milestone with inline confirm — also in the popup
- Both write to GitHub via REST (`PATCH`/`DELETE /repos/.../milestones/{n}`)
- New `applyMilestoneOverrides` merges due/title/deleted overrides so Gantt/cards/Hero reflect the change instantly while the cache catches up

## Test plan
- [ ] Click a milestone in the Gantt → popup opens
- [ ] Rename: click ✎, edit, OK → toast, title updates everywhere
- [ ] Delete: click "Удалить milestone" → "Да, удалить" → popup closes, milestone disappears
- [ ] No GitHub token → friendly error toast
- [ ] Escape during rename cancels without saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)