### PR TITLE
feat(loader): MakeIT brick-build splash, unify cold-start screens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import { getToken, clearToken, getAuth, clearAuth, clearClaudeKey, MONITOR_MATCH
 import { PasswordGate } from "./components/PasswordGate";
 import { SettingsBootstrap, SettingsUnavailable } from "./components/v4/SettingsBootstrap";
 import { SettingsPanel } from "./components/v4/SettingsPanel";
+import { BrandedLoader } from "./components/v4/BrandedLoader";
 import { useSettings } from "./hooks/useSettings";
 import { runOneTimeMigration } from "./utils/settings-migration";
 import {
@@ -522,7 +523,9 @@ function AppInner() {
             Tabs like Pipeline, Audit, Quality, Debate, Specs, Research, Transcripts,
             Monitoring have their own state and shouldn't be obscured by this banner. */}
         {projects.length === 0 && (tab === "dashboard" || tab === "projects" || tab === "milestones") && loading && (
-          <div className="v4-loading">Загрузка данных…</div>
+          // Same component as SettingsGate — keeps the cold-start sequence
+          // visually continuous (settings → data) instead of two screens.
+          <BrandedLoader stage="data" />
         )}
 
         {projects.length === 0 && (tab === "dashboard" || tab === "projects" || tab === "milestones") && !loading && !error && (
@@ -687,15 +690,10 @@ function SettingsGate() {
     if (settings.error === "unavailable") {
       return <SettingsUnavailable onRetry={settings.retry} />;
     }
-    // Initial loading state — short, but render something rather than a blank
-    // page so the user knows the app is alive while loadAllSettings() resolves.
-    return (
-      <div className="v4-app" style={{ gridTemplateColumns: "1fr", minHeight: "100vh" }}>
-        <main className="v4-main">
-          <div className="v4-loading">Загрузка настроек…</div>
-        </main>
-      </div>
-    );
+    // Initial loading — single branded loader covering the cold-start path.
+    // Same component is reused in AppInner for the data-fetching phase, so
+    // the user perceives one continuous loader, not two screens.
+    return <BrandedLoader stage="settings" />;
   }
   return <AppInner />;
 }

--- a/src/components/v4/BrandedLoader.tsx
+++ b/src/components/v4/BrandedLoader.tsx
@@ -1,0 +1,38 @@
+import { MakeItLoader } from "./MakeItLoader";
+
+/**
+ * Full-screen branded loader shown during the cold-start sequence:
+ *   settings → cache/projects.
+ *
+ * Visual is the MakeIT brick-build wordmark from the design handoff
+ * (see src/components/v4/MakeItLoader.tsx + .module.css). This wrapper
+ * adds the stage label so the user knows which phase they're waiting on
+ * and pins the loader full-screen so the cold-start sequence feels
+ * like one continuous screen, not two.
+ */
+
+export type LoaderStage = "settings" | "data" | "syncing";
+
+const STAGE_LABEL: Record<LoaderStage, string> = {
+  settings: "Загружаем настройки",
+  data: "Подтягиваем данные",
+  syncing: "Синхронизируем с GitHub",
+};
+
+interface Props {
+  stage: LoaderStage;
+  subtitle?: string;
+}
+
+export function BrandedLoader({ stage, subtitle }: Props) {
+  const label = STAGE_LABEL[stage];
+  return (
+    <div className="bl-root" role="status" aria-live="polite">
+      <div className="bl-card">
+        <MakeItLoader size={64} />
+        <div className="bl-stage">{label}</div>
+        {subtitle ? <div className="bl-subtitle">{subtitle}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/MakeItLoader.module.css
+++ b/src/components/v4/MakeItLoader.module.css
@@ -1,0 +1,106 @@
+/* MakeItLoader · brick-build animated lockup
+   3.6s loop · CSS-only · respects prefers-reduced-motion */
+
+.root {
+  display: inline-flex;
+  align-items: baseline;
+  line-height: 1;
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 700;
+  /* color is inherited from parent (or forced via inline style if dark prop set) */
+}
+
+.center {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.m {
+  margin-right: var(--ml-m-gap, 3px);
+  align-self: flex-end;
+  display: block;
+  overflow: visible;
+}
+
+.brick {
+  opacity: 0;
+  transform-origin: center;
+  animation: ml-drop 3.6s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+}
+
+.ake,
+.it {
+  display: inline-flex;
+  white-space: pre;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+.ake {
+  letter-spacing: -0.04em;
+}
+
+.it {
+  letter-spacing: -0.02em;
+  color: var(--ml-accent, #2563eb);
+  text-transform: uppercase;
+}
+
+.ch {
+  display: inline-block;
+  opacity: 0;
+  transform: translateY(-0.6em);
+  animation: ml-pop 3.6s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+}
+
+.caret {
+  display: inline-block;
+  width: var(--ml-caret-w, 4px);
+  height: 0.72em;
+  background: var(--ml-accent, #2563eb);
+  margin-left: var(--ml-caret-gap, 5px);
+  transform: translateY(var(--ml-caret-y, 2px));
+  opacity: 0;
+  animation:
+    ml-caret-in 3.6s steps(1, end) infinite,
+    ml-caret-blink 1.05s steps(2, end) infinite;
+}
+
+@keyframes ml-drop {
+  0%   { opacity: 0; transform: translateY(-100%) scaleY(1.3); }
+  12%  { opacity: 1; transform: translateY(0)     scaleY(0.9); }
+  16%  {              transform: translateY(-6%)  scaleY(1.05); }
+  20%  {              transform: translateY(0)    scaleY(1); opacity: 1; }
+  88%  { opacity: 1; }
+  95%  { opacity: 0; }
+  100% { opacity: 0; transform: translateY(0); }
+}
+
+@keyframes ml-pop {
+  0%, 18%   { opacity: 0; transform: translateY(-0.6em); }
+  25%, 88%  { opacity: 1; transform: translateY(0); }
+  95%, 100% { opacity: 0; }
+}
+
+@keyframes ml-caret-in {
+  0%, 30%   { opacity: 0; }
+  35%, 95%  { opacity: 1; }
+  100%      { opacity: 0; }
+}
+
+@keyframes ml-caret-blink {
+  50% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .brick,
+  .ch,
+  .caret {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}

--- a/src/components/v4/MakeItLoader.tsx
+++ b/src/components/v4/MakeItLoader.tsx
@@ -1,0 +1,111 @@
+import type { CSSProperties } from 'react';
+import styles from './MakeItLoader.module.css';
+
+export interface MakeItLoaderProps {
+  /** Pixel size of the wordmark text. M scales to `size * 0.72`. Default 56. */
+  size?: number;
+  /** Force dark scheme. If omitted, inherits `color` from parent. */
+  dark?: boolean;
+  /** Override accent color. Default `var(--v4-accent-600)` → `#2563EB`. */
+  accent?: string;
+  /** Center self in parent via flex. */
+  center?: boolean;
+  /** className passthrough. */
+  className?: string;
+}
+
+const M_BRICKS = [
+  'M 0 48 L 0 0 L 10 0 L 10 48 Z',
+  'M 9 16 L 10 0 L 26 24 L 25 38 Z',
+  'M 27 38 L 26 24 L 42 0 L 43 16 Z',
+  'M 43 48 L 43 0 L 52 0 L 52 48 Z',
+];
+
+/**
+ * Animated MakeIT lockup loader.
+ * 4 geometric bricks drop into an "M", followed by "ake IT" typing in,
+ * then a blinking blue caret. 3.6s loop. CSS-only, no JS timer.
+ */
+export function MakeItLoader({
+  size = 56,
+  dark,
+  accent = 'var(--v4-accent-600, #2563EB)',
+  center = false,
+  className,
+}: MakeItLoaderProps) {
+  const mHeight = size * 0.72;
+  const mWidth = mHeight * (52 / 48);
+  const caretWidth = size * 0.06;
+  const caretGap = size * 0.08;
+  const mGap = size * 0.05;
+
+  const rootStyle: CSSProperties = {
+    fontSize: size,
+    color: dark === true ? '#FFFFFF' : dark === false ? '#0E1320' : undefined,
+    ['--ml-accent' as string]: accent,
+    ['--ml-caret-w' as string]: `${caretWidth}px`,
+    ['--ml-caret-gap' as string]: `${caretGap}px`,
+    ['--ml-caret-y' as string]: `${size * 0.04}px`,
+    ['--ml-m-gap' as string]: `${mGap}px`,
+  };
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Загрузка"
+      className={[
+        styles.root,
+        center ? styles.center : '',
+        className ?? '',
+      ].filter(Boolean).join(' ')}
+      style={rootStyle}
+    >
+      <svg
+        className={styles.m}
+        width={mWidth}
+        height={mHeight}
+        viewBox="0 0 52 48"
+        aria-hidden="true"
+      >
+        {M_BRICKS.map((d, i) => (
+          <path
+            key={i}
+            className={styles.brick}
+            d={d}
+            fill="currentColor"
+            style={{ animationDelay: `${i * 0.13}s` }}
+          />
+        ))}
+      </svg>
+
+      <span className={styles.ake}>
+        {['a', 'k', 'e'].map((c, i) => (
+          <span
+            key={i}
+            className={styles.ch}
+            style={{ animationDelay: `${0.7 + i * 0.07}s` }}
+          >
+            {c}
+          </span>
+        ))}
+      </span>
+
+      <span className={styles.it}>
+        {['I', 'T'].map((c, i) => (
+          <span
+            key={i}
+            className={styles.ch}
+            style={{ animationDelay: `${0.95 + i * 0.07}s` }}
+          >
+            {c}
+          </span>
+        ))}
+      </span>
+
+      <span className={styles.caret} aria-hidden="true" />
+    </div>
+  );
+}
+
+export default MakeItLoader;

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -1891,6 +1891,45 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 }
 
 /* ────────────────────────────────────────
+   BRANDED LOADER (cold-start sequence)
+   Wraps MakeItLoader (brick-build wordmark)
+   in a full-screen overlay with a stage
+   label. The wordmark itself owns its
+   animation — see MakeItLoader.module.css.
+   ──────────────────────────────────────── */
+.bl-root {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: var(--v4-bg);
+  color: var(--v4-ink-900);
+  z-index: 50;
+}
+
+.bl-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 22px;
+  padding: 32px 40px;
+  text-align: center;
+}
+
+.bl-stage {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--v4-ink-600);
+  letter-spacing: 0.01em;
+}
+
+.bl-subtitle {
+  font-size: 12px;
+  color: var(--v4-ink-500);
+  margin-top: -10px;
+}
+
+/* ────────────────────────────────────────
    PROJECTS VIEW (full page, rich cards)
    ──────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- Drop in `MakeItLoader` (brick-build wordmark, CSS-only, 3.6s loop) from the design handoff in `handoff/loader-brick/`
- Add `BrandedLoader` wrapper that pins it full-screen and shows the current cold-start stage label
- Replace both `<div className="v4-loading">Загрузка настроек…</div>` and `Загрузка данных…` with one `<BrandedLoader stage=… />` — perceived as one continuous screen, not two
- Respects `prefers-reduced-motion`

## Stage labels
| `stage` | Label |
|---|---|
| `settings` | Загружаем настройки |
| `data` | Подтягиваем данные |
| `syncing` | Синхронизируем с GitHub (reserved) |

## Test plan
- [ ] Open dashboard, enter password → splash plays brick-build M, "ake IT" types in, caret blinks
- [ ] Stage label transitions «Загружаем настройки» → «Подтягиваем данные» without flicker
- [ ] Wait until projects render — splash unmounts cleanly
- [ ] System with `prefers-reduced-motion` enabled → no animation, just static wordmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)