### PR TITLE
fix(dashboard): stale fallback, inline loader, smoother tab switch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { PasswordGate } from "./components/PasswordGate";
 import { SettingsBootstrap, SettingsUnavailable } from "./components/v4/SettingsBootstrap";
 import { SettingsPanel } from "./components/v4/SettingsPanel";
 import { BrandedLoader, type LoaderStage } from "./components/v4/BrandedLoader";
+import { MakeItLoader } from "./components/v4/MakeItLoader";
 import { useSettings } from "./hooks/useSettings";
 import { runOneTimeMigration } from "./utils/settings-migration";
 import {
@@ -385,6 +386,26 @@ function AppInner({ onFirstFetchDone }: AppInnerProps = {}) {
     refreshMonitors();
   }, [refresh, refreshMonitors]);
 
+  // Auto-retry once if we land in the empty-no-error state after the initial
+  // fetch (e.g. cache backend returned nothing). Without this, the inline
+  // brick-build loader below would imply data is incoming when nothing is
+  // actually being requested. Gated by a ref so a persistently empty state
+  // can't loop.
+  const autoRetryRef = useRef(false);
+  useEffect(() => {
+    if (autoRetryRef.current) return;
+    if (
+      projects.length === 0 &&
+      !loading &&
+      !error &&
+      lastUpdated !== null &&
+      getToken()
+    ) {
+      autoRetryRef.current = true;
+      void refresh(true);
+    }
+  }, [projects.length, loading, error, lastUpdated, refresh]);
+
   // Epic-004 Task-05: one-time port of legacy `localStorage` secrets to the
   // server-side settings store. Runs once per page session AFTER the gate has
   // already confirmed `useSettings().ready === true` (AppInner only mounts in
@@ -544,8 +565,14 @@ function AppInner({ onFirstFetchDone }: AppInnerProps = {}) {
             AppInner. Subsequent loading states inside tabs render their
             own indicators. */}
 
-        {projects.length === 0 && (tab === "dashboard" || tab === "projects" || tab === "milestones") && !loading && !error && (
-          <div className="v4-loading">Нажмите «Обновить» для загрузки данных</div>
+        {projects.length === 0 && (tab === "dashboard" || tab === "projects" || tab === "milestones") && !error && (
+          // Inline brick-build loader for the empty-no-error state. Pairs
+          // with the auto-retry effect above so the visual matches reality
+          // (something is being fetched).
+          <div className="v4-inline-loader">
+            <MakeItLoader size={48} />
+            <div className="v4-inline-loader-caption">Подтягиваем данные с GitHub</div>
+          </div>
         )}
 
         {projects.length > 0 && tab === "dashboard" && (

--- a/src/components/v4/KpiRow.tsx
+++ b/src/components/v4/KpiRow.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import type { ProjectData, SummaryMetrics } from "../../types";
 import {
@@ -12,6 +12,13 @@ import { TweenedNumber } from "./TweenedNumber";
 interface IndexedStyle extends CSSProperties {
   "--i"?: number;
 }
+
+// One-shot entrance animation per browser session. Switching tabs unmounts
+// DashboardView, so KpiRow re-mounts and the entrance animation re-played
+// on every return — the staggered fade + 12 number tweens collided with
+// React reconciliation and felt janky. This flag keeps the entrance only
+// on the very first dashboard view; subsequent re-mounts render instantly.
+let kpiEntrancePlayed = false;
 
 interface Props {
   projects: ProjectData[];
@@ -228,10 +235,17 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
   const isVelDown = velocity.delta7dVsPrev < 0;
   const isVelUp = velocity.delta7dVsPrev > 0;
 
+  // Skip the .v4-kpi-enter keyframe on every mount after the first.
+  const skipEntrance = kpiEntrancePlayed;
+  useEffect(() => {
+    kpiEntrancePlayed = true;
+  }, []);
+  const tileClass = skipEntrance ? " v4-kpi--no-anim" : "";
+
   return (
     <div className="v4-kpi-row">
       {/* 1. Прогресс портфеля (accent) */}
-      <div className="v4-kpi v4-kpi--acc" style={{ "--i": 0 } as IndexedStyle}>
+      <div className={`v4-kpi v4-kpi--acc${tileClass}`} style={{ "--i": 0 } as IndexedStyle}>
         <div className="v4-kpi-lbl">
           <span className="v4-kpi-ic">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
@@ -286,7 +300,7 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
       </div>
 
       {/* 2. Открытые задачи */}
-      <div className="v4-kpi" style={{ "--i": 1 } as IndexedStyle}>
+      <div className={`v4-kpi${tileClass}`} style={{ "--i": 1 } as IndexedStyle}>
         <div className="v4-kpi-lbl">
           <span className="v4-kpi-ic v4-kpi-ic--b">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
@@ -341,7 +355,7 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
       </div>
 
       {/* 3. Velocity 7д + sparkline (hover tooltip) */}
-      <div className="v4-kpi" style={{ "--i": 2 } as IndexedStyle}>
+      <div className={`v4-kpi${tileClass}`} style={{ "--i": 2 } as IndexedStyle}>
         <div className="v4-kpi-lbl">
           <span className="v4-kpi-ic v4-kpi-ic--p">
             <svg viewBox="0 0 24 24" fill="currentColor">
@@ -379,7 +393,7 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
 
       {/* 4. Бюджет */}
       <div
-        className="v4-kpi"
+        className={`v4-kpi${tileClass}`}
         style={
           {
             "--i": 3,

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -529,6 +529,14 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 @keyframes v4-kpi-enter {
   to { opacity: 1; transform: translateY(0); }
 }
+/* Tab switches re-mount KpiRow; the entrance animation is suppressed on
+   subsequent mounts via this class so the staggered fade doesn't replay
+   each time the user returns to the dashboard. */
+.v4-kpi.v4-kpi--no-anim {
+  opacity: 1;
+  transform: none;
+  animation: none;
+}
 .v4-kpi:hover {
   transform: translateY(-2px);
   box-shadow: 0 10px 28px rgba(11, 16, 32, 0.07);

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -1890,6 +1890,25 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   font-size: 14px;
 }
 
+/* Inline brick-build loader for the in-app empty-data state.
+   Mirrors BrandedLoader visually but lives inside the main content
+   area (no fixed positioning) so the sidebar/topbar stay usable. */
+.v4-inline-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  padding: 100px 28px 80px;
+  text-align: center;
+  color: var(--v4-ink-900);
+}
+.v4-inline-loader-caption {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--v4-ink-600);
+  letter-spacing: 0.01em;
+}
+
 /* ────────────────────────────────────────
    BRANDED LOADER (cold-start sequence)
    Wraps MakeItLoader (brick-build wordmark)

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -571,7 +571,9 @@ export async function fetchDashboardData(
         void (async () => {
           try {
             const fresh = await fetchFromCache(false);
-            if (fresh) {
+            // Skip empty payloads — they'd clobber good local data with [].
+            // Wait for the next refresh cycle when the backend has results.
+            if (fresh && fresh.projects.length > 0) {
               writeLocalCache(fresh.projects, fresh.lastSync);
               onFreshData({ projects: fresh.projects, lastSync: fresh.lastSync });
             }
@@ -584,18 +586,27 @@ export async function fetchDashboardData(
 
   // 2. No fresh local cache — fetch from cache backend
   const cached = await fetchFromCache(forceRefresh);
-  if (cached) {
+  if (cached && cached.projects.length > 0) {
     writeLocalCache(cached.projects, cached.lastSync);
     return { projects: cached.projects, lastSync: cached.lastSync };
   }
 
-  // 3. Fallback: stale local cache (TTL expired but better than nothing)
-  if (!forceRefresh) {
-    const local = readLocalCache();
-    if (local) {
-      console.log("[Dashboard] Cache backend unreachable, using stale local cache");
-      return localCacheToResult(local);
-    }
+  // 3. Fallback: stale local cache. Triggered when the backend either
+  //    failed (cached === null) OR returned an empty payload (e.g. cache
+  //    container was just recreated and hasn't synced yet). Showing the
+  //    last known dashboard beats showing nothing — the next refresh
+  //    will reconcile once the backend has data.
+  const stale = readLocalCache();
+  if (stale && stale.data.length > 0) {
+    console.log("[Dashboard] Backend empty/unreachable, using stale local cache");
+    return localCacheToResult(stale);
+  }
+
+  // 3b. Backend returned a valid-but-empty payload AND we have nothing
+  //     local to fall back on. Surface the empty result honestly so the
+  //     UI can render its empty state.
+  if (cached) {
+    return { projects: cached.projects, lastSync: cached.lastSync };
   }
 
   // 4. Fallback: direct GitHub API (original logic)


### PR DESCRIPTION
Three related dashboard UX fixes that surfaced after #299–#301 landed.

## 1. Stale fallback — show old data instead of blank screen
After #299–#301 it was possible to land on a blank dashboard with «Нажмите Обновить» — even though valid data was loaded earlier. Reproduces when the cache backend container is just recreated and returns `{ data: [] }` before its first sync.

- `fetchDashboardData` now treats `cached.projects.length === 0` as a non-result, falls through to the stale-local-cache fallback (any age), and only surfaces an empty result when nothing else is available.
- SWR background refresh skips empty payloads — never overwrites good local data with `[]`.

## 2. Inline brick-build loader replaces «Нажмите Обновить»
- Empty-no-error state now renders the brick-build `MakeItLoader` (`size=48`) + caption «Подтягиваем данные с GitHub» inside the main content area (sidebar/topbar stay usable).
- One-shot auto-retry (ref-gated) so the visual matches reality.

## 3. Smoother tab switching
Switching dashboard ↔ milestones replayed the staggered `.v4-kpi-enter` animation on the four KPI tiles every time DashboardView re-mounted, colliding with React reconciliation and the TweenedNumber rAF loops. Felt janky.

- Module-level flag in `KpiRow` gates the entrance: it plays on the very first mount per browser session, then `v4-kpi--no-anim` class suppresses the keyframe on subsequent mounts so tiles render instantly.

## Test plan
- [ ] Restart `makeit_cache` container; reload the dashboard → previous data still visible (no blank screen)
- [ ] Clear `localStorage` + restart `makeit_cache` → inline brick-build loader spins with caption while auto-retry runs
- [ ] First open of dashboard → KPI tiles fade in staggered (existing behavior)
- [ ] Switch to Milestones, then back to Dashboard → KPI tiles render instantly, no stagger, no jank

🤖 Generated with [Claude Code](https://claude.com/claude-code)