### PR TITLE
fix: tab-switch animation jank + heatmap tooltip lag

### DIFF
--- a/src/components/v4/CommitsHeatmapPanel.tsx
+++ b/src/components/v4/CommitsHeatmapPanel.tsx
@@ -129,6 +129,29 @@ export function CommitsHeatmapPanel({ projects, lastUpdated }: Props) {
                 key={row.repo}
                 className={`v4-commit-row${isRowHover ? " is-on" : ""}`}
                 style={rowStyle}
+                onMouseMove={(e) => {
+                  // Handler lives on the row (not on .v4-commit-cells) so it
+                  // fires even when the cursor is over the row's padding,
+                  // project name, or total — keeping the tooltip in sync
+                  // when moving vertically between rows. mouseenter-per-cell
+                  // was unreliable: React's synthetic mouseenter polyfill
+                  // dropped events on fast moves and competed with cell
+                  // transforms, leaving the tooltip stuck on a stale cell.
+                  const cellsEl = e.currentTarget.querySelector(
+                    ".v4-commit-cells",
+                  ) as HTMLElement | null;
+                  if (!cellsEl) return;
+                  const rect = cellsEl.getBoundingClientRect();
+                  if (rect.width <= 0) return;
+                  const ratio = (e.clientX - rect.left) / rect.width;
+                  const next = Math.max(
+                    0,
+                    Math.min(DAYS - 1, Math.floor(ratio * DAYS)),
+                  );
+                  if (hover?.repo !== row.repo || hover?.col !== next) {
+                    setHover({ repo: row.repo, col: next });
+                  }
+                }}
               >
                 <span className="v4-nm">{row.repo}</span>
                 <div className="v4-commit-cells">
@@ -161,9 +184,6 @@ export function CommitsHeatmapPanel({ projects, lastUpdated }: Props) {
                             ? " v4-cc-wrap--col"
                             : ""
                         }`}
-                        onMouseEnter={() =>
-                          setHover({ repo: row.repo, col: colIdx })
-                        }
                       >
                         <div
                           className={`v4-cc${isHover ? " is-hover" : ""}`}

--- a/src/components/v4/DashboardView.tsx
+++ b/src/components/v4/DashboardView.tsx
@@ -13,6 +13,7 @@ import { StaleBanner } from "./StaleBanner";
 import { OrphanIssuesPanel } from "./OrphanIssuesPanel";
 import type { usePortfolioHealth } from "../../hooks/usePortfolioHealth";
 import type { usePortfolioOrphans } from "../../hooks/usePortfolioOrphans";
+import { useFirstMountClass } from "../../hooks/useFirstMountClass";
 
 interface Props {
   projects: ProjectData[];
@@ -120,8 +121,10 @@ export function DashboardView({
     return parts.join(" · ");
   }, [filtered.length, lastUpdated]);
 
+  const noEntranceClass = useFirstMountClass("dashboard");
+
   return (
-    <div className="v4-content">
+    <div className={`v4-content${noEntranceClass ? ` ${noEntranceClass}` : ""}`}>
       <div className="v4-ph">
         <div>
           <h1>MakeIT · сводка по проектам</h1>

--- a/src/components/v4/KpiRow.tsx
+++ b/src/components/v4/KpiRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import type { ProjectData, SummaryMetrics } from "../../types";
 import {
@@ -12,13 +12,6 @@ import { TweenedNumber } from "./TweenedNumber";
 interface IndexedStyle extends CSSProperties {
   "--i"?: number;
 }
-
-// One-shot entrance animation per browser session. Switching tabs unmounts
-// DashboardView, so KpiRow re-mounts and the entrance animation re-played
-// on every return — the staggered fade + 12 number tweens collided with
-// React reconciliation and felt janky. This flag keeps the entrance only
-// on the very first dashboard view; subsequent re-mounts render instantly.
-let kpiEntrancePlayed = false;
 
 interface Props {
   projects: ProjectData[];
@@ -235,17 +228,10 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
   const isVelDown = velocity.delta7dVsPrev < 0;
   const isVelUp = velocity.delta7dVsPrev > 0;
 
-  // Skip the .v4-kpi-enter keyframe on every mount after the first.
-  const skipEntrance = kpiEntrancePlayed;
-  useEffect(() => {
-    kpiEntrancePlayed = true;
-  }, []);
-  const tileClass = skipEntrance ? " v4-kpi--no-anim" : "";
-
   return (
     <div className="v4-kpi-row">
       {/* 1. Прогресс портфеля (accent) */}
-      <div className={`v4-kpi v4-kpi--acc${tileClass}`} style={{ "--i": 0 } as IndexedStyle}>
+      <div className="v4-kpi v4-kpi--acc" style={{ "--i": 0 } as IndexedStyle}>
         <div className="v4-kpi-lbl">
           <span className="v4-kpi-ic">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
@@ -300,7 +286,7 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
       </div>
 
       {/* 2. Открытые задачи */}
-      <div className={`v4-kpi${tileClass}`} style={{ "--i": 1 } as IndexedStyle}>
+      <div className="v4-kpi" style={{ "--i": 1 } as IndexedStyle}>
         <div className="v4-kpi-lbl">
           <span className="v4-kpi-ic v4-kpi-ic--b">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
@@ -355,7 +341,7 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
       </div>
 
       {/* 3. Velocity 7д + sparkline (hover tooltip) */}
-      <div className={`v4-kpi${tileClass}`} style={{ "--i": 2 } as IndexedStyle}>
+      <div className="v4-kpi" style={{ "--i": 2 } as IndexedStyle}>
         <div className="v4-kpi-lbl">
           <span className="v4-kpi-ic v4-kpi-ic--p">
             <svg viewBox="0 0 24 24" fill="currentColor">
@@ -393,7 +379,7 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
 
       {/* 4. Бюджет */}
       <div
-        className={`v4-kpi${tileClass}`}
+        className="v4-kpi"
         style={
           {
             "--i": 3,

--- a/src/components/v4/milestones/MilestonesView.tsx
+++ b/src/components/v4/milestones/MilestonesView.tsx
@@ -13,6 +13,7 @@ import { MilestonesStatusBar } from "./MilestonesStatusBar";
 import { MilestoneIssuesPopup } from "./MilestoneIssuesPopup";
 import { classifyMilestone } from "./classifyMilestone";
 import { deadlineBucket } from "./utils";
+import { useFirstMountClass } from "../../../hooks/useFirstMountClass";
 import { applyMilestoneOverrides } from "../../../utils/milestoneEdit";
 
 interface Props {
@@ -208,8 +209,10 @@ export function MilestonesView({ milestones: rawMilestones, projects, lastUpdate
     return stamp ? `${base} · обновлено ${stamp}` : base;
   })();
 
+  const noEntranceClass = useFirstMountClass("milestones");
+
   return (
-    <div className="v4-content">
+    <div className={`v4-content${noEntranceClass ? ` ${noEntranceClass}` : ""}`}>
       {/* Page head */}
       <div className="v4-ph">
         <div>

--- a/src/hooks/useFirstMountClass.ts
+++ b/src/hooks/useFirstMountClass.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks whether a given tab/view has been mounted at least once in this
+ * browser session. Returns the className to apply on the view's root —
+ * empty on the very first mount (so entrance animations play), and
+ * `v4-tab--no-entrance` on every subsequent re-mount so the staggered
+ * fades in v4.css and the WOW layer don't replay (and visibly stutter)
+ * when the user switches tabs.
+ *
+ * Module-level state intentionally — each tab key has exactly one
+ * "first mount" per page lifetime, regardless of how many React
+ * remounts happen.
+ */
+const seenViews = new Set<string>();
+
+export function useFirstMountClass(key: string): string {
+  // Capture once at component init via lazy initializer; subsequent renders
+  // reuse the same value. Using state (not ref) so we can safely read during
+  // render — the value never changes after mount, so React won't re-run.
+  const [isFirst] = useState(() => !seenViews.has(key));
+
+  useEffect(() => {
+    seenViews.add(key);
+  }, [key]);
+
+  return isFirst ? "" : "v4-tab--no-entrance";
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -529,14 +529,6 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 @keyframes v4-kpi-enter {
   to { opacity: 1; transform: translateY(0); }
 }
-/* Tab switches re-mount KpiRow; the entrance animation is suppressed on
-   subsequent mounts via this class so the staggered fade doesn't replay
-   each time the user returns to the dashboard. */
-.v4-kpi.v4-kpi--no-anim {
-  opacity: 1;
-  transform: none;
-  animation: none;
-}
 .v4-kpi:hover {
   transform: translateY(-2px);
   box-shadow: 0 10px 28px rgba(11, 16, 32, 0.07);
@@ -8586,4 +8578,35 @@ ul.v4-rsh-list {
   align-items: center;
   gap: 4px;
   backdrop-filter: blur(4px);
+}
+
+/* ════════════════════════════════════════════════════════════════════════════
+   ENTRANCE-ANIMATION SUPPRESSION (tab returns)
+   Re-mounting DashboardView / MilestonesView when the user switches tabs
+   replays every entrance keyframe (v4-kpi-enter, wow-kpi-in, wow-card-in,
+   wow-stack-grow, wow-chart-wipe, wow-cell-pop, v4-mshero-enter,
+   v4-spark-fade) — visibly stutters when colliding with React reconciliation
+   and rAF tween loops. The `v4-tab--no-entrance` class is applied by
+   useFirstMountClass on subsequent mounts; these rules nullify the
+   entrances so the view renders instantly.
+
+   Pulse / spin / hover transitions are intentionally untouched — only
+   one-shot mount-time entrances are suppressed.
+   ════════════════════════════════════════════════════════════════════════════ */
+.v4-tab--no-entrance .v4-kpi,
+.v4-tab--no-entrance .v4-kpi-row > .v4-kpi,
+.v4-tab--no-entrance .v4-proj-grid > .v4-pcard,
+.v4-tab--no-entrance .v4-stack-list > .v4-stack-row,
+.v4-tab--no-entrance .v4-heat-strip > .v4-commit-row,
+.v4-tab--no-entrance .v4-stack-bar .v4-seg,
+.v4-tab--no-entrance .v4-commit-cells .v4-cc,
+.v4-tab--no-entrance .v4-mshero,
+.v4-tab--no-entrance .v4-mshero-spark-area {
+  animation: none !important;
+  opacity: 1 !important;
+  transform: none !important;
+}
+.v4-tab--no-entrance .v4-closed-chart svg {
+  animation: none !important;
+  clip-path: none !important;
 }


### PR DESCRIPTION
Two related dashboard UX issues.

## 1. Tab-switch jank — comprehensive suppression
The previous KpiRow-local flag only covered `v4-kpi-enter` (line 526). The «WOW layer» in v4.css (lines 7727+) re-applied a SECOND set of entrance keyframes on every re-mount: `wow-kpi-in`, `wow-card-in`, `wow-stack-grow`, `wow-chart-wipe`, `wow-cell-pop`, `v4-mshero-enter`, `v4-spark-fade`. Combined with React reconciliation and rAF tween loops kicking off together, switching dashboard ↔ milestones visibly stuttered on every return.

- New `useFirstMountClass` hook applies a `v4-tab--no-entrance` class on the view's root from the second mount onwards
- CSS rules nullify ALL one-shot entrances under that class (`.v4-kpi`, `.v4-pcard`, `.v4-stack-row`, `.v4-commit-row`, `.v4-seg`, `.v4-cc`, `.v4-mshero`, `.v4-mshero-spark-area`, `.v4-closed-chart svg`)
- Spinner / pulse / hover transitions are untouched
- Replaces the partial KpiRow-local flag

## 2. Heatmap tooltip lag
«Активность · коммиты по дням» tooltip sometimes didn't update or showed the previous cell when the cursor moved to an adjacent cell. Cause: per-cell `onMouseEnter` relied on React's synthetic mouseenter polyfill, which dropped events on fast moves and competed with cell transforms.

- Replaced with a single `onMouseMove` on each `.v4-commit-row`
- Computes column from cursor X relative to `.v4-commit-cells` bounds with an idempotent guard against redundant setHover calls
- Lifting the handler to the row covers Y movement too — tooltip stays in sync when moving between rows even through the row padding gap

## Test plan
- [ ] First open of dashboard → KPI tiles + project cards + heatmap cells fade in staggered (existing behavior)
- [ ] Switch to Milestones, back to Dashboard → all entrance animations skipped, instant render, no jank
- [ ] Switch back to Milestones → mshero + sparkline render instantly
- [ ] Hover over heatmap cell → tooltip appears with correct date + count
- [ ] Sweep cursor across cells horizontally → tooltip follows every cell
- [ ] Move cursor vertically between rows → tooltip updates row name + count without sticking

🤖 Generated with [Claude Code](https://claude.com/claude-code)