### PR TITLE
docs(prd-003): revert FR-10 to masked-only listing contract

### DIFF
--- a/docs/prds/PRD-003.md
+++ b/docs/prds/PRD-003.md
@@ -47,7 +47,7 @@ Server-side хранилище секретов в Pipeline API:
 | FR-7 | Bootstrap-токен `PIPELINE_SETTINGS_TOKEN` хранится в localStorage отдельно (`pipeline_settings_token`), вводится единожды через UI-prompt | must-have |
 | FR-8 | При получении 401 от external API (GitHub/Claude/BetterStack) dashboard показывает inline-уведомление «токен истёк» с кнопкой быстрого открытия Настроек | should-have |
 | FR-9 | Pipeline API логирует факт обращения к settings (без значений) в существующий лог-канал | should-have |
-| FR-10 | Plain-text значения секретов возвращаются только на authenticated endpoints `GET /settings` и `GET /settings/{key}` (Bearer-token обязателен). Listing endpoint `GET /settings/keys` возвращает только имена ключей без значений; в логах значения не появляются никогда | must-have |
+| FR-10 | Plain-text значения секретов возвращаются ТОЛЬКО через `GET /settings/{key}` (single-key fetch). Listing endpoints не отдают plain-text никогда: `GET /settings` → `[{key, masked_value}, ...]`, `GET /settings/{key}` → `{key, value}` (единственный путь к plain-text), `GET /settings/keys` → только имена ключей без значений. Bearer-token обязателен для всех endpoints, но не служит оправданием bulk-read plain-text — это отдельный security-boundary. В логах значения не появляются никогда. См. контракт реализации: `docs/epics/epic-004/task-02.md`. | must-have |
 
 ## Нефункциональные требования
 


### PR DESCRIPTION
Closes #311

## Проблема
PR #267 переписал FR-10 в `docs/prds/PRD-003.md` так, что plain-text значения секретов разрешены и на `GET /settings`, и на `GET /settings/{key}`. Это создавало конфликт с:

- `docs/epics/epic-004/task-02.md:25` (фактический контракт реализации) — там явно `GET /settings → list[{key, masked_value}]`.
- `src/utils/settings.ts:113-115` — дашборд-клиент определяет `SettingsListItem` с `masked_value`, не `value`.

Будущий backend, прочитав FR-10 как есть, мог бы реализовать plain values из `GET /settings` — security-регресс (массовая выгрузка секретов одним listing-запросом) и сразу ломает dashboard-loader.

## Что сделано
FR-10 откатан к masked-only варианту для listing endpoint:
- `GET /settings` → `[{key, masked_value}, ...]`, никогда plain-text;
- `GET /settings/{key}` → единственный путь к plain-text;
- `GET /settings/keys` → только имена ключей.

Фраза про Bearer-token оставлена как security-boundary, но без оправдания plain-text bulk-read'а. Добавлена ссылка на контракт-источник (`task-02.md`).

## Тесты
Только docs-fix, код не менялся. Тесты не требуются.

## Самопроверка
- [x] Согласовано с `docs/epics/epic-004/task-02.md:25`
- [x] Согласовано с `src/utils/settings.ts:113-115` (`SettingsListItem.masked_value`)
- [x] FR-2 (список endpoints) и FR-9 (логирование) не противоречат новой формулировке
- [x] Senior review проведён, P1 issues: 0

## Источник
Codex review: https://github.com/Sergio1990-1/makeit-dashboard/pull/267#discussion_r3179128911