### PR TITLE
fix(milestones): keep popup open on transient milestone absence

### DIFF
--- a/src/components/v4/milestones/MilestonesView.tsx
+++ b/src/components/v4/milestones/MilestonesView.tsx
@@ -13,7 +13,7 @@ import { MilestonesStatusBar } from "./MilestonesStatusBar";
 import { MilestoneIssuesPopup } from "./MilestoneIssuesPopup";
 import { classifyMilestone } from "./classifyMilestone";
 import { deadlineBucket } from "./utils";
-import { applyMilestoneOverrides } from "../../../utils/milestoneEdit";
+import { applyMilestoneOverrides, getMilestoneOverrides } from "../../../utils/milestoneEdit";
 
 interface Props {
   milestones: Milestone[];
@@ -112,11 +112,18 @@ export function MilestonesView({ milestones: rawMilestones, projects, lastUpdate
 
   // Re-resolve the popup milestone against the latest data so issue counts
   // refresh while the popup is open. Match by URL — stable across refreshes.
-  // If the milestone vanished (deletion), return null so the popup closes
-  // automatically instead of holding onto a stale snapshot.
+  // Distinguish "deleted" (close popup) from "transient absence" (fall back to
+  // the snapshot): the GraphQL window is bounded (first: 20 open / 10 closed
+  // by DUE_DATE), so a refresh can momentarily drop a milestone off the edge
+  // and lose in-progress edits if we treat that as deletion. The deletion
+  // signal is the explicit `overrides[url].deleted` flag set by the delete
+  // flow.
   const popupMsLive = useMemo(() => {
     if (!popupMs) return null;
-    return milestones.find((m) => m.url === popupMs.url) ?? null;
+    const fresh = milestones.find((m) => m.url === popupMs.url);
+    if (fresh) return fresh;
+    const wasDeleted = getMilestoneOverrides()[popupMs.url]?.deleted === true;
+    return wasDeleted ? null : popupMs;
   }, [milestones, popupMs]);
 
   // Anchor "now" to lastUpdated so daysUntil/Gantt today line stay consistent


### PR DESCRIPTION
Closes #305

## Проблема
`popupMsLive` возвращал `null`, когда выбранный milestone не находился в свежих `milestones`. Поскольку GraphQL-запрос ограничен `first: 20` (open) / `first: 10` (closed) по `DUE_DATE`, обычное обновление или попадание milestone'а на границу окна временно убирает его из массива → popup закрывается, in-progress правки теряются.

До PR #298 был fallback на `popupMs` (`?? popupMs`), который защищал от такой transient-пропажи. PR #298 заменил его на «закрыть при любом отсутствии», что объединило две разные ситуации.

## Что сделано
В `src/components/v4/milestones/MilestonesView.tsx:117-128` различаем «удалён» и «временно отсутствует»:
- Если milestone есть в свежих данных → `fresh` (актуальные счётчики);
- Если отсутствует **и** есть `overrides[url].deleted === true` → `null` (popup закрывается);
- Если отсутствует и `deleted` флага нет → возвращаем `popupMs` snapshot (fallback, как до #298).

`getMilestoneOverrides()` уже экспортирован из `utils/milestoneEdit.ts`, добавлен в импорт.

## Тесты
Логика корректности проверяется чтением: `deleted` флаг ставится явно delete-флоу через `setDeletedOverride`, transient absence его не ставит. tsc + eslint чистые. Точное воспроизведение race-condition требует манипуляции окном GraphQL и не делается в preview-смоук-тесте, но dev-сервер стартует без ошибок.

## Самопроверка
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — clean
- [x] Senior review проведён, P1 issues: 0

## Источник
Codex review: https://github.com/Sergio1990-1/makeit-dashboard/pull/298#discussion_r3180899398