### PR TITLE
fix(transcripts): clear only submitted batch in UploadZone

### DIFF
--- a/src/components/v4/transcripts/UploadZone.tsx
+++ b/src/components/v4/transcripts/UploadZone.tsx
@@ -104,11 +104,15 @@ export function UploadZone({
 
   const handleSubmit = useCallback(async () => {
     if (files.length === 0 || !selectedProject || submitting) return;
+    // Snapshot the batch we're submitting. The user can still queue more
+    // files during the in-flight upload (drag/drop, "+ Добавить"); clearing
+    // by snapshot identity preserves those instead of dropping them.
+    const submitted = files;
     setSubmitting(true);
     setLocalError(null);
     try {
-      await onSubmit(files);
-      setFiles([]);
+      await onSubmit(submitted);
+      setFiles((prev) => prev.filter((f) => !submitted.includes(f)));
       if (inputRef.current) inputRef.current.value = "";
     } catch (err) {
       // Keep selected files so the user can retry without re-picking them.


### PR DESCRIPTION
Closes #307

## Проблема
`handleSubmit` после успешного `await onSubmit(files)` безусловно делал `setFiles([])`. Но «+ Добавить» / drop / file picker НЕ заблокированы во время submitting'а, поэтому файлы, добавленные пользователем во время in-flight upload'а, тихо терялись — `setFiles([])` чистил весь стейт, а не отправленный батч. Заметно на медленных upload'ах больших mp3.

## Что сделано
В [src/components/v4/transcripts/UploadZone.tsx:105-122](src/components/v4/transcripts/UploadZone.tsx#L105) делаю snapshot отправляемого батча по ссылке и после успеха удаляю только эти File-инстансы:

\`\`\`ts
const submitted = files;
await onSubmit(submitted);
setFiles((prev) => prev.filter((f) => !submitted.includes(f)));
\`\`\`

Identity-сравнение работает потому что `addFiles` пушит те же File-инстансы в массив (через `[...prev, ...valid]`), не клонирует. Файлы, добавленные во время in-flight upload'а, переживают очистку и попадают в следующий батч.

Не блокирую кнопку «+ Добавить» / drop во время submitting'а — это была альтернатива в issue, но live-добавление в очередь — более естественный UX, и фикс снимает риск потери данных.

## Тесты
`tsc --noEmit` clean, `eslint` clean, dev-сервер стартует без ошибок. Точная race-condition (drop во время slow upload) не воспроизводится в preview без валидного Pipeline backend и реальных аудиофайлов; корректность проверяется чтением.

## Самопроверка
- [x] tsc + eslint clean
- [x] Senior review проведён, P1 issues: 0

## Источник
Codex review: https://github.com/Sergio1990-1/makeit-dashboard/pull/278#discussion_r3179453512