### PR TITLE
fix(kpi): align Прогресс портфеля card to a single scope

### DIFF
--- a/src/components/v4/KpiRow.tsx
+++ b/src/components/v4/KpiRow.tsx
@@ -203,15 +203,25 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
   const openDelta = useMemo(() => calcOpenDelta(projects), [projects]);
   const progressDelta = useMemo(() => calcProgressDelta(projects), [projects]);
   const priorityTotals = useMemo(() => sumOpenPriorities(projects), [projects]);
-  const openCount = useMemo(
-    () => projects.reduce((s, p) => s + (p.openCount ?? 0), 0),
-    [projects],
-  );
+  // Derive total/done/open from the (possibly phase-filtered) `projects` so
+  // all three splits-row numbers and the headline percentage live in the same
+  // scope. Using `summary.*` here mixed global totals with a filtered open
+  // count, producing inconsistent rows like done + open !== total under an
+  // active phaseFilter.
+  const { totalCount, doneCount, openCount } = useMemo(() => {
+    let total = 0;
+    let done = 0;
+    let open = 0;
+    for (const p of projects) {
+      total += p.totalCount ?? 0;
+      done += p.doneCount ?? 0;
+      open += p.openCount ?? 0;
+    }
+    return { totalCount: total, doneCount: done, openCount: open };
+  }, [projects]);
 
   const pctDone =
-    summary.totalIssues > 0
-      ? Math.round((summary.doneCount / summary.totalIssues) * 100)
-      : 0;
+    totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0;
 
   const hasFinances = summary.totalBudget > 0;
   const paidPct = hasFinances
@@ -268,12 +278,12 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
           items={[
             {
               key: "total",
-              n: <TweenedNumber value={summary.totalIssues} />,
+              n: <TweenedNumber value={totalCount} />,
               l: "Всего",
             },
             {
               key: "done",
-              n: <TweenedNumber value={summary.doneCount} />,
+              n: <TweenedNumber value={doneCount} />,
               l: "Сделано",
             },
             {


### PR DESCRIPTION
Closes #308

## Проблема
В splits-row карточки «Прогресс портфеля» три значения брали данные из РАЗНЫХ scope'ов:
- `summary.totalIssues` и `summary.doneCount` — глобальные;
- `openCount` (локальный `useMemo` по `projects`) — отфильтрованный по фазе.

При активном `phaseFilter` (`pre-dev`/`development`/`support`) карточка показывала противоречивые числа: `done + open !== total`, а проценту (`pctDone = done/total`, тоже глобальный) не соответствовал displayed open count.

## Что сделано
В [src/components/v4/KpiRow.tsx:206-225](src/components/v4/KpiRow.tsx#L206) суммирую `totalCount` / `doneCount` / `openCount` из `projects` (уже отфильтрованного DashboardView'ом) одним проходом, и считаю `pctDone` от того же scope. Все четыре числа теперь движутся синхронно при смене phase-фильтра.

Финансовые поля (`summary.totalBudget` / `totalPaid` / `totalRemaining`) остаются на `summary.*` — у финансов нет phase-семантики, и они проектно-глобальные by design.

## Тесты
`tsc --noEmit` clean, `eslint` clean, dev-сервер стартует без ошибок. Визуальную KPI-верификацию в этом preview-окружении не сделать (нет валидного GitHub PAT для загрузки реальных данных), но изменение узкое и читается прозрачно.

## Самопроверка
- [x] tsc + eslint clean
- [x] Senior review: P1 issues = 0; финансовые `summary.*` поля сохранены сознательно

## Источник
Codex review: https://github.com/Sergio1990-1/makeit-dashboard/pull/277#discussion_r3179430181