### PR TITLE
fix(verify-agent): cap Fallback A by inspected files, not rendered

### DIFF
--- a/src/utils/verify-agent.ts
+++ b/src/utils/verify-agent.ts
@@ -470,12 +470,17 @@ async function executeFindSymbolTool(
   // Fallback A: no def-fragment hits but raw hits exist — bare-query fallback may
   // have surfaced files where the first text match is a reference, not the def.
   // Scan top-3 candidate paths from the raw hits via findDefinitionLine before
-  // falling through to blind path guessing.
+  // falling through to blind path guessing. Cap by *inspected* files, not by
+  // `rendered.length` — every miss leaves rendered at 0 and otherwise the loop
+  // would walk all 10 hits, burning ~10× the GitHub API budget per call when
+  // the symbol isn't indexed.
   if (rendered.length === 0 && hits.length > 0) {
+    let inspected = 0;
     for (const hit of hits) {
-      if (rendered.length >= 3) break;
+      if (inspected >= 3 || rendered.length >= 3) break;
       if (seenPaths.has(hit.path)) continue;
       seenPaths.add(hit.path);
+      inspected++;
       const file = await fetchFileWithCache(githubToken, owner, repo, hit.path, cache);
       if (!file) continue;
       const line = findDefinitionLine(file.content, symbol);


### PR DESCRIPTION
Closes #310

## Проблема
Fallback A в [src/utils/verify-agent.ts:474-485](src/utils/verify-agent.ts#L474) (комментарий явно говорит «Scan top-3 candidate paths») выходил из цикла по `rendered.length >= 3`. Но если `findDefinitionLine` ничего не нашёл, `rendered.length` не растёт, и цикл фетчит **все 10 hits** из code search'а — на каждом промахе лишний GitHub API request.

При активной верификации findings (символ не индексирован → Fallback A — единственный путь) это съедало ~10× rate limit (PAT 5000/h) на каждый вызов `find_symbol_definition`.

## Что сделано
Отдельный счётчик `inspected` для инспектированных файлов; выход по `inspected >= 3 || rendered.length >= 3`. Семантика теперь совпадает с комментарием в коде.

## Тесты
`tsc --noEmit` clean, `eslint` clean. Изменение — внутри browser-side audit-verification агента, не observable в preview без активного аудита.

## Самопроверка
- [x] tsc + eslint clean
- [x] Senior review: P1 issues = 0

## Источник
Codex review: https://github.com/Sergio1990-1/makeit-dashboard/pull/269#discussion_r3179151688