### PR TITLE
fix(pipeline): rollback baseline on failed start + count session runs correctly

### DIFF
--- a/src/components/v4/pipeline/PipelineView.tsx
+++ b/src/components/v4/pipeline/PipelineView.tsx
@@ -119,6 +119,10 @@ export function PipelineView({
   // as state (not ref) so the cost memo sees the right value in the same
   // render commit cycle when a new run starts.
   const [baselineResultCount, setBaselineResultCount] = useState(0);
+  // Count of distinct run-starts detected in this component mount (session).
+  // Incremented on every running: false → true transition, covering both
+  // click-initiated runs and mid-run mounts (page refresh while running).
+  const [sessionRunCount, setSessionRunCount] = useState(0);
   // Last completed run summary (shown when idle).
   const [lastRunSummary, setLastRunSummary] = useState<{
     done: number;
@@ -141,9 +145,11 @@ export function PipelineView({
   useEffect(() => {
     if (!status) return;
     if (status.running && !wasRunningRef.current) {
-      // New run started. If handleStart already captured the baseline
-      // synchronously, keep it — otherwise this is a mid-run mount and we
-      // take the current results length as the best-effort baseline.
+      // New run started — count it regardless of how the transition was triggered.
+      setSessionRunCount((c) => c + 1);
+      // If handleStart already captured the baseline synchronously, keep it —
+      // otherwise this is a mid-run mount and we take the current results
+      // length as the best-effort baseline.
       if (baselineSetByClickRef.current) {
         baselineSetByClickRef.current = false;
       } else {
@@ -173,11 +179,8 @@ export function PipelineView({
   const { sessionCost, sessionRuns } = useMemo(() => {
     if (!status) return { sessionCost: 0, sessionRuns: 0 };
     const cost = sumCost(status.results);
-    // A running pipeline is the same run that produced any existing results,
-    // so count "1" when either condition holds — never both.
-    const hasRun = status.results.length > 0 || (status.running && runStartedAt !== null);
-    return { sessionCost: cost, sessionRuns: hasRun ? 1 : 0 };
-  }, [status, runStartedAt]);
+    return { sessionCost: cost, sessionRuns: sessionRunCount };
+  }, [status, sessionRunCount]);
 
   // Classify dialog
   const [classifyDialogOpen, setClassifyDialogOpen] = useState(false);
@@ -225,19 +228,25 @@ export function PipelineView({
     ? `${GITHUB_OWNER}/${status.current_project}`
     : null;
 
-  function handleStart() {
+  async function handleStart() {
     // Capture the baseline at click time so results produced between this
     // moment and the first poll observing `running=true` are still attributed
     // to the new run. Issue #239.
     baselineSetByClickRef.current = true;
     setBaselineResultCount(statusRef.current?.results.length ?? 0);
     setRunStartedAt(Date.now());
-    void start({
+    const ok = await start({
       project: selectedProject || undefined,
       labels: selectedLabels.length > 0 ? selectedLabels : undefined,
       limit,
       complexity_filter: complexityFilter !== "all" ? complexityFilter : undefined,
     });
+    if (!ok) {
+      // Roll back the baseline so a subsequent successful run gets a fresh
+      // snapshot rather than computing cost/elapsed from this failed click.
+      baselineSetByClickRef.current = false;
+      setRunStartedAt(null);
+    }
   }
 
   // Project label for hero (shorthand without owner)

--- a/src/components/v4/pipeline/PipelineView.tsx
+++ b/src/components/v4/pipeline/PipelineView.tsx
@@ -232,8 +232,9 @@ export function PipelineView({
     // Capture the baseline at click time so results produced between this
     // moment and the first poll observing `running=true` are still attributed
     // to the new run. Issue #239.
+    const prevBaseline = statusRef.current?.results.length ?? 0;
     baselineSetByClickRef.current = true;
-    setBaselineResultCount(statusRef.current?.results.length ?? 0);
+    setBaselineResultCount(prevBaseline);
     setRunStartedAt(Date.now());
     const ok = await start({
       project: selectedProject || undefined,
@@ -242,10 +243,11 @@ export function PipelineView({
       complexity_filter: complexityFilter !== "all" ? complexityFilter : undefined,
     });
     if (!ok) {
-      // Roll back the baseline so a subsequent successful run gets a fresh
-      // snapshot rather than computing cost/elapsed from this failed click.
+      // Roll back all baseline state so a subsequent successful run gets a
+      // fresh snapshot rather than computing cost/elapsed from this failed click.
       baselineSetByClickRef.current = false;
       setRunStartedAt(null);
+      setBaselineResultCount(prevBaseline);
     }
   }
 

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -125,7 +125,7 @@ export function usePipeline() {
   }, []);
 
   const start = useCallback(
-    async (req: PipelineStartRequest) => {
+    async (req: PipelineStartRequest): Promise<boolean> => {
       setError(null);
       setStarting(true);
       try {
@@ -135,8 +135,10 @@ export function usePipeline() {
         // Reset backoff streak so we drop back to fast (2s) cadence immediately.
         notRunningStreakRef.current = 0;
         startPolling();
+        return true;
       } catch (err) {
         setError(err instanceof Error ? err.message : "Ошибка запуска");
+        return false;
       } finally {
         setStarting(false);
       }


### PR DESCRIPTION
Closes #306
Closes #309

## Что сделано

**#306 — rollback baseline when start fails**

`handleStart` optimistically captured `baselineSetByClickRef`, `baselineResultCount`, and `runStartedAt` before calling `start()` as fire-and-forget. If `/pipeline/start` returned an error, the ref stayed `true` and the timestamp kept the failed-click value. On the next successful run, the running-transition effect skipped its own baseline capture (because `baselineSetByClickRef` was still `true`), so `currentRunCost`, `elapsed`, and `lastRunSummary` were computed from stale state.

Fix:
- `start()` in `usePipeline.ts` now returns `Promise<boolean>` (`true` = success, `false` = error caught internally)
- `handleStart` is now `async`, awaits the result, and rolls back `baselineSetByClickRef` + `runStartedAt` on failure

**#309 — sessionRuns: count distinct run-starts**

`sessionRuns` was `hasRun ? 1 : 0` — capped at 1, unable to represent multi-run sessions where `status.results` accumulates results from previous runs.

Fix:
- Added `sessionRunCount: number` state, initialized to `0` on component mount
- Incremented with `setSessionRunCount((c) => c + 1)` at the top of the `running: false → true` branch in the existing transition effect — covers both click-initiated runs and mid-run page-refresh mounts
- `sessionRuns` memo now returns `sessionRunCount` directly

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review: P1 issues 0, P2 issues 0
- [x] `tsc --noEmit` чист
- [x] ESLint чист