### PR TITLE
ci: skip CI on docs-only changes (paths-ignore)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,14 @@ concurrency:
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - docs/**
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Why
GitHub-hosted runner queue saturates when many PRs land in a short window — the `test` job ends up waiting 15+ minutes behind shorter jobs. Most of those runs were triggered by docs-only PRs (anchor fixes, runbook tweaks) that don't need the test suite.

## Change
Add `paths-ignore` to `push:` / `pull_request:` triggers on the CI workflow(s). Skips entire workflow when the diff touches only:
- `**/*.md` (any markdown)
- `docs/**` (the docs tree)

Idempotent — `paths-ignore` entries are appended only if not already present. No branch protection on `main` requires the `test` check, so skipped workflows won't block merges.

## Scope
This is the same change rolled out across all MakeIT projects with active CI workflows.
