### PR TITLE
feat(pipeline): milestone dropdown in PipelineControlPanel

### DIFF
--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
 import { usePipeline } from "../hooks/usePipeline";
-import { GITHUB_OWNER, PROJECTS } from "../utils/config";
+import { GITHUB_OWNER, PROJECTS, getToken } from "../utils/config";
 import type { ComplexityFilter, ComplexityLevel, ClassifyProgress, ClassifyResponse, EscalationCategory, Outcome } from "../utils/pipeline";
 import { classifyIssues } from "../utils/pipeline";
+import { fetchOpenMilestones, type OpenMilestone } from "../utils/github";
 import type { ProjectData } from "../types";
 import { PipelineClosedChart } from "./PipelineClosedChart";
 import { IssueTimeline } from "./IssueTimeline";
@@ -233,6 +234,11 @@ function OutcomeBadge({ outcome }: { outcome: Outcome }) {
   );
 }
 
+/* Module-scoped cache: open milestones per "owner/repo". Persists across
+ * remounts of PipelineControlPanel and avoids hammering the REST API every
+ * time the user toggles labels / limit. Invalidated only by reload. */
+const milestoneCache = new Map<string, OpenMilestone[]>();
+
 /* ── Main component ── */
 
 interface PipelineControlPanelProps {
@@ -272,6 +278,10 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
     const valid: ComplexityFilter[] = ["auto", "assisted", "all"];
     return stored && valid.includes(stored as ComplexityFilter) ? (stored as ComplexityFilter) : "all";
   });
+  const [selectedMilestone, setSelectedMilestone] = useState<string>(() => {
+    return localStorage.getItem("pipeline_milestone") ?? "";
+  });
+  const [milestoneOptions, setMilestoneOptions] = useState<OpenMilestone[]>([]);
 
   useEffect(() => {
     localStorage.setItem("pipeline_project", selectedProject);
@@ -288,6 +298,50 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
   useEffect(() => {
     localStorage.setItem("pipeline_complexity", complexityFilter);
   }, [complexityFilter]);
+
+  useEffect(() => {
+    localStorage.setItem("pipeline_milestone", selectedMilestone);
+  }, [selectedMilestone]);
+
+  useEffect(() => {
+    if (!selectedProject) {
+      setMilestoneOptions([]);
+      return;
+    }
+    const cached = milestoneCache.get(selectedProject);
+    if (cached) {
+      setMilestoneOptions(cached);
+      return;
+    }
+    const token = getToken();
+    if (!token) {
+      setMilestoneOptions([]);
+      return;
+    }
+    const [owner, repo] = selectedProject.split("/");
+    if (!owner || !repo) {
+      setMilestoneOptions([]);
+      return;
+    }
+    let cancelled = false;
+    void fetchOpenMilestones(token, owner, repo).then((items) => {
+      if (cancelled) return;
+      milestoneCache.set(selectedProject, items);
+      setMilestoneOptions(items);
+    });
+    return () => { cancelled = true; };
+  }, [selectedProject]);
+
+  // If the current selection is no longer one of the open milestones for this
+  // project (e.g. project switched, or milestone was closed since cache built),
+  // clear it so we don't send a stale title that resolves to an empty fan-out.
+  useEffect(() => {
+    if (!selectedMilestone) return;
+    if (milestoneOptions.length === 0) return;
+    if (!milestoneOptions.some((m) => m.title === selectedMilestone)) {
+      setSelectedMilestone("");
+    }
+  }, [milestoneOptions, selectedMilestone]);
 
   useEffect(() => {
     if (available && selectedProject) void loadStats(selectedProject);
@@ -355,6 +409,7 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
       labels: selectedLabels.length > 0 ? selectedLabels : undefined,
       limit,
       complexity_filter: complexityFilter !== "all" ? complexityFilter : undefined,
+      milestone: selectedMilestone || undefined,
     });
   }
 
@@ -440,6 +495,32 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
             {PROJECTS.map((p) => (
               <option key={p.repo} value={`${p.owner}/${p.repo}`}>
                 {p.repo}
+              </option>
+            ))}
+          </select>
+
+          {/* Milestone selector (optional, AND with labels). Disabled when
+             pipeline is running, when no project is selected (the API needs
+             owner/repo to resolve title→id), or when the project has no open
+             milestones — keeps the dropdown from looking interactive but empty. */}
+          <select
+            className="input"
+            style={{ fontSize: "var(--text-sm)", padding: "4px 8px", minWidth: 160 }}
+            value={selectedMilestone}
+            onChange={(e) => setSelectedMilestone(e.target.value)}
+            disabled={isRunning || !selectedProject || milestoneOptions.length === 0}
+            title={
+              !selectedProject
+                ? "Выберите проект, чтобы увидеть milestones"
+                : milestoneOptions.length === 0
+                  ? "У проекта нет открытых milestones"
+                  : "Фильтр по milestone (опционально)"
+            }
+          >
+            <option value="">Все milestones</option>
+            {milestoneOptions.map((m) => (
+              <option key={m.number} value={m.title}>
+                {m.title}
               </option>
             ))}
           </select>

--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -279,7 +279,11 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
     return stored && valid.includes(stored as ComplexityFilter) ? (stored as ComplexityFilter) : "all";
   });
   const [selectedMilestone, setSelectedMilestone] = useState<string>(() => {
-    return localStorage.getItem("pipeline_milestone") ?? "";
+    // Per-project key so a milestone chosen for repo A doesn't bleed into repo
+    // B (titles can collide and would otherwise pass the stale-clear guard).
+    const initialProject = localStorage.getItem("pipeline_project")
+      ?? `${GITHUB_OWNER}/moliyakg`;
+    return localStorage.getItem(`pipeline_milestone:${initialProject}`) ?? "";
   });
   const [milestoneOptions, setMilestoneOptions] = useState<OpenMilestone[]>([]);
 
@@ -299,9 +303,25 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
     localStorage.setItem("pipeline_complexity", complexityFilter);
   }, [complexityFilter]);
 
+  // Persist milestone choice per-project. Skip writes for the empty value when
+  // there's nothing in storage to clear — keeps localStorage from being seeded
+  // with `pipeline_milestone:owner/repo=""` entries on first mount.
   useEffect(() => {
-    localStorage.setItem("pipeline_milestone", selectedMilestone);
-  }, [selectedMilestone]);
+    if (!selectedProject) return;
+    const key = `pipeline_milestone:${selectedProject}`;
+    if (selectedMilestone) {
+      localStorage.setItem(key, selectedMilestone);
+    } else {
+      localStorage.removeItem(key);
+    }
+  }, [selectedMilestone, selectedProject]);
+
+  // When the project changes, restore that project's saved milestone. The
+  // alternative (keeping the previous project's title) lets a same-named
+  // milestone in repo B silently inherit repo A's selection.
+  useEffect(() => {
+    setSelectedMilestone(localStorage.getItem(`pipeline_milestone:${selectedProject}`) ?? "");
+  }, [selectedProject]);
 
   useEffect(() => {
     if (!selectedProject) {
@@ -326,6 +346,10 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
     let cancelled = false;
     void fetchOpenMilestones(token, owner, repo).then((items) => {
       if (cancelled) return;
+      // null = transient auth/network failure — don't cache, so the next
+      // project switch (or dashboard refresh) retries instead of showing
+      // a permanently empty dropdown until the user reloads.
+      if (items === null) return;
       milestoneCache.set(selectedProject, items);
       setMilestoneOptions(items);
     });

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -102,6 +102,34 @@ function buildActivity(byDate: Record<string, number>): CommitActivity {
   };
 }
 
+export interface OpenMilestone {
+  number: number;
+  title: string;
+  due_on: string | null;
+}
+
+interface RestMilestone {
+  number: number;
+  title: string;
+  due_on: string | null;
+}
+
+/** Fetch open milestones for a single repo via REST. Returns [] on auth/network
+ * failure — the dropdown should degrade to "no filter" rather than block the
+ * Pipeline run UI. */
+export async function fetchOpenMilestones(
+  token: string,
+  owner: string,
+  repo: string,
+): Promise<OpenMilestone[]> {
+  const items = await restGet<RestMilestone[]>(
+    token,
+    `/repos/${owner}/${repo}/milestones?state=open&sort=due_on&direction=asc&per_page=100`,
+  );
+  if (!Array.isArray(items)) return [];
+  return items.map((m) => ({ number: m.number, title: m.title, due_on: m.due_on }));
+}
+
 const GITHUB_GRAPHQL = "https://api.github.com/graphql";
 
 async function graphql<T>(token: string, query: string, variables: Record<string, unknown> = {}): Promise<T> {

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -114,18 +114,23 @@ interface RestMilestone {
   due_on: string | null;
 }
 
-/** Fetch open milestones for a single repo via REST. Returns [] on auth/network
- * failure — the dropdown should degrade to "no filter" rather than block the
- * Pipeline run UI. */
+/** Fetch open milestones for a single repo via REST.
+ *
+ * Returns:
+ *   - `OpenMilestone[]` (possibly empty) on success — empty means "repo has no
+ *     open milestones", which is a legitimate steady state worth caching.
+ *   - `null` on auth/network failure — the caller should NOT cache this,
+ *     otherwise a transient 401 permanently breaks the dropdown until reload. */
 export async function fetchOpenMilestones(
   token: string,
   owner: string,
   repo: string,
-): Promise<OpenMilestone[]> {
+): Promise<OpenMilestone[] | null> {
   const items = await restGet<RestMilestone[]>(
     token,
     `/repos/${owner}/${repo}/milestones?state=open&sort=due_on&direction=asc&per_page=100`,
   );
+  if (items === null) return null;
   if (!Array.isArray(items)) return [];
   return items.map((m) => ({ number: m.number, title: m.title, due_on: m.due_on }));
 }

--- a/src/utils/pipeline.ts
+++ b/src/utils/pipeline.ts
@@ -9,6 +9,10 @@ export interface PipelineStartRequest {
   labels?: string[];
   limit?: number;
   complexity_filter?: ComplexityFilter;
+  /** Open-milestone title to filter issues by (AND with labels). Backend
+   * accepts the title string, normalises whitespace-only to "no filter", and
+   * passes through the special tokens `*` and `none` unchanged. */
+  milestone?: string;
 }
 
 export type PhaseStatus =


### PR DESCRIPTION
Closes #326

## Summary
- Adds optional **Milestone** dropdown to the Pipeline run controls (Task-02 of [epic-035](https://github.com/Sergio1990-1/makeit-pipeline/blob/main/docs/epics/epic-035.md)).
- Wires `milestone` (title string) into `POST /pipeline/start` payload — the Pipeline backend ([Task-01 #1124](https://github.com/Sergio1990-1/makeit-pipeline/issues/1124), merged in [makeit-pipeline #1135](https://github.com/Sergio1990-1/makeit-pipeline/pull/1135)) resolves title → numeric id and ANDs it with `--label`.

## Что сделано
- New `fetchOpenMilestones(token, owner, repo)` REST helper in `utils/github.ts` (sorted by `due_on`, returns `[]` on auth/network failure → UI degrades gracefully).
- Module-scoped `milestoneCache` keyed by `owner/repo` — first selection populates, label/limit toggles don't refetch.
- Selection persists in localStorage and self-clears when the saved title is no longer in the current project's open milestones.
- Empty selection = no filter; dropdown disabled while pipeline is running, when no project is selected, or when the project has no open milestones.

## Notes vs. issue spec
- Issue references path `src/components/Pipeline/PipelineTab.tsx` — that file doesn't exist; the actual run UI lives in `src/components/PipelineControlPanel.tsx` (the spec was written before a refactor). Implemented there.
- Backend contract (per PR #1135): pass milestone **title** as `str | None`. Special tokens `*` / `none` are passed through unchanged; whitespace-only is normalised server-side.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run build\` clean
- [ ] Manual: load dashboard with valid Pipeline settings + GitHub PAT → Pipeline tab shows milestone dropdown next to project selector → select milestone → start pipeline → confirm Pipeline backend filters by that milestone (E2E coverage of the resolve-and-filter path lives in makeit-pipeline tests added by PR #1135).

🤖 Generated with [Claude Code](https://claude.com/claude-code)