### PR TITLE
fix(settings): set default DB path to writable /data in Docker image

### DIFF
--- a/services/settings/Dockerfile
+++ b/services/settings/Dockerfile
@@ -12,6 +12,7 @@ COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3
 COPY --from=build /usr/local/bin /usr/local/bin
 COPY src/ ./src/
 USER settings
-ENV PYTHONPATH=/app/src
+ENV PYTHONPATH=/app/src \
+    MAKEIT_SETTINGS_DB_PATH=/data/settings.db
 EXPOSE 8768
 CMD ["uvicorn", "makeit_settings.app:app", "--host", "0.0.0.0", "--port", "8768"]


### PR DESCRIPTION
## Summary

Closes #331.

`services/settings/Dockerfile` creates the `settings` user with `useradd --system --uid 1001` (no `--create-home`, no `--home-dir`). As a result `Path.home()` for that user resolves to `/home/settings` which does not exist, and the user has no permission to create it. The default DB path in `settings_store.py` is `Path.home() / ".makeit-pipeline" / "settings.db"`, so `parent.mkdir(parents=True, exist_ok=True)` raises `PermissionError`. The lifespan handler catches it, sets `app.state.settings_store = None`, and every `/settings/*` request answers `503`.

Production hides this behind docker-compose, which already exports `MAKEIT_SETTINGS_DB_PATH=/data/settings.db`. But the image itself is not self-contained: `docker run` against the built image alone yields a broken service.

## Fix

Bake `MAKEIT_SETTINGS_DB_PATH=/data/settings.db` into the image. The `/data` directory is already created and chowned to `settings:settings` earlier in the same Dockerfile, so the writes succeed out of the box.

```dockerfile
ENV PYTHONPATH=/app/src \
    MAKEIT_SETTINGS_DB_PATH=/data/settings.db
```

Production docker-compose still sets the same env explicitly (already documented in `docs/superpowers/plans/2026-05-07-vps-settings-service.md`), so behaviour there is unchanged — Docker env from compose/k8s overrides image ENV as usual.

## Why ENV, not `useradd --create-home --home-dir`

- Cleaner: no extra `/home/settings` directory that nothing references.
- Self-documenting: makes the canonical writable location for the DB obvious to anyone reading the Dockerfile.
- Consistent with production: same path, same env name, same source of truth.

## Test plan

- [x] `git diff` shows only `services/settings/Dockerfile` modified (two lines, one ENV merge).
- [ ] CI image build succeeds (Docker daemon unavailable locally, deferred to CI).
- [ ] Post-deploy: `docker run --rm makeit-settings` followed by `curl :8768/settings/...` returns non-503.