### PR TITLE
fix(pipeline): bootstrap session run count on idle mount

### DIFF
--- a/src/components/v4/pipeline/PipelineView.tsx
+++ b/src/components/v4/pipeline/PipelineView.tsx
@@ -141,9 +141,32 @@ export function PipelineView({
   // results that arrive between the click and the first `running=true` poll
   // are still counted toward currentRunCost and the final run summary.
   const baselineSetByClickRef = useRef(false);
+  // One-shot guard for the session-run bootstrap on the first received status.
+  // Issue #332.
+  const bootstrappedRef = useRef(false);
 
   useEffect(() => {
     if (!status) return;
+
+    // Bootstrap on the first status if there are already finalized results
+    // from an earlier run in this API session (page mounted/refreshed mid-idle
+    // after a completed run). Counts as one "session run" — the backend keeps
+    // results only for the current API session, so all completed items belong
+    // to the same logical run as far as session metrics are concerned.
+    // Without this, sessionRunCount stays 0 while sessionCost > 0, producing
+    // an inconsistent "$X spent, 0 runs" KPI. Issue #332.
+    if (!bootstrappedRef.current) {
+      bootstrappedRef.current = true;
+      if (!status.running && status.results.length > 0) {
+        const finalCount = status.results.filter(
+          (r) => r.status !== "queued" && r.status !== "in_progress",
+        ).length;
+        if (finalCount > 0) {
+          setSessionRunCount(1);
+        }
+      }
+    }
+
     if (status.running && !wasRunningRef.current) {
       // New run started — count it regardless of how the transition was triggered.
       setSessionRunCount((c) => c + 1);


### PR DESCRIPTION
Closes #332

## Проблема
`sessionRunCount` инкрементировался только на переходе `running: false → true`. При page refresh в момент idle с уже завершёнными результатами от текущей API-сессии метрика оставалась 0, при том что `sessionCost > 0` (суммировался напрямую из `status.results`). KPI strip показывал «$X spent, 0 runs» — внутренне противоречиво.

## Решение
На первом получаемом status, если pipeline idle и есть финальные results, bootstrap `sessionRunCount = 1`. Backend держит results только current API session, поэтому все завершённые элементы относятся к одному логическому run. Следующие Start клики увеличивают через существующий transition tracker (mount idle с результатами + Start → sessionRuns = 2).

Реализовано через one-shot `bootstrappedRef` (присваивается до проверки, чтобы гарантировать срабатывание ровно один раз на mount). Mount при running=true → bootstrap пропускается, дальше работает обычный transition tracker.

## Альтернативы (отвергнуты)
- Считать distinct runs по timestamp-группам в `status.results` — fragile, нет надёжного маркера группировки на клиенте (в API нет run_id).
- Заменить sessionRuns другой метрикой (issues processed) — больший рефактор, меняет UX-семантику.

## Test plan
- [ ] Mount при idle + есть финальные результаты → sessionRuns = 1
- [ ] Mount при idle + нет результатов → sessionRuns = 0
- [ ] Mount при running → bootstrap skip, transition сработает нормально
- [ ] Start после idle-bootstrap → sessionRuns = 2 (1 bootstrap + 1 new transition)

## Проверки
- [x] tsc clean
- [x] lint clean
- [x] build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)