### PR TITLE
fix(pipeline): re-fetch milestones when GitHub token becomes available

### DIFF
--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { usePipeline } from "../hooks/usePipeline";
 import { GITHUB_OWNER, PROJECTS, getToken } from "../utils/config";
+import { SETTINGS_CHANGED_EVENT } from "../utils/settings";
 import type { ComplexityFilter, ComplexityLevel, ClassifyProgress, ClassifyResponse, EscalationCategory, Outcome } from "../utils/pipeline";
 import { classifyIssues } from "../utils/pipeline";
 import { fetchOpenMilestones, type OpenMilestone } from "../utils/github";
@@ -294,6 +295,10 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
   // we either kept a stale localStorage milestone forever (when fetch never
   // ran because of missing token) or cleared in-flight selections mid-fetch.
   const [milestoneLoadState, setMilestoneLoadState] = useState<MilestoneLoadState>("idle");
+  // Issue #330: bumped from the SETTINGS_CHANGED_EVENT listener when the GitHub
+  // token is saved/cleared elsewhere in the app. Included in the fetch effect's
+  // deps so the load re-runs against the new auth state without a full reload.
+  const [milestoneRefreshTick, setMilestoneRefreshTick] = useState(0);
 
   useEffect(() => {
     localStorage.setItem("pipeline_project", selectedProject);
@@ -375,6 +380,21 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
       setMilestoneLoadState("loaded");
     });
     return () => { cancelled = true; };
+  }, [selectedProject, milestoneRefreshTick]);
+
+  // Token-availability subscriber (issue #330): when github_token is saved or
+  // cleared elsewhere in the app (Settings panel, legacy TokenForm, logout),
+  // drop the cache entry for the current project so the fetch effect re-runs
+  // against the new auth state instead of serving the stale "no-token" cache.
+  useEffect(() => {
+    function onSettingsChange(e: Event) {
+      const detail = (e as CustomEvent<{ key?: string }>).detail;
+      if (detail?.key !== "github_token") return;
+      if (selectedProject) milestoneCache.delete(selectedProject);
+      setMilestoneRefreshTick((n) => n + 1);
+    }
+    window.addEventListener(SETTINGS_CHANGED_EVENT, onSettingsChange);
+    return () => window.removeEventListener(SETTINGS_CHANGED_EVENT, onSettingsChange);
   }, [selectedProject]);
 
   // If the current selection is no longer one of the open milestones for this

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,5 +1,5 @@
 import type { ProjectConfig } from "../types";
-import { deleteSetting, getSetting } from "./settings";
+import { deleteSetting, getSetting, notifySettingChanged } from "./settings";
 
 export const GITHUB_OWNER = "Sergio1990-1";
 export const GITHUB_PROJECT_NUMBER = 1;
@@ -85,6 +85,10 @@ export function getToken(): string | null {
 
 export function setToken(token: string): void {
   localStorage.setItem("github_token", token);
+  // Mirror the dispatch that `setSetting()` does for the canonical path so
+  // subscribers (issue #330) react the same way regardless of which form
+  // wrote the token.
+  notifySettingChanged("github_token");
 }
 
 // Logout / "Очистить" must wipe BOTH the legacy localStorage entry AND the
@@ -95,6 +99,7 @@ export function setToken(token: string): void {
 export function clearToken(): void {
   localStorage.removeItem("github_token");
   void deleteSetting("github_token").catch(() => {});
+  notifySettingChanged("github_token");
 }
 
 export function getClaudeKey(): string | null {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -34,6 +34,40 @@ const BOOTSTRAP_TOKEN_KEY = "pipeline_settings_token";
  */
 export const SETTINGS_AUTH_LOST_EVENT = "settings:auth-lost";
 
+/**
+ * Fired when a setting value is changed via `setSetting()` / `deleteSetting()`
+ * or — for legacy localStorage-backed secrets — `setToken()` / `clearToken()`
+ * (and friends) in `utils/config.ts`. The `detail.key` identifies the setting
+ * that changed so listeners can filter cheaply.
+ *
+ * Motivation (issue #330): components that read a secret via `getToken()` on
+ * mount and key effects off `[selectedProject]` had no signal when the user
+ * saved a token elsewhere (SettingsPanel, legacy TokenForm). They'd stay in a
+ * "no-token" state until a full page reload. Subscribing to this event lets
+ * them invalidate caches and re-run fetches without polling or prop-drilling.
+ *
+ * Dispatched only on successful write (and after the local mutation) so
+ * listeners can trust that a subsequent `getSetting()` / `getToken()` will
+ * return the new value.
+ */
+export const SETTINGS_CHANGED_EVENT = "settings:changed";
+
+/** Internal helper: fire the change event for `key`. No-op outside browsers. */
+function emitSettingsChanged(key: string): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(SETTINGS_CHANGED_EVENT, { detail: { key } }));
+}
+
+/**
+ * Exported for `utils/config.ts` so the legacy `setToken()` / `clearToken()`
+ * paths can emit the same event without duplicating the dispatch boilerplate.
+ * Not part of the public settings API surface — kept here so the event name
+ * and detail shape stay in one place.
+ */
+export function notifySettingChanged(key: string): void {
+  emitSettingsChanged(key);
+}
+
 /** 401 from the pipeline — bootstrap token is missing or invalid. */
 export class SettingsAuthError extends Error {
   constructor(message = "Pipeline settings: unauthorized") {
@@ -316,6 +350,10 @@ export async function setSetting(key: string, value: string): Promise<void> {
   await res.text().catch(() => "");
   if (!cache) cache = new Map();
   cache.set(key, value);
+  // Emit AFTER the local mutation lands so subscribers reading via
+  // `getSetting(key)` synchronously in their listener observe the new value.
+  // Skipped on failures because `request()` throws above this point.
+  emitSettingsChanged(key);
 }
 
 /** DELETE /settings/{key} — also removes from the in-memory cache on success. */
@@ -325,6 +363,7 @@ export async function deleteSetting(key: string): Promise<void> {
   });
   await res.text().catch(() => "");
   cache?.delete(key);
+  emitSettingsChanged(key);
 }
 
 /** GET /settings/keys — list of declared/known keys. */


### PR DESCRIPTION
Closes #330

## Проблема
Effect загрузки milestones в `PipelineControlPanel` зависел только от `[selectedProject]`. На первый mount без GitHub токена effect выходил в `milestoneLoadState = "no-token"` и больше не пересматривался — milestone dropdown оставался disabled до full reload после сохранения токена в Settings.

## Решение

### 1. `SETTINGS_CHANGED_EVENT` в `src/utils/settings.ts`
Новое событие по образцу существующего `SETTINGS_AUTH_LOST_EVENT`. Диспатчится из `setSetting()` и `deleteSetting()` ПОСЛЕ успешного локального обновления — listener'ы могут синхронно вычитать новое значение через `getSetting()`. На сетевых провалах не диспатчится (request() кидает до точки emit).

### 2. Legacy путь в `src/utils/config.ts`
`setToken()` и `clearToken()` пишут в localStorage напрямую (legacy путь для TokenForm / ChatPanel — см. комментарий в файле). Обе теперь вызывают `notifySettingChanged("github_token")` — экспортированный helper из settings.ts, чтобы event name и detail shape жили в одном месте.

### 3. Subscriber в `PipelineControlPanel`
Новый useEffect слушает `SETTINGS_CHANGED_EVENT`, фильтрует `detail.key === "github_token"`, инвалидирует `milestoneCache.delete(selectedProject)` и инкрементит `milestoneRefreshTick`. Основной fetch-effect получил `milestoneRefreshTick` в deps — re-run срабатывает синхронно после event'а.

## Почему такой подход
- Соответствует существующему паттерну (`SETTINGS_AUTH_LOST_EVENT`) — никакой новой архитектуры.
- Не требует Context/Zustand/refactor'a — один event, один listener, ~20 строк.
- Покрывает оба пути записи токена (Settings panel через `setSetting` + legacy через `setToken`).

## Test plan
- [ ] Mount без токена → state `"no-token"`, dropdown disabled
- [ ] Сохранить токен в Settings panel → event fires → fetch стартует → dropdown enabled
- [ ] Clear token (logout) → event fires → fetch снова уходит в `"no-token"`
- [ ] Legacy TokenForm save → тот же путь через `setToken()`

## Проверки
- [x] tsc -b clean
- [x] npm run lint clean
- [x] npm run build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)