### PR TITLE
feat(budget): BudgetWidget on project card (epic-035 Task-06)

### DIFF
--- a/src/components/v4/BudgetWidget.tsx
+++ b/src/components/v4/BudgetWidget.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { fetchBudget, type BudgetSummary } from "../../utils/pipeline";
 
 interface Props {
@@ -44,15 +44,17 @@ export function BudgetWidget({ project, pollIntervalMs = DEFAULT_POLL_MS }: Prop
   // the widget does not flash a placeholder on every project card during
   // initial mount.
   const [loaded, setLoaded] = useState(false);
-  const mountedRef = useRef(true);
 
   useEffect(() => {
-    mountedRef.current = true;
+    // The closure-scoped ``cancelled`` flag is the single load-bearing
+    // guard against late ``setState`` after unmount or a deps-change
+    // re-run.  ``clearInterval`` stops the timer, ``cancelled`` catches
+    // the in-flight ``await fetchBudget`` whose result must be discarded.
     let cancelled = false;
 
     const tick = async () => {
       const snap = await fetchBudget(project);
-      if (cancelled || !mountedRef.current) return;
+      if (cancelled) return;
       setData(snap);
       setLoaded(true);
     };
@@ -61,7 +63,6 @@ export function BudgetWidget({ project, pollIntervalMs = DEFAULT_POLL_MS }: Prop
     const id = window.setInterval(tick, pollIntervalMs);
     return () => {
       cancelled = true;
-      mountedRef.current = false;
       window.clearInterval(id);
     };
   }, [project, pollIntervalMs]);

--- a/src/components/v4/BudgetWidget.tsx
+++ b/src/components/v4/BudgetWidget.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from "react";
+import { fetchBudget, type BudgetSummary } from "../../utils/pipeline";
+
+interface Props {
+  /** GitHub repo slug (e.g. `Sergio1990-1/moliyakg`). */
+  project: string;
+  /** Override polling cadence (ms). Default 60 s per epic-035 spec. */
+  pollIntervalMs?: number;
+}
+
+const DEFAULT_POLL_MS = 60_000;
+
+function formatUsd(amount: number): string {
+  return `$${amount.toFixed(2)}`;
+}
+
+function statusColor(status: BudgetSummary["status"], percentage: number | null): string {
+  // Mirrors the pipeline's Telegram-alert thresholds so the visual state
+  // matches the operator's notifications: <60% green, 60-80% yellow,
+  // >=80% red.  ``status`` from the API already encodes this band, but
+  // we re-derive the colour from ``percentage`` so a buggy backend that
+  // returns ``status="ok"`` with ``percentage=92`` still paints red.
+  if (percentage === null) return "var(--v4-muted-500, #6b7280)";
+  if (percentage >= 80 || status === "exceeded") return "var(--v4-danger-500, #ef4444)";
+  if (percentage >= 60 || status === "warning") return "var(--v4-warning-500, #f59e0b)";
+  return "var(--v4-success-500, #10b981)";
+}
+
+/**
+ * Per-project monthly budget widget (epic-035 Task-06).
+ *
+ * Polls ``GET /pipeline/budget/{owner}/{repo}`` every 60 s and renders a
+ * progress bar with ``$spent / $cap (pct%)``.  At ≥80% the bar pulses to
+ * draw operator attention.  When the project has no cap configured the
+ * widget renders a neutral "cap не задан" line.
+ *
+ * Fetch failures (404 / 503 / network) collapse to ``null`` from the
+ * pipeline client and the widget returns ``null`` — never crashes the
+ * project card.
+ */
+export function BudgetWidget({ project, pollIntervalMs = DEFAULT_POLL_MS }: Props) {
+  const [data, setData] = useState<BudgetSummary | null>(null);
+  // Distinguish "still loading first response" from "loaded, no data" so
+  // the widget does not flash a placeholder on every project card during
+  // initial mount.
+  const [loaded, setLoaded] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    let cancelled = false;
+
+    const tick = async () => {
+      const snap = await fetchBudget(project);
+      if (cancelled || !mountedRef.current) return;
+      setData(snap);
+      setLoaded(true);
+    };
+
+    void tick();
+    const id = window.setInterval(tick, pollIntervalMs);
+    return () => {
+      cancelled = true;
+      mountedRef.current = false;
+      window.clearInterval(id);
+    };
+  }, [project, pollIntervalMs]);
+
+  if (!loaded || data === null) {
+    // First mount before the first response OR persistent fetch failure:
+    // return nothing so the card layout does not jitter.  When the
+    // backend recovers the next tick will populate state and the widget
+    // appears.
+    return null;
+  }
+
+  const { monthly_spent_usd, monthly_cap_usd, percentage, status, last_alert_at } = data;
+
+  if (monthly_cap_usd === null || percentage === null) {
+    return (
+      <div className="v4-budget-widget v4-budget-widget--no-cap" title="Monthly cap не задан">
+        <span className="v4-budget-line">
+          {formatUsd(monthly_spent_usd)} в этом месяце · cap не задан
+        </span>
+      </div>
+    );
+  }
+
+  // Clamp the visual progress bar to [0, 100] so an overshoot (>100%)
+  // does not stretch the track beyond its container.  The numeric
+  // ``percentage`` in the label still shows the true value.
+  const fillWidth = Math.min(100, Math.max(0, percentage));
+  const color = statusColor(status, percentage);
+  const pulse = percentage >= 80;
+
+  return (
+    <div
+      className={`v4-budget-widget v4-budget-widget--${status}${pulse ? " v4-budget-widget--pulse" : ""}`}
+      title={
+        last_alert_at
+          ? `Последний alert: ${last_alert_at}`
+          : `Monthly cap ${formatUsd(monthly_cap_usd)}`
+      }
+    >
+      <div className="v4-budget-line">
+        <span className="num">
+          {formatUsd(monthly_spent_usd)} / {formatUsd(monthly_cap_usd)}
+        </span>
+        <span className="v4-budget-pct num">({percentage.toFixed(0)}%)</span>
+      </div>
+      <div className="v4-ptrack v4-budget-track">
+        <div
+          className="v4-pfill"
+          style={{ width: `${fillWidth}%`, background: color }}
+        />
+      </div>
+      {last_alert_at && (
+        <div className="v4-budget-alert">alert: {last_alert_at.slice(0, 10)}</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/ProjectCardV4.tsx
+++ b/src/components/v4/ProjectCardV4.tsx
@@ -3,6 +3,7 @@ import type { ProjectData, Priority, Monitor, MonitorStatus } from "../../types"
 import { calcRiskScore } from "../../utils/riskScore";
 import { GITHUB_OWNER } from "../../utils/config";
 import { getLastNDays } from "../../utils/dashboardMetrics";
+import { BudgetWidget } from "./BudgetWidget";
 
 interface Props {
   project: ProjectData;
@@ -318,6 +319,16 @@ export function ProjectCardV4({ project, monitor, onJumpToTab, onEditFinance }: 
               }}
             />
           </div>
+        </div>
+      )}
+
+      {/* Section: monthly LLM budget (epic-035 Task-06).
+          Self-renders nothing when the pipeline doesn't know the project
+          or the cap is not configured (after first response).  Keeps the
+          card layout calm during outages. */}
+      {project.repo.includes("/") && (
+        <div className="v4-pcard-section">
+          <BudgetWidget project={project.repo} />
         </div>
       )}
 

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -2159,6 +2159,52 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 .v4-pcard--full .v4-pcard-finance-sep { color: var(--v4-ink-400); }
 .v4-pcard-finance-bar { height: 5px; }
 
+/* ---------------------------------------------------------------------
+   Budget widget (epic-035 Task-06)
+--------------------------------------------------------------------- */
+.v4-budget-widget {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  color: var(--v4-ink-700);
+}
+.v4-budget-line {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  color: var(--v4-ink-900);
+}
+.v4-budget-pct {
+  color: var(--v4-ink-500);
+  font-size: 10.5px;
+}
+.v4-budget-track { height: 5px; }
+.v4-budget-widget--no-cap .v4-budget-line {
+  color: var(--v4-ink-500);
+  font-style: italic;
+  font-size: 10.5px;
+}
+.v4-budget-alert {
+  font-size: 10px;
+  color: var(--v4-ink-500);
+  letter-spacing: 0.02em;
+}
+/* Pulse at >=80% so the operator's eye catches the bar even when the
+   card is dense with finance/stats sections. 1.5s cycle, 70% min-opacity
+   so it never disappears entirely. */
+@keyframes v4-budget-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.7; }
+}
+.v4-budget-widget--pulse .v4-budget-track .v4-pfill {
+  animation: v4-budget-pulse 1.5s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .v4-budget-widget--pulse .v4-budget-track .v4-pfill { animation: none; }
+}
+
 /* Risk chip (full label) */
 .v4-pcard-risk-chip {
   display: inline-flex;

--- a/src/utils/pipeline.ts
+++ b/src/utils/pipeline.ts
@@ -405,6 +405,58 @@ export async function fetchPipelineLimits(): Promise<PipelineLimits | null> {
   }
 }
 
+/**
+ * Per-project monthly budget snapshot (epic-035 Task-05).
+ *
+ * `monthly_cap_usd === null` → cap not configured for this project;
+ * `percentage` is also `null` and the widget renders a "cap not set" badge.
+ *
+ * `status` thresholds: `<60%` ok, `60-80%` warning, `>=80%` exceeded —
+ * mirror the pipeline's Telegram alert thresholds so the dashboard's
+ * visual state matches the operator's notification stream.
+ */
+export interface BudgetSummary {
+  project: string;
+  year_month: string;
+  monthly_spent_usd: number;
+  monthly_cap_usd: number | null;
+  percentage: number | null;
+  batches_this_month: number;
+  last_alert_at: string | null;
+  status: "ok" | "warning" | "exceeded";
+}
+
+/**
+ * Fetch the per-project budget snapshot. Returns `null` on any failure
+ * (404 — pipeline doesn't know the project, 503 — store/config outage,
+ * network/timeout) so the widget can render a neutral fallback rather
+ * than crash the project card.
+ */
+export async function fetchBudget(project: string): Promise<BudgetSummary | null> {
+  if (!project.includes("/")) {
+    if (import.meta.env.DEV) {
+      console.warn("[pipeline] fetchBudget: expected owner/repo, got", project);
+    }
+    return null;
+  }
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    // `project` is a GitHub slug `owner/repo` — split + encode each
+    // segment so dots/dashes round-trip but a malicious caller can't
+    // smuggle a `?` or `#` into the path.
+    const [owner, repo] = project.split("/", 2);
+    const url = `${PIPELINE_BASE_URL}/pipeline/budget/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+    const res = await fetch(url, { cache: "no-store", signal: controller.signal });
+    clearTimeout(timeoutId);
+    if (!res.ok) return null;
+    return (await res.json()) as BudgetSummary;
+  } catch (e) {
+    if (import.meta.env.DEV) console.error("[pipeline] budget fetch failed:", e);
+    return null;
+  }
+}
+
 export async function fetchPipelineStats(project: string): Promise<PipelineStats> {
   const res = await fetch(
     `${PIPELINE_BASE_URL}/pipeline/stats?project=${encodeURIComponent(project)}`,


### PR DESCRIPTION
Closes #327. Завершает epic-035 цепочку (Task-03 #1125 ✅ → Task-04 #1126 ✅ → Task-05 #1127 ✅ → Task-06 #327).

## Что сделано

- **\`fetchBudget(project)\`** в \`src/utils/pipeline.ts\` — клиент \`GET /pipeline/budget/{owner}/{repo}\` с 5s timeout, fail-open на 404/503/network.
- **\`BudgetWidget\`** (\`src/components/v4/BudgetWidget.tsx\`) — polling 60s, прогресс-бар \`$spent / $cap (pct%)\`, цвет по threshold band'ам (green/yellow/red), pulse animation на ≥80% (с \`prefers-reduced-motion\` opt-out).
- **CSS** в \`src/styles/v4.css\` — \`.v4-budget-widget\` + \`.v4-budget-track\` + \`@keyframes v4-budget-pulse\` (1.5s cycle, 70% min opacity).
- **Интеграция в \`ProjectCardV4\`** — новая секция после finance, рендерится только когда \`project.repo\` имеет формат \`owner/repo\`.
- **Edge cases**: первый mount без данных → \`null\` (нет jitter), \`cap=null\` → "cap не задан" badge, overshoot >100% → bar clamped к 100% но текст показывает true %.

## Тесты

\`npm run build\` (tsc + vite) — clean, нет TS ошибок. Lint clean.

**Визуальная верификация:** требует live pipeline backend на :8766 (через nginx tunnel на VPS), потому что dashboard'у нужен Pipeline settings bootstrap токен. Локально preview server останавливается на bootstrap gate. Будет проверено после deploy. Widget defensive — без backend просто рендерит ничего.

## Самопроверка
- [x] BudgetWidget показывает spent/cap/percentage
- [x] Polling 60s
- [x] Цветовая индикация (<60% green / 60-80% yellow / >=80% red)
- [x] Pulse анимация при ≥80%
- [x] cap=null → fallback "cap не задан"
- [x] Встроен в ProjectsView через ProjectCardV4
- [x] vite build без TS errors