### PR TITLE
docs(prd-008): Project Hub & Portfolio Health Surface plan

### DIFF
--- a/docs/PROJECT_HUB_DESIGN_BRIEF.md
+++ b/docs/PROJECT_HUB_DESIGN_BRIEF.md
@@ -1,0 +1,284 @@
+# Project Hub — design brief
+
+ТЗ для Claude Design. Задача: расширить «страницу проекта» (сейчас — только Health) в полноценный Project Hub из 5 вкладок и обновить страницу «Проекты» в виде превью-сетки с портфельными виджетами.
+
+Этот документ — продолжение `PROJECT_HEALTH_DESIGN_BRIEF.md`. Health остаётся как одна из 5 вкладок Hub без изменений визуала; редизайнятся обёртка, навигация, новые вкладки и portfolio surface.
+
+---
+
+## 1. Контекст
+
+MakeIT Dashboard — внутренний дашборд по портфелю из 12 проектов. Сейчас вкладка «Проекты» = сетка карточек, по клику на «Health» в правом верхнем углу карточки открывается `ProjectHealthPage` через `?repo=X` в URL.
+
+Цель Project Hub: за 30 секунд после открытия проекта владелец восстанавливает полный контекст и понимает, что нужно сделать прямо сейчас. Health — лишь один срез из шести.
+
+Цель Portfolio Surface (страница «Проекты»): за 10 секунд оценить состояние всех 12 проектов сразу + увидеть топ-обязательных действий по портфелю.
+
+---
+
+## 2. Архитектура страниц
+
+```
+?tab=projects                             — Portfolio Surface (превью-сетка + 4 виджета сверху)
+?tab=projects&repo=X                      — Project Hub, default tab Overview
+?tab=projects&repo=X&subtab=health        — Project Hub, явная вкладка
+                                            (overview / health / activity / decisions / delivery)
+```
+
+Старые ссылки `?tab=projects&repo=X` ведут на Hub Overview — поведение Health-страницы как первоэкрана уходит.
+
+---
+
+## 3. Portfolio Surface (страница «Проекты»)
+
+### 3.1 Layout
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  TopBar                                                          │
+├─────────────────────────────────────────────────────────────────┤
+│  ⓒ Portfolio Next Actions       │ ⓘ Renewals (top-5)            │
+│     (ranked top-5 с обоснованием)│    ближайшие SSL/contracts/  │
+│                                  │    deps                       │
+├─────────────────────────────────────────────────────────────────┤
+│  ⓟ Promise Tracker               │ ⓓ Latest Portfolio Digest     │
+│     overdue + due-this-week     │    (preview, кнопка regenerate)│
+├─────────────────────────────────────────────────────────────────┤
+│  Filters: phase / priority / search                             │
+├─────────────────────────────────────────────────────────────────┤
+│  ProjectScorecard  ProjectScorecard  ProjectScorecard           │
+│  ProjectScorecard  ProjectScorecard  ProjectScorecard           │
+│  ... (grid 3 col @1024+, 2 col @768, 1 col @<768)              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 ProjectScorecard (превью-карточка проекта)
+
+Минимальная карточка должна содержать:
+
+- **Header**: имя проекта (моноширинно), tier-pill, phase-badge, client-name мелким
+- **Health KPI**: grade A/B/C/D/F крупно справа + цветной dot
+- **Stats row**: open issues / in-progress / blocked / overdue-commitments (число + иконка)
+- **Drift dots**: 4 цветных дота в строке (commit / deploy / audit / client-touch). Tooltip раскрывает «N дней назад, норма Y дней».
+- **Footer**: last activity (ISO дата) + cost MTD ($N.XX)
+- Клик по всей карточке → Project Hub Overview
+- Hover: лёгкий highlight, focus-ring для клавиатурной навигации
+
+### 3.3 4 портфельных виджета сверху
+
+| Виджет | Что показывает | Empty state |
+|---|---|---|
+| **Portfolio Next Actions** | Top-5 ranked recommendations от Claude с обоснованием в одну строку и линком на проект | «Всё под контролем — нет срочных действий по портфелю» |
+| **Portfolio Renewals** | Top-5 ближайших expiry с цветом по urgency (red ≤7д, yellow ≤30д, gray >30д) | «На ближайшие 90 дней expiry нет» |
+| **Portfolio Promise Tracker** | Overdue commitments + due-this-week, группировка по клиенту | «Все обещания в срок» |
+| **Portfolio Digest** | Превью последнего weekly digest (3-5 строк) + кнопка «Сгенерировать новый» | «Дайджеста за эту неделю ещё нет — кнопка «Сгенерировать»»|
+
+Виджеты должны быть компактными — каждый занимает ≤25% высоты viewport на 1440×900.
+
+---
+
+## 4. Project Hub (страница проекта)
+
+### 4.1 Layout
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ← Все проекты                                                  │
+│  Project Header                                                 │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │ name • tier • phase • client    │ grade A • health 78%    │ │
+│  │ Next Best Action: «...»          │ кнопка «Регенерировать» │ │
+│  └────────────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────────────┤
+│  [ Overview ] [ Health ] [ Activity ] [ Decisions ] [ Delivery ]│
+├─────────────────────────────────────────────────────────────────┤
+│  Tab content                                                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 Header
+
+- **Слева**: имя репо моноширинно, tier-pill (T1/T2/T3), phase-badge, client-name мелким, last activity
+- **Справа**: health-grade крупно + health-score % + sparkline (placeholder под историю)
+- **Центр (sticky под header)**: «Next Best Action» — одна строка от Claude с обоснованием и линком на якорь нужной вкладки
+- На мобильном (≤640px) — collapse в одну колонку
+
+### 4.3 Вкладки
+
+| Вкладка | Виджеты | Default landing |
+|---|---|---|
+| **Overview** | NBA-блок (раскрытый), Pulse-summary (5 last events), Risks-summary (top-3), Commitments-summary (top-3 overdue + due-this-week) | Да |
+| **Health** | existing `ProjectHealthPage` целиком, без изменений | — |
+| **Activity** | Activity Pulse (vertical timeline), Project Inbox (since-last-visit), Open PRs list, Open Pipeline Runs list | — |
+| **Decisions & Risks** | Decision Log (chronological), Risk Register (CRUD), Commitments (per-project), Renewals (per-project) | — |
+| **Delivery** | DORA metrics (4 KPI), Project Digest (last week + history), Customer Health Score (gauge + 90д sparkline), Onboarding Readiness Checklist | — |
+
+Tab content загружается lazy. URL обновляется при смене tab. Browser back/forward работает.
+
+### 4.4 Состояния страницы
+
+| Состояние | Когда | Что показать |
+|---|---|---|
+| **loading-initial** | Hub только открыт, данные грузятся | Скелетон header + табов, активная вкладка показывает skeleton секций |
+| **loading-tab** | Переключение на новую вкладку, данные ещё не подгружены | Шапка остаётся, контент tab показывает skeleton |
+| **error** | Нет токена или GitHub отдал ошибку | Сообщение «не получилось загрузить», кнопка retry. Шапка остаётся видна с placeholder |
+| **partial** | Часть источников успешна, часть нет (например Pipeline API лежит) | Здоровые блоки рендерятся, упавшие показывают inline-warning «не удалось загрузить, retry» |
+| **classification-missing** | Репо не в `project_classification` | На Overview — баннер «Зарегистрируй в `PROJECT_CHECKLIST.yaml`», остальные вкладки работают на reduced функциональности |
+
+---
+
+## 5. Доступные данные
+
+Новый агрегирующий хук `useProjectHub(repo)` (расширяет `useProjectHealth`):
+
+```ts
+interface ProjectHubData {
+  // Базовое (из useProjectHealth)
+  project: ProjectData;
+  health: HealthReport;
+
+  // Новое (из новых источников Epic-011, Epic-012)
+  decisions: Decision[];           // chronological
+  risks: Risk[];                   // RiskRegister
+  commitments: Commitment[];       // PromiseTracker per-project
+  renewals: Renewal[];             // SSL/domains/contracts/deps per-project
+  pulse: PulseEvent[];             // unified timeline
+  inboxCount: number;              // since lastVisited
+  digest: DigestEntry | null;      // last weekly digest
+  dora: DoraMetrics | null;        // 4 metrics + 90d trend
+  customerHealth: CustomerHealthScore | null;
+  onboarding: OnboardingReport;    // extension of health Layer 2
+  nba: NextBestAction[];           // ranked top-5
+
+  // Lifecycle
+  loading: boolean;
+  loadingTab: Record<HubTab, boolean>;
+  error: Error | null;
+  refresh: () => void;
+  generateDigest: () => Promise<void>;
+  regenerateNBA: () => Promise<void>;
+}
+```
+
+Все типы — в `src/types/hub.ts` (новый файл, типы Decision/Risk/Commitment/Renewal/PulseEvent/DigestEntry/DoraMetrics/CustomerHealthScore/NextBestAction).
+
+---
+
+## 6. Иерархия внимания
+
+В порядке важности (что должно быть в верхней половине экрана):
+
+1. **Next Best Action** — что делать прямо сейчас, в одну строку
+2. **Health-grade** — визитка здоровья проекта
+3. **Active commitments / risks** — что обещано и что может рвануть
+4. **Drift indicators** — отклонения от нормы (на Scorecard, не в Hub)
+5. **Recent activity** — что произошло с прошлого визита
+
+Менее важно, но должно быть доступно:
+
+6. Decision Log — институциональная память
+7. Renewals и onboarding — фоновые операционные дела
+8. DORA — метрики, для саморефлексии раз в неделю
+
+---
+
+## 7. UX-правила
+
+- **Health не теряется** — пользователи привыкли открывать «Health». Теперь это вкладка, и если пользователь шёл на health (старый bookmark) — он попадает на Overview и сразу видит вкладку Health в строке табов. Подсказка-toast при первом таком переходе.
+- **Скан-данных не должно быть много на одну вкладку** — каждая tab фокусируется на одной задаче. Если блок начинает расти — выносится в отдельную вкладку.
+- **Manual triggers явны** — генерация Digest, регенерация NBA, scan Drift LLM — всё кнопками с понятной ценой (показывать ожидаемые ~$X.XX).
+- **NBA — не todo** — это рекомендации с обоснованием. Не делать чекбоксы. Делать кнопки «Создать issue из этого», «Отметить как сделанное вне дашборда».
+- **Risks/Commitments — CRUD** — добавление, редактирование, удаление работают inline, без модалок где возможно. CRUD не отправляет в backend (его нет), а пишет в `docs/risks.yaml` / `docs/commitments.yaml` через GitHub API commit.
+- **Inbox-badge на табах** — над «Activity» — число unread events since-last-visit, исчезает при открытии.
+
+---
+
+## 8. Дизайн-система
+
+Текущая — v4 (см. `src/styles/v4.css` переменные `--v4-*`):
+
+- Те же токены — никаких новых акцентных цветов
+- Светлая и тёмная темы обязательны
+- Severity-цвета (critical/high/medium/low) — переиспользовать
+- Новые элементы:
+  - `v4-tabs` — горизонтальная навигация Hub-вкладок с inbox-badge
+  - `v4-scorecard` — карточка проекта
+  - `v4-drift-dot` — цветной индикатор с tooltip
+  - `v4-nba-row` — строка рекомендации с обоснованием и actions
+  - `v4-pulse-event` — элемент timeline
+  - `v4-risk-row`, `v4-commitment-row`, `v4-decision-row` — табличные строки CRUD
+
+---
+
+## 9. Что трогать и что не трогать
+
+**Создаём:**
+- `src/components/v4/hub/ProjectHubPage.tsx`
+- `src/components/v4/hub/ProjectHubHeader.tsx`
+- `src/components/v4/hub/ProjectHubTabs.tsx`
+- `src/components/v4/hub/tabs/OverviewTab.tsx`
+- `src/components/v4/hub/tabs/ActivityTab.tsx`
+- `src/components/v4/hub/tabs/DecisionsRisksTab.tsx`
+- `src/components/v4/hub/tabs/DeliveryTab.tsx`
+- `src/components/v4/portfolio/ProjectScorecard.tsx`
+- `src/components/v4/portfolio/PortfolioNextActions.tsx`
+- `src/components/v4/portfolio/PortfolioPromiseTracker.tsx`
+- `src/components/v4/portfolio/PortfolioRenewals.tsx`
+- `src/components/v4/portfolio/PortfolioDigestPanel.tsx`
+- `src/components/v4/portfolio/DriftDots.tsx`
+- `src/hooks/useProjectHub.ts`
+- `src/types/hub.ts`
+
+**Меняем:**
+- `src/components/v4/ProjectsView.tsx` — рендерит Scorecards и портфельные виджеты сверху; при `selectedRepo` — рендерит `ProjectHubPage` вместо текущего `ProjectHealthPage`
+- `src/styles/v4.css` — добавляем секции `Project Hub`, `Portfolio Surface`
+
+**Не трогаем:**
+- `src/components/v4/health/ProjectHealthPage.tsx` — рендерится как content вкладки Health, без изменений
+- `src/types/health.ts`, `src/utils/health-engine.ts`, `src/utils/checklist.ts`
+- `src/hooks/useProjectHealth.ts` (расширяется через композицию в `useProjectHub`)
+- Структура других вкладок дашборда
+
+---
+
+## 10. Что обязательно должно работать после фичи
+
+- Открыл `/?tab=projects` → видишь сетку Scorecard'ов + 4 портфельных виджета
+- Клик по Scorecard → попадаешь на `?tab=projects&repo=X&subtab=overview` → Hub Overview
+- Переключение вкладок Hub без перезагрузки, URL обновляется
+- Browser back/forward переключает между списком, Hub, табами
+- Health вкладка показывает существующую `ProjectHealthPage` без визуальной регрессии
+- Refresh в любом месте Hub — состояние восстанавливается
+- Inbox-badge на «Activity» уменьшается до 0 после открытия вкладки
+- Кнопка «Сгенерировать» дайджест/NBA отрабатывает и кэширует результат
+- Темная тема работает во всех новых компонентах
+- Адаптив ≥ 1024px не разваливается, ≥ 768px — readable
+- Доступность: severity badges не передают смысл только цветом
+
+---
+
+## 11. Дальше (контекст для решений)
+
+В следующих итерациях:
+
+- Customer Health Score — пересмотр формулы после накопления данных (через 3-6 мес)
+- Stakeholder Map (вкладка Context) — отложено
+- Cross-project Dependency View — отложено
+- Sharing portfolio digest по email/Telegram
+- Project Hub mobile-optimized layout
+- Bulk operations across projects (например «верифицировать все P1-risks»)
+
+---
+
+## 12. Definition of Done
+
+- Все 11 виджетов реализованы и интегрированы согласно §3-§4
+- Существующая ProjectHealthPage работает без регрессий
+- 5 вкладок Hub переключаются, deep-link работает
+- Portfolio Surface рендерит Scorecards + 4 виджета
+- Type-check `npx tsc --noEmit` зелёный
+- Build `npm run build` зелёный
+- Светлая и тёмная темы
+- Адаптив ≥ 1024px
+- Inbox-badge корректно считается via `lastVisitedStore`
+- E2E-сценарий: открыл Portfolio → клик Scorecard → переключение всех 5 табов → back возвращает в Portfolio

--- a/docs/epics/epic-009.md
+++ b/docs/epics/epic-009.md
@@ -1,0 +1,65 @@
+# Epic-009: Project Hub Foundation
+
+## Метаданные
+- PRD: PRD-008
+- Epic-issue: #368
+- Milestone: #10
+- Дедлайн: 2026-05-25 (5 задач × 1 день + 5 буфер на интеграцию)
+- Статус: planning
+- Приоритет: P2-high
+
+## Обзор
+
+Базовая инфраструктура страницы проекта: routing, header, tabs, Overview tab, агрегирующий хук `useProjectHub`, миграция существующей `ProjectHealthPage` как контента вкладки Health.
+
+После эпика: можно открыть `?tab=projects&repo=X` → попасть в Hub Overview → переключить вкладку → попасть в Health (без визуальной регрессии). Activity/Decisions/Delivery — пустые placeholder'ы с пометкой «в разработке (Epic-011/012)».
+
+## Архитектурные решения
+
+- **URL scheme**: `?tab=projects&repo=X&subtab=Y`. Default subtab при отсутствии — `overview`. Старые `?tab=projects&repo=X` ведут на Overview (поведение Health-as-default отменяется); при первом таком переходе — toast-подсказка «Health теперь во вкладке».
+- **Routing** — продолжение существующего паттерна `URLSearchParams` + `pushState` + `popstate` (см. `ProjectsView.tsx:154+`). Никаких роутер-библиотек.
+- **`useProjectHub(repo)`** — композиция: оборачивает `useProjectHealth(repo)` + добавляет stub-поля для Decisions/Risks/Commitments/Renewals/Pulse/Inbox/Digest/DORA/CustomerHealth/Onboarding/NBA. В Epic-009 stub'ы возвращают `null`/`[]`; реальные источники заполняются в Epic-011/012.
+- **Tab content lazy** — каждый tab — отдельный React.lazy chunk. Skeleton при первой загрузке.
+- **inbox-badge** — placeholder = 0 в Epic-009; реальный счёт включится в Epic-011.
+
+## Изменения в БД
+
+N/A.
+
+## API изменения
+
+N/A (внутренние типы только).
+
+## Frontend изменения
+
+- `src/types/hub.ts` — новые типы: `HubTab`, `ProjectHubData`, stub-типы для будущих сущностей (Decision/Risk/Commitment/Renewal/PulseEvent/DigestEntry/DoraMetrics/CustomerHealthScore/NextBestAction)
+- `src/hooks/useProjectHub.ts` — новый хук
+- `src/components/v4/hub/ProjectHubPage.tsx` — корневой компонент Hub
+- `src/components/v4/hub/ProjectHubHeader.tsx` — header
+- `src/components/v4/hub/ProjectHubTabs.tsx` — навигация вкладок
+- `src/components/v4/hub/tabs/OverviewTab.tsx` — Overview content
+- `src/components/v4/hub/tabs/HealthTab.tsx` — wrapper над существующим `ProjectHealthPage`
+- `src/components/v4/hub/tabs/{ActivityTab,DecisionsRisksTab,DeliveryTab}.tsx` — placeholder'ы
+- `src/components/v4/ProjectsView.tsx` — при `selectedRepo` рендерит `ProjectHubPage` вместо `ProjectHealthPage`; URL расширяется `subtab` параметром
+- `src/styles/v4.css` — секция `Project Hub` (table tabs, header layout)
+
+## Влияние на существующий код
+
+- `ProjectsView.tsx` — изменение branch при `selectedRepo`. Старое поведение (открытие ProjectHealthPage) недоступно — теперь Health внутри Hub.
+- `ProjectHealthPage.tsx` — рендерится как content внутри `HealthTab.tsx`. Все props/handlers пробрасываются как было. Визуально не меняется.
+- URL `?tab=projects&repo=X` без `subtab` — теперь Overview (раньше — Health). Toast при первом переходе из старого bookmark.
+- AIInsightsPanel на Дашборде — не трогаем (Portfolio surface не входит в Epic-009).
+
+## Целостность бизнес-логики
+
+N/A.
+
+## Задачи
+
+| # | Задача | Зависимости | Параллельно | Размер |
+|---|--------|------------|-------------|--------|
+| 01 | `src/types/hub.ts` + skeleton `useProjectHub` (stub all new fields, wrap useProjectHealth) | — | да | M |
+| 02 | `ProjectHubPage` + `ProjectHubHeader` + URL routing (`subtab` param + popstate) | 01 | — | M |
+| 03 | `ProjectHubTabs` + 5 tab components (Overview real, остальные — placeholders), lazy-loading | 02 | — | M |
+| 04 | `OverviewTab` с 4 mini-blocks (NBA, Pulse-summary, Risks-summary, Commitments-summary) — все на stub data из useProjectHub | 03 | да (с #05) | M |
+| 05 | Migration ProjectsView: при selectedRepo → ProjectHubPage; one-time toast при переходе со старого URL без subtab | 02 | да (с #04) | S |

--- a/docs/epics/epic-009/task-01-types-and-hook-skeleton.md
+++ b/docs/epics/epic-009/task-01-types-and-hook-skeleton.md
@@ -1,0 +1,37 @@
+# Task-01: Типы Hub + skeleton useProjectHub
+
+## Метаданные
+- Epic: epic-009
+- GitHub Issue: #338
+- Приоритет: P2-high
+- Зависит от: —
+- Параллельно: да
+- Размер: M
+
+## Описание
+Подготовить фундамент типов и агрегирующий хук для Project Hub. Реальные источники для Decisions/Risks/Commitments/Renewals/Pulse/Digest/DORA/CustomerHealth/Onboarding/NBA заполняются в Epic-011/012 — сейчас все новые поля возвращают stub-значения (`null` / `[]` / `0`).
+
+1. Создать `src/types/hub.ts`:
+   - `HubTab = "overview" | "health" | "activity" | "decisions" | "delivery"`
+   - Stub-типы: `Decision`, `Risk`, `Commitment`, `Renewal`, `PulseEvent`, `DigestEntry`, `DoraMetrics`, `CustomerHealthScore`, `OnboardingReport`, `NextBestAction` (минимальные поля из PROJECT_HUB_DESIGN_BRIEF.md §5)
+   - `ProjectHubData` — полный shape из дизайн-брифа (project, health, новые stub-поля, loading/loadingTab/error/refresh/generateDigest/regenerateNBA)
+2. Создать `src/hooks/useProjectHub.ts`:
+   - Принимает `repo: string`
+   - Внутри вызывает `useProjectHealth(repo)` — переиспользует loading/error/refresh
+   - Возвращает `ProjectHubData` со stub-значениями для всех новых полей
+   - `loadingTab` инициализируется как `{ overview: false, health: loading, activity: false, decisions: false, delivery: false }`
+   - `generateDigest`/`regenerateNBA` — пустые async-функции с `// TODO: Epic-012` (resolved сразу)
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/PROJECT_HUB_DESIGN_BRIEF.md` §5 — shape `ProjectHubData`
+- `docs/prds/PRD-008.md` FR-42 — правила композиции
+- `src/hooks/useProjectHealth.ts` — публичное API
+- `src/types/health.ts` — соседний файл типов для стиля
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `HubTab` экспортируется как union из 5 строк
+- [ ] `useProjectHub("Beer_bot")` в dev-консоли возвращает объект с полями `decisions: []`, `nba: []`, `digest: null`
+- [ ] Хук не дёргает никакие новые API/endpoints — только композиция useProjectHealth
+- [ ] Все новые типы в `src/types/hub.ts` имеют JSDoc-комментарий «filled in Epic-011/012»

--- a/docs/epics/epic-009/task-02-hub-page-routing.md
+++ b/docs/epics/epic-009/task-02-hub-page-routing.md
@@ -1,0 +1,40 @@
+# Task-02: ProjectHubPage + Header + URL routing с subtab
+
+## Метаданные
+- Epic: epic-009
+- GitHub Issue: #339
+- Приоритет: P2-high
+- Зависит от: task-01
+- Параллельно: нет
+- Размер: M
+
+## Описание
+Создать корневой компонент Hub и Header, расширить URL-роутинг параметром `subtab`. После задачи: открыл `?tab=projects&repo=X&subtab=health` — увидел Header + placeholder под tabs/content; back/forward работает.
+
+1. Создать `src/components/v4/hub/ProjectHubPage.tsx`:
+   - Props: `{ repo: string, project?: ProjectData, onBackToList: () => void }`
+   - Внутри: `useProjectHub(repo)`, локальный state `activeTab: HubTab` (default из URL → `"overview"`)
+   - Layout: `← Все проекты` → `<ProjectHubHeader>` → slot под `<ProjectHubTabs>` (placeholder div в этой задаче) → slot под tab content
+2. Создать `src/components/v4/hub/ProjectHubHeader.tsx`:
+   - Props: `{ data: ProjectHubData }`
+   - Слева: repo (monospace), tier-pill, phase-badge, client, last activity
+   - Справа: health-grade крупно, score %, sparkline placeholder (`<div className="v4-sparkline-placeholder" />`)
+   - Центр: NBA-строка «Next Best Action: ...» (из `data.nba[0]?.text ?? "—"`), кнопка «Регенерировать» (disabled stub)
+3. Расширить URL-роутинг в `ProjectHubPage` (паттерн из `ProjectsView.tsx:153+`):
+   - Mount: читать `URLSearchParams.get('subtab')`, валидировать против `HubTab`, fallback `"overview"`
+   - `setActiveTab` → `pushState` с `?tab=projects&repo=X&subtab=Y`
+   - `popstate` listener синхронизирует `activeTab` с URL
+   - Использовать `lastSyncedSubtabRef` + `didMountPushRef` как в существующем коде
+
+## Контекст для Claude Code
+Прочитай:
+- `src/components/v4/ProjectsView.tsx:130-240` — паттерн URL persistence
+- `docs/PROJECT_HUB_DESIGN_BRIEF.md` §4.1, §4.2 — layout Header
+- `docs/prds/PRD-008.md` FR-11..FR-18
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `?tab=projects&repo=Beer_bot&subtab=health` на refresh восстанавливает state `activeTab = "health"`
+- [ ] Невалидный `subtab=foo` → fallback на `overview` + URL переписывается без `subtab=foo`
+- [ ] Browser back/forward переключает subtab без перезагрузки
+- [ ] Кнопка «← Все проекты» вызывает `onBackToList()` и снимает `repo`+`subtab` из URL

--- a/docs/epics/epic-009/task-03-hub-tabs-lazy.md
+++ b/docs/epics/epic-009/task-03-hub-tabs-lazy.md
@@ -1,0 +1,38 @@
+# Task-03: ProjectHubTabs + 5 tab-компонентов с lazy-loading
+
+## Метаданные
+- Epic: epic-009
+- GitHub Issue: #340
+- Приоритет: P2-high
+- Зависит от: task-02
+- Параллельно: нет
+- Размер: M
+
+## Описание
+Реализовать табы Hub и 5 tab-компонентов: Overview/Health — реальный контент, остальные — placeholder с пометкой «в разработке (Epic-011/012)». Каждый tab — отдельный chunk через `React.lazy`.
+
+1. Создать `src/components/v4/hub/ProjectHubTabs.tsx`:
+   - Props: `{ active: HubTab, onChange: (tab: HubTab) => void, inboxCount: number }`
+   - 5 кнопок с ARIA `role="tab"`, активная подсвечена
+   - На «Activity» — inbox-badge с `inboxCount` (в Epic-009 всегда 0 → бейдж не рендерится)
+2. Создать 5 файлов в `src/components/v4/hub/tabs/`:
+   - `OverviewTab.tsx` — в этой задаче пустой стаб `<div>Overview placeholder</div>` (real content — task-04)
+   - `HealthTab.tsx` — рендерит существующий `ProjectHealthPage` с пробросом `repo`/`project`
+   - `ActivityTab.tsx`, `DecisionsRisksTab.tsx`, `DeliveryTab.tsx` — placeholder вида: иконка + текст «Вкладка в разработке (Epic-011/Epic-012)» + ссылка на соответствующий epic doc
+3. В `ProjectHubPage.tsx`:
+   - Обернуть импорты табов в `React.lazy(() => import("./tabs/..."))`
+   - Активный tab оборачивается в `<Suspense fallback={<TabSkeleton />}>` (skeleton — простой div с классом `v4-tab-skeleton`)
+   - `inboxCount` — из `data.inboxCount` (stub 0 в Epic-009)
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/PROJECT_HUB_DESIGN_BRIEF.md` §4.3 — таблица вкладок
+- `src/components/v4/health/ProjectHealthPage.tsx:1-60` — props HealthTab
+- React docs: `lazy` + `Suspense`
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `npm run build` создаёт 4+ дополнительных chunk'а для tab-компонентов
+- [ ] Переключение subtab=health показывает существующий ProjectHealthPage без визуальной регрессии
+- [ ] Placeholder-вкладки рендерят текст с упоминанием Epic-011/Epic-012
+- [ ] Skeleton мелькает при первом открытии тяжёлого tab (Health)

--- a/docs/epics/epic-009/task-04-overview-tab.md
+++ b/docs/epics/epic-009/task-04-overview-tab.md
@@ -1,0 +1,36 @@
+# Task-04: OverviewTab с 4 mini-блоками
+
+## Метаданные
+- Epic: epic-009
+- GitHub Issue: #341
+- Приоритет: P2-high
+- Зависит от: task-03
+- Параллельно: да (с task-05)
+- Размер: M
+
+## Описание
+Реализовать вкладку Overview — первое, что видит пользователь после клика на Scorecard. Контент состоит из 4 mini-блоков: NBA, Pulse-summary, Risks-summary, Commitments-summary. Все данные из `useProjectHub` (в Epic-009 — stub-значения, реальные источники подключаются в Epic-011/012).
+
+1. Реализовать `src/components/v4/hub/tabs/OverviewTab.tsx`:
+   - Props: `{ data: ProjectHubData, onOpenTab: (tab: HubTab) => void }`
+   - Layout: 2×2 grid @1024px, stack @<768px
+2. Mini-блоки (каждый — отдельный sub-компонент в том же файле или в `hub/overview/`):
+   - **NBA-блок** (раскрытый): `data.nba[0]` — текст + обоснование + кнопки stub «Создать issue» / «Отметить сделанным». Если `nba` пуст → empty state «NBA пока не сгенерирован»
+   - **Pulse-summary**: 5 последних `data.pulse` (timestamp + type + label). Empty state «Пока нет событий» → линк «Открыть Activity»
+   - **Risks-summary**: top-3 `data.risks` filtered `severity in {critical, high}`. Empty state «Активных рисков нет»
+   - **Commitments-summary**: top-3 `data.commitments` filtered overdue + due-this-week. Empty state «Все обещания в срок»
+3. Каждый блок имеет footer-линк «Открыть полностью →», вызывает `onOpenTab("activity")` / `"decisions"` (FR-20)
+4. Использовать существующие токены `v4-*` из `src/styles/v4.css`; новых акцентных цветов не добавлять
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/PROJECT_HUB_DESIGN_BRIEF.md` §4.3 (строка Overview), §6 (иерархия внимания)
+- `docs/prds/PRD-008.md` FR-19, FR-20
+- `src/styles/v4.css` — секции severity-цвета и существующие card-стили
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] При stub-данных (все пусто) Overview рендерит 4 блока с осмысленными empty states, не падает
+- [ ] Линк «Открыть полностью» в Risks-блоке переключает subtab=decisions, URL обновляется
+- [ ] Layout 2×2 на ≥1024px, stack на <768px (проверить devtools)
+- [ ] Светлая + тёмная темы — оба читаются

--- a/docs/epics/epic-009/task-05-projects-view-migration.md
+++ b/docs/epics/epic-009/task-05-projects-view-migration.md
@@ -1,0 +1,35 @@
+# Task-05: Миграция ProjectsView на ProjectHubPage + legacy toast
+
+## Метаданные
+- Epic: epic-009
+- GitHub Issue: #342
+- Приоритет: P2-high
+- Зависит от: task-02
+- Параллельно: да (с task-04)
+- Размер: S
+
+## Описание
+Переключить рендер `ProjectsView.tsx`: при `selectedRepo` вместо текущего `<ProjectHealthPage>` рендерить `<ProjectHubPage>`. Добавить one-time toast при переходе со старого bookmark (URL без `subtab`).
+
+1. В `src/components/v4/ProjectsView.tsx`:
+   - В ветке `if (selectedRepo)` заменить `<ProjectHealthPage>` на `<ProjectHubPage>` с пробросом `repo`, `project`, `onBackToList={() => onSelectRepo(null)}`
+   - Удалить прямой импорт `ProjectHealthPage` (теперь используется внутри `HealthTab`)
+2. One-time legacy toast:
+   - В mount-эффекте, который читает `URLSearchParams`: если `?repo=X` присутствует и `?subtab=` отсутствует — поставить флаг
+   - Через `useToast()` показать сообщение «Health теперь во вкладке. Переключитесь сверху, чтобы вернуться к привычному виду» с длительностью ~6s
+   - Сохранять в `localStorage` ключ `makeit_hub_legacy_toast_shown = "1"` чтобы повторно не показывать
+3. Расширить URL-логику: при `selectedRepo` без `subtab` — НЕ добавлять `subtab=overview` автоматически (это сделает `ProjectHubPage` через свой mount-эффект); ProjectsView отвечает только за `repo`
+
+## Контекст для Claude Code
+Прочитай:
+- `src/components/v4/ProjectsView.tsx:130-240` — текущая URL-логика
+- `src/components/v4/toastContext.tsx` — API `useToast`
+- `docs/epics/epic-009.md` — раздел «Влияние на существующий код»
+- `docs/prds/PRD-008.md` FR-12
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] Открыл `?tab=projects&repo=Beer_bot` (без subtab) → попал на Overview + увидел toast «Health теперь во вкладке»
+- [ ] Повторный визит того же URL → toast не показывается (флаг в localStorage)
+- [ ] Открыл `?tab=projects&repo=Beer_bot&subtab=health` → toast НЕ показывается (явная вкладка)
+- [ ] `ProjectHealthPage` не импортируется напрямую в `ProjectsView.tsx`

--- a/docs/epics/epic-010.md
+++ b/docs/epics/epic-010.md
@@ -1,0 +1,68 @@
+# Epic-010: Portfolio Surface Redesign
+
+## Метаданные
+- PRD: PRD-008
+- Epic-issue: #369
+- Milestone: #11
+- Дедлайн: 2026-06-19 (7 задач × 1.5 дня + 3 буфер) — стартует после Epic-011 + Epic-012
+- Статус: planning
+- Приоритет: P2-high
+
+## Обзор
+
+Финальный эпик, склеивающий портфельный уровень. Переделать страницу «Проекты» в превью-сетку `ProjectScorecard` + 4 портфельных виджета сверху (Next Actions, Renewals, Promise Tracker, Digest). Использует данные, собранные в Epic-011 и Epic-012.
+
+После эпика: владелец открывает `/?tab=projects`, за 10 секунд видит состояние всех 12 проектов + топ-5 действий по портфелю + ближайшие expiry + overdue commitments + последний weekly digest.
+
+## Архитектурные решения
+
+- **Scorecard** — расширение существующего ProjectCard, не замена. Старые поля сохраняются как fallback при отсутствии новых данных.
+- **DriftDots** — отдельный компонент, 4 цветных дота с tooltip. Цвет: green (в норме), yellow (≥1.5× нормы), red (≥3× нормы). Норма — из `useDriftNorm(repo)` (Epic-012).
+- **PortfolioNextActions** — расширение существующего AIInsightsPanel. Текущий показывает портфельный health, новый добавляет ranked actions с обоснованием и линком на проект. Кэш — `localStorage` ключ `makeit_portfolio_nba`, week-cached.
+- **PortfolioPromiseTracker / PortfolioRenewals** — простые агрегаторы данных из Epic-011 (читают `commitments`/`renewals` по всем 12 репо, агрегируют, сортируют).
+- **PortfolioDigestPanel** — показывает превью последнего digest из `digests/{YYYY-WW}-portfolio.md` (cross-project version, генерируется Epic-012). Кнопка «Сгенерировать новый» триггерит regen.
+- **Sidebar badge** — `useDashboard()` hook + portfolio NBA count → `<span class="sidebar-badge">`.
+
+## Изменения в БД
+
+N/A.
+
+## API изменения
+
+N/A (consumes data from Epic-011, Epic-012).
+
+## Frontend изменения
+
+- `src/components/v4/portfolio/ProjectScorecard.tsx` — новый
+- `src/components/v4/portfolio/DriftDots.tsx` — новый
+- `src/components/v4/portfolio/PortfolioNextActions.tsx` — новый (расширяет AIInsightsPanel)
+- `src/components/v4/portfolio/PortfolioPromiseTracker.tsx` — новый
+- `src/components/v4/portfolio/PortfolioRenewals.tsx` — новый
+- `src/components/v4/portfolio/PortfolioDigestPanel.tsx` — новый
+- `src/components/v4/ProjectsView.tsx` — рефакторинг: вместо grid ProjectCard → 4-widget header + Scorecard grid
+- `src/components/Topbar.tsx` (или Sidebar) — badge с count NBA
+- `src/styles/v4.css` — секция `Portfolio Surface`
+
+## Влияние на существующий код
+
+- `ProjectsView.tsx` — полностью переработан layout, но routing (handle selectedRepo → Hub) из Epic-009 не трогается
+- `ProjectCard.tsx` — становится legacy, заменяется на `ProjectScorecard`. Старый файл удалить
+- `AIInsightsPanel.tsx` — продолжает работать на Дашборде (вкладка «Дашборд»); параллельно создаётся `PortfolioNextActions` на странице «Проекты». Не дублирование — разные сценарии (Дашборд = общее здоровье портфеля, Проекты = action-oriented)
+- Sidebar — добавляется badge, остальное не трогается
+- E2E-сценарий dashboard.spec — может потребовать обновления селекторов на новые компоненты
+
+## Целостность бизнес-логики
+
+N/A.
+
+## Задачи
+
+| # | Задача | Зависимости | Параллельно | Размер |
+|---|--------|------------|-------------|--------|
+| 01 | `ProjectScorecard` + `DriftDots` (data from useProjectHealth + useDriftNorm из Epic-012) | Epic-009 #03, Epic-012 #06 | — | M |
+| 02 | `PortfolioNextActions` (расширение AIInsightsPanel с ranked actions + cache) | Epic-012 #05 | да (с #03..#05) | M |
+| 03 | `PortfolioPromiseTracker` (cross-project agg from Epic-011 commitments) | Epic-011 #02 | да | S |
+| 04 | `PortfolioRenewals` (cross-project agg from Epic-011 renewals) | Epic-011 #04 | да | S |
+| 05 | `PortfolioDigestPanel` (preview last digest + regen button) | Epic-012 #02 | да | M |
+| 06 | `ProjectsView` redesign: 4-widget header + Scorecard grid + responsive (3/2/1 col) | 01..05 | — | M |
+| 07 | Sidebar NBA badge + E2E test (Portfolio → Scorecard → Hub → all tabs → back) | 06 | — | M |

--- a/docs/epics/epic-010/task-01-project-scorecard.md
+++ b/docs/epics/epic-010/task-01-project-scorecard.md
@@ -1,0 +1,39 @@
+# Task-01: ProjectScorecard + DriftDots
+
+## Метаданные
+- Epic: epic-010
+- GitHub Issue: #343
+- Приоритет: P2-high
+- Зависит от: Epic-009 #03 (Hub routing), Epic-012 #06 (useDriftNorm)
+- Параллельно: нет (база для #06)
+- Размер: M
+
+## Описание
+Превью-карточка проекта для Portfolio Surface. Расширение `ProjectCardV4`, но не замена в его текущем месте — это новый компонент в `portfolio/`. Старая карточка после Epic-010 #06 удаляется.
+
+Состав Scorecard (FR-2):
+1. **Header** — имя репо (моноширинно), tier-pill, phase-badge, client-name мелким, health-grade A/B/C/D/F справа крупно + цветной dot.
+2. **KPI row** — open / in-progress / blocked / overdue-commitments (число + иконка).
+3. **DriftDots** — 4 цветных дота: commit / deploy / audit / client-touch.
+4. **Footer** — last activity (relative), cost MTD (если есть).
+
+Клик по карточке вызывает `onSelectRepo(repo)` → Epic-009 routing уведёт в Hub Overview.
+
+`DriftDots` — отдельный компонент. Берёт `daysSinceX` и `normY` из `useProjectHealth` + `useDriftNorm(repo)`. Цвет: green (`days ≤ norm`), yellow (`days ≥ 1.5 × norm`), red (`days ≥ 3 × norm`). Tooltip: «commit: 4д назад, норма 2д».
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-010.md` — архитектурные решения
+- `docs/PROJECT_HUB_DESIGN_BRIEF.md` §3.2 — состав Scorecard
+- `docs/prds/PRD-008.md` FR-2, FR-3, FR-4
+- `src/components/v4/ProjectCardV4.tsx` — существующая карточка как референс
+- `src/hooks/useProjectHealth.ts` — данные drift / KPI
+- `src/types/health.ts` — типы grade / phase / tier
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] Открыл Portfolio → виден grid Scorecard'ов, все поля FR-2 на месте
+- [ ] DriftDots: 4 дота с правильным цветом, hover показывает tooltip с числами и нормой
+- [ ] Клик по Scorecard вызывает `onSelectRepo(repo)` (handler из Epic-009 проверяется визуально — переход в Hub)
+- [ ] Карточка адаптивна: на 1-col layout не ломается, текст не обрезается
+- [ ] Темная тема: цвета grade / drift dot читаемы

--- a/docs/epics/epic-010/task-02-portfolio-next-actions.md
+++ b/docs/epics/epic-010/task-02-portfolio-next-actions.md
@@ -1,0 +1,31 @@
+# Task-02: PortfolioNextActions
+
+## Метаданные
+- Epic: epic-010
+- GitHub Issue: #344
+- Приоритет: P2-high
+- Зависит от: Epic-012 #05 (Claude NBA aggregator)
+- Параллельно: да (с #03, #04, #05)
+- Размер: M
+
+## Описание
+Виджет в верхней 2×2-сетке Portfolio Surface. Показывает top-5 ranked next-best-actions по всему портфелю: каждая строка — `action` (1 строка), `rationale` (1-2 строки серым), ссылка на проект (→ Hub Overview конкретного репо).
+
+Это **расширение существующего `AIInsightsPanel`** (Дашборд) — не дублирование. `AIInsightsPanel` показывает общее здоровье портфеля, новый компонент — action-oriented top-5. Можно вынести общий fetch-слой в hook (`usePortfolioNba()`), но компоненты разные.
+
+Кэш — `localStorage` ключ `makeit_portfolio_nba`, формат `{ generatedAt: ISO, actions: NbaItem[] }`. TTL — 7 дней. Кнопка «Регенерировать» сбрасывает кэш и перезапрашивает (`generatePortfolioNba()` из Epic-012 #05). Если кэш свежий — кнопка показывает «Сгенерирован N дней назад».
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-010.md` — раздел «Архитектурные решения», `PortfolioNextActions`
+- `docs/prds/PRD-008.md` FR-5, FR-6
+- `src/components/v4/AIInsightsPanel.tsx` — существующий компонент-референс
+- `docs/epics/epic-012/task-05-*.md` — формат NBA aggregator output
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] Открыл Portfolio → виджет «Next Actions» с 5 строками или empty-state «Действия не требуются»
+- [ ] Каждая строка кликабельна, ведёт в `?tab=projects&repo=X&subtab=overview`
+- [ ] Кнопка «Регенерировать» сбрасывает `localStorage.makeit_portfolio_nba` и перезапрашивает
+- [ ] При наличии свежего кэша (<7д) показывается «Сгенерирован N дней назад», запроса не делает
+- [ ] Loading / error states обработаны

--- a/docs/epics/epic-010/task-03-portfolio-promise-tracker.md
+++ b/docs/epics/epic-010/task-03-portfolio-promise-tracker.md
@@ -1,0 +1,36 @@
+# Task-03: PortfolioPromiseTracker
+
+## Метаданные
+- Epic: epic-010
+- GitHub Issue: #345
+- Приоритет: P2-high
+- Зависит от: Epic-011 #02 (commitments per-project hook)
+- Параллельно: да (с #02, #04, #05)
+- Размер: S
+
+## Описание
+Cross-project агрегатор обещаний. Читает `docs/commitments.yaml` по всем 12 репо (через hook из Epic-011 #02), фильтрует `status === 'open'`, группирует по `client`, сортирует:
+1. **Overdue** (due < today) — наверху, красным.
+2. **Due this week** (due ≤ today + 7д) — желтым.
+3. Остальные — не показываются (полный список — в Hub Decisions & Risks).
+
+Каждая запись — одна строка: `[client] · текст обещания · due (relative)`. Клик → `?tab=projects&repo=X&subtab=decisions#commitments`.
+
+Empty state: «Все обещания в срок ✓» (приглушённым).
+
+Запросы по 12 репо параллелизировать через `Promise.all`. Кэш — sessionStorage `makeit_portfolio_promises`, TTL 5 минут (commitments меняются редко).
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-010.md` — раздел `PortfolioPromiseTracker`
+- `docs/prds/PRD-008.md` FR-5, FR-8
+- `docs/epics/epic-011/task-02-*.md` — формат `commitments.yaml` и hook
+- `src/utils/config.ts` — список 12 проектов
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] Виджет показывает overdue (красный) + due-this-week (жёлтый), сгруппировано по клиенту
+- [ ] При отсутствии overdue/due-this-week — empty state «Все обещания в срок ✓»
+- [ ] Клик по строке открывает соответствующий Hub Decisions & Risks
+- [ ] Параллельная загрузка 12 репо не блокирует UI (skeleton до завершения)
+- [ ] Кэш в sessionStorage работает (повторное открытие — без сетевых запросов в течение 5 мин)

--- a/docs/epics/epic-010/task-04-portfolio-renewals.md
+++ b/docs/epics/epic-010/task-04-portfolio-renewals.md
@@ -1,0 +1,38 @@
+# Task-04: PortfolioRenewals
+
+## Метаданные
+- Epic: epic-010
+- GitHub Issue: #346
+- Приоритет: P2-high
+- Зависит от: Epic-011 #04 (renewals per-project hook)
+- Параллельно: да (с #02, #03, #05)
+- Размер: S
+
+## Описание
+Cross-project агрегатор предстоящих обновлений / истечений. Читает `docs/renewals.yaml` по всем 12 репо + результаты сканера deprecated/CVE deps (Epic-011 #04), сортирует по `expiresAt` возрастанию, берёт top-5.
+
+Цвет по urgency:
+- **red** — `expiresAt ≤ today + 7д`
+- **yellow** — `≤ today + 30д`
+- **gray** — `> 30д`
+
+Формат строки: `[type-icon] · название · client · expires in Nд`. Типы: SSL, domain, contract, license, deprecated-dep, CVE-dep. Клик → `?tab=projects&repo=X&subtab=decisions#renewals`.
+
+Empty state: «Ближайших обновлений нет».
+
+Параллельная загрузка 12 репо через `Promise.all`. Кэш — sessionStorage `makeit_portfolio_renewals`, TTL 1 час (renewals — медленно меняющиеся данные).
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-010.md` — раздел `PortfolioRenewals`
+- `docs/prds/PRD-008.md` FR-5, FR-7
+- `docs/epics/epic-011/task-04-*.md` — формат `renewals.yaml` и dep-scanner
+- `src/utils/config.ts` — список 12 проектов
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] Виджет показывает top-5 ближайших по сроку, отсортированных asc
+- [ ] Цвет: red (≤7д), yellow (≤30д), gray (>30д); цвет не единственный носитель смысла (есть текст «in Nд»)
+- [ ] Иконка типа (SSL/domain/contract/license/dep/CVE) отображается
+- [ ] Клик ведёт в Hub Decisions & Risks с якорем `#renewals`
+- [ ] Empty state «Ближайших обновлений нет» при пустом результате

--- a/docs/epics/epic-010/task-05-portfolio-digest-panel.md
+++ b/docs/epics/epic-010/task-05-portfolio-digest-panel.md
@@ -1,0 +1,36 @@
+# Task-05: PortfolioDigestPanel
+
+## Метаданные
+- Epic: epic-010
+- GitHub Issue: #347
+- Приоритет: P2-high
+- Зависит от: Epic-012 #02 (cross-project digest generator)
+- Параллельно: да (с #02, #03, #04)
+- Размер: M
+
+## Описание
+Виджет в 2×2-сетке Portfolio Surface. Показывает превью последнего weekly digest по всему портфелю:
+1. Читает `digests/{YYYY-WW}-portfolio.md` через GitHub Contents API (репо `Sergio1990-1/makeit-dashboard`).
+2. Рендерит первые ~12 строк markdown через `transcript-markdown.ts` (DOMPurify + marked).
+3. Кнопка «Открыть полностью» → модалка / новый таб с полным markdown.
+4. Кнопка «Сгенерировать новый» → вызывает Epic-012 #02 generator, после успеха перезаписывает текущий week-файл и обновляет превью.
+
+Логика выбора файла: текущий ISO week `YYYY-WW` (`getISOWeek()`). Если файл отсутствует — показывается empty-state «Дайджест за эту неделю ещё не сгенерирован» + активная кнопка «Сгенерировать».
+
+Кэш — sessionStorage `makeit_portfolio_digest_{week}`, TTL — до конца недели. Повторное открытие в той же неделе не делает сетевых запросов.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-010.md` — раздел `PortfolioDigestPanel`
+- `docs/prds/PRD-008.md` FR-5, FR-9
+- `docs/epics/epic-012/task-02-*.md` — generator API + path convention
+- `src/utils/transcript-markdown.ts` — markdown-рендеринг
+- `src/utils/github-actions.ts` — пример GitHub Contents API чтения
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] Виджет показывает превью markdown (первые ~12 строк) если файл недели существует
+- [ ] Empty state с CTA «Сгенерировать» если файла нет
+- [ ] Кнопка «Открыть полностью» рендерит весь markdown в модалке / отдельном представлении
+- [ ] Кнопка «Сгенерировать новый» вызывает generator из Epic-012 #02, после успеха превью обновляется без полной перезагрузки страницы
+- [ ] Кэш sessionStorage предотвращает повторные GitHub-запросы в течение недели

--- a/docs/epics/epic-010/task-06-projects-view-redesign.md
+++ b/docs/epics/epic-010/task-06-projects-view-redesign.md
@@ -1,0 +1,59 @@
+# Task-06: ProjectsView redesign
+
+## Метаданные
+- Epic: epic-010
+- GitHub Issue: #348
+- Приоритет: P2-high
+- Зависит от: #01, #02, #03, #04, #05
+- Параллельно: нет (intеграция)
+- Размер: M
+
+## Описание
+Полный рефакторинг layout `ProjectsView.tsx`. Новая структура:
+
+```
+<v4-content>
+  <PageHeader />                          // заголовок + финансы
+  <PortfolioWidgets>                      // 2×2 grid @1024+, stack <768
+    <PortfolioNextActions />
+    <PortfolioRenewals />
+    <PortfolioPromiseTracker />
+    <PortfolioDigestPanel />
+  </PortfolioWidgets>
+  <FiltersBar />                          // phase / sort / search / group-by
+  <ScorecardGrid>                         // 3-col @1024+, 2-col @768, 1-col <768
+    <ProjectScorecard ... />              // ← вместо ProjectCardV4 + Health-кнопки
+  </ScorecardGrid>
+</v4-content>
+```
+
+Что **сохраняется**:
+- Toolbar (фильтры, поиск, сортировка, group-by-phase) — без изменений.
+- Aggregate strip (count / open / P1 / stale / progress) — без изменений.
+- URL persistence + popstate logic (Epic-008 #01) — без изменений.
+- Ветка `if (selectedRepo) return <ProjectHubPage />` из Epic-009 — без изменений (Hub-routing не трогаем).
+
+Что **удаляется**:
+- `ProjectCardV4.tsx` → удаляется после миграции (карточка-кнопка Health больше не нужна, клик по Scorecard сам ведёт в Hub).
+- `v4-project-health-btn` стиль в `v4.css` — удалить.
+
+Что **добавляется**:
+- `src/styles/v4.css` секция `/* Portfolio Surface */` — grid для widgets (2×2 → stack) и Scorecard grid.
+- Responsive breakpoints: 1024px, 768px.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-010.md` — целевая структура
+- `docs/PROJECT_HUB_DESIGN_BRIEF.md` §3.1 — layout схема
+- `docs/prds/PRD-008.md` FR-1, FR-5
+- `src/components/v4/ProjectsView.tsx` — текущий код
+- `src/styles/v4.css` — найди существующие секции для consistency
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] Открыл `?tab=projects` → виден 4-widget header + Scorecard grid; ширины 1024 / 768 / <768 переключают grid 3/2/1
+- [ ] Виджеты сверху адаптивны: 2×2 на 1024+, stack на <768
+- [ ] Клик по Scorecard ведёт в Hub Overview (Epic-009 routing работает без регрессии)
+- [ ] `ProjectCardV4.tsx` удалён, импортов на него нет, `npm run build` чистый
+- [ ] URL persistence (`?repo=`, back/forward) работает как до рефакторинга
+- [ ] Все существующие toolbar-функции (phase filter / sort / search / group-by) работают

--- a/docs/epics/epic-010/task-07-sidebar-badge-e2e.md
+++ b/docs/epics/epic-010/task-07-sidebar-badge-e2e.md
@@ -1,0 +1,41 @@
+# Task-07: Sidebar badge + E2E
+
+## Метаданные
+- Epic: epic-010
+- GitHub Issue: #349
+- Приоритет: P2-high
+- Зависит от: #06
+- Параллельно: нет (финальный)
+- Размер: M
+
+## Описание
+Завершающая задача эпика: визуальный полиш + E2E-проверка полного user journey.
+
+**Часть 1 — Sidebar badge (FR-10):**
+- В компоненте sidebar (или Topbar — где живёт навигация по вкладкам) на пункте «Проекты» добавить `<span class="sidebar-badge">` с числом NBA портфеля.
+- Источник числа: тот же кэш, что использует `PortfolioNextActions` (`localStorage.makeit_portfolio_nba`). Если кэша нет — badge не отображается (не триггерим Claude-запрос ради badge).
+- Стиль: компактный pill, цвет — `var(--v4-warn-700)` если NBA > 0, скрыт если 0.
+- Обновление: при `storage`-event и при переключении на вкладку «Проекты».
+
+**Часть 2 — E2E сценарий:**
+Расширить `tests/e2e/dashboard.spec.ts` (или создать `portfolio-hub.spec.ts`) сценарием:
+1. Открыть `?tab=projects` → дождаться рендера Scorecard grid.
+2. Кликнуть по первой Scorecard → URL стал `?tab=projects&repo=X&subtab=overview`, рендерится Hub Overview.
+3. Переключить все 5 табов Hub (overview / health / activity / decisions / delivery) → каждая отрисовывает свой контент, URL обновляется.
+4. Browser back → возврат в Portfolio Surface, `selectedRepo` сброшен, scroll preserved (тестировать через `window.scrollY`).
+5. Sidebar badge виден если кэш NBA непустой (mock localStorage перед открытием).
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-010.md` — раздел «Архитектурные решения», sidebar badge
+- `docs/prds/PRD-008.md` FR-10, FR-16, FR-17
+- `tests/e2e/` — существующие E2E сценарии и setup (Playwright)
+- `src/components/Sidebar.tsx` / `Topbar.tsx` — где находится навигация
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] Sidebar pill с числом NBA виден когда `localStorage.makeit_portfolio_nba` непустой, скрыт когда пустой
+- [ ] E2E сценарий проходит: Portfolio → Scorecard → Hub → все 5 табов → back возвращает на Portfolio
+- [ ] После back: `scrollY` сохранён (минимум — не равен 0 если до клика был scroll)
+- [ ] Badge обновляется при `storage`-event без перезагрузки
+- [ ] Все существующие E2E (dashboard.spec) проходят без регрессий

--- a/docs/epics/epic-011.md
+++ b/docs/epics/epic-011.md
@@ -1,0 +1,76 @@
+# Epic-011: New Data Sources — Activity, Decisions, Risks, Commitments, Renewals
+
+## Метаданные
+- PRD: PRD-008
+- Epic-issue: #370
+- Milestone: #12
+- Дедлайн: 2026-06-12 (9 задач × 1.5 дня + 5 буфер) — стартует после Epic-009
+- Статус: planning
+- Приоритет: P2-high
+
+## Обзор
+
+Парсеры, источники данных, sessionStorage-tracking и UI вкладок Activity + Decisions & Risks. После эпика данные доступны в `useProjectHub` (реальные, не stub).
+
+## Архитектурные решения
+
+- **Per-project yaml** — все метаданные в репо самого проекта: `docs/risks.yaml`, `docs/commitments.yaml`, `docs/renewals.yaml`. Дашборд читает через GitHub Contents API. CRUD пишет через PUT contents (создаёт коммит).
+- **commitments в BRIEF.md** — как первичный источник; `docs/commitments.yaml` опционален как extracted/synced версия. Парсер сначала ищет `commitments:` секцию в BRIEF.md, потом fallback на yaml.
+- **decisions** — парсятся из `decisions:` секции в BRIEF.md + conventional commits (`feat:` / `fix:` / `refactor:` — игнор; `decide:` / `accept:` — кандидаты). ADR файлы (`docs/adr/*.md`) — опциональный источник.
+- **risks.yaml** — schema: `{id, title, severity, probability, mitigation, owner, due, status, source}`. Source = `manual | transcript-extracted | audit-promoted`.
+- **renewals.yaml** — schema: `{type, name, expires_at, notes, source}`. Type ∈ ssl, domain, contract, license. Auto-сканер deprecated/CVE deps добавляет «virtual» entries без записи в yaml.
+- **Activity Pulse aggregator** — `activityPulseAggregator.ts` merge'ит 4 источника: GitHub events (commits/issues/PRs) → REST `/repos/{repo}/events`; Pipeline runs → existing pipeline.ts client; Transcripts → existing transcript.ts client; Audit findings → existing auditor.ts client. Limit 100 событий per source за 30 дней.
+- **lastVisitedStore** — `sessionStorage` ключ `makeit_hub_last_visited:{repo}` → ISO timestamp. Per-device, не синхронизируется. При reload — сохраняется в session. При close tab — теряется (это by design — «новая сессия = всё свежее»).
+- **Risk extraction из транскриптов** — manual trigger в Risk Register UI; кнопка «Extract from transcripts». Claude Haiku читает последние 5 транскриптов проекта, возвращает структурированный list рисков, пользователь approve/reject каждый.
+- **GitHub Contents API write** — CRUD на yaml файлы. Branch-creation не нужен (commits прямо в main). Минимизировать commits: batched-CRUD (одна транзакция = один commit с N изменениями).
+
+## Изменения в БД
+
+N/A.
+
+## API изменения
+
+- `src/utils/github-contents.ts` (новый): `readYaml(repo, path)`, `writeYaml(repo, path, data, commitMessage)`, обёртка над GitHub Contents API
+- `src/utils/decisionLogExtractor.ts` (новый): `extractDecisions(briefMd, commits) → Decision[]`
+- `src/utils/commitmentsExtractor.ts` (новый): `extractCommitments(briefMd, yaml) → Commitment[]`
+- `src/utils/renewalsScanner.ts` (новый): `scanRenewals(repo, yaml, packageJson) → Renewal[]`
+- `src/utils/activityPulseAggregator.ts` (новый): `aggregatePulse(repo, since) → PulseEvent[]`
+- `src/utils/lastVisitedStore.ts` (новый): `getLastVisited(repo) → ISO | null`, `markVisited(repo)`, `unreadCount(events, repo) → number`
+
+## Frontend изменения
+
+- `src/hooks/useProjectHub.ts` — расширяется: реальные `decisions`, `commitments`, `risks`, `renewals`, `pulse`, `inboxCount`
+- `src/components/v4/hub/tabs/ActivityTab.tsx` — реальная реализация (Pulse timeline + Inbox + Open PRs + Open Runs)
+- `src/components/v4/hub/tabs/DecisionsRisksTab.tsx` — реальная реализация (4 секции: Decisions / Risks / Commitments / Renewals)
+- `src/components/v4/hub/PulseTimeline.tsx` — vertical timeline
+- `src/components/v4/hub/RiskRegisterTable.tsx` — CRUD table
+- `src/components/v4/hub/CommitmentsTable.tsx` — CRUD table
+- `src/components/v4/hub/RenewalsTable.tsx` — read + CRUD over manual entries
+- `src/components/v4/hub/DecisionLog.tsx` — read-only chronological list
+- `src/styles/v4.css` — `Pulse Timeline`, `Hub Tables` секции
+
+## Влияние на существующий код
+
+- `useProjectHub` — stub-поля становятся реальными. Виджеты в Overview Tab автоматически начинают показывать настоящие данные.
+- GitHub API нагрузка — увеличивается на ~5 запросов per repo при открытии Hub (events / contents × 3 / PRs). Митигация — кэш sessionStorage 5 минут per repo.
+- Per-project репо — нужно опционально создать `docs/risks.yaml` / `docs/commitments.yaml` / `docs/renewals.yaml`. Если файлов нет — Hub показывает empty state с кнопкой «Создать». Bootstrap-шаблоны в `makeit-knowledge/Skills/templates/hub/`.
+
+## Целостность бизнес-логики
+
+- **CRUD через GitHub Contents API** — eventual consistency. При concurrent edit двух браузеров последний выигрывает. Митигация: ETag-проверка перед PUT, при conflict — показать «диалог сравнения» с force-overwrite опцией.
+- **lastVisitedStore — per-device** — open Hub на двух машинах = два независимых счётчика unread. By design.
+- **Pulse Events truncation** — limit 100 per source за 30 дней. Старые события не показываются. Если нужны — открыть GitHub напрямую (линк).
+
+## Задачи
+
+| # | Задача | Зависимости | Параллельно | Размер |
+|---|--------|------------|-------------|--------|
+| 01 | `github-contents.ts` + `decisionLogExtractor.ts` + DecisionLog component (read-only) | Epic-009 #03 | да (с #02..#04) | M |
+| 02 | `commitmentsExtractor.ts` + `CommitmentsTable` (CRUD) + write via contents API | Epic-009 #03 | да | L |
+| 03 | `riskRegister.ts` types + `RiskRegisterTable` (CRUD) + write via contents API | Epic-009 #03 | да | L |
+| 04 | `renewalsScanner.ts` + `RenewalsTable` (read + CRUD over manual entries) + deps scanner | Epic-009 #03 | да | L |
+| 05 | `lastVisitedStore.ts` + sessionStorage tracking + inbox-badge на ActivityTab | Epic-009 #03 | да | S |
+| 06 | `activityPulseAggregator.ts` (merge 4 sources, dedup, sort) + PulseTimeline component | Epic-009 #03 | да (с #07) | L |
+| 07 | `ActivityTab` сборка: Pulse + Inbox + Open PRs + Open Runs | 05, 06 | — | M |
+| 08 | `DecisionsRisksTab` сборка: 4 секции в layout, navigation между ними | 01, 02, 03, 04 | — | M |
+| 09 | Risk extraction from transcripts (Claude Haiku, manual trigger, approve/reject UI) + bootstrap templates в makeit-knowledge | 03 | — | M |

--- a/docs/epics/epic-011/task-01-decision-log.md
+++ b/docs/epics/epic-011/task-01-decision-log.md
@@ -1,0 +1,31 @@
+# Task-01: Decision Log (extractor + read-only UI)
+
+## Метаданные
+- Epic: epic-011
+- GitHub Issue: #350
+- Приоритет: P2-high
+- Зависит от: Epic-009 #03
+- Параллельно: да (с #02..#04)
+- Размер: M
+
+## Описание
+Базовый слой работы с GitHub Contents API + парсер решений + read-only компонент журнала решений.
+
+1. `src/utils/github-contents.ts` — обёртка над GitHub Contents REST API: `readYaml(repo, path)` (GET + base64 decode + YAML parse, возвращает `{data, sha}` или `null`), `writeYaml(repo, path, data, message, sha?)` (PUT с base64 encode + ETag через sha). Ошибки 404 → null, 409 → ConflictError.
+2. `src/utils/decisionLogExtractor.ts` — `extractDecisions(briefMd, commits) → Decision[]`. Парсит `## decisions:` или `### Decisions` секцию BRIEF.md (bullet-list) + conventional commits с префиксами `decide:` / `accept:` (игнор `feat:` / `fix:`). Сортировка по дате desc.
+3. `src/components/v4/hub/DecisionLog.tsx` — chronological list с датой, автором, источником (`brief` / `commit` / `adr`).
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-011.md` — архитектурные решения
+- `docs/PROJECT_HUB_DESIGN_BRIEF.md` §4.3 Decisions & Risks
+- `docs/prds/PRD-008.md` FR-23, FR-24
+- `src/utils/github.ts` — пример GraphQL клиента и работы с токеном
+- `src/types/hub.ts` (Epic-009) — тип `Decision`
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `readYaml` возвращает `null` для несуществующего файла без throw
+- [ ] `extractDecisions` парсит решения из BRIEF.md fixtures + игнорирует `feat:` коммиты
+- [ ] `DecisionLog.tsx` рендерит список с датой/источником, пустой state при `decisions.length === 0`
+- [ ] `useProjectHub` отдаёт реальные `decisions` (не stub) на тестовом репо

--- a/docs/epics/epic-011/task-02-commitments.md
+++ b/docs/epics/epic-011/task-02-commitments.md
@@ -1,0 +1,30 @@
+# Task-02: Commitments (extractor + CRUD таблица)
+
+## Метаданные
+- Epic: epic-011
+- GitHub Issue: #351
+- Приоритет: P2-high
+- Зависит от: Epic-009 #03, Task-01 (github-contents.ts)
+- Параллельно: да
+- Размер: L
+
+## Описание
+Источник №1 — BRIEF.md (секция `commitments:`), fallback — `docs/commitments.yaml`. CRUD из UI пишет в yaml через GitHub Contents API.
+
+1. `src/utils/commitmentsExtractor.ts` — `extractCommitments(briefMd, yaml) → Commitment[]`. Сначала парсит `## Commitments` / `commitments:` в BRIEF.md (bullet-list с датой/клиентом), затем merge'ит с `docs/commitments.yaml` (yaml-приоритет для дубликатов по `text + client`). Schema: `{text: string, due: ISO, client: string, status: 'open' | 'done' | 'overdue'}`.
+2. `src/components/v4/hub/CommitmentsTable.tsx` — таблица с inline-add row, edit-in-place, delete-confirm. На submit → `writeYaml('docs/commitments.yaml', ...)`. Статус `overdue` вычисляется на клиенте по `due < now`.
+3. Batched-CRUD: накапливать N изменений → один commit «chore(hub): update commitments» с агрегированным diff.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-011.md` — секция commitments
+- `docs/prds/PRD-008.md` FR-26, FR-27
+- `src/utils/github-contents.ts` (после Task-01)
+- `src/types/hub.ts` — тип `Commitment`
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `extractCommitments` корректно мержит BRIEF.md + yaml (yaml-приоритет)
+- [ ] CRUD в UI: add row → write yaml → reload показывает новую запись
+- [ ] При отсутствии файла — empty state с кнопкой «Создать docs/commitments.yaml»
+- [ ] Overdue (due < сегодня) подсвечивается красным

--- a/docs/epics/epic-011/task-03-risk-register.md
+++ b/docs/epics/epic-011/task-03-risk-register.md
@@ -1,0 +1,32 @@
+# Task-03: Risk Register (types + CRUD таблица + ETag conflict)
+
+## Метаданные
+- Epic: epic-011
+- GitHub Issue: #352
+- Приоритет: P2-high
+- Зависит от: Epic-009 #03, Task-01 (github-contents.ts)
+- Параллельно: да
+- Размер: L
+
+## Описание
+Risk Register над `docs/risks.yaml`. CRUD + ETag conflict resolution (когда yaml изменили из другого браузера/коммита).
+
+1. `src/types/hub.ts` — расширить: `Risk = {id: string, title: string, severity: 'low'|'med'|'high'|'critical', probability: 'low'|'med'|'high', mitigation: string, owner: string, due: ISO | null, status: 'open'|'mitigated'|'accepted'|'closed', source: 'manual'|'transcript-extracted'|'audit-promoted'}`.
+2. `src/components/v4/hub/RiskRegisterTable.tsx` — sortable table (по severity desc default), inline edit, severity/probability как dropdown, status pills. Кнопка «Add risk» → modal form.
+3. ETag conflict dialog — при 409 от PUT contents показать «Кто-то изменил risks.yaml. [Reload remote] / [Overwrite anyway]». При reload — re-read + merge локальных изменений поверх.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-011.md` — schema risks.yaml, ETag-стратегия
+- `docs/prds/PRD-008.md` FR-28, FR-29, FR-30
+- `docs/PROJECT_HUB_DESIGN_BRIEF.md` §4.3 Risk Register
+- `src/utils/github-contents.ts` — sha как ETag
+- `src/types/hub.ts`
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] CRUD над `docs/risks.yaml`: add / edit / delete → commit в репо
+- [ ] Sort по severity (critical > high > med > low) работает
+- [ ] ETag conflict — диалог появляется, оба действия корректны
+- [ ] `source` отображается badge'ом (manual / transcript-extracted / audit-promoted)
+- [ ] Empty state с кнопкой «Создать docs/risks.yaml» при отсутствии файла

--- a/docs/epics/epic-011/task-04-renewals.md
+++ b/docs/epics/epic-011/task-04-renewals.md
@@ -1,0 +1,31 @@
+# Task-04: Renewals (manual yaml + auto-scanner deprecated deps)
+
+## Метаданные
+- Epic: epic-011
+- GitHub Issue: #353
+- Приоритет: P2-high
+- Зависит от: Epic-009 #03, Task-01 (github-contents.ts)
+- Параллельно: да
+- Размер: L
+
+## Описание
+Отслеживание сроков продлений: SSL, домены, контракты, лицензии — вручную в yaml; deprecated/CVE deps — автосканом из `package.json`.
+
+1. `src/utils/renewalsScanner.ts` — `scanRenewals(repo, yaml, packageJson) → Renewal[]`. Читает `docs/renewals.yaml` (manual entries) + сканирует `package.json` через GitHub Contents (опционально npm audit endpoint, без сетевого вызова если нельзя — просто mark `deprecated: true` поля). Виртуальные entries для deps помечаются `source: 'auto-scan'` и НЕ пишутся в yaml.
+2. `src/components/v4/hub/RenewalsTable.tsx` — таблица с фильтром по type (ssl / domain / contract / license / dep). CRUD только для manual entries; auto-scan entries read-only с tooltip «Auto-detected, fix in package.json». Sort по `expires_at` asc.
+3. Schema: `{type: 'ssl'|'domain'|'contract'|'license'|'dep', name: string, expires_at: ISO | null, notes: string, source: 'manual'|'auto-scan'}`.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-011.md` — секция renewals
+- `docs/prds/PRD-008.md` FR-31, FR-32
+- `src/utils/github-contents.ts`
+- `src/types/hub.ts`
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `scanRenewals` мержит yaml + auto-scan корректно (нет дублей)
+- [ ] CRUD работает только для `source === 'manual'`; auto-scan rows disabled
+- [ ] Sort по `expires_at` (ближайший срок первым), null в конце
+- [ ] Истёкшие (`expires_at < now`) подсвечены красным, скоро истекающие (< 30 дн) — жёлтым
+- [ ] Empty state с кнопкой «Создать docs/renewals.yaml»

--- a/docs/epics/epic-011/task-05-last-visited.md
+++ b/docs/epics/epic-011/task-05-last-visited.md
@@ -1,0 +1,34 @@
+# Task-05: lastVisitedStore + inbox-badge на Activity Tab
+
+## Метаданные
+- Epic: epic-011
+- GitHub Issue: #354
+- Приоритет: P2-high
+- Зависит от: Epic-009 #03
+- Параллельно: да (с #01..#04)
+- Размер: S
+
+## Описание
+Per-device sessionStorage-tracking «когда последний раз открывал Activity для проекта». На основе этого — badge с unread-count для каждого репо.
+
+1. `src/utils/lastVisitedStore.ts`:
+   - `getLastVisited(repo: string): ISO | null` — читает `sessionStorage['makeit_hub_last_visited:' + repo]`.
+   - `markVisited(repo: string): void` — пишет `new Date().toISOString()`.
+   - `unreadCount(events: PulseEvent[], repo: string): number` — фильтрует events по `timestamp > lastVisited` (если lastVisited null — возвращает 0, не events.length, чтобы первое открытие не флудило).
+2. Wiring: `ActivityTab` на mount → `markVisited(currentRepo)`. Badge `<InboxBadge count={unreadCount(...)} />` на табе.
+3. По design — sessionStorage (не localStorage): close tab = новая сессия = всё свежее.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-011.md` — секция lastVisitedStore
+- `docs/prds/PRD-008.md` FR-39
+- `src/components/v4/hub/tabs/ActivityTab.tsx` (stub из Epic-009)
+- `src/types/hub.ts` — `PulseEvent`
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `getLastVisited` возвращает null для нового репо, ISO после markVisited
+- [ ] `unreadCount` возвращает 0 при `lastVisited === null` (первое открытие)
+- [ ] Badge на ActivityTab показывает корректное число до открытия таба
+- [ ] После открытия ActivityTab — badge становится 0 (markVisited вызвался)
+- [ ] Reload страницы сохраняет lastVisited; close tab — теряет

--- a/docs/epics/epic-011/task-06-activity-pulse.md
+++ b/docs/epics/epic-011/task-06-activity-pulse.md
@@ -1,0 +1,38 @@
+# Task-06: Activity Pulse aggregator + PulseTimeline компонент
+
+## Метаданные
+- Epic: epic-011
+- GitHub Issue: #355
+- Приоритет: P2-high
+- Зависит от: Epic-009 #03
+- Параллельно: да (с #07)
+- Размер: L
+
+## Описание
+Агрегатор событий из 4 источников и vertical timeline компонент для Activity Tab.
+
+1. `src/utils/activityPulseAggregator.ts` — `aggregatePulse(repo, since: ISO) → PulseEvent[]`. Merge'ит:
+   - GitHub events → REST `GET /repos/{repo}/events` (commits, issues, PRs, releases)
+   - Pipeline runs → existing `pipeline.ts` client
+   - Transcripts → existing `transcript.ts` client
+   - Audit findings → existing `auditor.ts` client
+   Каждый источник: limit 100 событий за последние 30 дней. Dedup по `{source, id}`. Sort по `timestamp` desc.
+2. `PulseEvent` schema: `{id, source: 'github'|'pipeline'|'transcript'|'audit', type: string, timestamp: ISO, title: string, url?: string, meta?: Record<string, unknown>}`.
+3. `src/components/v4/hub/PulseTimeline.tsx` — vertical timeline: дата-группировка («Сегодня» / «Вчера» / «N дней назад»), иконка по source, click → открыть `url` в новой вкладке. Empty state.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-011.md` — Activity Pulse aggregator секция
+- `docs/prds/PRD-008.md` FR-42, FR-43
+- `docs/PROJECT_HUB_DESIGN_BRIEF.md` — Activity tab
+- `src/utils/pipeline.ts`, `src/utils/transcript.ts`, `src/utils/auditor.ts` — клиенты
+- `src/utils/github.ts` — GitHub auth/headers
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `aggregatePulse` возвращает merged sorted-desc список из 4 источников
+- [ ] Limit 100 per source соблюдается; total ≤ 400 events
+- [ ] Dedup по `{source, id}` работает
+- [ ] `PulseTimeline` группирует по дате (Сегодня / Вчера / N дней назад)
+- [ ] Click по event → `window.open(url, '_blank')` если url задан
+- [ ] sessionStorage кэш 5 минут per repo (по PRD митигации)

--- a/docs/epics/epic-011/task-07-activity-tab.md
+++ b/docs/epics/epic-011/task-07-activity-tab.md
@@ -1,0 +1,37 @@
+# Task-07: ActivityTab сборка (Pulse + Inbox + Open PRs + Open Runs)
+
+## Метаданные
+- Epic: epic-011
+- GitHub Issue: #356
+- Приоритет: P2-high
+- Зависит от: Task-05, Task-06
+- Параллельно: нет
+- Размер: M
+
+## Описание
+Финальная сборка `ActivityTab.tsx`: 4 секции в едином layout + filter by event type + lastVisited tracking.
+
+1. `src/components/v4/hub/tabs/ActivityTab.tsx`:
+   - Section «Inbox» (вверху) — unread events (timestamp > lastVisited), визуально выделены.
+   - Section «Pulse Timeline» — `<PulseTimeline events={pulse} />` с filter chips по `source` (github / pipeline / transcript / audit).
+   - Section «Open PRs» — список открытых PR из GitHub (используем готовый GraphQL запрос или REST).
+   - Section «Open Pipeline Runs» — список running pipeline задач из `usePipeline`.
+2. `useEffect` на mount → `markVisited(repo)` (after render, чтобы Inbox показался хоть раз).
+3. Filter chips — стейт в самом табе, не персистится.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-011.md` — Activity Tab layout
+- `docs/PROJECT_HUB_DESIGN_BRIEF.md` — Activity tab секция
+- `docs/prds/PRD-008.md` FR-42, FR-43
+- `src/components/v4/hub/PulseTimeline.tsx` (Task-06)
+- `src/utils/lastVisitedStore.ts` (Task-05)
+- `src/hooks/useProjectHub.ts` — данные `pulse`, `openPRs`, `openRuns`
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] 4 секции рендерятся в правильном порядке (Inbox / Pulse / PRs / Runs)
+- [ ] Filter chips фильтруют timeline без перезагрузки
+- [ ] При открытии таба — `markVisited` вызывается один раз
+- [ ] После открытия — badge на табе становится 0
+- [ ] Пустые секции показывают empty state (не схлопываются)

--- a/docs/epics/epic-011/task-08-decisions-risks-tab.md
+++ b/docs/epics/epic-011/task-08-decisions-risks-tab.md
@@ -1,0 +1,33 @@
+# Task-08: DecisionsRisksTab сборка (4 секции + якоря)
+
+## Метаданные
+- Epic: epic-011
+- GitHub Issue: #357
+- Приоритет: P2-high
+- Зависит от: Task-01, Task-02, Task-03, Task-04
+- Параллельно: нет
+- Размер: M
+
+## Описание
+Финальная сборка таба с 4 разделами + section anchors для deep-link из Overview NBA.
+
+1. `src/components/v4/hub/tabs/DecisionsRisksTab.tsx` — layout с 4 секциями (в порядке): Decision Log → Risk Register → Commitments → Renewals.
+2. Section anchors: `<section id="decisions">`, `id="risks"`, `id="commitments"`, `id="renewals"`. На mount читать `location.hash` → `scrollIntoView({behavior: 'smooth'})`.
+3. Sticky sidebar (или горизонтальные tabs внутри таба на узких экранах) с навигацией между секциями. Active section detection через IntersectionObserver.
+4. Header каждой секции — title + кол-во записей + кнопка «Add» (где применимо).
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-011.md` — структура таба
+- `docs/PROJECT_HUB_DESIGN_BRIEF.md` §4.3 Decisions & Risks
+- `docs/prds/PRD-008.md` FR-23..FR-32
+- `src/components/v4/hub/DecisionLog.tsx`, `RiskRegisterTable.tsx`, `CommitmentsTable.tsx`, `RenewalsTable.tsx`
+- `src/components/v4/hub/tabs/OverviewTab.tsx` — NBA блок (источник deep-link)
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] 4 секции рендерятся в правильном порядке с якорями
+- [ ] `#risks` в URL → scroll к Risk Register после загрузки
+- [ ] Sidebar показывает active section при скролле
+- [ ] Counters в header каждой секции совпадают с `data.length`
+- [ ] Empty state каждой секции делегирован соответствующему компоненту

--- a/docs/epics/epic-011/task-09-risk-extraction-from-transcripts.md
+++ b/docs/epics/epic-011/task-09-risk-extraction-from-transcripts.md
@@ -1,0 +1,34 @@
+# Task-09: Risk extraction из транскриптов + bootstrap templates
+
+## Метаданные
+- Epic: epic-011
+- GitHub Issue: #358
+- Приоритет: P2-high
+- Зависит от: Task-03
+- Параллельно: нет
+- Размер: M
+
+## Описание
+Manual-trigger извлечение рисков из последних 5 транскриптов проекта через Claude Haiku + approve/reject UI + bootstrap-шаблоны для новых проектов.
+
+1. `src/utils/extractRisksFromTranscripts.ts` — `extractRisks(repo) → ProposedRisk[]`. Берёт последние 5 BRIEF.md из transcript API, шлёт в Claude Haiku с промптом «извлеки риски в формате `{title, severity, probability, mitigation, source: transcript-id}`». Возвращает структурированный list.
+2. UI: в `RiskRegisterTable` — кнопка «Extract from transcripts». Click → loading → modal со списком предложенных рисков, у каждого Approve / Reject / Edit. Approve → append в `docs/risks.yaml` с `source: 'transcript-extracted'`.
+3. Bootstrap templates — отдельный PR в `makeit-knowledge` репозиторий: `Skills/templates/hub/risks.yaml`, `commitments.yaml`, `renewals.yaml`, `project_norm.yaml`. Минимальные валидные skeletons с комментариями-примерами для каждого поля.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-011.md` — Risk extraction секция
+- `docs/prds/PRD-008.md` FR-30
+- `src/utils/claude.ts` — Claude API клиент (Haiku подходит)
+- `src/utils/transcript.ts` — transcript API
+- `src/components/v4/hub/RiskRegisterTable.tsx` (Task-03)
+- `makeit-knowledge` репо — структура `Skills/templates/`
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] Кнопка «Extract from transcripts» работает на проекте с транскриптами
+- [ ] Modal показывает proposed risks с Approve / Reject / Edit
+- [ ] Approved risk появляется в risks.yaml с `source: 'transcript-extracted'`
+- [ ] Reject — никаких записей в yaml
+- [ ] PR в makeit-knowledge с 4 шаблонами создан и описан
+- [ ] При пустой истории транскриптов — graceful empty state

--- a/docs/epics/epic-012.md
+++ b/docs/epics/epic-012.md
@@ -1,0 +1,98 @@
+# Epic-012: Delivery Metrics & Intelligence
+
+## Метаданные
+- PRD: PRD-008
+- Epic-issue: #371
+- Milestone: #13
+- Дедлайн: 2026-06-10 (9 задач × 1.5 дня + 3 буфер) — стартует после Epic-009
+- Статус: planning
+- Приоритет: P2-high
+- Внешний блокер: [pipeline#1129](https://github.com/Sergio1990-1/makeit-pipeline/issues/1129) (monthly rollover metrics.jsonl) — для DORA нужен парсер архивных метрик
+
+## Обзор
+
+DORA-метрики, Project Digest, Customer Health Score, Onboarding Readiness Checklist, Next Best Action engine, конфиг норм для Drift Detection. После эпика: вкладка Delivery полностью функциональна; PortfolioNextActions (Epic-010) получает реальные ranked actions; DriftDots на Scorecard (Epic-010) получают per-project нормы.
+
+## Архитектурные решения
+
+- **DORA calculator** — `doraCalculator.ts` собирает 4 метрики:
+  - **Deploy Frequency**: commits на `main` за период (с фильтром по conventional commits — `feat:` / `fix:` / `release:`). Optional: tagged releases.
+  - **Lead Time for Changes**: медиана от первого коммита PR (= PR.created_at для squash-merge) до merge.
+  - **MTTR**: медиана downtime по BetterStack monitor этого проекта. Сопоставление repo ↔ monitor — через existing matching rules в `config.ts`.
+  - **Change Failure Rate**: % деплоев (= merges на main), за которыми в течение 7 дней последовал commit с `fix:` или audit с critical finding.
+  - Бенчмарк (elite/high/medium/low) — стандартный DORA per metric.
+- **Project Digest** — `weeklyDigestGenerator.ts`. Claude Sonnet (fallback Haiku при budget). Input: pulse за неделю + closed issues + merged PRs + commitments delivered + audit findings. Output: markdown секции `## Shipped / ## In progress / ## Blocked / ## Decisions / ## Clients touched / ## Spend`. Сохраняется в `digests/{repo}/{YYYY-WW}.md` в самом dashboard repo через GitHub Contents API (per-project дайджесты + кросс-портфельный `digests/{YYYY-WW}-portfolio.md`).
+- **Customer Health Score** — `customerHealthScore.ts`. Формула:
+  ```
+  score = sentiment×0.3 + cadence×0.3 + delivery×0.3 + paid×0.1
+  ```
+  - `sentiment` (0-100): Claude Haiku над последними 3 транскриптами проекта → ratings positive/neutral/negative с весом
+  - `cadence` (0-100): актуальный интервал между встречами vs baseline (из `project_norm.yaml` `client_touch_interval_days`). 100 если ≤ baseline, линейный спад до 0 при 3× baseline
+  - `delivery` (0-100): % commitments delivered on-time за 90 дней. Считает status=done within due-date
+  - `paid` (0-100): 100 если paid вовремя; 0 если задолженность > 30 дней; линейный спад
+  - При отсутствии транскриптов > 120 дней — score = «n/a» (не показываем)
+  - Sparkline 90 дней — пересчёт раз в неделю (триггер из manual button или регенерации NBA)
+- **Onboarding Readiness** — расширение `health-engine.ts` Layer 2. 6 новых правил:
+  - `onboarding.readme_fresh` — last commit on README.md за 90 дней
+  - `onboarding.brief_exists` — `docs/BRIEF.md` существует
+  - `onboarding.deploy_doc` — `docs/DEPLOY.md` или раздел `## Deploy` в README
+  - `onboarding.env_example` — `.env.example` существует
+  - `onboarding.ci_green` — последний CI run на main = success
+  - `onboarding.audit_fresh` — audit запускался за последние 30 дней
+- **Next Best Action engine** — `nextBestActionEngine.ts`. Per-project: Claude Sonnet over (top-3 findings + top-3 risks + top-3 overdue commitments + drift indicators + inbox top-5) → ranked top-3 recommendations с обоснованием. Aggregation per portfolio = берёт top-1 от каждого проекта, сортирует по severity, возвращает top-5.
+- **project_norm.yaml** — per-project в самом репо `docs/project_norm.yaml`. Schema: `{commit_cadence_days, deploy_freq_days, audit_freq_days, client_touch_interval_days}`. Дефолты в `makeit-knowledge/Skills/PROJECT_NORMS_DEFAULTS.yaml` (per tier). При отсутствии per-project файла — дефолт по tier.
+- **Budget cap** — `claudeBudget.ts`. Hard cap $30/mo на весь portfolio. Tracking: каждый Claude call логируется в `localStorage` с tokens + estimated cost. При 80% — UI warning. При 110% — fallback на Haiku для всех call'ов до конца месяца.
+
+## Изменения в БД
+
+N/A.
+
+## API изменения
+
+- `src/utils/doraCalculator.ts` (новый)
+- `src/utils/weeklyDigestGenerator.ts` (новый)
+- `src/utils/customerHealthScore.ts` (новый)
+- `src/utils/onboardingReadinessRules.ts` (новый — встраивается в health-engine Layer 2 как 6 правил)
+- `src/utils/nextBestActionEngine.ts` (новый)
+- `src/utils/claudeBudget.ts` (новый — global cost tracking + cap enforcement)
+- `src/utils/driftNorm.ts` (новый — чтение per-project + default норм)
+- `src/utils/health-engine.ts` — добавить 6 onboarding правил в Layer 2 (через `onboardingReadinessRules.ts`)
+- `Skills/PROJECT_NORMS_DEFAULTS.yaml` в makeit-knowledge — дефолты норм per tier (PR в knowledge репо)
+
+## Frontend изменения
+
+- `src/components/v4/hub/tabs/DeliveryTab.tsx` — реальная реализация (DORA + Digest + Customer Health + Onboarding)
+- `src/components/v4/hub/DoraCards.tsx` — 4 KPI с DORA-benchmark цветом
+- `src/components/v4/hub/DigestViewer.tsx` — markdown viewer + history dropdown + regenerate button
+- `src/components/v4/hub/CustomerHealthGauge.tsx` — gauge 0-100 + sparkline 90d
+- `src/components/v4/hub/OnboardingChecklist.tsx` — 6 правил с ✓/✗ + remediation
+- `src/components/v4/SettingsBudgetPanel.tsx` — новая секция в Settings: текущий spend / cap / breakdown по типам call'ов
+- `src/hooks/useProjectHub.ts` — расширяется реальными `dora`, `digest`, `customerHealth`, `onboarding`, `nba`
+- `src/styles/v4.css` — `Delivery Tab`, `Dora Cards`, `Gauge` секции
+
+## Влияние на существующий код
+
+- `health-engine.ts` — добавляются 6 правил, общее количество правил растёт с 50 до 56. По проектам с unfilled docs scores сдвинется (вниз). Документировать в release note.
+- Claude API spend — рост до $30/mo. Budget cap + fallback на Haiku при превышении.
+- BetterStack matching rules (`config.ts`) — используется для MTTR. Нужна явная связь repo ↔ monitor по name patterns. Уже частично есть в matching rules, может потребоваться доуточнение.
+- Pipeline metrics.jsonl — нужен формат с tags для DORA-attribution per repo. Требует [pipeline#1129](https://github.com/Sergio1990-1/makeit-pipeline/issues/1129) для rollover; без него за 30 дней архив не доступен. Альтернатива на v1: считать DORA только за live-окно.
+
+## Целостность бизнес-логики
+
+- **DORA — конвенция**: Deploy Frequency считаем как «merges на main» (упрощение для микро-команды без формальных релизов). CFR — fix-коммиты + audit critical findings в 7-дневном окне после deploy. Документировать в DELIVERY.md (новый файл).
+- **Customer Health «n/a»** — при отсутствии транскриптов > 120 дней не показывать число (избежать ложной уверенности).
+- **Budget cap soft-overflow** — при превышении 110% переключение на Haiku, не отказ от запроса. Hard-stop только при > 200% (защита от runaway loop).
+
+## Задачи
+
+| # | Задача | Зависимости | Параллельно | Размер |
+|---|--------|------------|-------------|--------|
+| 01 | `claudeBudget.ts` (cost tracking + cap enforcement) + `SettingsBudgetPanel` UI | — | да (с #02..#06) | M |
+| 02 | `weeklyDigestGenerator.ts` + `DigestViewer` + cache + regenerate button | 01 | да | L |
+| 03 | `doraCalculator.ts` + `DoraCards` (4 metrics + benchmark colors) + DELIVERY.md doc | — | да | L |
+| 04 | `onboardingReadinessRules.ts` + 6 правил в health-engine + `OnboardingChecklist` component | — | да | M |
+| 05 | `nextBestActionEngine.ts` (per-project + portfolio aggregation) + cache | 01 | да | L |
+| 06 | `driftNorm.ts` + `Skills/PROJECT_NORMS_DEFAULTS.yaml` PR в makeit-knowledge + bootstrap `docs/project_norm.yaml` templates | — | да | M |
+| 07 | `customerHealthScore.ts` (sentiment via Haiku + cadence + delivery + paid) + `CustomerHealthGauge` | 01, Epic-011 #02 | да (с #08) | L |
+| 08 | `DeliveryTab` сборка: DORA + Digest + Customer Health + Onboarding в layout | 02, 03, 04, 07 | — | M |
+| 09 | `useProjectHub` integration: реальные dora/digest/customerHealth/onboarding/nba поля | 02, 03, 04, 05, 07 | — | S |

--- a/docs/epics/epic-012/task-01-claude-budget.md
+++ b/docs/epics/epic-012/task-01-claude-budget.md
@@ -1,0 +1,31 @@
+# Task-01: Claude budget tracker + Settings panel
+
+## Метаданные
+- Epic: epic-012
+- GitHub Issue: #359
+- Приоритет: P2-high
+- Зависит от: —
+- Параллельно: да (с #02-#06)
+- Размер: M
+
+## Описание
+Hard cap на расход Claude API — $30/мес на весь портфель. Каждый вызов логируется в localStorage с tokens + estimated cost. Tier-логика: 80% — warning в UI, 110% — автоматический fallback на Haiku до конца месяца, 200% — hard-stop (защита от runaway loop).
+
+1. `src/utils/claudeBudget.ts` — API: `logCall({type, model, inputTokens, outputTokens})`, `getSpend() → {month, total, byType, capPct}`, `shouldFallbackToHaiku() → boolean`, `isHardStopped() → boolean`. Cost-таблица по моделям (Sonnet $3/$15 per Mtok, Haiku $0.80/$4). Storage key `makeit_claude_budget:{YYYY-MM}`.
+2. `src/components/v4/SettingsBudgetPanel.tsx` — новая секция в Settings: текущий spend / cap $30 / прогресс-бар (зелёный/жёлтый/красный) / breakdown по call-type (digest, nba, sentiment, verify) / кнопка «Reset month» с confirm.
+3. Hard cap и порог fallback должны быть конфигурируемыми (константы в начале файла), не зашиты в UI.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-012.md` — секция Budget cap
+- `docs/prds/PRD-008.md` FR-41
+- `src/utils/claude.ts` — текущая интеграция Claude API (точка интеграции для logCall)
+- `src/components/v4/SettingsView.tsx` — куда монтировать panel
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `logCall` корректно считает cost по input/output tokens × tariff модели
+- [ ] При 110% spend → `shouldFallbackToHaiku()` возвращает true и не сбрасывается до следующего месяца
+- [ ] При 200% spend → `isHardStopped()` блокирует все calls (callers проверяют флаг)
+- [ ] `SettingsBudgetPanel` показывает spend / cap / breakdown с обновлением после каждого call
+- [ ] Reset month очищает текущий месячный bucket после confirm

--- a/docs/epics/epic-012/task-02-weekly-digest.md
+++ b/docs/epics/epic-012/task-02-weekly-digest.md
@@ -1,0 +1,33 @@
+# Task-02: Weekly Project Digest (generator + viewer)
+
+## Метаданные
+- Epic: epic-012
+- GitHub Issue: #360
+- Приоритет: P2-high
+- Зависит от: Task-01 (claudeBudget)
+- Параллельно: да
+- Размер: L
+
+## Описание
+Еженедельный дайджест per-project и кросс-портфельный. Claude Sonnet с fallback на Haiku при budget-overflow (`shouldFallbackToHaiku()`).
+
+1. `src/utils/weeklyDigestGenerator.ts` — `generateDigest(repo, weekISO) → markdown`. Input: pulse за неделю + closed issues + merged PRs + commitments delivered + audit findings за период. Output markdown секции `## Shipped / ## In progress / ## Blocked / ## Decisions / ## Clients touched / ## Spend`. Сохранение через `github-contents.writeFile()` в `digests/{repo}/{YYYY-WW}.md`. Portfolio-уровень: `generatePortfolioDigest(weekISO)` — собирает все per-project digests + меты → `digests/{YYYY-WW}-portfolio.md`.
+2. Week-cache в localStorage: `makeit_digest:{repo}:{YYYY-WW}` (TTL до конца недели). Кнопка regenerate инвалидирует cache.
+3. `src/components/v4/hub/DigestViewer.tsx` — markdown viewer (через `marked` + DOMPurify) + history dropdown (последние 12 недель) + кнопка «Regenerate» с preview ожидаемой стоимости (estimate tokens × tariff) до подтверждения.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-012.md` — секция Project Digest
+- `docs/prds/PRD-008.md` FR-34
+- `src/utils/claude.ts` — Claude API клиент
+- `src/utils/claudeBudget.ts` (после Task-01)
+- `src/utils/github-contents.ts` — writeFile API
+- `src/utils/transcript-markdown.ts` — образец marked + DOMPurify
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `generateDigest` выдаёт все 6 секций даже при пустом input (placeholder «—»)
+- [ ] При `shouldFallbackToHaiku()` модель в request — `haiku`, в UI бейдж «budget fallback»
+- [ ] File сохраняется в `digests/{repo}/{YYYY-WW}.md` в dashboard repo, portfolio-файл — в корне `digests/`
+- [ ] History dropdown показывает последние 12 weeks; click → load и render
+- [ ] Regenerate показывает estimated cost preview до подтверждения

--- a/docs/epics/epic-012/task-03-dora-metrics.md
+++ b/docs/epics/epic-012/task-03-dora-metrics.md
@@ -1,0 +1,37 @@
+# Task-03: DORA-метрики (calculator + cards + doc)
+
+## Метаданные
+- Epic: epic-012
+- GitHub Issue: #361
+- Приоритет: P2-high
+- Зависит от: —
+- Параллельно: да
+- Размер: L
+
+## Описание
+4 DORA-метрики для per-project Delivery tab: Deploy Frequency, Lead Time for Changes, MTTR, Change Failure Rate. Бенчмарк elite/high/medium/low — стандартный DORA per metric.
+
+1. `src/utils/doraCalculator.ts` — `computeDora(repo, windowDays=30) → {deployFreq, leadTime, mttr, cfr}`:
+   - **Deploy Frequency**: count(commits на `main` с conventional prefix `feat:` / `fix:` / `release:`) / windowDays.
+   - **Lead Time**: median(`PR.merged_at` − `PR.created_at`) для merged PRs в окне.
+   - **MTTR**: median downtime BetterStack monitor, сопоставленного с repo через matching rules в `config.ts`. n/a если monitor не найден.
+   - **CFR**: % deploys, за которыми в течение 7 дней последовал commit с `fix:` ИЛИ audit с critical finding.
+2. `src/components/v4/hub/DoraCards.tsx` — 4 KPI карточки в grid с цветом по DORA-benchmark (elite=зелёный, high=светло-зелёный, medium=жёлтый, low=красный). Tooltip — конвенции из DELIVERY.md.
+3. `docs/DELIVERY.md` — новый файл: документирует упрощения (deploys = merges на main с конвенциями, CFR — 7-дневное окно с fix-коммитами + critical audit findings), benchmark thresholds, ограничения live-окна без архивов pipeline.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-012.md` — секция DORA calculator
+- `docs/prds/PRD-008.md` FR-33
+- `src/utils/github.ts` — GraphQL queries по commits и PRs
+- `src/utils/betterstack.ts` — downtime API
+- `src/utils/config.ts` — repo ↔ monitor matching rules
+- DORA report 2024 — benchmark thresholds
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `computeDora` для тестового repo возвращает 4 числа + per-metric tier
+- [ ] При отсутствии monitor — MTTR = «n/a», card показывает прочерк (не 0)
+- [ ] DoraCards подсвечиваются по DORA-tier (elite/high/medium/low) — визуально проверяемо
+- [ ] `docs/DELIVERY.md` описывает все 4 формулы, conventions, benchmark пороги
+- [ ] CFR корректно учитывает critical audit findings в 7-дневном окне после deploy

--- a/docs/epics/epic-012/task-04-onboarding-readiness.md
+++ b/docs/epics/epic-012/task-04-onboarding-readiness.md
@@ -1,0 +1,39 @@
+# Task-04: Onboarding Readiness Checklist (6 правил)
+
+## Метаданные
+- Epic: epic-012
+- GitHub Issue: #362
+- Приоритет: P2-high
+- Зависит от: —
+- Параллельно: да
+- Размер: M
+
+## Описание
+Расширение health-engine Layer 2 шестью правилами готовности проекта к onboarding нового разработчика/клиента. Отдельный компонент показывает текущее состояние правил.
+
+1. `src/utils/onboardingReadinessRules.ts` — экспортирует массив из 6 rule-объектов в формате health-engine Layer 2:
+   - `onboarding.readme_fresh` — last commit на `README.md` за 90 дней
+   - `onboarding.brief_exists` — `docs/BRIEF.md` существует
+   - `onboarding.deploy_doc` — `docs/DEPLOY.md` существует ИЛИ в README есть `## Deploy`
+   - `onboarding.env_example` — `.env.example` существует
+   - `onboarding.ci_green` — последний CI run на `main` = success
+   - `onboarding.audit_fresh` — audit запускался за последние 30 дней
+2. Регистрация правил в `src/utils/health-engine.ts` Layer 2 (общее количество правил растёт с 50 до 56).
+3. `src/components/v4/hub/OnboardingChecklist.tsx` — рендер 6 правил в виде списка с ✓/✗ и tooltip-remediation (текст из rule.remediation).
+4. PR в makeit-knowledge: `Skills/PROJECT_CHECKLIST.yaml` — добавить 6 новых правил с описанием и remediation-инструкциями.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-012.md` — секция Onboarding Readiness
+- `docs/prds/PRD-008.md` FR-36
+- `src/utils/health-engine.ts` — формат rule-объектов Layer 2
+- `src/utils/github-actions.ts` — чтение файлов и CI runs
+- makeit-knowledge `Skills/PROJECT_CHECKLIST.yaml` — текущая структура
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] 6 правил подключены в health-engine, общее число правил = 56
+- [ ] Каждое правило корректно возвращает pass/fail для тестового repo
+- [ ] OnboardingChecklist рендерит ✓/✗ + tooltip с remediation
+- [ ] PR в makeit-knowledge с обновлённым `Skills/PROJECT_CHECKLIST.yaml` создан
+- [ ] Release note в `docs/DELIVERY.md` или CHANGELOG: «health scores могут сдвинуться вниз из-за 6 новых правил»

--- a/docs/epics/epic-012/task-05-next-best-action.md
+++ b/docs/epics/epic-012/task-05-next-best-action.md
@@ -1,0 +1,33 @@
+# Task-05: Next Best Action engine (per-project + portfolio)
+
+## Метаданные
+- Epic: epic-012
+- GitHub Issue: #363
+- Приоритет: P2-high
+- Зависит от: Task-01 (claudeBudget)
+- Параллельно: да
+- Размер: L
+
+## Описание
+Ranked рекомендации «что делать дальше» — per-project и кросс-портфельные. Claude Sonnet с fallback на Haiku при budget-overflow.
+
+1. `src/utils/nextBestActionEngine.ts` — `computeProjectNBA(repo) → Action[3]`. Input: top-3 audit findings + top-3 risks + top-3 overdue commitments + drift indicators + inbox top-5. Prompt → Claude Sonnet → ranked top-3 с полями `{title, rationale, severity, link}`. Кэш `makeit_nba:{repo}` week-cached.
+2. `computePortfolioNBA() → Action[5]` — собирает top-1 от каждого проекта, сортирует по severity, возвращает top-5. Кэш `makeit_portfolio_nba` week-cached.
+3. Кнопка «Regenerate» инвалидирует cache для конкретного scope. При `shouldFallbackToHaiku()` — бейдж «budget fallback» в UI.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-012.md` — секция Next Best Action engine
+- `docs/prds/PRD-008.md` FR-38, FR-39
+- `src/utils/claude.ts` + `src/utils/claudeBudget.ts` (после Task-01)
+- `src/utils/health-engine.ts` — источник risks/findings
+- `src/utils/commitmentsExtractor.ts` (Epic-011 #02) — overdue commitments
+- `src/components/v4/hub/PortfolioNextActions.tsx` (Epic-010) — consumer portfolio NBA
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `computeProjectNBA` для тестового repo возвращает массив из 3 с заполненными полями
+- [ ] `computePortfolioNBA` возвращает top-5 с проектами из разных repos
+- [ ] Week-cache работает: повторный вызов в той же неделе не вызывает Claude API
+- [ ] Regenerate инвалидирует cache и делает реальный API call
+- [ ] При hard-stop budget — возвращает stale cache + warning (не падает)

--- a/docs/epics/epic-012/task-06-drift-norms.md
+++ b/docs/epics/epic-012/task-06-drift-norms.md
@@ -1,0 +1,32 @@
+# Task-06: Drift norms (per-project конфиг + defaults)
+
+## Метаданные
+- Epic: epic-012
+- GitHub Issue: #364
+- Приоритет: P2-high
+- Зависит от: —
+- Параллельно: да
+- Размер: M
+
+## Описание
+Per-project конфиг норм для Drift Detection: `docs/project_norm.yaml` в самом репо проекта. При отсутствии — дефолт по tier из makeit-knowledge.
+
+1. `src/utils/driftNorm.ts` — `loadProjectNorm(repo, tier) → ProjectNorm`. Schema: `{commit_cadence_days, deploy_freq_days, audit_freq_days, client_touch_interval_days}`. Сначала пытается читать `docs/project_norm.yaml` из repo через github-contents API; при отсутствии — fallback на дефолт из `Skills/PROJECT_NORMS_DEFAULTS.yaml` (makeit-knowledge) по tier проекта. Cache в localStorage `makeit_drift_norm:{repo}` с TTL 24ч.
+2. PR в makeit-knowledge: `Skills/PROJECT_NORMS_DEFAULTS.yaml` — структура per tier (`tier-1`, `tier-2`, `tier-3`) с 4 полями каждой. Tier-1 = строгие нормы, tier-3 = lenient.
+3. Bootstrap template: `Skills/templates/hub/project_norm.yaml` в makeit-knowledge — образец per-project файла с комментариями для копирования в новые репо.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-012.md` — секция project_norm.yaml
+- `docs/prds/PRD-008.md` FR-40
+- `src/utils/github-contents.ts` — чтение файлов из repo
+- `src/utils/config.ts` — tier поля проектов
+- makeit-knowledge репо — структура `Skills/`
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `loadProjectNorm` возвращает per-project значения если файл существует
+- [ ] При отсутствии файла — fallback на tier-default из knowledge репо
+- [ ] Cache в localStorage с TTL 24ч (новый запрос после истечения)
+- [ ] PR в makeit-knowledge: `PROJECT_NORMS_DEFAULTS.yaml` + bootstrap template созданы
+- [ ] CustomerHealthScore и DriftDots (Epic-010) подхватывают per-project нормы (smoke test)

--- a/docs/epics/epic-012/task-07-customer-health.md
+++ b/docs/epics/epic-012/task-07-customer-health.md
@@ -1,0 +1,41 @@
+# Task-07: Customer Health Score (gauge + sparkline)
+
+## Метаданные
+- Epic: epic-012
+- GitHub Issue: #365
+- Приоритет: P2-high
+- Зависит от: Task-01 (claudeBudget), Epic-011 #02 (commitments)
+- Параллельно: да (с #08)
+- Размер: L
+
+## Описание
+Composite-score 0-100 для каждого проекта по 4 компонентам: sentiment, cadence, delivery, paid.
+
+1. `src/utils/customerHealthScore.ts` — `computeHealth(repo) → {score, components, sparkline}`. Формула:
+   ```
+   score = sentiment×0.3 + cadence×0.3 + delivery×0.3 + paid×0.1
+   ```
+   - **sentiment** (0-100): Claude Haiku над последними 3 транскриптами → positive/neutral/negative с весами
+   - **cadence** (0-100): актуальный интервал встреч vs `client_touch_interval_days` из `driftNorm`. 100 при ≤ baseline, линейный спад до 0 при 3× baseline
+   - **delivery** (0-100): % commitments delivered on-time за 90 дней (status=done within due-date)
+   - **paid** (0-100): 100 если paid вовремя, 0 при задолженности > 30 дней, линейный спад
+   - При отсутствии транскриптов > 120 дней → `score = 'n/a'`
+2. Sparkline 90d — массив дневных score-значений. Пересчёт раз в неделю (триггер из manual button или регенерации NBA). Кэш `makeit_health:{repo}` с историей.
+3. `src/components/v4/hub/CustomerHealthGauge.tsx` — gauge 0-100 с цветовыми зонами (0-40 красный, 40-70 жёлтый, 70-100 зелёный) + sparkline 90d под ним. При `n/a` — placeholder «нет данных, требуется свежий транскрипт».
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-012.md` — секция Customer Health Score
+- `docs/prds/PRD-008.md` FR-37
+- `src/utils/claude.ts` + `src/utils/claudeBudget.ts` (Task-01)
+- `src/utils/driftNorm.ts` (Task-06)
+- `src/utils/commitmentsExtractor.ts` (Epic-011 #02)
+- `src/utils/transcript.ts` — транскрипты per project
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `computeHealth` возвращает score + 4 компонента для тестового repo
+- [ ] При отсутствии транскриптов > 120 дней → `score = 'n/a'`, gauge показывает placeholder
+- [ ] CustomerHealthGauge подсвечивается по цветовой зоне
+- [ ] Sparkline 90d рендерится с дневной гранулярностью
+- [ ] Manual «Recompute» button инвалидирует cache и пересчитывает sentiment через Haiku

--- a/docs/epics/epic-012/task-08-delivery-tab.md
+++ b/docs/epics/epic-012/task-08-delivery-tab.md
@@ -1,0 +1,32 @@
+# Task-08: Delivery tab — сборка layout
+
+## Метаданные
+- Epic: epic-012
+- GitHub Issue: #366
+- Приоритет: P2-high
+- Зависит от: Task-02, Task-03, Task-04, Task-07
+- Параллельно: нет
+- Размер: M
+
+## Описание
+Сборка вкладки Delivery в Project Hub: DoraCards + DigestViewer + CustomerHealthGauge + OnboardingChecklist в responsive layout.
+
+1. `src/components/v4/hub/tabs/DeliveryTab.tsx` — заменяет stub из Epic-009. Layout (desktop ≥1280px): row-1 = DoraCards (full-width, 4 columns), row-2 = `CustomerHealthGauge` (left, 1fr) + `OnboardingChecklist` (right, 1fr), row-3 = `DigestViewer` (full-width). На mobile (<768px) — single column stack.
+2. Props принимает из `useProjectHub` — `dora`, `digest`, `customerHealth`, `onboarding` (после Task-09 будут реальные данные; пока — заглушки совместимые с API).
+3. Empty states: per-section если данных нет (например, `dora = null` → «Недостаточно merges на main за окно»).
+4. Section в `src/styles/v4.css` — `.delivery-tab`, `.delivery-row`, breakpoints.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-012.md` — секция Frontend изменения
+- `docs/PROJECT_HUB_DESIGN_BRIEF.md` §4.3 Delivery tab
+- `src/components/v4/hub/tabs/` — другие tabs как образец layout-структуры
+- `src/styles/v4.css` — текущие hub-стили
+- Компоненты из задач #02, #03, #04, #07
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] DeliveryTab рендерит все 4 секции в правильном порядке
+- [ ] Responsive: на mobile (<768px) — single column, desktop (≥1280px) — 2-column для row-2
+- [ ] Empty state корректный для каждой секции при отсутствии данных
+- [ ] CSS секция `.delivery-tab` добавлена в `v4.css`, без regression других tabs

--- a/docs/epics/epic-012/task-09-hub-integration.md
+++ b/docs/epics/epic-012/task-09-hub-integration.md
@@ -1,0 +1,37 @@
+# Task-09: useProjectHub integration (реальные данные)
+
+## Метаданные
+- Epic: epic-012
+- GitHub Issue: #367
+- Приоритет: P2-high
+- Зависит от: Task-02, Task-03, Task-04, Task-05, Task-07
+- Параллельно: нет
+- Размер: S
+
+## Описание
+Заменить Epic-009 stubs реальными источниками в `useProjectHub`. Поля `dora`, `digest`, `customerHealth`, `onboarding`, `nba` теперь приходят из соответствующих утилит. OverviewTab подхватывает реальный NBA mini-block.
+
+1. `src/hooks/useProjectHub.ts` — для каждого поля вызывать соответствующую утилиту:
+   - `dora` → `doraCalculator.computeDora(repo)`
+   - `digest` → последний weekly digest для repo (через `weeklyDigestGenerator.loadDigest` или кэш)
+   - `customerHealth` → `customerHealthScore.computeHealth(repo)`
+   - `onboarding` → результаты 6 rules из `onboardingReadinessRules`
+   - `nba` → `nextBestActionEngine.computeProjectNBA(repo)`
+2. Loading-state per section (не блокировать весь Hub при одной долгой выборке). Errors per section — graceful (показываем error placeholder, остальные tabs работают).
+3. `src/components/v4/hub/tabs/OverviewTab.tsx` — NBA mini-block (top-3) теперь использует реальный `nba` из hub state вместо stub-массива.
+
+## Контекст для Claude Code
+Прочитай:
+- `docs/epics/epic-012.md` — секция Frontend изменения
+- `src/hooks/useProjectHub.ts` — текущие stubs Epic-009
+- `src/types/hub.ts` — типы полей
+- Утилиты из задач #02, #03, #04, #05, #07
+- `src/components/v4/hub/tabs/OverviewTab.tsx` — NBA mini-block
+
+## Критерии выполнения
+- [ ] type-check + lint + build чистые
+- [ ] `useProjectHub` возвращает реальные `dora`, `digest`, `customerHealth`, `onboarding`, `nba`
+- [ ] Loading-state per section: одна медленная секция не блокирует другие
+- [ ] Error в одной секции не валит весь Hub (graceful placeholder)
+- [ ] OverviewTab NBA mini-block показывает реальные top-3 actions из engine
+- [ ] PortfolioNextActions (Epic-010) подхватывает реальный portfolio NBA (smoke test)

--- a/docs/prds/PRD-008.md
+++ b/docs/prds/PRD-008.md
@@ -1,0 +1,198 @@
+# PRD-008: Project Hub & Portfolio Health Surface
+
+## Метаданные
+- Статус: draft
+- Автор: Sergei
+- Дата: 2026-05-15
+- Приоритет: P2-high
+- Scope: large (4 эпика, ~30 задач)
+- Связан с: PRD-004..007 (Project Health), `docs/PROJECT_HEALTH_DESIGN_BRIEF.md`, `docs/PROJECT_HUB_DESIGN_BRIEF.md`
+
+## Проблема
+
+При портфеле из 12+ проектов владелец **теряет контекст**:
+
+1. Контекст проекта разбросан по 4+ вкладкам (Дашборд / Проекты / Pipeline / Audit) — чтобы понять состояние одного репо, нужно переключаться и собирать в голове.
+2. Обещания клиентам, риски, истёкшие SSL/контракты, decisions с встреч — нигде систематически не записаны и не отслеживаются. Любой такой пропуск стоит репутации или денег.
+3. Drift'а (давно нет коммитов, давно не было аудита, давно не было контакта с клиентом) не видно — «зомби-проекты» накапливаются молча.
+4. Нет агрегированной рекомендации «что трогать сейчас» — каждое утро владелец сам решает, открывая по очереди тяжёлые вкладки.
+5. Существующий Project Health (50 правил × 4 слоя) даёт срез гигиены, но не отвечает на вопрос «что делать прямо сейчас и почему».
+
+## Решение
+
+Реструктурировать страницу «Проекты» в двухуровневую схему:
+
+1. **Portfolio Surface** (страница «Проекты») — превью-сетка Scorecards с цветными drift-индикаторами + 4 портфельных виджета сверху (Next Actions, Renewals, Promise Tracker, Digest).
+2. **Project Hub** (страница проекта) — 5 вкладок: Overview, Health (существующая), Activity, Decisions & Risks, Delivery.
+
+Реализовать 11 виджетов, источники данных к ним и единый агрегирующий хук `useProjectHub(repo)`.
+
+Hub становится «вторым домом» владельца — каждое утро открыл `/projects`, увидел top-actions, drilled-down в нужный проект, разгрёб inbox, отметил действия. Health остаётся как одна из вкладок без изменений.
+
+## Пользователи и роли
+
+| Роль | Что делает | Ключевые потребности |
+|---|---|---|
+| Владелец/Куратор (Sergei) | Solo-managing 12+ проектов. Daily-driver дашборда | Single-screen overview всего портфеля, drill-down в проект за 1 клик, нулевой риск пропустить commitment/expiry/risk |
+| AI-агенты (через Chat / skills) | Создают issues, обновляют metadata | Read-API к данным Hub (через существующий Chat), машинно-читаемый формат risks/commitments/renewals |
+
+## Бизнес-процесс
+
+N/A. Дашборд не управляет заказами/платежами/складом. Это инструмент visibility + lightweight CRUD над метаданными в репо.
+
+## Функциональные требования
+
+### Portfolio Surface (страница «Проекты»)
+
+| ID | Требование | Приоритет |
+|---|---|---|
+| FR-1 | Страница `?tab=projects` без `repo` рендерит превью-сетку `ProjectScorecard` (grid 3-col @1024px, 2-col @768px, 1-col @<768px) | must |
+| FR-2 | Каждая Scorecard содержит: имя репо, client, tier-pill, phase-badge, health-grade, KPI row (open/in-progress/blocked/overdue-commitments), DriftDots (4 цветных дота: commit/deploy/audit/client-touch), last activity, cost MTD | must |
+| FR-3 | Клик по Scorecard переходит в Hub Overview (`?tab=projects&repo=X&subtab=overview`) | must |
+| FR-4 | DriftDots цвет: green (в норме), yellow (≥1.5× нормы), red (≥3× нормы). Tooltip раскрывает «N дней назад, норма Y дней» | must |
+| FR-5 | Сверху страницы 4 портфельных виджета (top-row): Next Actions, Renewals, Promise Tracker, Digest. Layout 2×2 grid @1024px, stack @<768px | must |
+| FR-6 | Portfolio Next Actions показывает top-5 ranked recommendations с обоснованием и линком на проект. Кнопка «Регенерировать» (cached на неделю) | must |
+| FR-7 | Portfolio Renewals показывает top-5 ближайших expiry, цвет по urgency (red ≤7д, yellow ≤30д, gray >30д) | must |
+| FR-8 | Portfolio Promise Tracker группирует commitments по клиенту, показывает overdue + due-this-week | must |
+| FR-9 | Portfolio Digest показывает превью последнего weekly digest + кнопку «Сгенерировать новый» (кэш на неделю) | must |
+| FR-10 | Sidebar badge на пункте меню «Проекты» — суммарное число NBA портфеля | should |
+
+### Project Hub (страница проекта)
+
+| ID | Требование | Приоритет |
+|---|---|---|
+| FR-11 | URL `?tab=projects&repo=X` без subtab → Hub Overview. `?tab=projects&repo=X&subtab=Y` → конкретная вкладка (Y ∈ overview, health, activity, decisions, delivery) | must |
+| FR-12 | Старый URL `?tab=projects&repo=X` (без subtab) ведёт на Overview (поведение Health-as-default отменяется) | must |
+| FR-13 | Header содержит: имя репо, tier, phase, client, last activity, health-grade, score%, sparkline-placeholder | must |
+| FR-14 | Header содержит «Next Best Action» — одну строку с обоснованием и линком на якорь нужной вкладки. Кнопка «Регенерировать» (cached на неделю) | must |
+| FR-15 | Строка табов под header: Overview / Health / Activity / Decisions & Risks / Delivery. На «Activity» — inbox-badge (число событий since-last-visit) | must |
+| FR-16 | Browser back/forward переключает между Portfolio, Hub-табами без перезагрузки | must |
+| FR-17 | Кнопка «← Все проекты» в header возвращает на Portfolio Surface | must |
+| FR-18 | Refresh в Hub восстанавливает текущую вкладку и selectedRepo через URL | must |
+
+### Вкладка Overview
+
+| ID | Требование | Приоритет |
+|---|---|---|
+| FR-19 | Overview содержит 4 mini-блока: NBA-блок (раскрытый), Pulse-summary (5 last events), Risks-summary (top-3 critical/high), Commitments-summary (top-3 overdue + due-this-week) | must |
+| FR-20 | Каждый mini-блок имеет линк «Открыть полностью» на соответствующую вкладку Hub | should |
+
+### Вкладка Health
+
+| ID | Требование | Приоритет |
+|---|---|---|
+| FR-21 | Health вкладка рендерит существующий `ProjectHealthPage` без визуальных изменений | must |
+| FR-22 | Все существующие функции Health (refresh, scan drift, bulk create issues) работают без регрессий | must |
+
+### Вкладка Activity
+
+| ID | Требование | Приоритет |
+|---|---|---|
+| FR-23 | Activity содержит: vertical timeline Pulse Events, Project Inbox (since-last-visit), Open PRs list, Open Pipeline Runs list | must |
+| FR-24 | Pulse Events merge'ит: GitHub events (commits/issues/PRs), Pipeline runs (start/stop/stage transitions), Transcripts (uploaded/processed), Audit findings (created). Отсортированы chronologically (desc). Фильтр по типу | must |
+| FR-25 | Open `Activity` → inbox-badge на табе обнуляется, `lastVisitedStore[repo]` обновляется на текущий timestamp | must |
+| FR-26 | Pulse Events с timestamp > lastVisited подсвечены | should |
+
+### Вкладка Decisions & Risks
+
+| ID | Требование | Приоритет |
+|---|---|---|
+| FR-27 | Вкладка содержит 4 секции: Decision Log, Risk Register, Commitments, Renewals | must |
+| FR-28 | Decision Log читает `docs/BRIEF.md` (секция `decisions:`) + conventional commits, отображает chronologically | must |
+| FR-29 | Risk Register — CRUD над `docs/risks.yaml` в репо проекта. CRUD коммитит через GitHub Contents API | must |
+| FR-30 | Risk Register умеет triggered-extraction: кнопка «Extract from transcripts» запускает Claude над последними 5 транскриптами проекта и предлагает риски на одобрение | should |
+| FR-31 | Commitments — read `docs/commitments.yaml` + inline-CRUD. Поля: text, due, client, status (open/done/cancelled) | must |
+| FR-32 | Renewals — read `docs/renewals.yaml` + сканер deprecated/CVE deps в `package.json`. Inline-CRUD над manual entries | must |
+
+### Вкладка Delivery
+
+| ID | Требование | Приоритет |
+|---|---|---|
+| FR-33 | Delivery содержит: DORA metrics (4 KPI), Project Digest (last week + history), Customer Health Score (gauge + 90д sparkline), Onboarding Readiness Checklist | must |
+| FR-34 | DORA метрики: Deploy Frequency, Lead Time for Changes, MTTR, Change Failure Rate. Цвет по DORA elite/high/medium/low benchmark | must |
+| FR-35 | Deploy Frequency = коммиты на main за период (наряду с tagged releases если есть). Lead Time = медиана от первого коммита PR до merge. MTTR = медиана downtime по BetterStack monitor этого проекта. CFR = % деплоев с critical-finding в следующем audit | must |
+| FR-36 | Project Digest — markdown-блок weekly auto-changelog (shipped/in-progress/blocked/decisions/clients-touched/spend). Хранится в `digests/{repo}/{YYYY-WW}.md` в dashboard repo через GitHub Contents API. Кэш на неделю | must |
+| FR-37 | Customer Health Score = sentiment×0.3 + cadence×0.3 + delivery×0.3 + paid×0.1. Формулы: sentiment — Claude над последними 3 транскриптами (0-100); cadence — каданс встреч за 90д vs baseline; delivery — % commitments delivered on-time за 90д; paid — 100 если paid вовремя, 0 если задолженность. Sparkline 90д | must |
+| FR-38 | Onboarding Readiness — extension Health Layer 2 правилами: README актуальный (commit за 90д), есть `docs/BRIEF.md`, есть deploy-инструкция (`docs/DEPLOY.md` или раздел в README), есть `.env.example`, последний CI run зелёный, audit за 30 дней | must |
+
+### Источники данных (cross-cutting)
+
+| ID | Требование | Приоритет |
+|---|---|---|
+| FR-39 | Все per-project yaml метаданные (risks/commitments/renewals/project_norm) хранятся в самом проектном репо в `docs/` | must |
+| FR-40 | Дефолтные normы (commit cadence, deploy freq, audit freq, client touch freq) хранятся в `makeit-knowledge/Skills/PROJECT_NORMS_DEFAULTS.yaml`. Per-project override в `docs/project_norm.yaml` | must |
+| FR-41 | Все Claude-вызовы (NBA, Digest, Risk extraction, sentiment) имеют budget cap $30/mo на весь portfolio. При превышении — fallback на Haiku. Cost dashboard в существующем Settings panel | must |
+| FR-42 | `useProjectHub(repo)` — единственный hook агрегации. Виджеты — только presentation. Расширяет существующий `useProjectHealth` композицией | must |
+| FR-43 | `lastVisitedStore.ts` — sessionStorage `makeit_hub_last_visited:{repo}` → ISO timestamp. Per-device tracking. Reset при logout | must |
+
+## Нефункциональные требования
+
+- **Производительность**: Hub-page first paint ≤ 1.5с при cached данных, ≤ 5с при cold load. Portfolio Surface — ≤ 2с при 12 проектах
+- **Каскадирование ошибок**: упавший источник (Pipeline API лежит) не ломает Hub целиком — соответствующий блок показывает inline-warning, остальное работает
+- **Budget hard cap**: $30/mo на Claude API для всех Hub-фич. Hard-stop при достижении 110%, soft warning при 80%
+- **Type-check + lint + build** остаются чистыми после каждой задачи
+- **Темы**: светлая + тёмная — обязательно
+- **Адаптив**: ≥1024px без регрессий, ≥768px — readable, <768px — graceful degradation
+- **Accessibility**: severity-badges не передают смысл только цветом, focus-ring на всех clickable элементах, ARIA-roles для tabs
+
+## Влияние на существующий функционал
+
+| Что | Риск | Митигация |
+|---|---|---|
+| `ProjectsView.tsx` | Полная переработка: вместо ProjectCard сетки → Scorecards + 4 виджета сверху + Hub-роутер на selectedRepo | Существующий ProjectCard переименовать → ProjectScorecard и расширить. Старая ветка `if (selectedRepo)` → ProjectHubPage вместо ProjectHealthPage |
+| Routing URL | Старый `?tab=projects&repo=X` теперь показывает Overview, не Health | Документировать в migration note; задача 03 в Epic-009 — one-time toast при первом таком переходе |
+| `ProjectHealthPage.tsx` | Рендерится внутри HubTabs как content вкладки Health, без изменений | Не трогать ProjectHealthPage; обернуть в `<HealthTab>` компонент |
+| `useProjectHealth.ts` | Используется внутри `useProjectHub` через композицию | Публичное API хука стабильно |
+| `AIInsightsPanel.tsx` | Существующий портфельный health-блок на Дашборде | Сохраняется; PortfolioNextActions использует ту же `usePortfolioHealth` для подсказок NBA |
+| Sidebar | Добавляется NBA-badge на пункте «Проекты» | Не ломает остальное меню |
+| GitHub API rate limit | +повышенная нагрузка: чтение `docs/*.yaml` из 12 репо + PR list per repo + monitor downtime | Кэширование per-repo в sessionStorage 30 мин; ETag для contents API; lazy-load по вкладкам |
+| `localStorage` quota | risks/commitments/decisions могут расти; digest cache (12 проектов × 4 недели) | Soft-cap, отображать warning при >80% quota |
+| Project Health Layer 2 | Добавляются 6 onboarding правил → score у некоторых проектов сдвинется | Документировать в release note; grace для new projects сохраняется |
+| Claude API spend | +до $30/mo (NBA, digest, sentiment, risk extraction) | Budget cap с fallback на Haiku; cost dashboard для visibility |
+
+## Критерии приёмки
+
+- [ ] Открыл `/?tab=projects` → видишь сетку Scorecards (3 cols @1440px) + 4 портфельных виджета сверху
+- [ ] Каждая Scorecard содержит все поля из FR-2; DriftDots цветовая логика работает (FR-4)
+- [ ] Клик по Scorecard переводит на Hub Overview, URL обновляется (FR-3, FR-11)
+- [ ] Hub Overview содержит 4 mini-блока (FR-19); все линки «Открыть полностью» работают
+- [ ] Переключение всех 5 вкладок Hub без перезагрузки; URL обновляется; back/forward работает (FR-15, FR-16)
+- [ ] Вкладка Health показывает существующую ProjectHealthPage без визуальных изменений (FR-21); все её функции работают (FR-22)
+- [ ] Вкладка Activity показывает Pulse, Inbox, open PRs, open Runs; inbox-badge обнуляется при открытии (FR-23, FR-25)
+- [ ] Вкладка Decisions & Risks: Decision Log читается из BRIEF.md; Risk Register CRUD пишет в `docs/risks.yaml`; «Extract from transcripts» предлагает риски (FR-28..32)
+- [ ] Вкладка Delivery: все 4 DORA метрики рассчитаны и показаны с benchmark-цветом; Project Digest можно сгенерировать кнопкой; Customer Health отображает score + sparkline; Onboarding Readiness Checklist рендерит 6 правил (FR-33..38)
+- [ ] Кнопка «← Все проекты» возвращает на Portfolio Surface (FR-17)
+- [ ] Budget cap: после достижения $30/mo все Claude-вызовы переключаются на Haiku, в UI показывается warning (FR-41)
+- [ ] Type-check `npx tsc --noEmit` чистый
+- [ ] Build `npm run build` чистый
+- [ ] Светлая + тёмная темы работают во всех новых компонентах
+- [ ] Адаптив: на 1024px portfolio = 3 col, на 768px = 2 col; Hub Overview не разваливается
+- [ ] E2E: открыл Portfolio → клик Scorecard → переключение всех 5 табов → back возвращает в Portfolio с сохранённым scroll
+
+## Открытые вопросы
+
+- [ВОПРОС] Sparkline истории health-score (placeholder в Header) — отдельный PRD после накопления данных? Сейчас оставить пустым slot
+- [ВОПРОС] Customer Health Score — формула dummy для проектов без транскриптов? Предложение: показывать «n/a» если последний транскрипт >120 дней
+- [ВОПРОС] Risk extraction из транскриптов — какой default frequency check? Manual триггер из UI, без авто-сканирования
+
+## Out of scope (для PRD-008)
+
+- Stakeholder Map (вкладка Context)
+- Cross-project Dependency View
+- Mobile-optimized layout
+- Bulk operations across projects
+- Sharing digest по email/Telegram
+- Sparkline history health-score (только placeholder)
+- Pinned/favorites projects
+- Custom views (Kanban, list, table) на Portfolio Surface
+
+## Milestones (план реализации)
+
+| Эпик | Что | Зависимости | Размер |
+|---|---|---|---|
+| Epic-009 | Project Hub Foundation: routing, tabs, Overview, Health integration | — | M (~2 нед) |
+| Epic-011 | New Data Sources: Activity, Decisions, Risks, Commitments, Renewals + Activity/Decisions tabs UI | Epic-009 | L (~4 нед) |
+| Epic-012 | Delivery Metrics & Intelligence: DORA, Digest, Customer Health, Onboarding, NBA engine, project_norm config + Delivery tab UI | Epic-009, Epic-011 (часть), pipeline#1129 | L (~4 нед) |
+| Epic-010 | Portfolio Surface Redesign: Scorecards, DriftDots, 4 portfolio widgets, NBA badge | Epic-011 + Epic-012 (данные) | M (~2 нед) |
+
+Порядок: Epic-009 → (Epic-011 + Epic-012 параллельно) → Epic-010 (склейка).


### PR DESCRIPTION
## Summary

PRD-008 + 4 эпика (009-012) + 30 task-файлов + UX design brief для перестройки страницы «Проекты» в двухуровневую схему:

- **Portfolio Surface** — превью-сетка `ProjectScorecard` с drift-индикаторами + 4 портфельных виджета (Next Actions, Renewals, Promise Tracker, Digest)
- **Project Hub** — 5 вкладок per repo (Overview / Health / Activity / Decisions & Risks / Delivery)

Существующая `ProjectHealthPage` сохраняется без изменений как вкладка Health внутри Hub.

11 виджетов покрывают: Service Scorecards, Drift Detection, Renewals, Promise Tracker, Risk Register, Activity Pulse, Project Inbox, Customer Health Score, Next Best Action, DORA metrics, Project Digest, Onboarding Readiness.

## Файлы (36, +1870 строк)

- [`docs/PROJECT_HUB_DESIGN_BRIEF.md`](https://github.com/Sergio1990-1/makeit-dashboard/blob/docs/prd-008-project-hub/docs/PROJECT_HUB_DESIGN_BRIEF.md) — UX-бриф
- [`docs/prds/PRD-008.md`](https://github.com/Sergio1990-1/makeit-dashboard/blob/docs/prd-008-project-hub/docs/prds/PRD-008.md) — PRD (43 FR)
- [`docs/epics/epic-009.md`](https://github.com/Sergio1990-1/makeit-dashboard/blob/docs/prd-008-project-hub/docs/epics/epic-009.md) ... [epic-012.md](https://github.com/Sergio1990-1/makeit-dashboard/blob/docs/prd-008-project-hub/docs/epics/epic-012.md) — 4 эпика
- `docs/epics/epic-009/` ... `epic-012/` — 30 task-файлов

## GitHub tracking

| Эпик | Milestone | Tracker | Tasks | Дедлайн |
|---|---|---|---|---|
| Epic-009: Project Hub Foundation | #10 | #368 | #338-342 | 2026-05-25 |
| Epic-011: New Data Sources | #12 | #370 | #350-358 | 2026-06-12 |
| Epic-012: Delivery & Intelligence | #13 | #371 | #359-367 | 2026-06-10 |
| Epic-010: Portfolio Surface | #11 | #369 | #343-349 | 2026-06-19 |

Все 34 issues в [MakeIT Tracker #1](https://github.com/users/Sergio1990-1/projects/1).

## Test plan

- [x] Type-check: N/A (только docs)
- [x] Build: N/A (только docs)
- [ ] Markdown rendering на GitHub читабелен
- [ ] Ссылки в PRD на FR-номера консистентны
- [ ] Task-файлы содержат `GitHub Issue: #NNN` (real numbers, не #TBD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)