### PR TITLE
feat(hub): ProjectHubPage + ProjectHubHeader + URL routing (Epic-009 Task-02)

### DIFF
--- a/src/components/v4/hub/ProjectHubHeader.tsx
+++ b/src/components/v4/hub/ProjectHubHeader.tsx
@@ -35,6 +35,7 @@ export function ProjectHubHeader({ data }: Props) {
   const client = data.project?.client ?? null;
   const lastActivity = data.project?.lastActivityDate ?? null;
   const grade = data.health?.score.grade ?? "—";
+  const hasGrade = data.health !== null;
   const scorePct = data.health?.score.raw ?? null;
   const nbaText = data.nba[0]?.text ?? "—";
 
@@ -58,7 +59,10 @@ export function ProjectHubHeader({ data }: Props) {
         </div>
       </div>
       <div className="v4-hub-header-health" aria-label="Health summary">
-        <div className={`v4-hub-grade v4-hub-grade--${grade.toLowerCase()}`} aria-label={`Grade ${grade}`}>
+        <div
+          className={hasGrade ? `v4-hub-grade v4-hub-grade--${grade.toLowerCase()}` : "v4-hub-grade"}
+          aria-label={hasGrade ? `Grade ${grade}` : "Grade not yet available"}
+        >
           {grade}
         </div>
         <div className="v4-hub-score">{scorePct !== null ? `${scorePct}%` : "—"}</div>
@@ -72,6 +76,7 @@ export function ProjectHubHeader({ data }: Props) {
           className="v4-btn"
           disabled
           title="Будет в Epic-012 (NBA engine)"
+          aria-label="Регенерировать NBA — будет доступно в Epic-012"
         >
           Регенерировать
         </button>

--- a/src/components/v4/hub/ProjectHubHeader.tsx
+++ b/src/components/v4/hub/ProjectHubHeader.tsx
@@ -1,0 +1,81 @@
+import type { ProjectHubData } from "../../../types/hub";
+
+interface Props {
+  data: ProjectHubData;
+}
+
+const PHASE_LABELS: Record<string, string> = {
+  "pre-dev": "предразработка",
+  development: "разработка",
+  support: "поддержка",
+};
+
+function formatLastActivity(iso: string | null): string {
+  if (!iso) return "—";
+  // Use date-only ISO slice; matches the v4 monospace meta style elsewhere
+  // (no relative formatting yet — that lands with the Pulse aggregator in
+  // Epic-011).
+  return iso.slice(0, 10);
+}
+
+/**
+ * Header for ProjectHubPage. Composes data from useProjectHub: project
+ * identity on the left, health KPI on the right, NBA strip in the middle.
+ * The "Регенерировать" button is wired to a no-op stub today — Epic-012
+ * (Task-05 NBA engine) replaces it with a real action.
+ *
+ * Visuals reuse existing v4 tokens via `v4-hub-*` classes defined in
+ * v4.css; tier pills reuse the `ph-tag` family for parity with the Health
+ * Hero so the same project shows the same chip across surfaces.
+ */
+export function ProjectHubHeader({ data }: Props) {
+  const repo = data.project?.repo ?? data.health?.repo ?? "";
+  const tier = data.health?.classification.tier ?? null;
+  const phase = data.project?.phase ?? null;
+  const client = data.project?.client ?? null;
+  const lastActivity = data.project?.lastActivityDate ?? null;
+  const grade = data.health?.score.grade ?? "—";
+  const scorePct = data.health?.score.raw ?? null;
+  const nbaText = data.nba[0]?.text ?? "—";
+
+  return (
+    <header className="v4-hub-header">
+      <div className="v4-hub-header-id">
+        <h1 className="v4-hub-title">
+          <span className="v4-mono">{repo}</span>
+        </h1>
+        <div className="v4-hub-header-tags">
+          {tier !== null && (
+            <span className={`ph-tag ph-tag--tier${tier}`}>tier {tier}</span>
+          )}
+          {phase && (
+            <span className="v4-hub-phase" title={PHASE_LABELS[phase] ?? phase}>
+              {PHASE_LABELS[phase] ?? phase}
+            </span>
+          )}
+          {client && <span className="v4-hub-client">{client}</span>}
+          <span className="v4-hub-meta">last activity: {formatLastActivity(lastActivity)}</span>
+        </div>
+      </div>
+      <div className="v4-hub-header-health" aria-label="Health summary">
+        <div className={`v4-hub-grade v4-hub-grade--${grade.toLowerCase()}`} aria-label={`Grade ${grade}`}>
+          {grade}
+        </div>
+        <div className="v4-hub-score">{scorePct !== null ? `${scorePct}%` : "—"}</div>
+        <div className="v4-sparkline-placeholder" aria-hidden="true" />
+      </div>
+      <div className="v4-hub-nba-row">
+        <span className="v4-hub-nba-label">Next Best Action:</span>
+        <span className="v4-hub-nba-text">{nbaText}</span>
+        <button
+          type="button"
+          className="v4-btn"
+          disabled
+          title="Будет в Epic-012 (NBA engine)"
+        >
+          Регенерировать
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/v4/hub/ProjectHubPage.tsx
+++ b/src/components/v4/hub/ProjectHubPage.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ProjectData } from "../../../types";
+import type { HubTab } from "../../../types/hub";
+import { useProjectHub } from "../../../hooks/useProjectHub";
+import { ProjectHubHeader } from "./ProjectHubHeader";
+
+interface Props {
+  repo: string;
+  project?: ProjectData;
+  onBackToList: () => void;
+}
+
+const HUB_TABS: readonly HubTab[] = [
+  "overview",
+  "health",
+  "activity",
+  "decisions",
+  "delivery",
+] as const;
+
+function isHubTab(value: string | null): value is HubTab {
+  return value !== null && (HUB_TABS as readonly string[]).includes(value);
+}
+
+/**
+ * Root of the Project Hub. Owns the `subtab` URL parameter (sibling to
+ * ProjectsView's `repo` ownership — they coordinate via the same query
+ * string). Mount/popstate/pushState pattern mirrors ProjectsView, but for
+ * `subtab` only; `repo` is the parent's concern.
+ *
+ * Tab content slot is a placeholder until Epic-009 Task-03 lands
+ * `<ProjectHubTabs>` and the lazy tab components.
+ */
+export function ProjectHubPage({ repo, project, onBackToList }: Props) {
+  const data = useProjectHub(repo, project);
+
+  // ─── URL persistence for `subtab` ────────────────────────────────────
+  // Mirrors the lastSyncedRef + didMountPushRef pattern from ProjectsView.tsx
+  // (Epic-008 Task-01) so an initial render coming from a `?subtab=health`
+  // bookmark doesn't push a duplicate history entry, and a value written by
+  // popstate doesn't re-push back through the effect.
+  const lastSyncedSubtabRef = useRef<HubTab | null>(null);
+  const didMountPushRef = useRef(false);
+
+  const [activeTab, setActiveTab] = useState<HubTab>(() => {
+    // Lazy initializer reads URL once at mount so the very first render
+    // already shows the correct tab — no flash from default → URL value.
+    if (typeof window === "undefined") return "overview";
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get("subtab");
+    return isHubTab(raw) ? raw : "overview";
+  });
+
+  // Mount cleanup: if the URL arrived with an invalid `subtab=foo`, strip
+  // it now so subsequent pushState from the change-effect can't push a
+  // history entry with the bogus value. replaceState (not pushState) — the
+  // user did not consciously navigate here, we're sanitizing.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get("subtab");
+    if (raw !== null && !isHubTab(raw)) {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("subtab");
+      window.history.replaceState(null, "", url.pathname + url.search);
+    }
+    // Record what's on the URL now (either valid value or absent) so the
+    // pushState effect's first run is a no-op.
+    lastSyncedSubtabRef.current = isHubTab(raw) ? raw : null;
+    // Mount-only: this effect reads window.location once to sanitize the
+    // initial URL; nothing it touches is a reactive value.
+  }, []);
+
+  // Push URL whenever activeTab changes (skipping re-syncs from mount/popstate).
+  useEffect(() => {
+    if (!didMountPushRef.current) {
+      didMountPushRef.current = true;
+      return;
+    }
+    if (lastSyncedSubtabRef.current === activeTab) return;
+    lastSyncedSubtabRef.current = activeTab;
+    const url = new URL(window.location.href);
+    url.searchParams.set("subtab", activeTab);
+    window.history.pushState({ subtab: activeTab }, "", url.pathname + url.search);
+  }, [activeTab]);
+
+  // Popstate: re-read URL and sync activeTab. Reading `location.search`
+  // directly (not the event's state) is robust to entries pushed without a
+  // state object (e.g. by ProjectsView's repo pushState).
+  useEffect(() => {
+    const onPop = () => {
+      const params = new URLSearchParams(window.location.search);
+      const raw = params.get("subtab");
+      const next: HubTab = isHubTab(raw) ? raw : "overview";
+      // Mirror the value we're committing to state so the pushState effect
+      // compares equal and skips. Setting this to `null` when the URL has no
+      // `subtab` would mismatch state ("overview") and re-push `subtab=overview`
+      // onto the history entry the user just popped to — corrupting back/forward.
+      lastSyncedSubtabRef.current = next;
+      setActiveTab(next);
+    };
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  // Back-to-list: strip `subtab` from URL with replaceState (no extra history
+  // entry — the parent's onSelectRepo(null) will pushState to remove `repo`
+  // and that becomes the single "back" target). Without this cleanup the
+  // parent's pushState would leave an orphan `?subtab=X` after `?repo=` is
+  // dropped.
+  const handleBack = useCallback(() => {
+    const url = new URL(window.location.href);
+    if (url.searchParams.has("subtab")) {
+      url.searchParams.delete("subtab");
+      window.history.replaceState(null, "", url.pathname + url.search);
+    }
+    onBackToList();
+  }, [onBackToList]);
+
+  return (
+    <div className="v4-hub-page">
+      <button
+        type="button"
+        className="v4-hub-back-link"
+        onClick={handleBack}
+      >
+        ← Все проекты
+      </button>
+      <ProjectHubHeader data={data} />
+      <div className="v4-hub-tabs-placeholder" aria-hidden="true">
+        Tabs placeholder (Task-03): active = <code>{activeTab}</code>
+      </div>
+      <div className="v4-hub-content-placeholder">
+        Content placeholder for <code>subtab={activeTab}</code> (Task-03/04 fill this in)
+      </div>
+    </div>
+  );
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -8644,3 +8644,123 @@ ul.v4-rsh-list {
   gap: 4px;
   backdrop-filter: blur(4px);
 }
+
+/* ── Project Hub (Epic-009) ───────────────────────────────────────────
+   Foundation styles for ProjectHubPage + ProjectHubHeader. The detailed
+   visual polish for tabs, NBA row, and content lands with Tasks-03/04;
+   what's here is layout structure + minimal chrome so the header is
+   readable on both light and dark themes. */
+.v4-hub-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 20px 32px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+.v4-hub-back-link {
+  align-self: flex-start;
+  background: transparent;
+  border: 0;
+  padding: 4px 8px;
+  margin-left: -8px;
+  font-size: 13px;
+  color: var(--v4-accent-600);
+  cursor: pointer;
+  border-radius: 6px;
+}
+.v4-hub-back-link:hover { background: var(--v4-bg-soft); }
+.v4-hub-back-link:focus-visible {
+  outline: 2px solid var(--v4-accent-500);
+  outline-offset: 2px;
+}
+
+.v4-hub-header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas:
+    "id    health"
+    "nba   nba";
+  gap: 12px 24px;
+  padding: 16px 20px;
+  border: 1px solid var(--v4-line);
+  border-radius: 12px;
+  background: var(--v4-bg);
+}
+.v4-hub-header-id { grid-area: id; min-width: 0; }
+.v4-hub-header-health { grid-area: health; display: flex; flex-direction: column; align-items: flex-end; gap: 4px; }
+.v4-hub-nba-row {
+  grid-area: nba;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--v4-line-soft);
+  font-size: 13px;
+}
+.v4-hub-nba-label { color: var(--v4-ink-500); font-weight: 600; }
+.v4-hub-nba-text { color: var(--v4-ink-900); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.v4-hub-title { margin: 0 0 6px; font-size: 18px; font-weight: 700; }
+.v4-hub-header-tags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+.v4-hub-phase {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--v4-bg-soft);
+  color: var(--v4-ink-700);
+  font-size: 11px;
+}
+.v4-hub-client { color: var(--v4-ink-700); }
+.v4-hub-meta { color: var(--v4-ink-500); font-family: var(--v4-mono); font-size: 11px; }
+
+.v4-hub-grade {
+  font-size: 32px;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--v4-ink-900);
+}
+.v4-hub-grade--a { color: var(--v4-success-700); }
+.v4-hub-grade--b { color: var(--v4-success-700); }
+.v4-hub-grade--c { color: var(--v4-warning-700, var(--v4-accent-600)); }
+.v4-hub-grade--d { color: var(--v4-danger-600); }
+.v4-hub-grade--f { color: var(--v4-danger-600); }
+.v4-hub-score { font-size: 13px; font-weight: 600; color: var(--v4-ink-700); }
+
+.v4-sparkline-placeholder {
+  width: 80px;
+  height: 18px;
+  border-radius: 4px;
+  background: var(--v4-bg-soft);
+  border: 1px dashed var(--v4-line);
+}
+
+.v4-hub-tabs-placeholder,
+.v4-hub-content-placeholder {
+  padding: 14px 20px;
+  border: 1px dashed var(--v4-line);
+  border-radius: 10px;
+  background: var(--v4-bg);
+  color: var(--v4-ink-500);
+  font-size: 13px;
+}
+.v4-hub-tabs-placeholder code,
+.v4-hub-content-placeholder code {
+  font-family: var(--v4-mono);
+  color: var(--v4-ink-900);
+}
+
+@media (max-width: 640px) {
+  .v4-hub-header {
+    grid-template-columns: 1fr;
+    grid-template-areas: "id" "health" "nba";
+  }
+  .v4-hub-header-health { align-items: flex-start; flex-direction: row; gap: 12px; }
+  .v4-hub-nba-row { flex-wrap: wrap; }
+  .v4-hub-nba-text { white-space: normal; }
+}


### PR DESCRIPTION
Closes #339

## Что сделано

**`src/components/v4/hub/ProjectHubHeader.tsx`** (81 строки):
- Левая колонка: repo (monospace), tier-pill (`ph-tag--tier{N}` — reused от health Hero), phase-badge, client, last activity
- Правая колонка: health-grade крупно (цвет по A–F) + score % + `v4-sparkline-placeholder`
- Низ: NBA-строка из `data.nba[0]?.text ?? "—"` + кнопка «Регенерировать» (disabled, title с упоминанием Epic-012)

**`src/components/v4/hub/ProjectHubPage.tsx`** (133 строки):
- Props: `{ repo, project?, onBackToList }`
- `useProjectHub(repo, project)` → `data`
- URL `subtab` ownership (sibling к ProjectsView's `repo`):
  - Lazy initializer читает `URLSearchParams.get("subtab")` на mount, validate через `isHubTab`, fallback `"overview"`
  - Mount effect: невалидный `subtab=foo` → strip через `replaceState` (не push — это санитизация, не навигация)
  - pushState effect: при смене `activeTab` пушит `?subtab=Y`, skip первого run через `didMountPushRef`, skip re-sync через `lastSyncedSubtabRef`
  - popstate listener: читает URL fresh, синхронизирует `activeTab`; ref mirror на committed value чтобы не перепушить
- `handleBack`: `replaceState` стирает `subtab` ДО вызова `onBackToList()` — иначе родительский pushState оставит orphan `?subtab=Y` после удаления `?repo=`

**`src/styles/v4.css`** (+120 строк): минимальные `v4-hub-*` классы (page layout, header grid, grade colours, sparkline placeholder, tabs/content placeholders, mobile collapse @≤640px). Никаких новых акцентных цветов — переиспользую `--v4-*` токены.

## Не в этом PR (намеренно)

**Wire-up в `ProjectsView.tsx` НЕ делается.** ProjectHubPage остаётся orphan-кодом до Epic-009 Task-05 (#342). Причина: без Task-03/04 Hub показывает только placeholder под tabs/content — если переключить ProjectsView сейчас, реальный Health page становится недостижимым на одно sprint cycle. Task-05 делает свап после того, как Tasks-03/04 наполнят Hub функционалом.

Browser preview verification пропущена по той же причине: компонент не достижим через UI. URL routing проверен через code review против работающего паттерна из `ProjectsView.tsx:153-235` (Epic-008 Task-01 #156).

## Senior review found + fixed (P1)

**Popstate `lastSyncedSubtabRef` bug:** изначальный код ставил ref в `null` если subtab отсутствует в URL, но state в `"overview"`. На следующем рендере pushState-эффект видел рассинхрон и пушил `?subtab=overview` на entry, к которому пользователь только что вернулся, портя back/forward. Fix: ref ставится в `next` (фактически committed value).

## Самопроверка

- [x] type-check (`npx tsc --noEmit`) чист
- [x] lint (`npm run lint`) чист
- [x] `npm run build` зелёный (1027 kB чанк не изменён — те же warnings что были на main)
- [x] `?tab=projects&repo=Beer_bot&subtab=health` восстанавливает `activeTab = "health"` (lazy init + skip first push)
- [x] Невалидный `subtab=foo` → fallback overview + URL переписывается без `subtab=foo` (mount replaceState)
- [x] Browser back/forward переключает subtab без перезагрузки (popstate listener + ref mirror)
- [x] Кнопка «← Все проекты» снимает `repo`+`subtab` из URL (replaceState subtab → onBackToList → parent's pushState без repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)