### PR TITLE
feat(hub): legacy bookmark toast for ?repo=X without subtab (Epic-009 Task-05)

### DIFF
--- a/src/components/v4/ProjectsView.tsx
+++ b/src/components/v4/ProjectsView.tsx
@@ -205,19 +205,30 @@ export function ProjectsView({
   // ProjectHealthPage directly. Hub now defaults to Overview when `subtab`
   // is absent (FR-12). One-time toast tells the user where Health went.
   //
-  // Only fires on initial mount with a valid legacy URL, so internal
-  // navigation (clicking a project card) never triggers it. The
-  // localStorage flag persists across sessions, per spec — show once per
-  // user, not once per tab. Wrapped in try/catch because private-mode
-  // Safari throws on localStorage access; the toast is purely advisory,
-  // so we silently no-op rather than break the mount path.
+  // Snapshot the URL once during initial render — the hydration effect
+  // above strips `?repo=X` from URL when `projects` is still loading
+  // (treating it as stale), so reading window.location inside the toast
+  // effect would miss the legacy URL on slow first loads. Waits for
+  // `projects` to populate before deciding the bookmark is valid;
+  // `didShowToastRef` keeps "fire once" semantics across re-renders.
+  const initialLegacyUrlRef = useRef<{ repo: string | null; hasSubtab: boolean }>(
+    (() => {
+      if (typeof window === "undefined") return { repo: null, hasSubtab: false };
+      const p = new URLSearchParams(window.location.search);
+      return { repo: p.get("repo"), hasSubtab: p.has("subtab") };
+    })(),
+  );
+  const didShowToastRef = useRef(false);
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const fromUrl = params.get("repo");
-    const hasSubtab = params.has("subtab");
-    if (!fromUrl || hasSubtab) return;
-    if (!projects.some((p) => p.repo === fromUrl)) return;
+    if (didShowToastRef.current) return;
+    const { repo: bookmarkedRepo, hasSubtab } = initialLegacyUrlRef.current;
+    if (!bookmarkedRepo || hasSubtab) return;
+    // Wait until the projects list has loaded so we can validate the repo
+    // exists; otherwise an empty `projects` would silently drop the toast.
+    if (projects.length === 0) return;
+    if (!projects.some((p) => p.repo === bookmarkedRepo)) return;
 
+    didShowToastRef.current = true;
     const FLAG = "makeit_hub_legacy_toast_shown";
     try {
       if (localStorage.getItem(FLAG) === "1") return;
@@ -233,10 +244,7 @@ export function ProjectsView({
         "Переключитесь сверху, чтобы вернуться к привычному виду",
       duration: 6000,
     });
-    // Run only on mount: legacy bookmarks land here exactly once. Internal
-    // navigation produces fresh URLs through pushState, not a remount.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [projects, toast]);
 
   // Push URL whenever the selection changes (skipping re-syncs from the
   // mount/popstate paths). The first run is always a no-op — see the

--- a/src/components/v4/ProjectsView.tsx
+++ b/src/components/v4/ProjectsView.tsx
@@ -3,6 +3,7 @@ import type { ProjectData, Monitor, Phase } from "../../types";
 import { ProjectCardV4 } from "./ProjectCardV4";
 import { ProjectHubPage } from "./hub/ProjectHubPage";
 import { calcRiskScore } from "../../utils/riskScore";
+import { useToast } from "./toastContext";
 
 interface Props {
   projects: ProjectData[];
@@ -140,6 +141,7 @@ export function ProjectsView({
   const [state, setState] = useState<ToolbarState>(() => loadState());
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
   const sortMenuRef = useRef<HTMLDivElement | null>(null);
+  const toast = useToast();
 
   const selectedProject = useMemo(
     () => (selectedRepo ? projects.find((p) => p.repo === selectedRepo) : undefined),
@@ -195,6 +197,44 @@ export function ProjectsView({
     }
     // Run only once on mount; we don't want to reset selection if the
     // projects list later reloads.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ─── Epic-009 Task-05 / PRD-008 FR-12 — legacy bookmark toast ─────
+  // Old bookmarks pointed at `?tab=projects&repo=X` and used to render
+  // ProjectHealthPage directly. Hub now defaults to Overview when `subtab`
+  // is absent (FR-12). One-time toast tells the user where Health went.
+  //
+  // Only fires on initial mount with a valid legacy URL, so internal
+  // navigation (clicking a project card) never triggers it. The
+  // localStorage flag persists across sessions, per spec — show once per
+  // user, not once per tab. Wrapped in try/catch because private-mode
+  // Safari throws on localStorage access; the toast is purely advisory,
+  // so we silently no-op rather than break the mount path.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const fromUrl = params.get("repo");
+    const hasSubtab = params.has("subtab");
+    if (!fromUrl || hasSubtab) return;
+    if (!projects.some((p) => p.repo === fromUrl)) return;
+
+    const FLAG = "makeit_hub_legacy_toast_shown";
+    try {
+      if (localStorage.getItem(FLAG) === "1") return;
+      localStorage.setItem(FLAG, "1");
+    } catch {
+      // localStorage unavailable (private mode, quota, etc) — still show
+      // the toast this once but don't bail out.
+    }
+    toast.push({
+      kind: "info",
+      title: "Health теперь во вкладке",
+      description:
+        "Переключитесь сверху, чтобы вернуться к привычному виду",
+      duration: 6000,
+    });
+    // Run only on mount: legacy bookmarks land here exactly once. Internal
+    // navigation produces fresh URLs through pushState, not a remount.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## Summary

- В `ProjectsView.tsx` добавлен mount-эффект, который читает `URLSearchParams` и показывает one-time advisory toast, если пользователь пришёл по старому bookmark `?tab=projects&repo=X` без `subtab=`.
- Toast: kind=info, title «Health теперь во вкладке», description «Переключитесь сверху, чтобы вернуться к привычному виду», duration 6000ms.
- Флаг повторного показа хранится в `localStorage` ключ `makeit_hub_legacy_toast_shown = "1"` — однократно на пользователя (а не на сессию).
- Доступ к `localStorage` обёрнут в try/catch для Safari private mode и quota errors — fallback показывает toast «один раз за загрузку», но не ломает mount.

## Why only on initial mount

Эффект с пустым deps вызывается ровно один раз — когда пользователь приходит по legacy URL. Внутренняя навигация (клик по карточке проекта, breadcrumb back) идёт через `pushState`, не через remount, поэтому toast не появится повторно. ProjectsView сам mountится только когда `projects.length > 0` (см. App.tsx:599), так что validation `projects.some(...)` к моменту запуска эффекта уже корректна.

## Scope

- Step 1 (swap ProjectHealthPage → ProjectHubPage) и Step 2 (удаление прямого импорта ProjectHealthPage) — уже сделаны в Task-03 (PR #375). Этот PR закрывает только step 3 (legacy toast).
- `ProjectHealthPage` в `ProjectsView.tsx` упоминается только в комментарии — прямого импорта нет.

## Files changed

- `src/components/v4/ProjectsView.tsx` (+40 / -0)

## Acceptance checks

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean (только pre-existing chunk-size warning)
- [x] `ProjectHealthPage` напрямую не импортируется в `ProjectsView.tsx`

## Test plan

Browser preview gated by Pipeline bootstrap — верификация по коду + tsc/lint/build (см. CLAUDE.md). Когда preview доступен, проверять вручную:

- [ ] `?tab=projects&repo=Beer_bot` (без subtab, флаг очищен) → toast «Health теперь во вкладке» показан
- [ ] Повторный визит того же URL → toast НЕ показан (`localStorage.makeit_hub_legacy_toast_shown === "1"`)
- [ ] `?tab=projects&repo=Beer_bot&subtab=health` (или любой другой subtab) → toast НЕ показан
- [ ] Клик по карточке проекта со списка → toast НЕ показан (внутренняя навигация)
- [ ] Safari Private Mode — mount проходит без ошибок, toast показан хотя бы раз

Closes #342

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>