### PR TITLE
feat(budget): Claude budget tracker + Settings panel (Epic-012 Task-01)

### DIFF
--- a/src/components/v4/SettingsBudgetPanel.tsx
+++ b/src/components/v4/SettingsBudgetPanel.tsx
@@ -1,0 +1,272 @@
+import { useSyncExternalStore, useState } from "react";
+import {
+  FALLBACK_PCT,
+  HARD_STOP_PCT,
+  MONTHLY_CAP_USD,
+  WARN_PCT,
+  getSpendSnapshot,
+  resetCurrentMonth,
+  subscribe,
+  type ClaudeCallType,
+} from "../../utils/claudeBudget";
+
+/**
+ * Settings section showing this month's Claude API spend against the
+ * portfolio-wide hard cap (Epic-012 Task-01 / FR-41).
+ *
+ * Pure read-only view sourced from `claudeBudget` via
+ * `useSyncExternalStore`. The store re-notifies on every `logCall` /
+ * `resetCurrentMonth`, so the panel stays live without polling.
+ *
+ * The panel is intentionally dumb: it does not enforce thresholds — that
+ * is the job of `assertNotHardStopped` / `effectiveModel` at call sites.
+ */
+
+function fmtUsd(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
+
+/** Tier-based colour for the progress bar and percentage label. */
+function tierColor(pct: number): string {
+  if (pct >= FALLBACK_PCT) return "var(--v4-danger-700, #b91c1c)";
+  if (pct >= WARN_PCT) return "var(--v4-warning-700, #b45309)";
+  return "var(--v4-success-700, #15803d)";
+}
+
+/** Background tint matching tier — used for the progress bar fill. */
+function tierFill(pct: number): string {
+  if (pct >= FALLBACK_PCT) return "var(--v4-danger-500, #ef4444)";
+  if (pct >= WARN_PCT) return "var(--v4-warning-500, #f59e0b)";
+  return "var(--v4-success-500, #10b981)";
+}
+
+/** Russian label for a known call category. Unknown values pass through. */
+function typeLabel(type: ClaudeCallType | string): string {
+  switch (type) {
+    case "audit":
+      return "Audit issue gen";
+    case "verify":
+      return "Audit verify";
+    case "chat":
+      return "Чат";
+    case "drift":
+      return "Drift checks";
+    case "digest":
+      return "Project Digest";
+    case "nba":
+      return "Next Best Action";
+    case "sentiment":
+      return "Sentiment";
+    case "other":
+      return "Прочее";
+    default:
+      return type;
+  }
+}
+
+export function SettingsBudgetPanel() {
+  // External store keeps the panel in sync with every Claude call
+  // without polling. `getSpendSnapshot` returns a reference-stable
+  // value between mutations so React doesn't see a fake change every
+  // render — `subscribe` invalidates the snapshot on `notify()`.
+  const spend = useSyncExternalStore(subscribe, getSpendSnapshot, getSpendSnapshot);
+  const [confirmReset, setConfirmReset] = useState(false);
+
+  // Clamp the visual fill to [0, 100] so an overshoot doesn't blow the
+  // bar past its container; the numeric label still shows the true value.
+  const fillPct = Math.min(100, Math.max(0, spend.capPct));
+  const color = tierColor(spend.capPct);
+  const fill = tierFill(spend.capPct);
+
+  // Sort breakdown by spend desc so the biggest contributors lead. Empty
+  // bucket → friendlier message instead of an empty list.
+  const breakdownEntries = Object.entries(spend.byType)
+    .filter(([, v]) => typeof v === "number" && v > 0)
+    .sort((a, b) => (b[1] as number) - (a[1] as number));
+
+  let tierMessage: { text: string; color: string } | null = null;
+  if (spend.capPct >= HARD_STOP_PCT) {
+    tierMessage = {
+      text: `Hard-stop активен (≥${HARD_STOP_PCT}%) — все Claude-запросы отклоняются до конца месяца или сброса.`,
+      color: "var(--v4-danger-700, #b91c1c)",
+    };
+  } else if (spend.capPct >= FALLBACK_PCT) {
+    tierMessage = {
+      text: `Активен fallback на Haiku (≥${FALLBACK_PCT}%) — Sonnet/Opus автоматически заменяются.`,
+      color: "var(--v4-danger-700, #b91c1c)",
+    };
+  } else if (spend.capPct >= WARN_PCT) {
+    tierMessage = {
+      text: `Расход выше ${WARN_PCT}% — приближаемся к fallback на Haiku.`,
+      color: "var(--v4-warning-700, #b45309)",
+    };
+  }
+
+  return (
+    <div
+      style={{
+        marginTop: 4,
+        padding: 12,
+        border: "1px solid var(--v4-border, rgba(0,0,0,0.1))",
+        borderRadius: 10,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          marginBottom: 4,
+        }}
+      >
+        <div style={{ fontWeight: 600, fontSize: 13 }}>Claude API budget</div>
+        <div style={{ fontSize: 12, color: "var(--v4-ink-500)" }}>{spend.month}</div>
+      </div>
+
+      <div style={{ color: "var(--v4-ink-500)", fontSize: 12, marginBottom: 10 }}>
+        Hard cap {fmtUsd(MONTHLY_CAP_USD)} в месяц на весь портфель. На {WARN_PCT}% — UI
+        warning, на {FALLBACK_PCT}% — авто-fallback на Haiku, на {HARD_STOP_PCT}% — hard-stop.
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          marginBottom: 6,
+          gap: 8,
+        }}
+      >
+        <span style={{ fontVariantNumeric: "tabular-nums", fontSize: 13 }}>
+          {fmtUsd(spend.total)} / {fmtUsd(spend.capUsd)}
+        </span>
+        <span
+          style={{
+            fontVariantNumeric: "tabular-nums",
+            fontSize: 13,
+            fontWeight: 600,
+            color,
+          }}
+        >
+          {spend.capPct.toFixed(0)}%
+        </span>
+      </div>
+
+      <div
+        role="progressbar"
+        aria-label="Claude API spend"
+        aria-valuenow={Math.round(spend.capPct)}
+        aria-valuemin={0}
+        aria-valuemax={HARD_STOP_PCT}
+        style={{
+          height: 8,
+          background: "var(--v4-border, rgba(0,0,0,0.08))",
+          borderRadius: 4,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            width: `${fillPct}%`,
+            height: "100%",
+            background: fill,
+            transition: "width 200ms ease",
+          }}
+        />
+      </div>
+
+      {tierMessage !== null && (
+        <div
+          style={{
+            marginTop: 8,
+            fontSize: 12,
+            color: tierMessage.color,
+          }}
+        >
+          {tierMessage.text}
+        </div>
+      )}
+
+      <div style={{ marginTop: 12 }}>
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--v4-ink-500)",
+            marginBottom: 6,
+          }}
+        >
+          Разбивка по типу вызовов
+        </div>
+        {breakdownEntries.length === 0 ? (
+          <div style={{ fontSize: 12, color: "var(--v4-ink-500)" }}>
+            В этом месяце ещё не было Claude API вызовов.
+          </div>
+        ) : (
+          <ul
+            style={{
+              listStyle: "none",
+              padding: 0,
+              margin: 0,
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+            }}
+          >
+            {breakdownEntries.map(([type, amount]) => (
+              <li
+                key={type}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  fontSize: 12,
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                <span>{typeLabel(type)}</span>
+                <span>{fmtUsd(amount as number)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        {confirmReset ? (
+          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            <span style={{ fontSize: 12, color: "var(--v4-ink-700)" }}>
+              Сбросить расход за {spend.month}? История прошлых месяцев останется.
+            </span>
+            <button
+              type="button"
+              className="v4-btn"
+              onClick={() => setConfirmReset(false)}
+            >
+              Отмена
+            </button>
+            <button
+              type="button"
+              className="v4-btn"
+              style={{ color: "var(--v4-danger-700, #b91c1c)" }}
+              onClick={() => {
+                resetCurrentMonth();
+                setConfirmReset(false);
+              }}
+            >
+              Подтвердить сброс
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className="v4-btn"
+            onClick={() => setConfirmReset(true)}
+            disabled={spend.total === 0}
+            title={spend.total === 0 ? "Нечего сбрасывать" : "Сбросить месячный расход"}
+          >
+            Сбросить месяц
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/SettingsBudgetPanel.tsx
+++ b/src/components/v4/SettingsBudgetPanel.tsx
@@ -69,6 +69,10 @@ export function SettingsBudgetPanel() {
   // without polling. `getSpendSnapshot` returns a reference-stable
   // value between mutations so React doesn't see a fake change every
   // render — `subscribe` invalidates the snapshot on `notify()`.
+  //
+  // Third arg is the SSR snapshot. The dashboard is SPA-only so it
+  // never fires in practice, but passing the same identity-stable
+  // getter keeps the contract consistent if SSR is ever added.
   const spend = useSyncExternalStore(subscribe, getSpendSnapshot, getSpendSnapshot);
   const [confirmReset, setConfirmReset] = useState(false);
 

--- a/src/components/v4/SettingsPanel.tsx
+++ b/src/components/v4/SettingsPanel.tsx
@@ -33,6 +33,7 @@ import {
   setSetting,
 } from "../../utils/settings";
 import { useToast } from "./toastContext";
+import { SettingsBudgetPanel } from "./SettingsBudgetPanel";
 
 /** Friendly RU labels for the well-known managed keys. */
 const KEY_LABELS: Record<string, string> = {
@@ -514,6 +515,8 @@ export function SettingsPanel({ onClose, onBootstrapCleared }: Props) {
               Сменить bootstrap-токен
             </button>
           </div>
+
+          <SettingsBudgetPanel />
 
           <div
             style={{

--- a/src/utils/claude.ts
+++ b/src/utils/claude.ts
@@ -4,6 +4,12 @@ import { GITHUB_OWNER, GITHUB_PROJECT_NUMBER, getToken } from "./config";
 import { maybeDispatchAuthLostFromError } from "./external-auth-events";
 import { selectFindingsForVerification } from "./verification";
 import {
+  assertNotHardStopped,
+  effectiveModel,
+  logCall,
+  type ClaudeCallType,
+} from "./claudeBudget";
+import {
   listRepoFiles,
   readRepoFile,
   createIssue,
@@ -596,8 +602,13 @@ export async function generateIssuesFromFindings(
         : "";
 
     try {
+      // Refuse the call when monthly Claude spend is past the hard-stop
+      // threshold (Epic-012 Task-01 / FR-41). The outer try/catch logs
+      // and continues so a single budget refusal doesn't poison the loop.
+      assertNotHardStopped();
+      const auditModel = effectiveModel("claude-sonnet-4-6");
       const response = await client.messages.create({
-        model: "claude-sonnet-4-6",
+        model: auditModel,
         max_tokens: 4096,
         system: _AUDIT_BATCH_PROMPT,
         messages: [
@@ -610,6 +621,15 @@ export async function generateIssuesFromFindings(
         // FR-8: surface invalid Claude key as auth-lost. Re-throw so the
         // outer try/catch's existing log-and-continue logic still runs.
         throw maybeDispatchAuthLostFromError("claude", e);
+      });
+      // Account for the spend BEFORE we touch the response payload so a
+      // parse failure later still records the cost — Claude billed us
+      // either way.
+      logCall({
+        type: "audit",
+        model: auditModel,
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
       });
 
       const text = response.content
@@ -658,12 +678,19 @@ export async function callClaudeWithTool<T>(
   toolDef: { name: string; description: string; input_schema: object },
   model: "claude-haiku-4-5-20251001" | "claude-opus-4-7",
   maxTokens = 1024,
+  callType: ClaudeCallType = "drift",
 ): Promise<T> {
   const client = new Anthropic({ apiKey, dangerouslyAllowBrowser: true });
 
+  // FR-41: refuse when the monthly budget is past hard-stop; downgrade
+  // Opus → Haiku when past the fallback threshold. We do not downgrade
+  // explicitly-requested Haiku since that's already the cheapest tier.
+  assertNotHardStopped();
+  const actualModel = effectiveModel(model);
+
   const response = await client.messages
     .create({
-      model,
+      model: actualModel,
       max_tokens: maxTokens,
       system: systemPrompt,
       messages: [{ role: "user", content: userMessage }],
@@ -674,13 +701,20 @@ export async function callClaudeWithTool<T>(
       throw maybeDispatchAuthLostFromError("claude", e);
     });
 
+  logCall({
+    type: callType,
+    model: actualModel,
+    inputTokens: response.usage.input_tokens,
+    outputTokens: response.usage.output_tokens,
+  });
+
   for (const block of response.content) {
     if (block.type === "tool_use" && block.name === toolDef.name) {
       return block.input as T;
     }
   }
   throw new Error(
-    `model did not call tool "${toolDef.name}" (model=${model})`,
+    `model did not call tool "${toolDef.name}" (model=${actualModel})`,
   );
 }
 
@@ -713,9 +747,15 @@ export async function sendChatMessage(
 
   // Tool use loop — max 20 iterations
   for (let i = 0; i < 20; i++) {
+    // FR-41 budget guards. The hard-stop check sits inside the loop on
+    // purpose: a single chat session can rack up dozens of tool-use
+    // iterations, and we want every one of them to honour a fresh
+    // hard-stop (e.g. another tab pushed us over the cap).
+    assertNotHardStopped();
+    const chatModel = effectiveModel("claude-sonnet-4-6");
     const response = await client.messages
       .create({
-        model: "claude-sonnet-4-6",
+        model: chatModel,
         max_tokens: 4096,
         system: [
           { type: "text", text: SYSTEM_RULES, cache_control: { type: "ephemeral" } },
@@ -730,6 +770,13 @@ export async function sendChatMessage(
         // chat panel's existing error UX.
         throw maybeDispatchAuthLostFromError("claude", e);
       });
+
+    logCall({
+      type: "chat",
+      model: chatModel,
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+    });
 
     // Check if we need to handle tool calls
     if (response.stop_reason === "tool_use") {

--- a/src/utils/claudeBudget.ts
+++ b/src/utils/claudeBudget.ts
@@ -1,0 +1,339 @@
+/**
+ * Claude API budget tracker (Epic-012 Task-01, FR-41).
+ *
+ * Hard cap on monthly Claude API spend across the whole portfolio.
+ * Every Claude call must:
+ *   1. Check `isHardStopped()` before issuing the request.
+ *   2. Optionally swap the model to Haiku when `shouldFallbackToHaiku()`
+ *      returns true (>= FALLBACK_PCT of cap).
+ *   3. Call `logCall(...)` with the response's token usage.
+ *
+ * Storage: `localStorage` under key `makeit_claude_budget:{YYYY-MM}`.
+ * Each month gets its own bucket so we never lose history; only the
+ * current month is consulted by the cap-checks.
+ *
+ * Thresholds and pricing live in constants at the top of the file —
+ * adjust them there, not in callers or UI.
+ */
+
+// ── Configurable constants ────────────────────────────────────────────────
+
+/** Monthly hard cap on Claude API spend (USD). */
+export const MONTHLY_CAP_USD = 30;
+
+/** Warning threshold (% of cap) — UI shows yellow above this. */
+export const WARN_PCT = 80;
+
+/**
+ * Fallback threshold (% of cap) — `shouldFallbackToHaiku()` returns
+ * true above this so callers can downgrade Sonnet/Opus to Haiku.
+ */
+export const FALLBACK_PCT = 110;
+
+/**
+ * Hard-stop threshold (% of cap) — `isHardStopped()` returns true
+ * above this, callers must refuse to make the request. This protects
+ * against runaway loops.
+ */
+export const HARD_STOP_PCT = 200;
+
+/**
+ * Per-million-token pricing in USD, keyed by a normalised model family.
+ * Source: anthropic.com/pricing as of 2026-05.
+ *
+ * Lookup is fuzzy: any model id whose lowercased form contains the family
+ * substring matches (e.g. `claude-sonnet-4-6` → `sonnet`). Unknown models
+ * fall back to `unknown` so we still log usage but with zero cost — the
+ * tester sees the call and we don't crash.
+ */
+const PRICE_PER_MTOK: Record<string, { input: number; output: number }> = {
+  haiku: { input: 0.8, output: 4 },
+  sonnet: { input: 3, output: 15 },
+  opus: { input: 15, output: 75 },
+  unknown: { input: 0, output: 0 },
+};
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+/**
+ * Logical call category. Drives the breakdown in the Settings UI so the
+ * user can see where the spend is going. Keep this list narrow — add new
+ * values here, not as ad-hoc strings at call sites.
+ */
+export type ClaudeCallType =
+  | "digest"
+  | "nba"
+  | "sentiment"
+  | "verify"
+  | "audit"
+  | "chat"
+  | "drift"
+  | "other";
+
+export interface LogCallInput {
+  type: ClaudeCallType;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+interface MonthBucket {
+  /** YYYY-MM, redundant with the key but useful when reading raw storage. */
+  month: string;
+  /** Total accumulated spend (USD). */
+  total: number;
+  /** Breakdown per ClaudeCallType (USD). */
+  byType: Partial<Record<ClaudeCallType, number>>;
+  /** Number of recorded calls (for debugging — UI does not require it). */
+  calls: number;
+}
+
+export interface SpendSummary {
+  /** Current YYYY-MM bucket inspected. */
+  month: string;
+  /** Total spend this month (USD). */
+  total: number;
+  /** Spend per category (USD). */
+  byType: Partial<Record<ClaudeCallType, number>>;
+  /** Percentage of `MONTHLY_CAP_USD` consumed (0..∞, can exceed 100). */
+  capPct: number;
+  /** Configured monthly cap (USD), echoed for UI convenience. */
+  capUsd: number;
+}
+
+// ── Internals ─────────────────────────────────────────────────────────────
+
+const STORAGE_PREFIX = "makeit_claude_budget";
+
+/**
+ * Browser-side change notifier. UI subscribes; mutations call notify().
+ * No external deps; intentionally tiny — `useSyncExternalStore` only
+ * needs subscribe + getSnapshot. We expose subscribe via a helper at
+ * the bottom of the file.
+ */
+const listeners = new Set<() => void>();
+
+/**
+ * Cached SpendSummary returned by `getSpendSnapshot`. Held until the
+ * next `notify()` so `useSyncExternalStore` sees a stable reference
+ * between mutations — without this, React strict-mode flags a tearing
+ * loop because `getSpend()` constructs a fresh object every call.
+ */
+let cachedSnapshot: SpendSummary | null = null;
+
+function notify(): void {
+  // Invalidate the snapshot BEFORE notifying so listeners that re-read
+  // through `getSpendSnapshot` observe the post-mutation state.
+  cachedSnapshot = null;
+  for (const fn of listeners) {
+    try {
+      fn();
+    } catch (e) {
+      // A bad listener should never poison the loop.
+      console.warn("claudeBudget listener threw:", e);
+    }
+  }
+}
+
+/** Format a Date as YYYY-MM in UTC (deterministic across timezones). */
+function monthKey(d: Date = new Date()): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
+}
+
+function storageKey(month: string): string {
+  return `${STORAGE_PREFIX}:${month}`;
+}
+
+function readBucket(month: string): MonthBucket {
+  const empty: MonthBucket = { month, total: 0, byType: {}, calls: 0 };
+  if (typeof localStorage === "undefined") return empty;
+  const raw = localStorage.getItem(storageKey(month));
+  if (raw === null) return empty;
+  try {
+    const parsed = JSON.parse(raw) as Partial<MonthBucket>;
+    // Defensive: a corrupt or partial bucket must not crash the app.
+    return {
+      month,
+      total: typeof parsed.total === "number" && isFinite(parsed.total) ? parsed.total : 0,
+      byType:
+        parsed.byType && typeof parsed.byType === "object"
+          ? (parsed.byType as MonthBucket["byType"])
+          : {},
+      calls: typeof parsed.calls === "number" && isFinite(parsed.calls) ? parsed.calls : 0,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+function writeBucket(bucket: MonthBucket): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(storageKey(bucket.month), JSON.stringify(bucket));
+  } catch (e) {
+    // Quota exceeded or storage disabled — log but don't break the call.
+    console.warn("claudeBudget: failed to persist bucket:", e);
+  }
+}
+
+/**
+ * Resolve a model id to a price family. Fuzzy substring match handles
+ * versioned ids like `claude-sonnet-4-6` and `claude-haiku-4-5-20251001`
+ * without a per-version table.
+ */
+function resolvePricing(model: string): { input: number; output: number } {
+  const lc = model.toLowerCase();
+  if (lc.includes("haiku")) return PRICE_PER_MTOK.haiku;
+  if (lc.includes("sonnet")) return PRICE_PER_MTOK.sonnet;
+  if (lc.includes("opus")) return PRICE_PER_MTOK.opus;
+  return PRICE_PER_MTOK.unknown;
+}
+
+/** USD cost for a single call. Internal — exported for unit tests if needed. */
+export function estimateCost(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): number {
+  const price = resolvePricing(model);
+  // tokens × ($/Mtok) ÷ 1e6
+  return (
+    (Math.max(0, inputTokens) * price.input) / 1_000_000 +
+    (Math.max(0, outputTokens) * price.output) / 1_000_000
+  );
+}
+
+// ── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * Record a Claude API call against the current month's bucket.
+ *
+ * Safe to call from any context (browser, test, SSR — no-op without
+ * `localStorage`). Never throws; on any persistence error the in-memory
+ * notification still fires so listeners stay consistent with whatever
+ * localStorage now holds.
+ */
+export function logCall(input: LogCallInput): void {
+  const cost = estimateCost(input.model, input.inputTokens, input.outputTokens);
+  if (!isFinite(cost) || cost < 0) {
+    // Defensive — a corrupt input shouldn't poison the bucket.
+    return;
+  }
+  const month = monthKey();
+  const bucket = readBucket(month);
+  bucket.total = bucket.total + cost;
+  bucket.byType[input.type] = (bucket.byType[input.type] ?? 0) + cost;
+  bucket.calls += 1;
+  writeBucket(bucket);
+  notify();
+}
+
+/** Snapshot of the current month's spend, suitable for UI rendering. */
+export function getSpend(): SpendSummary {
+  const month = monthKey();
+  const bucket = readBucket(month);
+  const capPct = MONTHLY_CAP_USD > 0 ? (bucket.total / MONTHLY_CAP_USD) * 100 : 0;
+  return {
+    month,
+    total: bucket.total,
+    byType: bucket.byType,
+    capPct,
+    capUsd: MONTHLY_CAP_USD,
+  };
+}
+
+/**
+ * Reference-stable variant of `getSpend()` for `useSyncExternalStore`.
+ * Returns the same object until the next mutation calls `notify()`.
+ *
+ * Always-fresh callers (cap checks, log-call internals) should keep
+ * using `getSpend()` so they observe the latest write within the same
+ * tick.
+ */
+export function getSpendSnapshot(): SpendSummary {
+  if (cachedSnapshot === null) cachedSnapshot = getSpend();
+  return cachedSnapshot;
+}
+
+/**
+ * True when the current month's spend has crossed `FALLBACK_PCT` of the
+ * cap. Callers should swap Sonnet/Opus → Haiku for the rest of the
+ * request lifecycle. The flag clears on month rollover.
+ */
+export function shouldFallbackToHaiku(): boolean {
+  return getSpend().capPct >= FALLBACK_PCT;
+}
+
+/**
+ * True when the current month's spend has crossed `HARD_STOP_PCT` of the
+ * cap. Callers must refuse to make further Claude calls (typically by
+ * throwing a typed error). Protects against runaway tool-use loops.
+ */
+export function isHardStopped(): boolean {
+  return getSpend().capPct >= HARD_STOP_PCT;
+}
+
+/**
+ * Wipe the current month's bucket. Used by the Settings panel after
+ * an explicit user confirm. Other months are left untouched so history
+ * is preserved.
+ */
+export function resetCurrentMonth(): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.removeItem(storageKey(monthKey()));
+  } catch (e) {
+    console.warn("claudeBudget: failed to reset bucket:", e);
+  }
+  notify();
+}
+
+/**
+ * Subscribe to spend changes. Returns an unsubscribe function.
+ * Designed for `useSyncExternalStore` so React re-renders stay correct
+ * without cross-tab `storage` event plumbing (single-tab app).
+ */
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Error type thrown when a call is refused due to hard-stop.
+ * Callers can `instanceof BudgetHardStopError` to distinguish from
+ * network/auth errors and surface a specific UI message.
+ */
+export class BudgetHardStopError extends Error {
+  constructor(message = "Claude API budget hard-stopped (monthly cap exceeded 200%)") {
+    super(message);
+    this.name = "BudgetHardStopError";
+  }
+}
+
+/**
+ * Convenience guard for callers: throws `BudgetHardStopError` when the
+ * monthly cap is over the hard-stop threshold. Use at the top of every
+ * Claude API entry point.
+ */
+export function assertNotHardStopped(): void {
+  if (isHardStopped()) throw new BudgetHardStopError();
+}
+
+/**
+ * Pick the actual model id to send, honouring fallback. If the requested
+ * model is already Haiku, returns it unchanged. Otherwise, when fallback
+ * is active, returns `haikuFallback` (default: `claude-haiku-4-5-20251001`).
+ */
+export function effectiveModel(
+  requested: string,
+  haikuFallback = "claude-haiku-4-5-20251001",
+): string {
+  const lc = requested.toLowerCase();
+  if (lc.includes("haiku")) return requested;
+  if (shouldFallbackToHaiku()) return haikuFallback;
+  return requested;
+}

--- a/src/utils/claudeBudget.ts
+++ b/src/utils/claudeBudget.ts
@@ -148,6 +148,11 @@ function storageKey(month: string): string {
 
 function readBucket(month: string): MonthBucket {
   const empty: MonthBucket = { month, total: 0, byType: {}, calls: 0 };
+  // In-memory fallback wins over disk when both exist — it captures
+  // writes that localStorage rejected (quota / disabled). When there
+  // is no fallback, fall through to the disk read.
+  const fallback = inMemoryFallback.get(month);
+  if (fallback !== undefined) return fallback;
   if (typeof localStorage === "undefined") return empty;
   const raw = localStorage.getItem(storageKey(month));
   if (raw === null) return empty;
@@ -168,13 +173,41 @@ function readBucket(month: string): MonthBucket {
   }
 }
 
+/**
+ * In-memory snapshot of a bucket whose `writeBucket` rejected (quota
+ * exceeded / storage disabled / Safari private mode). When present
+ * for a given month, `readBucket` prefers it over `localStorage` —
+ * so subsequent reads see the new total even though disk is stuck.
+ *
+ * Cleared per-month when a future write succeeds (disk caught up) or
+ * when `resetCurrentMonth` runs.
+ *
+ * Without this overlay a failed write would silently undercount the
+ * spend: the listener would still fire (UI re-renders), then read
+ * the stale on-disk total and show wrong cap %.
+ */
+const inMemoryFallback: Map<string, MonthBucket> = new Map();
+
+/**
+ * Persist the bucket. On success, drops any fallback overlay (disk
+ * is now authoritative). On failure, records the bucket in memory
+ * so reads observe the correct total within the session. Either way
+ * the in-process state stays consistent with what `readBucket` will
+ * return on the next call — the sole reason `notify()` callers can
+ * trust their listeners to read fresh.
+ */
 function writeBucket(bucket: MonthBucket): void {
-  if (typeof localStorage === "undefined") return;
+  if (typeof localStorage === "undefined") {
+    inMemoryFallback.set(bucket.month, bucket);
+    return;
+  }
   try {
     localStorage.setItem(storageKey(bucket.month), JSON.stringify(bucket));
+    inMemoryFallback.delete(bucket.month);
   } catch (e) {
-    // Quota exceeded or storage disabled — log but don't break the call.
+    // Quota exceeded / storage disabled / Safari private mode etc.
     console.warn("claudeBudget: failed to persist bucket:", e);
+    inMemoryFallback.set(bucket.month, bucket);
   }
 }
 
@@ -210,10 +243,11 @@ export function estimateCost(
 /**
  * Record a Claude API call against the current month's bucket.
  *
- * Safe to call from any context (browser, test, SSR — no-op without
- * `localStorage`). Never throws; on any persistence error the in-memory
- * notification still fires so listeners stay consistent with whatever
- * localStorage now holds.
+ * Safe to call from any context (browser, test, SSR). Never throws.
+ * Persistence errors (quota / disabled storage / private mode) fall
+ * back to an in-memory overlay so subsequent `getSpend` calls (and
+ * the UI listening via `subscribe`) observe the correct total within
+ * the session — the overlay is checked first by `readBucket`.
  */
 export function logCall(input: LogCallInput): void {
   const cost = estimateCost(input.model, input.inputTokens, input.outputTokens);
@@ -281,9 +315,18 @@ export function isHardStopped(): boolean {
  * is preserved.
  */
 export function resetCurrentMonth(): void {
-  if (typeof localStorage === "undefined") return;
+  const month = monthKey();
+  // Drop the in-memory fallback first so a no-localStorage environment
+  // (SSR, private mode) still resets correctly. Without this the
+  // subsequent localStorage-only branch would leave the overlay in
+  // place and `readBucket` would still return its stale total.
+  inMemoryFallback.delete(month);
+  if (typeof localStorage === "undefined") {
+    notify();
+    return;
+  }
   try {
-    localStorage.removeItem(storageKey(monthKey()));
+    localStorage.removeItem(storageKey(month));
   } catch (e) {
     console.warn("claudeBudget: failed to reset bucket:", e);
   }

--- a/src/utils/verify-agent.ts
+++ b/src/utils/verify-agent.ts
@@ -7,6 +7,7 @@ import {
   readRepoFile,
   searchCodeSymbol,
 } from "./github-actions";
+import { assertNotHardStopped, effectiveModel, logCall } from "./claudeBudget";
 
 export const VERIFY_MODEL = "claude-sonnet-4-6";
 
@@ -668,10 +669,15 @@ Verify it now.`;
 
     try {
       for (let iter = 0; iter < MAX_ITERATIONS; iter++) {
+        // FR-41: refuse this verification iteration when the budget hard-
+        // stop is active. Caught by the outer per-finding try/catch and
+        // surfaced as a verification error — better than silently spending.
+        assertNotHardStopped();
+        const verifyModel = effectiveModel(VERIFY_MODEL);
         const response = await client.messages
           .create(
             {
-              model: VERIFY_MODEL,
+              model: verifyModel,
               max_tokens: 1024,
               system: VERIFY_SYSTEM_PROMPT,
               tools: [VERIFY_TOOL, VERIFY_GREP_TOOL, VERIFY_FIND_SYMBOL_TOOL],
@@ -684,6 +690,16 @@ Verify it now.`;
             // rejected. Re-throw to preserve the existing retry / error path.
             throw maybeDispatchAuthLostFromError("claude", e);
           });
+
+        // Account spend before processing the response so a downstream
+        // parsing/loop failure still records the cost — Anthropic billed
+        // us either way.
+        logCall({
+          type: "verify",
+          model: verifyModel,
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+        });
 
         if (response.stop_reason === "tool_use") {
           currentMessages = [


### PR DESCRIPTION
Closes #359

## Что сделано
- `src/utils/claudeBudget.ts` — pure module: `logCall`, `getSpend`, `getSpendSnapshot`, `shouldFallbackToHaiku`, `isHardStopped`, `assertNotHardStopped`, `effectiveModel`, `BudgetHardStopError`. Конфигурируемые константы `MONTHLY_CAP_USD=30`, `WARN_PCT=80`, `FALLBACK_PCT=110`, `HARD_STOP_PCT=200`. Storage key `makeit_claude_budget:{YYYY-MM}` (UTC).
- `src/components/v4/SettingsBudgetPanel.tsx` — UI секции в Settings: spend / cap / прогресс-бар (зелёный/жёлтый/красный) / breakdown по типу вызовов / Reset month с confirm. Подписка через `useSyncExternalStore` + reference-stable snapshot.
- Интеграция во ВСЕ Claude API call sites:
  - `src/utils/claude.ts`: audit batch (`'audit'`), `callClaudeWithTool` (опц. `callType: ClaudeCallType = 'drift'`), `sendChatMessage` chat loop (`'chat'`)
  - `src/utils/verify-agent.ts`: verify tool loop (`'verify'`)
  - Каждый site: `assertNotHardStopped()` ДО вызова, `effectiveModel()` для подмены Sonnet/Opus → Haiku при fallback, `logCall({...response.usage})` после.
- `SettingsPanel.tsx`: монтирование `<SettingsBudgetPanel />` между секциями «Подключение» и «Опасная зона».

## Как работает FR-41
- 80% (≥$24) → жёлтое предупреждение в UI
- 110% (≥$33) → `shouldFallbackToHaiku()` → `effectiveModel` подменяет Sonnet/Opus на `claude-haiku-4-5-20251001` для всех новых вызовов до конца месяца
- 200% (≥$60) → `isHardStopped()` → call sites бросают `BudgetHardStopError`, защита от runaway loops
- Сброс — только текущий месяц через confirm в Settings; история прошлых месяцев сохраняется

## Тесты
Test runner в проекте отсутствует (только lint+build). Самопроверка:
- [x] `npx tsc --noEmit` чисто
- [x] `npm run lint` чисто
- [x] `npm run build` чисто

## Самопроверка / Senior review
- [x] Все критерии issue #359 выполнены
- [x] `logCall` корректно считает cost: tokens × $/Mtok ÷ 1e6
- [x] При 110% spend `shouldFallbackToHaiku()` = true и не сбрасывается до следующего месяца (хранится bucket текущего месяца)
- [x] При 200% spend `isHardStopped()` блокирует все calls (call sites вызывают `assertNotHardStopped`)
- [x] `SettingsBudgetPanel` обновляется live после каждого call (через `subscribe` + invalidate cache)
- [x] Reset month очищает текущий месячный bucket после confirm
- [x] P1 review: race conditions на localStorage отсутствуют (single-tab SPA, JS single-threaded)
- [x] P1 review: useSyncExternalStore не вызывает infinite re-render — добавлен `getSpendSnapshot` с invalidate-on-notify
- [x] P1 review: corrupt JSON в bucket → graceful fallback на пустой bucket
- [x] Backward-compatible изменение `callClaudeWithTool` (новый optional 7-й параметр)

🤖 Generated with [Claude Code](https://claude.com/claude-code)