### PR TITLE
feat(hub): Decision Log — extractor + read-only UI (Epic-011 Task-01)

### DIFF
--- a/src/components/v4/hub/DecisionLog.tsx
+++ b/src/components/v4/hub/DecisionLog.tsx
@@ -1,0 +1,171 @@
+import type { Decision } from "../../../types/hub";
+
+/**
+ * Read-only chronological list of project decisions (Epic-011 Task-01).
+ *
+ * Renders one row per `Decision` with date, title, optional description,
+ * and a source badge (`brief` / `commit` / `adr`). Empty state is built
+ * in — callers don't need to special-case `decisions.length === 0`.
+ *
+ * Pure presentation: no fetching, no mutation. Data comes pre-sorted
+ * (newest first) from `useProjectHub` → `extractDecisions`.
+ */
+
+interface Props {
+  decisions: Decision[];
+}
+
+/**
+ * Pull a `brief` / `commit` / `adr` tag out of `Decision.source`.
+ * The extractor stores `source` as `<tag>` or `<tag>:<id>` so the
+ * badge is stable while the suffix can carry a sha / url / doc id.
+ */
+function sourceTag(source: string | undefined): string {
+  if (!source) return "—";
+  const colon = source.indexOf(":");
+  return colon < 0 ? source : source.slice(0, colon);
+}
+
+/** Optional URL embedded in `Decision.source` after the tag. */
+function sourceLink(source: string | undefined): string | null {
+  if (!source) return null;
+  const colon = source.indexOf(":");
+  if (colon < 0) return null;
+  const rest = source.slice(colon + 1);
+  return /^https?:\/\//.test(rest) ? rest : null;
+}
+
+/**
+ * Format an ISO date as a short, human-readable string. Falls back to
+ * `—` so an empty/malformed date never renders as the literal string
+ * `"undefined"` or `Invalid Date`.
+ */
+function formatDate(iso: string | undefined): string {
+  if (!iso) return "—";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "—";
+  return new Date(t).toLocaleDateString("ru-RU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+/** Human label for a source tag — keeps the badge compact. */
+function sourceLabel(tag: string): string {
+  switch (tag) {
+    case "brief":
+      return "Brief";
+    case "commit":
+      return "Commit";
+    case "adr":
+      return "ADR";
+    default:
+      return tag;
+  }
+}
+
+export function DecisionLog({ decisions }: Props) {
+  if (decisions.length === 0) {
+    return (
+      <div
+        style={{
+          padding: 16,
+          border: "1px dashed var(--v4-border, rgba(0,0,0,0.1))",
+          borderRadius: 10,
+          color: "var(--v4-ink-500)",
+          fontSize: 13,
+        }}
+      >
+        Решений ещё нет. Добавь BRIEF.md с разделом «Decisions» или коммит с
+        префиксом <code>decide:</code>/<code>accept:</code>.
+      </div>
+    );
+  }
+
+  return (
+    <ul
+      style={{
+        listStyle: "none",
+        padding: 0,
+        margin: 0,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      {decisions.map((d) => {
+        const tag = sourceTag(d.source);
+        const link = sourceLink(d.source);
+        return (
+          <li
+            key={d.id}
+            style={{
+              padding: 12,
+              border: "1px solid var(--v4-border, rgba(0,0,0,0.08))",
+              borderRadius: 8,
+              display: "flex",
+              flexDirection: "column",
+              gap: 6,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "baseline",
+                gap: 8,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 12,
+                  color: "var(--v4-ink-500)",
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                {formatDate(d.date)}
+              </div>
+              {link ? (
+                <a
+                  href={link}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={{
+                    fontSize: 11,
+                    padding: "2px 8px",
+                    borderRadius: 999,
+                    background: "var(--v4-border, rgba(0,0,0,0.08))",
+                    color: "var(--v4-ink-700)",
+                    textDecoration: "none",
+                  }}
+                  title={link}
+                >
+                  {sourceLabel(tag)}
+                </a>
+              ) : (
+                <span
+                  style={{
+                    fontSize: 11,
+                    padding: "2px 8px",
+                    borderRadius: 999,
+                    background: "var(--v4-border, rgba(0,0,0,0.08))",
+                    color: "var(--v4-ink-700)",
+                  }}
+                >
+                  {sourceLabel(tag)}
+                </span>
+              )}
+            </div>
+            <div style={{ fontWeight: 600, fontSize: 14 }}>{d.title}</div>
+            {d.description && (
+              <div style={{ fontSize: 13, color: "var(--v4-ink-700)" }}>
+                {d.description}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/v4/hub/ProjectHubPage.tsx
+++ b/src/components/v4/hub/ProjectHubPage.tsx
@@ -163,7 +163,7 @@ export function ProjectHubPage({ repo, project, onBackToList }: Props) {
           {activeTab === "overview" && <OverviewTab data={data} onOpenTab={setActiveTab} />}
           {activeTab === "health" && <HealthTab repo={repo} project={project} />}
           {activeTab === "activity" && <ActivityTab />}
-          {activeTab === "decisions" && <DecisionsRisksTab />}
+          {activeTab === "decisions" && <DecisionsRisksTab decisions={data.decisions} />}
           {activeTab === "delivery" && <DeliveryTab />}
         </Suspense>
       </div>

--- a/src/components/v4/hub/tabs/DecisionsRisksTab.tsx
+++ b/src/components/v4/hub/tabs/DecisionsRisksTab.tsx
@@ -1,21 +1,45 @@
 import { Icon } from "../../health/Icon";
+import { DecisionLog } from "../DecisionLog";
+import type { Decision } from "../../../../types/hub";
 
 const EPIC_URL = "https://github.com/Sergio1990-1/makeit-dashboard/blob/main/docs/epics/epic-011.md";
 
+interface Props {
+  decisions: Decision[];
+}
+
 /**
- * Placeholder. Epic-011 (Decision Log + Risk Register + Commitments +
- * Renewals, Tasks 01–04, 08) fills this with the four sections + anchors.
+ * Decision Log lives here today (Epic-011 Task-01). Risk Register,
+ * Commitments, and Renewals get their own sections in Tasks 02–04 and
+ * the four-section assembly + anchors lands in Task-08.
  */
-export function DecisionsRisksTab() {
+export function DecisionsRisksTab({ decisions }: Props) {
   return (
-    <div className="v4-hub-tab-stub">
-      <Icon name="book" />
-      <div>
-        <strong>Вкладка в разработке</strong>
-        <p>
-          Decision Log, Risk Register, Commitments и Renewals появятся в{" "}
-          <a href={EPIC_URL} target="_blank" rel="noreferrer">Epic-011</a>.
-        </p>
+    <div className="v4-hub-decisions-tab" style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+      <section aria-labelledby="hub-decision-log-heading">
+        <h2
+          id="hub-decision-log-heading"
+          style={{
+            margin: "0 0 12px",
+            fontSize: 16,
+            fontWeight: 600,
+          }}
+        >
+          Decision Log
+        </h2>
+        <DecisionLog decisions={decisions} />
+      </section>
+
+      <div className="v4-hub-tab-stub">
+        <Icon name="book" />
+        <div>
+          <strong>Risk Register, Commitments, Renewals — в разработке</strong>
+          <p>
+            Появятся в{" "}
+            <a href={EPIC_URL} target="_blank" rel="noreferrer">Epic-011</a>{" "}
+            (Tasks 02–04, 08).
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/hooks/useProjectHub.ts
+++ b/src/hooks/useProjectHub.ts
@@ -1,7 +1,13 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useProjectHealth } from "./useProjectHealth";
 import type { ProjectData } from "../types";
 import type { HubTab, OnboardingReport, ProjectHubData } from "../types/hub";
+import {
+  listRecentCommits,
+  readMarkdown,
+  type CommitInfo,
+} from "../utils/github-contents";
+import { extractDecisions } from "../utils/decisionLogExtractor";
 
 // Stable empty stubs so consumers can rely on reference equality. The Hub
 // surfaces (Overview, Activity, etc.) render empty states from these in
@@ -37,6 +43,36 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     [healthError],
   );
 
+  // ── Decision Log (Epic-011 Task-01) ────────────────────────────────
+  // Two sources: the project's BRIEF.md (optional, often absent) and
+  // the most-recent commits filtered for `decide:`/`accept:` prefixes.
+  // Both fetches are best-effort: any failure collapses to empty so the
+  // tab still renders rather than blocking the whole Hub.
+  const [briefMd, setBriefMd] = useState<string | null>(null);
+  const [commits, setCommits] = useState<CommitInfo[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      // Run in parallel — they're independent and the Hub has nothing
+      // to do with either response while we wait.
+      const [briefRes, commitsRes] = await Promise.all([
+        readMarkdown(repo, "docs/BRIEF.md").catch(() => null),
+        listRecentCommits(repo, 50).catch(() => [] as CommitInfo[]),
+      ]);
+      if (cancelled) return;
+      setBriefMd(briefRes?.content ?? null);
+      setCommits(commitsRes);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [repo]);
+
+  const decisions = useMemo(
+    () => extractDecisions(briefMd, commits),
+    [briefMd, commits],
+  );
+
   // `loadingTab` mirrors the per-tab loading state. In Epic-009 only Health
   // has a real loading signal; the rest stay false until their producers
   // (Epic-011/012) wire in their own async work.
@@ -60,10 +96,14 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     // TODO: Epic-012 — NBA engine recompute.
   }, []);
 
+  // Fall back to the stable empty array when the extractor produced no
+  // decisions — keeps reference equality for downstream memo deps.
+  const finalDecisions = decisions.length > 0 ? decisions : EMPTY_DECISIONS;
+
   return {
     project: project ?? null,
     health: report,
-    decisions: EMPTY_DECISIONS,
+    decisions: finalDecisions,
     risks: EMPTY_RISKS,
     commitments: EMPTY_COMMITMENTS,
     renewals: EMPTY_RENEWALS,

--- a/src/utils/decisionLogExtractor.ts
+++ b/src/utils/decisionLogExtractor.ts
@@ -44,12 +44,22 @@ const DECISION_COMMIT_PREFIXES = ["decide:", "accept:"];
 // const _IGNORED_PREFIXES = ["feat:", "fix:", "chore:", "docs:", "style:", "refactor:", "test:", "build:", "ci:", "perf:"];
 
 /**
- * Match a section heading in a BRIEF.md. We accept both `##` and `###`,
- * with optional emoji or trailing colon, e.g. `## 📋 Decisions:`.
+ * Match a section heading in a BRIEF.md. Accepts both `##` and `###`,
+ * with optional leading emoji/punctuation and optional trailing colon —
+ * `## 📋 Decisions:` and `### Decisions` both match.
  *
- * Anchored to the start of the line via the `m` flag at call site.
+ * The `Decisions?` token must be a STANDALONE heading, not a substring
+ * inside a larger phrase. So `## Past decisions we regret` and
+ * `## Pricing decisions matter` correctly DO NOT match — the heading
+ * must end (modulo trailing punctuation/whitespace) right after the
+ * keyword. Without this guard we'd scrape bullets out of unrelated
+ * sections.
+ *
+ * The leading-decoration class `[^\w\n]*` allows emoji or punctuation
+ * (e.g. `## 📋 Decisions`) but not letters/digits/underscore — those
+ * would change the heading's meaning. Anchored via `/m`.
  */
-const DECISION_HEADING_RE = /^#{2,3}\s+[^\n]*decisions?[^\n]*$/im;
+const DECISION_HEADING_RE = /^#{2,3}[^\S\n]+[^\w\n]*\s*decisions?\s*[:.]?\s*$/im;
 
 /** Match the next heading (any level) — we use it to know when to stop. */
 const NEXT_HEADING_RE = /^#{1,6}\s+/m;
@@ -94,15 +104,33 @@ function extractBriefBullets(briefMd: string): string[] {
 }
 
 /**
- * Try to pull an ISO date out of the very top of a BRIEF.md. The
- * Pipeline writes `date: 2026-05-01` or `# 2026-05-01 — Title` near
- * the top; we look for the first 10-char date in the first 1 KiB and
- * give up if there isn't one (decision falls back to undated).
+ * Try to pull an ISO date out of the BRIEF.md top matter.
+ *
+ * Two recognised producers:
+ *   1. YAML front-matter (`---\ndate: 2026-05-01\n…`) at the very top.
+ *   2. An H1 starting with the date — `# 2026-05-01 — Title`.
+ *
+ * Both are anchored: the date must appear in `date:` field or right
+ * after `#`, NOT anywhere in the body. Without anchoring we'd pick up
+ * dates from quoted dialogue ("Met with client 2024-03-01") and
+ * mis-stamp every decision with that date.
+ *
+ * Returns `null` when neither pattern matches — decisions fall back
+ * to undated and sort to the end of the list.
  */
 function extractBriefDate(briefMd: string): string | null {
-  const head = briefMd.slice(0, 1024);
-  const m = head.match(/(\d{4}-\d{2}-\d{2})/);
-  return m ? m[1] : null;
+  // Front-matter form: `date: YYYY-MM-DD` on its own line within the
+  // first 2 KiB. `^\s*date:` is anchored to start-of-line via `/m`.
+  const head = briefMd.slice(0, 2048);
+  const fm = head.match(/^\s*date:\s*(\d{4}-\d{2}-\d{2})\s*$/im);
+  if (fm) return fm[1];
+
+  // H1 form: `# YYYY-MM-DD …` — must start at column 0 (no leading
+  // whitespace), and the date must be the very first token after `#`.
+  const h1 = head.match(/^#\s+(\d{4}-\d{2}-\d{2})\b/m);
+  if (h1) return h1[1];
+
+  return null;
 }
 
 /** True when a commit subject is a decision/accept commit. */
@@ -144,8 +172,11 @@ export function extractDecisions(
       const description = lead ? rest : undefined;
       out.push({
         // Stable id so React keys don't churn between renders for the
-        // same brief text. `idx` keeps duplicates distinct.
-        id: `brief:${idx}:${title.slice(0, 40)}`,
+        // same brief text. Index alone is unique within a single brief
+        // — earlier we suffixed `title.slice(0,40)` for human-readability
+        // but two bullets sharing a 40-char title prefix would collide
+        // and React would reuse the wrong DOM node.
+        id: `brief:${idx}`,
         date: briefDate,
         title: title.slice(0, 200),
         description: description && description.length > 0 ? description : undefined,

--- a/src/utils/decisionLogExtractor.ts
+++ b/src/utils/decisionLogExtractor.ts
@@ -1,0 +1,184 @@
+/**
+ * Decision Log extractor (Epic-011 Task-01, FR-23, FR-24).
+ *
+ * Pure extraction layer: takes a BRIEF.md string and a list of recent
+ * commits, produces a chronological `Decision[]`.
+ *
+ * Two sources are merged:
+ *   1. **Brief** — bullet items under `## Decisions` / `### Decisions`
+ *      headings in the project's BRIEF.md (the Pipeline-generated
+ *      transcript synthesis). Each bullet becomes one Decision.
+ *   2. **Commits** — conventional commits whose subject starts with
+ *      `decide:` or `accept:` (case-insensitive). `feat:`, `fix:`,
+ *      `chore:`, `docs:`, etc. are intentionally ignored — those
+ *      describe what shipped, not what was decided.
+ *
+ * Sort order: newest first. Items without a usable date sort last
+ * (rather than crash) so partial data never blocks render.
+ */
+
+import type { Decision } from "../types/hub";
+import type { CommitInfo } from "./github-contents";
+
+/**
+ * Provenance tag attached to each `Decision.source`. Kept as a
+ * three-value union so the read-only UI can render a stable badge per
+ * row without a per-source string-matching.
+ *
+ * Stored at the start of `Decision.source` followed by `:` and a
+ * source-specific identifier (sha, line index, doc id) — e.g.
+ * `commit:abc123ef`. UI splits on the first `:` to render the tag
+ * separately from the identifier.
+ */
+export type DecisionSourceTag = "brief" | "commit" | "adr";
+
+/** Prefixes (case-insensitive) we treat as decision/accept commits. */
+const DECISION_COMMIT_PREFIXES = ["decide:", "accept:"];
+
+/**
+ * Conventional commit prefixes that look like they could be decisions
+ * but explicitly aren't. Documented here to make the contract obvious
+ * — the implementation just matches `DECISION_COMMIT_PREFIXES`, but
+ * anyone updating that list should remember why these are out.
+ */
+// const _IGNORED_PREFIXES = ["feat:", "fix:", "chore:", "docs:", "style:", "refactor:", "test:", "build:", "ci:", "perf:"];
+
+/**
+ * Match a section heading in a BRIEF.md. We accept both `##` and `###`,
+ * with optional emoji or trailing colon, e.g. `## 📋 Decisions:`.
+ *
+ * Anchored to the start of the line via the `m` flag at call site.
+ */
+const DECISION_HEADING_RE = /^#{2,3}\s+[^\n]*decisions?[^\n]*$/im;
+
+/** Match the next heading (any level) — we use it to know when to stop. */
+const NEXT_HEADING_RE = /^#{1,6}\s+/m;
+
+/** Match a single bullet line (`-`, `*`, or numbered). */
+const BULLET_RE = /^\s*(?:[-*]|\d+\.)\s+(.+?)\s*$/gm;
+
+/** Strip leading bold marker from a bullet (`**foo** — bar`). */
+function stripLeadingBold(line: string): { lead: string | null; rest: string } {
+  const m = line.match(/^\*\*(.+?)\*\*\s*[—\-:]\s*(.*)$/);
+  if (m === null) return { lead: null, rest: line };
+  return { lead: m[1], rest: m[2] };
+}
+
+/**
+ * Parse the Decisions section out of a BRIEF.md. Returns the bullet
+ * texts in source order; an empty array when no section exists or when
+ * the section is empty.
+ */
+function extractBriefBullets(briefMd: string): string[] {
+  const headingMatch = briefMd.match(DECISION_HEADING_RE);
+  if (headingMatch === null || headingMatch.index === undefined) return [];
+  // The section runs from the line *after* the heading until the next
+  // heading or EOF. `+ headingMatch[0].length` skips the heading line.
+  const startIdx = headingMatch.index + headingMatch[0].length;
+  const after = briefMd.slice(startIdx);
+  const nextMatch = after.match(NEXT_HEADING_RE);
+  const sectionText = nextMatch && nextMatch.index !== undefined
+    ? after.slice(0, nextMatch.index)
+    : after;
+  const bullets: string[] = [];
+  // `BULLET_RE` is `/g` — we have to reset `lastIndex` because reusing
+  // a global regex carries state across calls and would silently skip
+  // matches in the same module on the next invocation.
+  BULLET_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = BULLET_RE.exec(sectionText)) !== null) {
+    const text = m[1].trim();
+    if (text.length > 0) bullets.push(text);
+  }
+  return bullets;
+}
+
+/**
+ * Try to pull an ISO date out of the very top of a BRIEF.md. The
+ * Pipeline writes `date: 2026-05-01` or `# 2026-05-01 — Title` near
+ * the top; we look for the first 10-char date in the first 1 KiB and
+ * give up if there isn't one (decision falls back to undated).
+ */
+function extractBriefDate(briefMd: string): string | null {
+  const head = briefMd.slice(0, 1024);
+  const m = head.match(/(\d{4}-\d{2}-\d{2})/);
+  return m ? m[1] : null;
+}
+
+/** True when a commit subject is a decision/accept commit. */
+function isDecisionCommit(subject: string): boolean {
+  const lc = subject.toLowerCase();
+  return DECISION_COMMIT_PREFIXES.some((p) => lc.startsWith(p));
+}
+
+/** Strip the conventional prefix (`decide:` / `accept:`) from a subject. */
+function stripDecisionPrefix(subject: string): string {
+  const colon = subject.indexOf(":");
+  if (colon < 0) return subject;
+  return subject.slice(colon + 1).trim();
+}
+
+/**
+ * Extract decisions from a BRIEF.md (may be `null`) and a list of
+ * recent commits. Result is sorted by date descending; entries with
+ * no parseable date sort to the end.
+ *
+ * Pure: no I/O, no globals, deterministic for the same inputs. Safe
+ * to test with string fixtures.
+ */
+export function extractDecisions(
+  briefMd: string | null,
+  commits: CommitInfo[],
+): Decision[] {
+  const out: Decision[] = [];
+
+  // ── BRIEF source ─────────────────────────────────────────────────
+  if (briefMd !== null && briefMd.length > 0) {
+    const briefDate = extractBriefDate(briefMd) ?? "";
+    const bullets = extractBriefBullets(briefMd);
+    bullets.forEach((bullet, idx) => {
+      const { lead, rest } = stripLeadingBold(bullet);
+      // Prefer the bold lead as the title (clearer in the UI), keep
+      // the rest as the description. Fall back to the whole bullet.
+      const title = lead ?? rest;
+      const description = lead ? rest : undefined;
+      out.push({
+        // Stable id so React keys don't churn between renders for the
+        // same brief text. `idx` keeps duplicates distinct.
+        id: `brief:${idx}:${title.slice(0, 40)}`,
+        date: briefDate,
+        title: title.slice(0, 200),
+        description: description && description.length > 0 ? description : undefined,
+        source: "brief",
+      });
+    });
+  }
+
+  // ── Commit source ────────────────────────────────────────────────
+  for (const c of commits) {
+    if (!isDecisionCommit(c.subject)) continue;
+    const cleanSubject = stripDecisionPrefix(c.subject);
+    if (cleanSubject.length === 0) continue;
+    out.push({
+      id: `commit:${c.sha}`,
+      date: c.date,
+      title: cleanSubject.slice(0, 200),
+      description: c.author ? `by ${c.author}` : undefined,
+      source: c.url ? `commit:${c.url}` : "commit",
+    });
+  }
+
+  // ── Sort: newest first; undated to the end ───────────────────────
+  out.sort((a, b) => {
+    const ad = a.date && a.date.length > 0 ? Date.parse(a.date) : NaN;
+    const bd = b.date && b.date.length > 0 ? Date.parse(b.date) : NaN;
+    const aValid = !Number.isNaN(ad);
+    const bValid = !Number.isNaN(bd);
+    if (aValid && bValid) return bd - ad;
+    if (aValid) return -1;
+    if (bValid) return 1;
+    return 0;
+  });
+
+  return out;
+}

--- a/src/utils/github-contents.ts
+++ b/src/utils/github-contents.ts
@@ -1,0 +1,256 @@
+/**
+ * GitHub Contents REST API wrapper (Epic-011 Task-01, FR-23).
+ *
+ * Read/write small repo files (≤1 MiB) for Project Hub state that lives
+ * directly in the project repo: decision logs, risk register, manual
+ * commitments and renewals YAML. Uses base64 + sha-based ETag like
+ * GitHub natively does.
+ *
+ * Failure model:
+ *   - 404 from GET → `null` (caller treats absence as "no data yet").
+ *   - 409 from PUT → `ConflictError` (caller refreshes sha and retries).
+ *   - Other non-2xx → throws with the response status in the message.
+ *
+ * Token: read via `getToken()` (browser localStorage). 401 dispatches
+ * the standard auth-lost event so SettingsPanel can prompt for rotation.
+ *
+ * Bonus helper `listRecentCommits` lives here because every Hub feature
+ * needs commit subjects and the Contents API neighbour is the natural
+ * place to keep small REST helpers.
+ */
+
+import yaml from "js-yaml";
+import { GITHUB_OWNER, getToken } from "./config";
+import { dispatchExternalAuthLost } from "./external-auth-events";
+
+const GITHUB_REST = "https://api.github.com";
+
+/** Thrown by `writeYaml` when the server reports an ETag/sha mismatch. */
+export class ConflictError extends Error {
+  constructor(message = "GitHub Contents write conflict (sha mismatch)") {
+    super(message);
+    this.name = "ConflictError";
+  }
+}
+
+/** Information about a single commit, suitable for decision-log mining. */
+export interface CommitInfo {
+  /** 40-char commit sha. */
+  sha: string;
+  /** First line of the commit message (subject). */
+  subject: string;
+  /** Full commit message (subject + body), useful when the body matters. */
+  message: string;
+  /** Author display name (falls back to login if missing). */
+  author: string;
+  /** ISO-8601 commit author date. */
+  date: string;
+  /** HTML URL on github.com. */
+  url: string;
+}
+
+interface ContentsResponse {
+  content?: string;
+  encoding?: string;
+  sha: string;
+}
+
+/** Build the standard Authorization headers, throwing if no token. */
+function authHeaders(): HeadersInit {
+  const token = getToken();
+  if (!token) throw new Error("GitHub token не настроен");
+  return {
+    Authorization: `bearer ${token}`,
+    Accept: "application/vnd.github.v3+json",
+  };
+}
+
+/**
+ * Resolve a repo argument to `owner/repo`. Accepts either bare
+ * `repo-name` (assumes the dashboard's `GITHUB_OWNER`) or a fully
+ * qualified `owner/repo` string. Centralised so call sites don't each
+ * re-implement the split.
+ */
+function resolveRepoSlug(repo: string): string {
+  return repo.includes("/") ? repo : `${GITHUB_OWNER}/${repo}`;
+}
+
+/**
+ * Decode a base64 string into UTF-8. The Contents API returns base64
+ * even for short text files, so we always have to decode. We use
+ * `atob` + manual UTF-8 reassembly because `atob` returns latin1 and
+ * silently mangles multi-byte characters otherwise.
+ */
+function base64DecodeUtf8(b64: string): string {
+  // Strip whitespace — GitHub wraps base64 at 60-char lines.
+  const clean = b64.replace(/\s+/g, "");
+  const bin = atob(clean);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder("utf-8").decode(bytes);
+}
+
+/** Encode a UTF-8 string into base64 (PUT body). Mirror of the decoder. */
+function base64EncodeUtf8(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+/**
+ * Internal: fetch a file and return its raw text + sha. `null` on 404.
+ * Other non-2xx responses throw — callers don't usually expect them.
+ */
+async function readContent(
+  repo: string,
+  path: string,
+): Promise<{ content: string; sha: string } | null> {
+  const slug = resolveRepoSlug(repo);
+  const url = `${GITHUB_REST}/repos/${slug}/contents/${encodeURI(path)}`;
+  const res = await fetch(url, { headers: authHeaders() });
+  if (res.status === 401) dispatchExternalAuthLost("github");
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`GitHub Contents GET ${slug}/${path} failed: ${res.status}`);
+  }
+  const body = (await res.json()) as ContentsResponse;
+  // The Contents API can return a directory listing (array) when the
+  // path is a folder — guard so callers don't get JSON garbage.
+  if (typeof body.content !== "string") {
+    throw new Error(
+      `GitHub Contents GET ${slug}/${path} returned no content (is it a directory?)`,
+    );
+  }
+  // Files >1 MiB come back with `content === ""` and `encoding === "none"`.
+  // Surface as null so caller can fall back; the proper API for big files
+  // is the blobs endpoint, which we intentionally don't pull in here.
+  if (body.encoding && body.encoding !== "base64") {
+    return null;
+  }
+  return { content: base64DecodeUtf8(body.content), sha: body.sha };
+}
+
+/** Read a file as plain text. `null` on 404. */
+export async function readMarkdown(
+  repo: string,
+  path: string,
+): Promise<{ content: string; sha: string } | null> {
+  return readContent(repo, path);
+}
+
+/**
+ * Read a YAML file and parse it into `T`. Returns `null` on 404 so
+ * callers can treat "file doesn't exist yet" as a normal empty state.
+ *
+ * Parse errors throw — a corrupt YAML file is a real problem the user
+ * needs to see, not a silent empty-state fallback.
+ */
+export async function readYaml<T>(
+  repo: string,
+  path: string,
+): Promise<{ data: T; sha: string } | null> {
+  const raw = await readContent(repo, path);
+  if (raw === null) return null;
+  const parsed = yaml.load(raw.content) as T;
+  return { data: parsed, sha: raw.sha };
+}
+
+/**
+ * Create or update a YAML file. Pass `sha` to update an existing file
+ * (omit it for first-time creation). On a 409 the call throws
+ * `ConflictError` so the caller can re-read, merge, and retry.
+ */
+export async function writeYaml<T>(
+  repo: string,
+  path: string,
+  data: T,
+  message: string,
+  sha?: string,
+): Promise<{ sha: string }> {
+  const slug = resolveRepoSlug(repo);
+  const url = `${GITHUB_REST}/repos/${slug}/contents/${encodeURI(path)}`;
+  // `lineWidth: -1` disables yaml-load's automatic line-folding so
+  // round-tripping a value never silently mutates whitespace.
+  const yamlText = yaml.dump(data, { lineWidth: -1, noRefs: true });
+  const body: Record<string, string> = {
+    message,
+    content: base64EncodeUtf8(yamlText),
+  };
+  if (sha) body.sha = sha;
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: { ...authHeaders(), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (res.status === 401) dispatchExternalAuthLost("github");
+  if (res.status === 409) throw new ConflictError();
+  if (!res.ok) {
+    throw new Error(`GitHub Contents PUT ${slug}/${path} failed: ${res.status}`);
+  }
+  const responseBody = (await res.json()) as { content?: { sha?: string } };
+  const newSha = responseBody.content?.sha ?? sha ?? "";
+  return { sha: newSha };
+}
+
+/** Raw JSON shape returned by GitHub's `/repos/{}/commits` endpoint. */
+interface RawCommit {
+  sha: string;
+  html_url?: string;
+  commit?: {
+    message?: string;
+    author?: { name?: string; date?: string };
+    committer?: { name?: string; date?: string };
+  };
+  author?: { login?: string } | null;
+}
+
+/**
+ * Fetch the most-recent commits on the repo's default branch.
+ * Returns at most `limit` (default 50) commits in newest-first order.
+ *
+ * On any failure (auth, network, parse) returns `[]` rather than
+ * throwing — Hub views render an empty state better than they handle
+ * an exception cascade.
+ */
+export async function listRecentCommits(
+  repo: string,
+  limit = 50,
+): Promise<CommitInfo[]> {
+  const slug = resolveRepoSlug(repo);
+  // Cap to GitHub's per-page max so a single request covers the
+  // common case. Clamp `limit` defensively — a caller passing 1000 is
+  // a bug we'd rather paper over than hammer the API.
+  const perPage = Math.min(Math.max(1, limit), 100);
+  try {
+    const res = await fetch(
+      `${GITHUB_REST}/repos/${slug}/commits?per_page=${perPage}`,
+      { headers: authHeaders() },
+    );
+    if (res.status === 401) dispatchExternalAuthLost("github");
+    if (!res.ok) return [];
+    const raw = (await res.json()) as RawCommit[];
+    if (!Array.isArray(raw)) return [];
+    return raw.map((c) => {
+      const message = c.commit?.message ?? "";
+      const subject = message.split("\n", 1)[0] ?? "";
+      // Prefer the GitHub login (stable handle) over the commit's
+      // `author.name` (free-text, often a real name) when both exist;
+      // commit views in the Hub already show real names, the log
+      // benefits from a consistent identifier.
+      const author = c.author?.login ?? c.commit?.author?.name ?? "";
+      const date =
+        c.commit?.author?.date ?? c.commit?.committer?.date ?? "";
+      return {
+        sha: c.sha,
+        subject,
+        message,
+        author,
+        date,
+        url: c.html_url ?? "",
+      };
+    });
+  } catch {
+    return [];
+  }
+}

--- a/src/utils/github-contents.ts
+++ b/src/utils/github-contents.ts
@@ -114,14 +114,17 @@ async function readContent(
   if (!res.ok) {
     throw new Error(`GitHub Contents GET ${slug}/${path} failed: ${res.status}`);
   }
-  const body = (await res.json()) as ContentsResponse;
-  // The Contents API can return a directory listing (array) when the
-  // path is a folder — guard so callers don't get JSON garbage.
-  if (typeof body.content !== "string") {
-    throw new Error(
-      `GitHub Contents GET ${slug}/${path} returned no content (is it a directory?)`,
-    );
-  }
+  const parsed = (await res.json()) as ContentsResponse | unknown[];
+  // The Contents API returns a JSON ARRAY when `path` is a directory
+  // instead of an object with `content`. Treat that as not-found
+  // rather than throwing — callers (`readMarkdown`/`readYaml`) treat
+  // `null` as the documented empty state, and a path typo that
+  // resolves to a folder shouldn't crash callers like `useProjectHub`
+  // (which fans this out via Promise.all and would propagate the
+  // throw all the way to the Hub render boundary).
+  if (Array.isArray(parsed)) return null;
+  const body = parsed as ContentsResponse;
+  if (typeof body.content !== "string") return null;
   // Files >1 MiB come back with `content === ""` and `encoding === "none"`.
   // Surface as null so caller can fall back; the proper API for big files
   // is the blobs endpoint, which we intentionally don't pull in here.
@@ -212,6 +215,14 @@ interface RawCommit {
  * On any failure (auth, network, parse) returns `[]` rather than
  * throwing — Hub views render an empty state better than they handle
  * an exception cascade.
+ *
+ * Failure visibility note: a 401 dispatches the standard
+ * `external-auth-lost` event (so SettingsPanel prompts for a new
+ * token), but the function itself still returns `[]` — there is no
+ * separate "auth failed" return state for the Decision Log to render.
+ * Acceptable today: the auth banner is the canonical surface; the log
+ * being empty is a downstream symptom the user resolves by rotating
+ * the token.
  */
 export async function listRecentCommits(
   repo: string,


### PR DESCRIPTION
Closes #350

## Что сделано
- **`src/utils/github-contents.ts`** — обёртка над GitHub Contents REST API:
  - `readYaml<T>(repo, path)` — GET + base64-decode + YAML parse → `{data, sha} | null` (404 → null)
  - `writeYaml(repo, path, data, message, sha?)` — PUT с base64-encode (409 → `ConflictError`)
  - `readMarkdown(repo, path)` — для BRIEF.md
  - `listRecentCommits(repo, limit=50)` — last commits с `{sha, subject, message, author, date, url}`
  - UTF-8-safe base64 (`atob`/`btoa` mangle multibyte иначе)
  - 401 → `dispatchExternalAuthLost("github")` как везде в проекте
- **`src/utils/decisionLogExtractor.ts`** — `extractDecisions(briefMd, commits) → Decision[]`. Pure:
  - Parser BRIEF.md: `## Decisions` / `### Decisions` (case-insensitive, поддержка emoji), bullet list
  - Commits: только префиксы `decide:` / `accept:` (case-insensitive); `feat:`/`fix:`/etc игнорируются
  - Сортировка по дате desc, undated → в конец
- **`src/components/v4/hub/DecisionLog.tsx`** — read-only список с датой, title, описанием, source badge (`Brief` / `Commit` / `ADR`). Источники с URL → бейдж становится ссылкой. Встроенный empty state.
- **`src/hooks/useProjectHub.ts`** — параллельная загрузка `docs/BRIEF.md` + последних 50 коммитов через github-contents, передача в `extractDecisions`. Fallback на стабильный empty array для referential equality.
- **`src/components/v4/hub/tabs/DecisionsRisksTab.tsx`** — секция Decision Log сверху, существующий stub Risk Register / Commitments / Renewals оставлен (Tasks 02–04, 08).

`js-yaml` уже был в зависимостях — новых пакетов не добавлено.

## Тесты
Test runner в проекте отсутствует (только lint+build). Самопроверка:
- [x] `npx tsc --noEmit` чисто
- [x] `npm run lint` чисто
- [x] `npm run build` чисто

## Самопроверка / Senior review
- [x] Все критерии issue #350 выполнены
- [x] `readYaml` возвращает `null` для 404 без throw, бросает на 5xx (видимая ошибка)
- [x] `extractDecisions` парсит BRIEF секцию, игнорирует `feat:`/`fix:`/etc
- [x] `DecisionLog` рендерит список + empty state
- [x] `useProjectHub` отдаёт реальные `decisions` (на любом репо где есть `decide:` коммиты)
- [x] P1 review: secrets/token не утекают (используется существующий `getToken`/`dispatchExternalAuthLost`)
- [x] P1 review: read-modify-write на YAML файле защищено sha (ETag) → 409 ConflictError
- [x] P1 review: regex `BULLET_RE` с флагом `/g` сбрасывается через `lastIndex = 0` перед каждым use (state не утекает)
- [x] P1 review: UTF-8 base64 декодер правильный (русский в BRIEF не ломается)
- [x] P1 review: useEffect cancelled flag защищает от late setState после unmount
- [x] P2 review: edge cases — пустой brief, пустые commits, malformed date — все падают в graceful fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)