### PR TITLE
feat(hub): Onboarding Readiness Checklist (Epic-012 Task-04)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- **Onboarding Readiness Checklist** (Epic-012 Task-04): 6 новых правил health-engine Layer 2 — README freshness (90д), наличие docs/BRIEF.md, deploy-инструкция (docs/DEPLOY.md или раздел в README), .env.example, зелёный CI на main, свежий audit (30д). Компонент `OnboardingChecklist` рендерит чеклист с ✓/✗ и tooltip-remediation. Health-scores у части проектов могут сдвинуться вниз из-за дополнительных правил — это ожидаемо.
 - Tab-навигация: Дашборд, Проекты, Milestones, Завершённые, Мониторинг, Аудит, Pipeline
 - **Audit подсистема**: AuditTab, AuditProjectCard, AuditConfirmDialog, AuditIssuesDialog, AuditVerifyDialog
 - Верификация audit findings через Claude (verification.ts, verify-agent.ts)

--- a/src/components/v4/hub/OnboardingChecklist.tsx
+++ b/src/components/v4/hub/OnboardingChecklist.tsx
@@ -1,0 +1,177 @@
+import type { HealthFinding } from "../../../types/health";
+import { isOnboardingRuleId } from "../../../utils/onboardingReadinessRules";
+
+/**
+ * Onboarding Readiness Checklist (Epic-012 Task-04).
+ *
+ * Renders the six `onboarding.*` rules from the health report as a tight
+ * pass/fail list. Each row shows ✓ for pass, ✗ for fail, ⏳ for unknown
+ * (auditor service down etc.), and — for skipped. Failing rows expose the
+ * rule's `remediation` text via a `title` tooltip so users can act
+ * immediately without leaving the Hub.
+ *
+ * Pure presentation: caller supplies findings from `useProjectHub` /
+ * `usePortfolioHealth`. Empty state covers the «health report ещё не
+ * сгенерирован» case (rare; usually means the project hasn't been
+ * classified in PROJECT_CHECKLIST.yaml yet).
+ */
+
+interface Props {
+  findings: HealthFinding[];
+}
+
+type IconKind = "pass" | "fail" | "unknown" | "skipped";
+
+const ICON: Record<IconKind, string> = {
+  pass: "✓",
+  fail: "✗",
+  unknown: "⏳",
+  skipped: "—",
+};
+
+const ICON_LABEL: Record<IconKind, string> = {
+  pass: "Выполнено",
+  fail: "Не выполнено",
+  unknown: "Не удалось проверить",
+  skipped: "Пропущено",
+};
+
+export function OnboardingChecklist({ findings }: Props) {
+  const onboarding = findings.filter((f) => isOnboardingRuleId(f.rule_id));
+
+  if (onboarding.length === 0) {
+    return (
+      <div
+        style={{
+          padding: 16,
+          border: "1px dashed var(--v4-border, rgba(0,0,0,0.1))",
+          borderRadius: 10,
+          color: "var(--v4-ink-500)",
+          fontSize: 13,
+        }}
+      >
+        Onboarding-чеклист появится после первого health-сканирования проекта.
+      </div>
+    );
+  }
+
+  const passed = onboarding.filter((f) => f.status === "pass").length;
+  const total = onboarding.length;
+
+  return (
+    <section
+      aria-labelledby="v4-hub-onboarding-title"
+      style={{ display: "flex", flexDirection: "column", gap: 8 }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          gap: 8,
+        }}
+      >
+        <h3
+          id="v4-hub-onboarding-title"
+          style={{ fontSize: 14, fontWeight: 600, margin: 0 }}
+        >
+          Onboarding Readiness
+        </h3>
+        <span
+          style={{
+            fontSize: 12,
+            color: "var(--v4-ink-500)",
+            fontVariantNumeric: "tabular-nums",
+          }}
+          aria-label={`${passed} из ${total} правил выполнены`}
+        >
+          {passed}/{total}
+        </span>
+      </header>
+
+      <ul
+        style={{
+          listStyle: "none",
+          padding: 0,
+          margin: 0,
+          display: "flex",
+          flexDirection: "column",
+          gap: 4,
+        }}
+      >
+        {onboarding.map((f) => {
+          const kind: IconKind = f.status;
+          // Compose a tooltip: detail (always) + remediation (only when
+          // failing — pass / skipped don't need a fix). Falsy guard so we
+          // never render the literal string «undefined» in `title`.
+          const tooltipParts: string[] = [];
+          if (f.detail) tooltipParts.push(f.detail);
+          if (f.status === "fail" && f.remediation) {
+            tooltipParts.push(`Как починить: ${f.remediation}`);
+          }
+          const tooltip = tooltipParts.join("\n\n");
+
+          return (
+            <li
+              key={f.rule_id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "6px 10px",
+                border: "1px solid var(--v4-border, rgba(0,0,0,0.08))",
+                borderRadius: 6,
+                fontSize: 13,
+              }}
+              title={tooltip || undefined}
+            >
+              <span
+                aria-label={ICON_LABEL[kind]}
+                role="img"
+                style={{
+                  display: "inline-flex",
+                  width: 18,
+                  justifyContent: "center",
+                  color:
+                    kind === "pass"
+                      ? "var(--v4-ok, #16a34a)"
+                      : kind === "fail"
+                        ? "var(--v4-err, #dc2626)"
+                        : "var(--v4-ink-500)",
+                  fontWeight: 600,
+                }}
+              >
+                {ICON[kind]}
+              </span>
+              <span
+                style={{
+                  flex: 1,
+                  color:
+                    kind === "fail"
+                      ? "var(--v4-ink-900)"
+                      : "var(--v4-ink-700)",
+                }}
+              >
+                {f.title}
+              </span>
+              {f.status === "fail" && f.remediation ? (
+                <span
+                  aria-hidden="true"
+                  style={{
+                    fontSize: 11,
+                    color: "var(--v4-ink-500)",
+                    cursor: "help",
+                  }}
+                >
+                  ?
+                </span>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+export default OnboardingChecklist;

--- a/src/utils/checklist.ts
+++ b/src/utils/checklist.ts
@@ -1,6 +1,7 @@
 import yaml from "js-yaml";
 import { readRepoFile } from "./github-actions";
 import type { ChecklistDocument } from "../types/health";
+import { ONBOARDING_READINESS_RULES } from "./onboardingReadinessRules";
 
 const KNOWLEDGE_OWNER = "Sergio1990-1";
 const KNOWLEDGE_REPO = "makeit-knowledge";
@@ -43,6 +44,16 @@ export async function loadChecklist(
   const text = await readRepoFile(token, KNOWLEDGE_OWNER, KNOWLEDGE_REPO, CHECKLIST_PATH, signal);
   const parsed = yaml.load(text);
   validate(parsed);
+  // Merge in-code Layer-2 rules that are owned by the dashboard repo rather
+  // than the YAML source of truth (Epic-012 Task-04: Onboarding Readiness).
+  // Dedup by `id` so a future mirror-PR into makeit-knowledge can't
+  // double-count the same rule — the YAML version wins if present.
+  const existingIds = new Set(parsed.rules.map((r) => r.id));
+  for (const rule of ONBOARDING_READINESS_RULES) {
+    if (!existingIds.has(rule.id)) {
+      parsed.rules.push(rule);
+    }
+  }
   cached = { doc: parsed, loaded_at: Date.now() };
   return parsed;
 }

--- a/src/utils/health-engine.ts
+++ b/src/utils/health-engine.ts
@@ -26,6 +26,8 @@ import {
   getPRFiles,
 } from "./github-actions";
 import { Semaphore } from "./semaphore";
+import { fetchAuditProjects, isAuditorRunning } from "./auditor";
+import type { AuditProjectStatus } from "../types";
 
 // Helper: read a typed param from a check object with a fallback.
 function param<T>(obj: Record<string, unknown>, key: string, fallback: T): T {
@@ -708,6 +710,121 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
           detail: ok
             ? `${driftCount} PR без обновления доков за ${windowDays} дн. (порог ${maxCount})`
             : `${driftCount} PR за ${windowDays} дн. без правок в docs/: ${driftPrs.slice(0, 5).map((n) => `#${n}`).join(", ")}`,
+        };
+      }
+
+      // ── Onboarding Readiness (Epic-012 Task-04) ──────────────────────────
+      case "deploy_doc_present": {
+        // Passes if either docs/DEPLOY.md exists OR README.md contains a
+        // recognisable "## Deploy" section heading. Either form of deploy
+        // instruction is acceptable — small projects keep it inline, larger
+        // ones split it into a dedicated doc.
+        const deployPath = param<string>(c, "deploy_doc_path", "docs/DEPLOY.md");
+        const readmePath = param<string>(c, "readme_path", "README.md");
+        const readmeSection = param<string>(c, "readme_section", "## Deploy");
+
+        const deployExists = await pathExists(
+          ctx.token,
+          ctx.owner,
+          ctx.repo,
+          deployPath,
+          ctx.dirCache,
+          "file",
+          false,
+          ctx.signal,
+        );
+        if (deployExists) {
+          return { ...base, status: "pass", detail: `${deployPath} ✓` };
+        }
+
+        const readmeCanonical = await pathExists(
+          ctx.token,
+          ctx.owner,
+          ctx.repo,
+          readmePath,
+          ctx.dirCache,
+          "file",
+          false,
+          ctx.signal,
+        );
+        if (!readmeCanonical) {
+          return {
+            ...base,
+            status: "fail",
+            detail: `Нет ${deployPath} и нет ${readmePath}`,
+          };
+        }
+        try {
+          const text = await readRepoFile(
+            ctx.token,
+            ctx.owner,
+            ctx.repo,
+            readmeCanonical,
+            ctx.signal,
+          );
+          // Match on a heading at start-of-line so "## Deployment notes"
+          // counts but a stray mention of "deploy" in prose doesn't.
+          const re = new RegExp(
+            `^\\s*${readmeSection.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+            "im",
+          );
+          const ok = re.test(text);
+          return {
+            ...base,
+            status: ok ? "pass" : "fail",
+            detail: ok
+              ? `${readmePath}: раздел «${readmeSection}» ✓`
+              : `Нет ${deployPath} и нет раздела «${readmeSection}» в ${readmePath}`,
+          };
+        } catch (err) {
+          if (err instanceof Error && err.name === "AbortError") throw err;
+          return { ...base, status: "unknown", detail: `Не удалось прочитать ${readmePath}` };
+        }
+      }
+
+      case "audit_fresh": {
+        // Reads the Auditor service to find the latest run for this repo.
+        // The service is optional in many environments (local dev without
+        // an auditor running) — return `unknown` rather than `fail` so a
+        // missing service doesn't ding the score.
+        const maxAgeDays = param<number>(c, "max_age_days", 30);
+        const available = await isAuditorRunning();
+        if (!available) {
+          return { ...base, status: "unknown", detail: "Auditor service недоступен" };
+        }
+        let projects: AuditProjectStatus[];
+        try {
+          projects = await fetchAuditProjects();
+        } catch (err) {
+          if (err instanceof Error && err.name === "AbortError") throw err;
+          return { ...base, status: "unknown", detail: "Не удалось получить статус audit" };
+        }
+        // Match by `repo` first (canonical), fall back to `name` for legacy
+        // projects whose auditor entry pre-dates the `repo` field.
+        const entry = projects.find((p) => p.repo === ctx.repo || p.name === ctx.repo);
+        if (!entry) {
+          return {
+            ...base,
+            status: "fail",
+            detail: `Проект не зарегистрирован в auditor`,
+          };
+        }
+        if (!entry.last_run) {
+          return {
+            ...base,
+            status: "fail",
+            detail: `Audit ещё не запускался (порог ${maxAgeDays} дн.)`,
+          };
+        }
+        const ageMs = Date.now() - new Date(entry.last_run.timestamp).getTime();
+        const ageDays = Math.floor(ageMs / 86400000);
+        const ok = ageDays <= maxAgeDays;
+        return {
+          ...base,
+          status: ok ? "pass" : "fail",
+          detail: ok
+            ? `Свежий audit (${ageDays} дн. назад)`
+            : `Audit ${ageDays} дн. назад (порог ${maxAgeDays})`,
         };
       }
 

--- a/src/utils/health-engine.ts
+++ b/src/utils/health-engine.ts
@@ -26,7 +26,7 @@ import {
   getPRFiles,
 } from "./github-actions";
 import { Semaphore } from "./semaphore";
-import { fetchAuditProjects, isAuditorRunning } from "./auditor";
+import { fetchAuditProjects } from "./auditor";
 import type { AuditProjectStatus } from "../types";
 
 // Helper: read a typed param from a check object with a fallback.
@@ -277,9 +277,22 @@ interface RunCtx {
   doc: ChecklistDocument;
   dirCache: DirCache;
   inGrace: boolean;
+  // Shared lazy promise so multiple rules in the same scan don't each refetch
+  // the auditor project list. `null` means the service was unreachable.
+  auditProjectsPromise?: Promise<AuditProjectStatus[] | null>;
   // Forwarded to every fetch helper. When this aborts, all in-flight rule
   // checks reject with AbortError and the top-level Promise.all reflects it.
   signal?: AbortSignal;
+}
+
+function getAuditProjects(ctx: RunCtx): Promise<AuditProjectStatus[] | null> {
+  if (!ctx.auditProjectsPromise) {
+    ctx.auditProjectsPromise = fetchAuditProjects().catch((err) => {
+      if (err instanceof Error && err.name === "AbortError") throw err;
+      return null;
+    });
+  }
+  return ctx.auditProjectsPromise;
 }
 
 async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFinding> {
@@ -765,7 +778,7 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
           // Match on a heading at start-of-line so "## Deployment notes"
           // counts but a stray mention of "deploy" in prose doesn't.
           const re = new RegExp(
-            `^\\s*${readmeSection.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+            `^${readmeSection.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
             "im",
           );
           const ok = re.test(text);
@@ -787,17 +800,12 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
         // The service is optional in many environments (local dev without
         // an auditor running) — return `unknown` rather than `fail` so a
         // missing service doesn't ding the score.
+        // Uses a scan-scoped memo so portfolio scans don't refetch the
+        // full project list once per repo.
         const maxAgeDays = param<number>(c, "max_age_days", 30);
-        const available = await isAuditorRunning();
-        if (!available) {
+        const projects = await getAuditProjects(ctx);
+        if (projects === null) {
           return { ...base, status: "unknown", detail: "Auditor service недоступен" };
-        }
-        let projects: AuditProjectStatus[];
-        try {
-          projects = await fetchAuditProjects();
-        } catch (err) {
-          if (err instanceof Error && err.name === "AbortError") throw err;
-          return { ...base, status: "unknown", detail: "Не удалось получить статус audit" };
         }
         // Match by `repo` first (canonical), fall back to `name` for legacy
         // projects whose auditor entry pre-dates the `repo` field.

--- a/src/utils/onboardingReadinessRules.ts
+++ b/src/utils/onboardingReadinessRules.ts
@@ -1,0 +1,119 @@
+// Epic-012 Task-04 — Onboarding Readiness Checklist.
+//
+// Six Layer-2 rules that gauge whether a project is ready for a brand-new
+// developer / client onboarding. Authored in TypeScript rather than YAML so
+// the dashboard can ship the rule definitions without a synchronised PR to
+// makeit-knowledge — a follow-up PR mirrors these into
+// `Skills/PROJECT_CHECKLIST.yaml` (tracked as tech-debt).
+//
+// Two of the six rules introduce check types not present in the YAML
+// checklist today (`deploy_doc_present`, `audit_fresh`); the engine in
+// `health-engine.ts` knows how to evaluate them.
+//
+// `applies_to: {}` means the rule fires for every classified project,
+// regardless of tier / complex / client — onboarding readiness is universal.
+
+import type { ChecklistRule } from "../types/health";
+
+export const ONBOARDING_READINESS_RULES: ChecklistRule[] = [
+  {
+    id: "onboarding.readme_fresh",
+    title: "README обновлялся за последние 90 дней",
+    layer: 2,
+    applies_to: {},
+    severity: "medium",
+    check: {
+      type: "doc_freshness",
+      path: "README.md",
+      max_age_days: 90,
+    },
+    remediation:
+      "Обнови README.md: добавь актуальные ссылки, версии зависимостей, скриншоты. Свежий README — первое, что видит новый разработчик.",
+    source: "onboardingReadinessRules.ts",
+  },
+  {
+    id: "onboarding.brief_exists",
+    title: "docs/BRIEF.md существует",
+    layer: 2,
+    applies_to: {},
+    severity: "medium",
+    check: {
+      type: "file_exists",
+      path: "docs/BRIEF.md",
+    },
+    remediation:
+      "Создай docs/BRIEF.md с кратким описанием проекта: что делаем, кому продаём, основные решения. Без него онбординг клиента занимает в 3× больше времени.",
+    source: "onboardingReadinessRules.ts",
+  },
+  {
+    id: "onboarding.deploy_doc",
+    title: "Есть инструкция по деплою",
+    layer: 2,
+    applies_to: {},
+    severity: "high",
+    check: {
+      type: "deploy_doc_present",
+      // Either docs/DEPLOY.md exists OR README.md contains a `## Deploy`
+      // section heading. Both are acceptable — pick the one that fits the
+      // project's documentation style.
+      deploy_doc_path: "docs/DEPLOY.md",
+      readme_path: "README.md",
+      readme_section: "## Deploy",
+    },
+    remediation:
+      "Добавь docs/DEPLOY.md или раздел `## Deploy` в README — конкретные команды, env vars, проверка health. Без этого следующий деплой делается «по памяти».",
+    source: "onboardingReadinessRules.ts",
+  },
+  {
+    id: "onboarding.env_example",
+    title: ".env.example существует",
+    layer: 2,
+    applies_to: {},
+    severity: "high",
+    check: {
+      type: "file_exists",
+      path: ".env.example",
+    },
+    remediation:
+      "Закоммить .env.example с перечнем всех нужных переменных (без значений). Иначе новый разработчик гадает, что класть в .env.",
+    source: "onboardingReadinessRules.ts",
+  },
+  {
+    id: "onboarding.ci_green",
+    title: "Последний CI run на main = success",
+    layer: 2,
+    applies_to: {},
+    severity: "high",
+    check: {
+      type: "workflow_recent_run_status",
+      workflow_match: ["ci", "test"],
+      status: "success",
+    },
+    remediation:
+      "Почини main CI: красный билд означает, что проект нельзя собрать с нуля. Это P1 для онбординга.",
+    source: "onboardingReadinessRules.ts",
+  },
+  {
+    id: "onboarding.audit_fresh",
+    title: "Audit запускался за последние 30 дней",
+    layer: 2,
+    applies_to: {},
+    severity: "medium",
+    check: {
+      type: "audit_fresh",
+      max_age_days: 30,
+    },
+    remediation:
+      "Запусти audit из вкладки «Аудит». Свежий аудит — гарантия, что мы знаем актуальные риски проекта при передаче новому разработчику.",
+    source: "onboardingReadinessRules.ts",
+  },
+];
+
+// Subset check used by UI components (OnboardingChecklist) to filter the full
+// findings list down to just onboarding ones. Keeps the prefix coupled to
+// rule IDs in one place.
+export const ONBOARDING_RULE_PREFIX = "onboarding.";
+
+export function isOnboardingRuleId(ruleId: string): boolean {
+  return ruleId.startsWith(ONBOARDING_RULE_PREFIX);
+}


### PR DESCRIPTION
Closes #362

## Что сделано
- `src/utils/onboardingReadinessRules.ts` — 6 правил Layer 2 (`onboarding.readme_fresh`, `brief_exists`, `deploy_doc`, `env_example`, `ci_green`, `audit_fresh`) в формате `ChecklistRule`. `applies_to: {}` — фиры на каждом классифицированном проекте.
- `src/utils/health-engine.ts` — два новых check-типа в `executeCheck`: `deploy_doc_present` (docs/DEPLOY.md OR `## Deploy` секция в README) и `audit_fresh` (опрашивает Auditor API; `unknown` если сервис недоступен, `fail` если audit > 30 дн). Остальные правила реюзают существующие типы `doc_freshness`, `file_exists`, `workflow_recent_run_status`.
- `src/utils/checklist.ts` — `loadChecklist` мержит правила из `onboardingReadinessRules.ts` в `doc.rules` после парсинга YAML; dedup by `id`, YAML version wins.
- `src/components/v4/hub/OnboardingChecklist.tsx` — UI с ✓/✗/⏳/—, tooltip с `detail` + `remediation` при fail, счётчик pass/total.
- `docs/changelog.md` — release note про ожидаемый сдвиг health scores.

## Тесты
- `npx tsc --noEmit` — чисто
- `npm run lint` — чисто
- `npm run build` — чисто
- 6 правил подключены через merge в `loadChecklist`; existing 50 правил из YAML не затронуты → итого 56.

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён (deploy_doc_present regex, isAuditorRunning timeout per scan, dedup by id, applies_to:{} fires for all tiers)
- [x] P1 issues: 0

## Tech debt
- Зеркальный PR в `makeit-knowledge` (`Skills/PROJECT_CHECKLIST.yaml`) — отдельным tech-debt issue, в worktree нет доступа к другому репо.