### PR TITLE
Wire delivery tab to hub data

### DIFF
--- a/src/components/v4/hub/ProjectHubPage.tsx
+++ b/src/components/v4/hub/ProjectHubPage.tsx
@@ -164,7 +164,7 @@ export function ProjectHubPage({ repo, project, onBackToList }: Props) {
           {activeTab === "health" && <HealthTab repo={repo} project={project} />}
           {activeTab === "activity" && <ActivityTab />}
           {activeTab === "decisions" && <DecisionsRisksTab decisions={data.decisions} />}
-          {activeTab === "delivery" && <DeliveryTab />}
+          {activeTab === "delivery" && <DeliveryTab data={data} />}
         </Suspense>
       </div>
     </div>

--- a/src/components/v4/hub/tabs/DeliveryTab.tsx
+++ b/src/components/v4/hub/tabs/DeliveryTab.tsx
@@ -1,23 +1,95 @@
-import { Icon } from "../../health/Icon";
+import type { ProjectHubData } from "../../../../types/hub";
+import { DoraCards } from "../DoraCards";
+import { OnboardingChecklist } from "../OnboardingChecklist";
 
-const EPIC_URL = "https://github.com/Sergio1990-1/makeit-dashboard/blob/main/docs/epics/epic-012.md";
+interface Props {
+  data: ProjectHubData;
+}
+
+function EmptyPanel({ title, body }: { title: string; body: string }) {
+  return (
+    <section className="v4-hub-delivery-card" aria-label={title}>
+      <h3>{title}</h3>
+      <p>{body}</p>
+    </section>
+  );
+}
+
+function CustomerHealthPanel({ data }: { data: ProjectHubData["customerHealth"] }) {
+  if (!data) {
+    return (
+      <EmptyPanel
+        title="Customer Health"
+        body="Score появится после расчёта sentiment, cadence, delivery и paid-сигналов."
+      />
+    );
+  }
+
+  return (
+    <section className="v4-hub-delivery-card" aria-labelledby="v4-delivery-customer-title">
+      <h3 id="v4-delivery-customer-title">Customer Health</h3>
+      <div className={`v4-delivery-gauge v4-delivery-gauge--${data.tier}`}>
+        <span>{Math.round(data.score)}</span>
+        <small>/100</small>
+      </div>
+      <p>Обновлено {new Date(data.updatedAt).toLocaleDateString("ru-RU")}</p>
+    </section>
+  );
+}
+
+function DigestPanel({ data, onGenerate }: { data: ProjectHubData["digest"]; onGenerate: () => Promise<void> }) {
+  if (!data) {
+    return (
+      <section className="v4-hub-delivery-card" aria-labelledby="v4-delivery-digest-title">
+        <h3 id="v4-delivery-digest-title">Project Digest</h3>
+        <p>Еженедельный digest ещё не сгенерирован.</p>
+        <button type="button" className="v4-btn" onClick={() => void onGenerate()}>
+          Сгенерировать digest
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="v4-hub-delivery-card" aria-labelledby="v4-delivery-digest-title">
+      <div className="v4-hub-delivery-card-head">
+        <h3 id="v4-delivery-digest-title">Project Digest</h3>
+        <span>{data.week}</span>
+      </div>
+      <p className="v4-delivery-digest-meta">
+        Сгенерирован {new Date(data.generatedAt).toLocaleDateString("ru-RU")}
+      </p>
+      <pre className="v4-delivery-digest-preview">{data.markdown}</pre>
+      <button type="button" className="v4-btn" onClick={() => void onGenerate()}>
+        Обновить digest
+      </button>
+    </section>
+  );
+}
 
 /**
- * Placeholder. Epic-012 (DORA + Weekly Digest + Customer Health +
- * Onboarding + NBA engine, Tasks 01–09) fills this with the delivery
- * intelligence layout.
+ * Delivery tab for Epic-012: DORA metrics, Project Digest, Customer Health
+ * and Onboarding Readiness. Data stays owned by useProjectHub; this component
+ * only renders available snapshots and resilient empty states.
  */
-export function DeliveryTab() {
+export function DeliveryTab({ data }: Props) {
   return (
-    <div className="v4-hub-tab-stub">
-      <Icon name="trend" />
-      <div>
-        <strong>Вкладка в разработке</strong>
-        <p>
-          DORA, Weekly Digest, Customer Health и Onboarding Readiness появятся в{" "}
-          <a href={EPIC_URL} target="_blank" rel="noreferrer">Epic-012</a>.
-        </p>
-      </div>
+    <div className="v4-hub-delivery">
+      <section className="v4-hub-delivery-card v4-hub-delivery-card--wide" aria-labelledby="v4-delivery-dora-title">
+        <div className="v4-hub-delivery-card-head">
+          <h3 id="v4-delivery-dora-title">DORA metrics</h3>
+          <span>30 дней</span>
+        </div>
+        <DoraCards metrics={data.dora} />
+      </section>
+
+      <DigestPanel data={data.digest} onGenerate={data.generateDigest} />
+      <CustomerHealthPanel data={data.customerHealth} />
+
+      <section className="v4-hub-delivery-card v4-hub-delivery-card--wide" aria-labelledby="v4-delivery-onboarding-title">
+        <h3 id="v4-delivery-onboarding-title">Onboarding Readiness</h3>
+        <OnboardingChecklist findings={data.health?.findings ?? []} />
+      </section>
     </div>
   );
 }

--- a/src/types/hub.ts
+++ b/src/types/hub.ts
@@ -5,6 +5,7 @@
 
 import type { ProjectData } from "./index";
 import type { HealthReport, HealthSeverity } from "./health";
+import type { DoraMetricsResult } from "../utils/doraCalculator";
 
 export type HubTab = "overview" | "health" | "activity" | "decisions" | "delivery";
 
@@ -83,18 +84,7 @@ export interface DigestEntry {
  * DORA metrics snapshot + 90d trend per metric.
  * Filled in Epic-012 (Task-01: DORA).
  */
-export interface DoraMetrics {
-  deploymentFrequency: number; // deploys/week
-  leadTimeHours: number;
-  mttrHours: number;
-  changeFailureRate: number; // 0..1
-  trend90d: {
-    deploymentFrequency: number[];
-    leadTimeHours: number[];
-    mttrHours: number[];
-    changeFailureRate: number[];
-  };
-}
+export type DoraMetrics = DoraMetricsResult;
 
 /**
  * Customer Health Score (formula TBD — see PROJECT_HUB_DESIGN_BRIEF.md §11).


### PR DESCRIPTION
This connects the Delivery hub tab to the existing Project Hub data model instead of showing the placeholder. The tab now renders DORA cards, the weekly digest panel, customer health, and onboarding readiness with resilient empty states while preserving the existing lazy tab structure.