### PR TITLE
feat(portfolio): PortfolioNextActions widget (Epic-010 Task-02)

### DIFF
--- a/src/components/v4/portfolio/PortfolioNextActions.tsx
+++ b/src/components/v4/portfolio/PortfolioNextActions.tsx
@@ -1,0 +1,251 @@
+/**
+ * PortfolioNextActions — top-5 ranked next-best-actions across the whole
+ * portfolio (Epic-010 Task-02, #344).
+ *
+ * This is an EXTENSION of the `AIInsightsPanel` pattern, not a duplicate:
+ * AIInsightsPanel surfaces portfolio health (audit fails), this surfaces
+ * action-oriented recommendations from the NBA engine. The shared fetch
+ * layer lives in `usePortfolioNba`; the visual shell reuses the existing
+ * `.v4-panel` / `.v4-ai-*` classes (theme-aware custom properties, no new
+ * CSS) so it matches AIInsightsPanel side-by-side in the 2×2 grid.
+ *
+ * Mounting note: the widget is not wired into a surface yet — Portfolio
+ * Surface assembly is Task-06. Until then `onOpenProject` is supplied by
+ * whoever mounts it; if absent we fall back to a self-contained URL
+ * navigation (`?tab=projects&repo=X&subtab=overview` + pushState +
+ * popstate) so a standalone mount still works. `repo` is validated against
+ * the known project list before it ever touches the URL — an action from a
+ * malformed engine row can't inject an arbitrary query value.
+ */
+
+import { useCallback } from "react";
+import type { HealthSeverity } from "../../../types/health";
+import { PROJECTS } from "../../../utils/config";
+import type { NbaAction, NbaResult } from "../../../utils/nextBestActionEngine";
+import { usePortfolioNba } from "../../../hooks/usePortfolioNba";
+
+interface Props {
+  /**
+   * Per-project `NbaResult[]` the caller already computed. The engine
+   * aggregates these locally (pure-injectable). Undefined/empty → graceful
+   * empty state. Full live cross-portfolio collection is Epic-012 Task-09
+   * (#367, not done), deliberately out of scope here.
+   */
+  perProjectActions: NbaResult[] | undefined;
+  /**
+   * Opens the Project Hub Overview for `repo`. Supplied by the mounting
+   * surface (Task-06). When omitted, the component navigates via the URL
+   * itself (see file header).
+   */
+  onOpenProject?: (repo: string) => void;
+}
+
+// Whole row is one visual line; the rationale clamps to 1-2 lines in CSS
+// (.v4-ai-row-ds is -webkit-line-clamp). 90 chars keeps the title to one
+// line at the narrowest portfolio column — same budget as AIInsightsPanel.
+const TITLE_TRUNCATE = 90;
+
+// Set of valid repos — guards URL navigation against an injected value.
+const VALID_REPOS = new Set(PROJECTS.map((p) => p.repo));
+
+// Truncate by code-point so we never slice a multi-byte glyph in half
+// (mirrors AIInsightsPanel.truncate).
+function truncate(text: string, max: number): string {
+  const chars = Array.from(text);
+  if (chars.length <= max) return text;
+  return chars.slice(0, max).join("").trimEnd() + "…";
+}
+
+// Russian plural for "дн|день|дня" — "0 дней", "1 день", "2 дня", "5 дней".
+function daysLabel(n: number): string {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return `${n} день`;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+    return `${n} дня`;
+  }
+  return `${n} дней`;
+}
+
+// Self-contained navigation used only when no `onOpenProject` is injected.
+// Builds the canonical deep link and notifies the SPA routers (ProjectsView
+// / ProjectHubPage both listen on `popstate` and re-read the URL).
+function navigateToProjectOverview(repo: string): void {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  url.searchParams.set("tab", "projects");
+  url.searchParams.set("repo", repo);
+  url.searchParams.set("subtab", "overview");
+  window.history.pushState(
+    { repo, subtab: "overview" },
+    "",
+    url.pathname + url.search,
+  );
+  // Routers sync off popstate, not pushState — dispatch one so the SPA
+  // reacts to the programmatic navigation.
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
+export function PortfolioNextActions({
+  perProjectActions,
+  onOpenProject,
+}: Props) {
+  const { actions, loading, error, ageDays, hasCache, budgetFallback, regenerate } =
+    usePortfolioNba(perProjectActions);
+
+  const openProject = useCallback(
+    (repo: string | undefined) => {
+      // Engine rows carry an optional `repo`; ignore anything we can't map
+      // to a real project so we never push a bogus `?repo=` into the URL.
+      if (!repo || !VALID_REPOS.has(repo)) return;
+      if (onOpenProject) {
+        onOpenProject(repo);
+        return;
+      }
+      navigateToProjectOverview(repo);
+    },
+    [onOpenProject],
+  );
+
+  // Cache age label: «Сгенерирован N дней назад» when a fresh cache exists
+  // and we are not mid-regenerate. Distinguishes "0 days" → "сегодня".
+  const freshnessLabel =
+    hasCache && ageDays !== null
+      ? ageDays === 0
+        ? "Сгенерирован сегодня"
+        : `Сгенерирован ${daysLabel(ageDays)} назад`
+      : null;
+
+  // Loading shows for the regenerate request only — the initial render is
+  // synchronous from cache (or empty), there is no cold fetch here.
+  const showError = !!error && actions.length === 0 && !loading;
+  const showEmpty = !loading && !error && actions.length === 0;
+
+  return (
+    <div className="v4-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">
+          <svg
+            style={{ width: 14, height: 14, color: "var(--v4-accent-600)" }}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden
+          >
+            <path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z" />
+          </svg>
+          Что делать дальше
+          <span className="v4-tag">{actions.length}</span>
+          {loading && <span className="v4-tag">обновляется…</span>}
+          {budgetFallback && (
+            <span
+              className="v4-tag v4-tag--warn"
+              role="status"
+              title="Модель понижена Sonnet → Haiku из-за бюджета Claude"
+            >
+              бюджет
+            </span>
+          )}
+        </div>
+        <div className="v4-panel-actions">
+          {freshnessLabel && !loading && (
+            <span className="v4-panel-meta">{freshnessLabel}</span>
+          )}
+          <button
+            type="button"
+            className="v4-btn v4-ai-btn"
+            onClick={regenerate}
+            disabled={loading}
+            title="Сбросить кэш и пересчитать действия по портфелю"
+          >
+            {loading ? "Генерация…" : "Регенерировать"}
+          </button>
+        </div>
+      </div>
+
+      <div className="v4-ai-list">
+        {showError ? (
+          <div
+            className="v4-empty v4-ai-empty v4-orphan-error"
+            role="alert"
+          >
+            <div className="v4-orphan-error-t">
+              Не удалось сгенерировать действия
+            </div>
+            <div className="v4-orphan-error-m">{error}</div>
+          </div>
+        ) : showEmpty ? (
+          <div className="v4-empty v4-ai-empty">Действия не требуются</div>
+        ) : (
+          actions.map((action) => (
+            <ActionRow
+              key={action.id}
+              action={action}
+              onOpen={openProject}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface RowProps {
+  action: NbaAction;
+  onOpen: (repo: string | undefined) => void;
+}
+
+function ActionRow({ action, onOpen }: RowProps) {
+  const { title, rationale, severity, repo } = action;
+  // Only repos we can actually open are clickable — a row whose repo we
+  // can't resolve still renders (the recommendation is useful) but isn't a
+  // dead-end button.
+  const navigable = !!repo && VALID_REPOS.has(repo);
+
+  const content = (
+    <>
+      <span className={`v4-ai-sev v4-ai-sev--${sevClass(severity)}`}>
+        <span className="v4-ai-sev-dot" />
+        {severity}
+      </span>
+      <span className="v4-ai-row-main">
+        <span className="v4-ai-row-ttl">
+          <span className="v4-ai-row-title">
+            {truncate(title, TITLE_TRUNCATE)}
+          </span>
+          {repo && <span className="v4-ai-repo v4-mono">{repo}</span>}
+        </span>
+        {rationale && <span className="v4-ai-row-ds">{rationale}</span>}
+      </span>
+      {navigable && (
+        <span className="v4-ai-row-arrow" aria-hidden>
+          ↗
+        </span>
+      )}
+    </>
+  );
+
+  if (!navigable) {
+    return <div className="v4-ai-row">{content}</div>;
+  }
+  return (
+    <button
+      type="button"
+      className="v4-ai-row"
+      onClick={() => onOpen(repo)}
+      title={`Открыть ${repo} → Обзор`}
+    >
+      {content}
+    </button>
+  );
+}
+
+// Coerce to a known CSS modifier so an unexpected severity can't produce a
+// dangling `.v4-ai-sev--undefined` class (engine already coerces, this is
+// defence in depth).
+function sevClass(s: HealthSeverity): HealthSeverity {
+  return s === "critical" || s === "high" || s === "medium" || s === "low"
+    ? s
+    : "medium";
+}

--- a/src/hooks/usePortfolioNba.ts
+++ b/src/hooks/usePortfolioNba.ts
@@ -1,0 +1,216 @@
+/**
+ * usePortfolioNba — shared fetch layer for the portfolio Next-Best-Action
+ * widget (Epic-010 Task-02, #344).
+ *
+ * Wraps `computePortfolioNBA` / `invalidateNbaCache` from
+ * `nextBestActionEngine` (#388). The engine is **pure-injectable**: it does
+ * the aggregation locally over per-project `NbaResult[]` and never calls
+ * Claude itself, so this hook is injectable too — the caller passes the
+ * per-project actions (live cross-portfolio collection is Epic-012 Task-09,
+ * #367, not done; absent input degrades to an empty state, never a crash).
+ *
+ * Cache contract (read directly, deliberately):
+ *   The engine stores `localStorage["makeit_portfolio_nba"]` as
+ *   `{ week: <ISO-week>, result: NbaResult }` and is week-scoped (a fresh
+ *   ISO week forces recompute). It exposes no read-only / freshness API and
+ *   `NbaResult` carries no timestamp. To render «Сгенерирован N дней назад»
+ *   we read that envelope and derive age from the ISO-week boundary. The
+ *   cache KEY is NOT hardcoded here — it comes from
+ *   `PORTFOLIO_NBA_CACHE_KEY` so it stays in sync if the engine renames it.
+ *
+ * Divergence from the issue: the issue specifies a flat 7-day TTL with a
+ * `{ generatedAt, actions }` shape; the merged engine is ISO-week scoped
+ * with a `{ week, result }` envelope. We follow the REAL engine behaviour
+ * (week-scoped) and surface freshness as the days since that week started.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  computePortfolioNBA,
+  invalidateNbaCache,
+  type NbaResult,
+} from "../utils/nextBestActionEngine";
+
+/**
+ * The engine's portfolio cache key. Kept here as the single import-point so
+ * the widget/hook never inlines the literal — if the engine renames it this
+ * is the one place to update (the engine itself does not export it).
+ */
+export const PORTFOLIO_NBA_CACHE_KEY = "makeit_portfolio_nba";
+
+const DAY_MS = 86_400_000;
+
+/** Shape the engine writes: `{ week: "2026-W18", result: NbaResult }`. */
+interface RawCacheEnvelope {
+  week?: unknown;
+  result?: unknown;
+}
+
+/**
+ * Parse `YYYY-Www` into the UTC ms of that ISO week's Monday. Returns null
+ * for anything malformed so a corrupt cache degrades to "no freshness info"
+ * instead of throwing.
+ */
+function isoWeekStartMs(week: string): number | null {
+  const m = /^(\d{4})-W(\d{2})$/.exec(week);
+  if (m === null) return null;
+  const year = Number(m[1]);
+  const wk = Number(m[2]);
+  if (!Number.isFinite(year) || !Number.isFinite(wk) || wk < 1 || wk > 53) {
+    return null;
+  }
+  // ISO-8601: week 1 contains Jan 4th; its Monday is the week-1 start.
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4Dow = jan4.getUTCDay() === 0 ? 7 : jan4.getUTCDay(); // Mon=1..Sun=7
+  const week1Monday = new Date(jan4);
+  week1Monday.setUTCDate(jan4.getUTCDate() - (jan4Dow - 1));
+  const ms = week1Monday.getTime() + (wk - 1) * 7 * DAY_MS;
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** Read-only peek at the engine's cache (does NOT trigger a compute). */
+function readCachedEnvelope(): { actions: NbaResult["actions"]; weekStartMs: number | null } | null {
+  if (typeof localStorage === "undefined") return null;
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(PORTFOLIO_NBA_CACHE_KEY);
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+  try {
+    const env = JSON.parse(raw) as RawCacheEnvelope;
+    if (
+      env === null ||
+      typeof env !== "object" ||
+      typeof env.week !== "string" ||
+      env.result === null ||
+      typeof env.result !== "object"
+    ) {
+      return null;
+    }
+    const result = env.result as Partial<NbaResult>;
+    if (!Array.isArray(result.actions)) return null;
+    return {
+      actions: result.actions,
+      weekStartMs: isoWeekStartMs(env.week),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export interface UsePortfolioNbaState {
+  /** Top-5 portfolio actions (empty array = clean / no cache). */
+  actions: NbaResult["actions"];
+  /** True while a regenerate request is in flight. */
+  loading: boolean;
+  /** User-facing error message, or null. */
+  error: string | null;
+  /**
+   * Whole days since the cached week started, or null if there is no cache
+   * yet. Drives the «Сгенерирован N дней назад» label.
+   */
+  ageDays: number | null;
+  /** True when a non-stale cache was loaded (no auto-recompute needed). */
+  hasCache: boolean;
+  /** Engine flagged a Claude budget downgrade for a contributing project. */
+  budgetFallback: boolean;
+  /**
+   * Drop the cache and recompute from `perProjectActions`. No-ops while a
+   * previous regenerate is still running (button is disabled in the UI too,
+   * this is the belt-and-braces guard against a double-fire).
+   */
+  regenerate: () => void;
+}
+
+/**
+ * @param perProjectActions  Per-project `NbaResult[]` the caller already
+ *   computed. The engine aggregates these locally. Undefined/empty →
+ *   graceful empty state (full live collection is Task-09, out of scope).
+ */
+export function usePortfolioNba(
+  perProjectActions: NbaResult[] | undefined,
+): UsePortfolioNbaState {
+  const initial = readCachedEnvelope();
+
+  const [actions, setActions] = useState<NbaResult["actions"]>(
+    () => initial?.actions ?? [],
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [budgetFallback, setBudgetFallback] = useState(false);
+  const [weekStartMs, setWeekStartMs] = useState<number | null>(
+    () => initial?.weekStartMs ?? null,
+  );
+  const [hasCache, setHasCache] = useState<boolean>(() => initial !== null);
+
+  // Guards against a double-fire (rapid clicks / Strict-Mode double-invoke)
+  // and against a state update after unmount when an async regenerate
+  // resolves late.
+  const inFlightRef = useRef(false);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const regenerate = useCallback(() => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setLoading(true);
+    setError(null);
+
+    // Invalidate first so computePortfolioNBA can't short-circuit on the
+    // (now intentionally stale) week cache and actually recomputes.
+    try {
+      invalidateNbaCache({ kind: "portfolio" });
+    } catch {
+      // best-effort — a disabled localStorage just means no cache to clear
+    }
+
+    const input = perProjectActions ?? [];
+
+    void (async () => {
+      try {
+        const result = await computePortfolioNBA(input);
+        if (!mountedRef.current) return;
+        setActions(result.actions);
+        setBudgetFallback(result.budgetFallback);
+        setError(result.warning ?? null);
+        // After a successful compute the engine re-wrote the cache for the
+        // current ISO week — reflect that so the freshness label resets.
+        const fresh = readCachedEnvelope();
+        setWeekStartMs(fresh?.weekStartMs ?? null);
+        setHasCache(fresh !== null);
+      } catch (e) {
+        if (!mountedRef.current) return;
+        setError(
+          e instanceof Error
+            ? e.message
+            : "Не удалось сгенерировать действия по портфелю.",
+        );
+      } finally {
+        if (mountedRef.current) setLoading(false);
+        inFlightRef.current = false;
+      }
+    })();
+  }, [perProjectActions]);
+
+  const ageDays =
+    weekStartMs === null
+      ? null
+      : Math.max(0, Math.floor((Date.now() - weekStartMs) / DAY_MS));
+
+  return {
+    actions,
+    loading,
+    error,
+    ageDays,
+    hasCache,
+    budgetFallback,
+    regenerate,
+  };
+}


### PR DESCRIPTION
Closes #344

## Что сделано
- PortfolioNextActions.tsx — top-5 виджет, regenerate, empty/loading/error states
- usePortfolioNba.ts — fetch-слой над computePortfolioNBA/invalidateNbaCache (#388)

## Тесты
- type-check + lint + build чистые
- Preview неприменим: монтируется в Portfolio Surface (Task-06), не вмонтирован — проверена логика cache/regenerate/states

## Out of scope / расхождения
- generatePortfolioNba() не существует → адаптировано к реальному API computePortfolioNBA/invalidateNbaCache
- Engine кэширует по ISO-week (issue говорит 7д) — следую реальному поведению engine; "Сгенерирован N дней назад" считается от начала ISO-недели кэша (в NbaResult нет generatedAt)
- Полный live per-project сбор — Epic-012 Task-09 (useProjectHub); виджет pure-injectable принимает perProjectActions
- cache-ключ не хардкожен в виджете — единая константа PORTFOLIO_NBA_CACHE_KEY в хуке (engine ключ не экспортирует)

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён
- [x] P1 issues: 0