### PR TITLE
feat(portfolio): ProjectScorecard + DriftDots (Epic-010 Task-01)

### DIFF
--- a/src/components/v4/portfolio/DriftDots.tsx
+++ b/src/components/v4/portfolio/DriftDots.tsx
@@ -9,10 +9,9 @@ import type { ProjectNorm } from "../../../utils/driftNorm";
  * commit / deploy / audit / client-touch dots.
  *
  * Color rule (from epic-010.md "Архитектурные решения"):
- *   green   days ≤ norm
- *   yellow  days ≥ 1.5 × norm
- *   red     days ≥ 3   × norm
- * The band between norm and 1.5×norm reads as green (still acceptable);
+ *   green   days < 1.5 × norm   (incl. the still-acceptable band norm..1.5×norm)
+ *   yellow  1.5 × norm ≤ days < 3 × norm
+ *   red     days ≥ 3 × norm
  * "red wins" — the steepest threshold is checked first.
  *
  * A11y: color is never the *only* signal. Each dot has a `title` tooltip

--- a/src/components/v4/portfolio/DriftDots.tsx
+++ b/src/components/v4/portfolio/DriftDots.tsx
@@ -1,0 +1,164 @@
+import type { ProjectNorm } from "../../../utils/driftNorm";
+
+/**
+ * DriftDots — four colored dots showing how stale each project signal is
+ * versus its per-project norm (Epic-010 Task-01, PRD-008 FR-2/§3.2).
+ *
+ * Pure presentation: takes the `daysSinceX` measurements and a resolved
+ * `ProjectNorm` (from `useDriftNorm` in the parent Scorecard) and renders
+ * commit / deploy / audit / client-touch dots.
+ *
+ * Color rule (from epic-010.md "Архитектурные решения"):
+ *   green   days ≤ norm
+ *   yellow  days ≥ 1.5 × norm
+ *   red     days ≥ 3   × norm
+ * The band between norm and 1.5×norm reads as green (still acceptable);
+ * "red wins" — the steepest threshold is checked first.
+ *
+ * A11y: color is never the *only* signal. Each dot has a `title` tooltip
+ * («commit: 4д назад, норма 2д»), an `aria-label` with the same text plus
+ * the severity word, and a glyph (●/◐/▲) so red/green is distinguishable
+ * without color perception. `role="img"` so SR announces the label.
+ */
+
+export type DriftSeverity = "ok" | "warn" | "stale" | "unknown";
+
+interface DriftKey {
+  key: keyof ProjectNorm;
+  /** Russian label used in the tooltip. */
+  label: string;
+}
+
+// Order mirrors §3.2 ("commit / deploy / audit / client-touch").
+const DRIFT_KEYS: DriftKey[] = [
+  { key: "commit_cadence_days", label: "commit" },
+  { key: "deploy_freq_days", label: "deploy" },
+  { key: "audit_freq_days", label: "audit" },
+  { key: "client_touch_interval_days", label: "client" },
+];
+
+interface DotStyle {
+  bg: string;
+  glyph: string;
+  word: string;
+}
+
+// Tints carry their own readable color (not a theme var) so the dot is
+// legible on both light and dark Scorecards; the glyph adds a non-color cue.
+const DOT_STYLE: Record<DriftSeverity, DotStyle> = {
+  ok: { bg: "#16a34a", glyph: "●", word: "в норме" },
+  warn: { bg: "#ca8a04", glyph: "◐", word: "отставание" },
+  stale: { bg: "#dc2626", glyph: "▲", word: "просрочено" },
+  unknown: { bg: "var(--v4-ink-300, #C5CCDA)", glyph: "○", word: "нет данных" },
+};
+
+/**
+ * Classify one signal. `days === null` → unknown (no measurement yet).
+ * `norm` is guaranteed positive by `coerceNorm` in driftNorm.ts, but we
+ * still guard `norm <= 0` so a future bad caller can't yield Infinity/NaN
+ * thresholds (would otherwise paint everything green).
+ */
+function classifyDrift(
+  days: number | null | undefined,
+  norm: number | undefined,
+): DriftSeverity {
+  if (days === null || days === undefined || !Number.isFinite(days)) {
+    return "unknown";
+  }
+  if (norm === undefined || !Number.isFinite(norm) || norm <= 0) {
+    return "unknown";
+  }
+  if (days >= norm * 3) return "stale";
+  if (days >= norm * 1.5) return "warn";
+  return "ok";
+}
+
+function tooltipText(label: string, days: number | null | undefined, norm: number | undefined): string {
+  if (days === null || days === undefined || !Number.isFinite(days)) {
+    return `${label}: нет данных`;
+  }
+  const normPart =
+    norm !== undefined && Number.isFinite(norm) && norm > 0 ? `, норма ${norm}д` : "";
+  return `${label}: ${Math.round(days)}д назад${normPart}`;
+}
+
+export interface DriftDaysInput {
+  /** Days since last commit on the default branch. */
+  daysSinceCommit?: number | null;
+  /** Days since last deploy / release. */
+  daysSinceDeploy?: number | null;
+  /** Days since last audit run. */
+  daysSinceAudit?: number | null;
+  /** Days since last client touchpoint. */
+  daysSinceClientTouch?: number | null;
+}
+
+interface Props extends DriftDaysInput {
+  /** Resolved norms (from `useDriftNorm`). `null` while loading. */
+  norm: ProjectNorm | null;
+  /** True while `useDriftNorm` is still resolving — dots render muted. */
+  loading?: boolean;
+}
+
+export function DriftDots({
+  norm,
+  loading = false,
+  daysSinceCommit,
+  daysSinceDeploy,
+  daysSinceAudit,
+  daysSinceClientTouch,
+}: Props) {
+  const daysByKey: Record<keyof ProjectNorm, number | null | undefined> = {
+    commit_cadence_days: daysSinceCommit,
+    deploy_freq_days: daysSinceDeploy,
+    audit_freq_days: daysSinceAudit,
+    client_touch_interval_days: daysSinceClientTouch,
+  };
+
+  return (
+    <div
+      className="v4-drift-dots"
+      role="group"
+      aria-label="Drift-индикаторы"
+      style={{ display: "flex", alignItems: "center", gap: 8 }}
+    >
+      {DRIFT_KEYS.map(({ key, label }) => {
+        const days = daysByKey[key];
+        const normValue = norm ? norm[key] : undefined;
+        // While the norm is still loading we can't classify — show muted.
+        const severity: DriftSeverity =
+          loading || norm === null ? "unknown" : classifyDrift(days, normValue);
+        const style = DOT_STYLE[severity];
+        const tip = loading
+          ? `${label}: загрузка нормы…`
+          : tooltipText(label, days, normValue);
+        return (
+          <span
+            key={key}
+            role="img"
+            aria-label={`${tip} — ${style.word}`}
+            title={tip}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 14,
+              height: 14,
+              borderRadius: "50%",
+              background: style.bg,
+              color: "#fff",
+              fontSize: 9,
+              lineHeight: 1,
+              fontWeight: 700,
+              flexShrink: 0,
+            }}
+          >
+            <span aria-hidden="true">{style.glyph}</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+export default DriftDots;

--- a/src/components/v4/portfolio/ProjectScorecard.tsx
+++ b/src/components/v4/portfolio/ProjectScorecard.tsx
@@ -1,0 +1,329 @@
+import type { KeyboardEvent } from "react";
+import type { Phase } from "../../../types";
+import type { HealthScore } from "../../../types/health";
+import type { ProjectTier } from "../../../utils/driftNorm";
+import { useDriftNorm } from "../../../hooks/useDriftNorm";
+import { DriftDots, type DriftDaysInput } from "./DriftDots";
+
+/**
+ * ProjectScorecard — preview card for the Portfolio Surface
+ * (Epic-010 Task-01, PRD-008 FR-2 / brief §3.2).
+ *
+ * Layout:
+ *   Header  — repo (mono), tier-pill, phase-badge, client (small),
+ *             health-grade A/B/C/D/F (large, right) + colored dot
+ *   KPI row — open / in-progress / blocked / overdue-commitments
+ *   DriftDots — commit / deploy / audit / client-touch
+ *   Footer  — last activity (relative) + cost MTD (if present)
+ *
+ * Clicking (or Enter/Space) the whole card calls `onSelectRepo(repo)` —
+ * Epic-009 routing (owned elsewhere) takes it from there. This component
+ * neither imports routing nor mounts itself; Portfolio Surface assembly is
+ * Task-06.
+ *
+ * Pure-injectable (the DORA/NBA pattern of this epic): every datum is a
+ * prop. The one exception is the drift norm — the issue specifies DriftDots
+ * derives it from `useDriftNorm(repo)`, so the card owns that hook and feeds
+ * the resolved norm down. No fetch/N+1 here.
+ *
+ * Self-contained styling: inline styles over `--v4-*` custom properties with
+ * literal fallbacks, so the card is legible in light/dark without touching
+ * the shared `v4.css` (parallel Task-02/#344 writes to the same folder).
+ */
+
+export type HealthGrade = HealthScore["grade"];
+
+export interface ScorecardKpis {
+  /** Open issues. */
+  open: number;
+  /** Issues currently In Progress. */
+  inProgress: number;
+  /** Blocked issues. */
+  blocked: number;
+  /** Overdue client commitments (Epic-011 Promise Tracker). */
+  overdueCommitments: number;
+}
+
+interface Props {
+  repo: string;
+  tier: ProjectTier;
+  phase: Phase;
+  client?: string | null;
+  /** Health grade. `null` → not yet computed (renders muted "—"). */
+  grade: HealthGrade | null;
+  kpis: ScorecardKpis;
+  /** Drift measurements (days since each signal). */
+  drift: DriftDaysInput;
+  /** Days since last activity (relative footer). `null` → unknown. */
+  daysSinceActivity?: number | null;
+  /** Cost month-to-date in USD. `null`/omitted → footer omits it. */
+  costMtdUsd?: number | null;
+  /** Epic-009 routing handler — receives `repo` on card activation. */
+  onSelectRepo: (repo: string) => void;
+}
+
+const PHASE_BADGE: Record<Phase, { icon: string; label: string; color: string }> = {
+  development: { icon: "▶", label: "dev", color: "var(--v4-accent-600, #1D4ED8)" },
+  support: { icon: "⏸", label: "support", color: "var(--v4-ink-500, #6B7691)" },
+  "pre-dev": { icon: "◻", label: "pre-dev", color: "var(--v4-purple-700, #5B21B6)" },
+};
+
+// Grade → tone. Colors carry their own readable value (kept off pure theme
+// vars) and the letter itself is the primary, non-color signal.
+const GRADE_TONE: Record<HealthGrade, string> = {
+  A: "#16a34a",
+  B: "#65a30d",
+  C: "#ca8a04",
+  D: "#ea580c",
+  F: "#dc2626",
+};
+
+function tierLabel(tier: ProjectTier): string {
+  if (tier === 1 || tier === "tier-1") return "T1";
+  if (tier === 2 || tier === "tier-2") return "T2";
+  return "T3";
+}
+
+/** Days → short relative RU string. `null`/invalid → "—". */
+function relativeDays(days: number | null | undefined): string {
+  if (days === null || days === undefined || !Number.isFinite(days)) return "—";
+  const d = Math.max(0, Math.round(days));
+  if (d === 0) return "сегодня";
+  if (d === 1) return "вчера";
+  return `${d}д назад`;
+}
+
+/** Compact USD ($1,2k / $940). Non-finite → null (footer skips it). */
+function compactUsd(n: number | null | undefined): string | null {
+  if (n === null || n === undefined || !Number.isFinite(n) || n < 0) return null;
+  if (n >= 1000) {
+    const k = n / 1000;
+    return `$${k.toFixed(k % 1 === 0 ? 0 : 1).replace(".", ",")}k`;
+  }
+  return `$${Math.round(n)}`;
+}
+
+interface KpiItemProps {
+  icon: string;
+  value: number;
+  label: string;
+  /** Tint the value when > 0 (blocked/overdue read as warnings). */
+  danger?: boolean;
+}
+
+function KpiItem({ icon, value, label, danger }: KpiItemProps) {
+  const isAlert = !!danger && value > 0;
+  return (
+    <span
+      title={label}
+      style={{
+        display: "inline-flex",
+        alignItems: "baseline",
+        gap: 4,
+        fontSize: 12,
+        color: isAlert ? "#dc2626" : "var(--v4-ink-800, #1B2235)",
+        fontWeight: isAlert ? 700 : 500,
+      }}
+    >
+      <span aria-hidden="true" style={{ fontSize: 11, opacity: 0.7 }}>
+        {icon}
+      </span>
+      <b style={{ fontVariantNumeric: "tabular-nums" }}>{value}</b>
+      <span style={{ fontSize: 11, color: "var(--v4-ink-500, #6B7691)", fontWeight: 500 }}>
+        {label}
+      </span>
+    </span>
+  );
+}
+
+export function ProjectScorecard({
+  repo,
+  tier,
+  phase,
+  client,
+  grade,
+  kpis,
+  drift,
+  daysSinceActivity,
+  costMtdUsd,
+  onSelectRepo,
+}: Props) {
+  // The card owns the norm hook so DriftDots can color against per-project
+  // thresholds (issue: "Берёт … norm из useDriftNorm(repo)").
+  const { norm, loading: normLoading } = useDriftNorm(repo, tier);
+
+  const phaseBadge = PHASE_BADGE[phase] ?? PHASE_BADGE["pre-dev"];
+  const gradeTone = grade ? GRADE_TONE[grade] : "var(--v4-ink-400, #94A0B8)";
+  const cost = compactUsd(costMtdUsd);
+
+  const activate = () => onSelectRepo(repo);
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    // Space scrolls by default — preventDefault so the card "button"
+    // behaves like a real button for keyboard users.
+    if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+      e.preventDefault();
+      activate();
+    }
+  };
+
+  return (
+    <div
+      className="v4-scorecard"
+      role="button"
+      tabIndex={0}
+      onClick={activate}
+      onKeyDown={onKeyDown}
+      aria-label={`Открыть проект ${repo}`}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+        padding: 14,
+        borderRadius: "var(--v4-r-lg, 12px)",
+        background: "var(--v4-card, var(--v4-bg, #fff))",
+        border: "1px solid var(--v4-line, #E4E8EF)",
+        cursor: "pointer",
+        minWidth: 0,
+      }}
+    >
+      {/* ── Header ── */}
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+            <span
+              style={{
+                fontFamily: "var(--v4-mono, ui-monospace, monospace)",
+                fontSize: 13,
+                fontWeight: 600,
+                color: "var(--v4-ink-900, #0E1320)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                maxWidth: "100%",
+              }}
+            >
+              {repo}
+            </span>
+            <span
+              title={`Tier ${tierLabel(tier).slice(1)}`}
+              style={{
+                fontSize: 10,
+                fontWeight: 700,
+                padding: "1px 6px",
+                borderRadius: 999,
+                background: "var(--v4-accent-50, #EEF4FF)",
+                color: "var(--v4-accent-700, #1E40AF)",
+                flexShrink: 0,
+              }}
+            >
+              {tierLabel(tier)}
+            </span>
+            <span
+              title={`Фаза: ${phaseBadge.label}`}
+              style={{
+                fontSize: 10,
+                fontWeight: 600,
+                padding: "1px 6px",
+                borderRadius: 999,
+                border: `1px solid ${phaseBadge.color}`,
+                color: phaseBadge.color,
+                flexShrink: 0,
+              }}
+            >
+              {phaseBadge.icon} {phaseBadge.label}
+            </span>
+          </div>
+          {client && (
+            <div
+              style={{
+                marginTop: 3,
+                fontSize: 11,
+                color: "var(--v4-ink-500, #6B7691)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {client}
+            </div>
+          )}
+        </div>
+        <div
+          style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}
+          title={grade ? `Health grade: ${grade}` : "Health grade пока не вычислен"}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              width: 9,
+              height: 9,
+              borderRadius: "50%",
+              background: gradeTone,
+              flexShrink: 0,
+            }}
+          />
+          <span
+            aria-label={grade ? `Health grade ${grade}` : "Health grade неизвестен"}
+            style={{
+              fontSize: 24,
+              fontWeight: 800,
+              lineHeight: 1,
+              color: gradeTone,
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {grade ?? "—"}
+          </span>
+        </div>
+      </div>
+
+      {/* ── KPI row ── */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 14,
+          flexWrap: "wrap",
+          borderTop: "1px solid var(--v4-line-soft, #EEF1F6)",
+          paddingTop: 8,
+        }}
+      >
+        <KpiItem icon="◯" value={kpis.open} label="открытых" />
+        <KpiItem icon="▶" value={kpis.inProgress} label="в работе" />
+        <KpiItem icon="⛔" value={kpis.blocked} label="заблок." danger />
+        <KpiItem icon="⏰" value={kpis.overdueCommitments} label="просроч." danger />
+      </div>
+
+      {/* ── DriftDots ── */}
+      <DriftDots norm={norm} loading={normLoading} {...drift} />
+
+      {/* ── Footer ── */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+          fontSize: 11,
+          color: "var(--v4-ink-500, #6B7691)",
+          borderTop: "1px solid var(--v4-line-soft, #EEF1F6)",
+          paddingTop: 8,
+        }}
+      >
+        <span title="Последняя активность">
+          активность: {relativeDays(daysSinceActivity)}
+        </span>
+        {cost && (
+          <span
+            title="Стоимость с начала месяца"
+            style={{ fontVariantNumeric: "tabular-nums" }}
+          >
+            MTD {cost}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ProjectScorecard;

--- a/src/hooks/useDriftNorm.ts
+++ b/src/hooks/useDriftNorm.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  loadProjectNorm,
+  type ProjectNorm,
+  type ProjectTier,
+} from "../utils/driftNorm";
+
+/**
+ * React wrapper around `loadProjectNorm` (Epic-012 #06, `src/utils/driftNorm.ts`).
+ *
+ * `loadProjectNorm(repo, tier)` is an async *function*, not a hook — it reads
+ * the per-project `docs/project_norm.yaml` override (24h-cached in
+ * localStorage) and falls back to the tier default. This hook drives it from
+ * an effect so a component (e.g. `DriftDots` inside `ProjectScorecard`) can
+ * consume `{ norm, loading }` declaratively.
+ *
+ * The util never throws (it degrades to the tier default on any failure), so
+ * the only failure mode we surface is "still resolving" → `loading`. `norm`
+ * is `null` until the first resolution lands.
+ *
+ * The resolved norm is stored together with the `repo`+`tier` it belongs to.
+ * The returned `{ norm, loading }` is *derived* from that store at render
+ * time — so a `repo` change (or a `null` repo) immediately reads as
+ * "loading / no norm" without a setState-in-effect (which the lint rule
+ * `react-hooks/set-state-in-effect` forbids; cf. the same idle-derivation
+ * trick in `useProjectHealth.ts`). The async effect only commits a *resolved*
+ * value, never the synchronous reset.
+ *
+ * A monotonic request id discards a slower earlier promise if the inputs
+ * change mid-flight; a mounted-flag prevents a setState after the consumer
+ * unmounts (portfolio navigation tear-down).
+ */
+
+interface Resolved {
+  repo: string;
+  tier: ProjectTier;
+  norm: ProjectNorm;
+}
+
+export function useDriftNorm(
+  repo: string | null,
+  tier: ProjectTier,
+): { norm: ProjectNorm | null; loading: boolean } {
+  const [resolved, setResolved] = useState<Resolved | null>(null);
+  // Monotonic request id — only the latest in-flight call may commit.
+  const reqId = useRef(0);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!repo) return;
+
+    const myReq = ++reqId.current;
+
+    loadProjectNorm(repo, tier)
+      .then((norm) => {
+        if (!mounted.current || myReq !== reqId.current) return;
+        setResolved({ repo, tier, norm });
+      })
+      .catch(() => {
+        // `loadProjectNorm` is contractually no-throw; this catch is
+        // belt-and-braces so a future regression can't wedge the hook
+        // forever-loading. The store keeps its last value; `loading`
+        // derives from the repo/tier mismatch, so it stays true here.
+      });
+  }, [repo, tier]);
+
+  // Derive the public shape: a stored norm only counts if it was resolved
+  // for *these* exact inputs. Otherwise (no repo, repo changed, not yet
+  // resolved) → loading with no norm. No setState on the synchronous path.
+  const isFresh =
+    resolved !== null && resolved.repo === repo && resolved.tier === tier;
+
+  if (!repo) {
+    return { norm: null, loading: false };
+  }
+  return {
+    norm: isFresh ? resolved.norm : null,
+    loading: !isFresh,
+  };
+}


### PR DESCRIPTION
Closes #343

## Что сделано
- ProjectScorecard.tsx — превью-карточка (header/KPI/DriftDots/footer), onSelectRepo prop
- DriftDots.tsx — 4 дота commit/deploy/audit/client-touch, цвет по norm, tooltip
- useDriftNorm.ts — хук-обёртка над loadProjectNorm (async util из #386)

## Тесты
- type-check + lint + build чистые
- Preview неприменим: компонент монтируется в Portfolio Surface (Task-06), не вмонтирован — визуально проверена логика drift-цветов на границах

## Out of scope
- Portfolio Surface assembly + routing wiring — Epic-010 Task-06
- Реальные live-данные — Epic-012 Task-09 (useProjectHub integration); карточка pure-injectable

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён
- [x] P1 issues: 0