### PR TITLE
PortfolioRenewals cross-project widget (Epic-010 Task-04)

### DIFF
--- a/src/components/v4/portfolio/PortfolioRenewals.tsx
+++ b/src/components/v4/portfolio/PortfolioRenewals.tsx
@@ -1,0 +1,406 @@
+/**
+ * PortfolioRenewals — cross-project upcoming-renewals aggregator
+ * (Epic-010 Task-04, #346).
+ *
+ * Surfaces the top-5 nearest expiries across the whole portfolio: SSL /
+ * domain / contract / license dates from each repo's `docs/renewals.yaml`
+ * plus deprecated-dependency findings auto-scanned from `package.json`.
+ * The full per-project list lives in the Hub Decisions & Risks tab; this
+ * widget is the "what expires soonest, everywhere" glance.
+ *
+ * Data flow: `usePortfolioRenewals` fans out over the config `PROJECTS`
+ * list (no hardcoded repo list), reads each repo's renewals yaml +
+ * package.json through github-contents, merges via `scanRenewals`, and
+ * caches the result in sessionStorage for 1 hour. This widget is pure
+ * presentation: sort by expiry ascending → take top-5 → render with an
+ * urgency dot + an explicit "через Nд" label (colour is never the only
+ * carrier of meaning — WCAG 1.4.1).
+ *
+ * Mounting note: not wired into a surface yet — Portfolio Surface
+ * assembly is Epic-010 Task-06 (#348). Until then `onOpenProject` is
+ * supplied by whoever mounts it; absent → self-contained URL navigation
+ * (`?tab=projects&repo=X&subtab=decisions#renewals` + pushState +
+ * popstate), mirroring PortfolioPromiseTracker. `repo` is validated
+ * against the known project list before it ever touches the URL — a
+ * renewal from a malformed repo string can't inject an arbitrary query
+ * value.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { PROJECTS } from "../../../utils/config";
+import {
+  usePortfolioRenewals,
+  type PortfolioRenewal,
+} from "../../../hooks/usePortfolioRenewals";
+import type { RenewalType } from "../../../types/hub";
+
+interface Props {
+  /**
+   * Opens the project's Hub Decisions & Risks tab for `repo`. Supplied by
+   * the mounting surface (Task-06). When omitted, the component navigates
+   * via the URL itself (see file header).
+   */
+  onOpenProject?: (repo: string) => void;
+}
+
+const DAY_MS = 86_400_000;
+/** Top of the urgency ladder: ≤7 days out is red. */
+const URGENT_DAYS = 7;
+/** Mid rung: ≤30 days out is amber. Beyond that is gray. */
+const SOON_DAYS = 30;
+/** How many rows the widget shows (issue spec: top-5 nearest). */
+const MAX_ROWS = 5;
+
+// Guards URL navigation against an injected `?repo=` value — only repos we
+// actually know about are ever pushed.
+const VALID_REPOS = new Set(PROJECTS.map((p) => p.repo));
+
+/** Urgency bucket — also the CSS modifier suffix and the dot/label class. */
+type Urgency = "red" | "yellow" | "gray";
+
+/** Human label per renewal type (Russian UI). */
+const TYPE_LABEL: Record<RenewalType, string> = {
+  ssl: "SSL",
+  domain: "Домен",
+  contract: "Контракт",
+  license: "Лицензия",
+  dep: "Зависимость",
+};
+
+/** UTC midnight of `now` — date-only comparison, no time-of-day drift. */
+function startOfTodayUtc(now: number): number {
+  const d = new Date(now);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}
+
+/**
+ * Whole-day signed delta between an expiry date and today (both at UTC
+ * midnight). `null` when the date is missing or unparseable — those rows
+ * are undated (typically auto-scan deps) and sort to the bottom.
+ */
+function daysUntil(expiresAt: string | null, todayUtc: number): number | null {
+  if (!expiresAt) return null;
+  const t = Date.parse(expiresAt);
+  if (Number.isNaN(t)) return null;
+  return Math.round((startOfTodayUtc(t) - todayUtc) / DAY_MS);
+}
+
+/**
+ * Map a day-delta to an urgency bucket. An already-expired date (negative
+ * delta) is the most urgent — it stays red. Undated rows are gray (no
+ * deadline pressure, surfaced only so a deprecated dep stays visible).
+ */
+function urgencyOf(diffDays: number | null): Urgency {
+  if (diffDays === null) return "gray";
+  if (diffDays <= URGENT_DAYS) return "red";
+  if (diffDays <= SOON_DAYS) return "yellow";
+  return "gray";
+}
+
+// Russian plural for days — "1 день", "2 дня", "5 дней".
+function daysLabel(n: number): string {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return `${n} день`;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+    return `${n} дня`;
+  }
+  return `${n} дней`;
+}
+
+/**
+ * Explicit textual urgency — the colour is decorative only, this text
+ * carries the meaning (WCAG 1.4.1, "in Nд" from the issue spec).
+ * Expired → «истекло N дней назад», future → «через N дней» / «сегодня» /
+ * «завтра», undated → «без срока».
+ */
+function expiryLabel(diffDays: number | null): string {
+  if (diffDays === null) return "без срока";
+  if (diffDays < 0) return `истекло ${daysLabel(-diffDays)} назад`;
+  if (diffDays === 0) return "истекает сегодня";
+  if (diffDays === 1) return "истекает завтра";
+  return `через ${daysLabel(diffDays)}`;
+}
+
+// Self-contained navigation used only when no `onOpenProject` is injected.
+// Deep-links to the project's Hub Decisions & Risks tab; the `#renewals`
+// anchor is the canonical link target from the issue spec (harmless if no
+// element consumes it yet). Routers sync off popstate.
+function navigateToRenewals(repo: string): void {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  url.searchParams.set("tab", "projects");
+  url.searchParams.set("repo", repo);
+  url.searchParams.set("subtab", "decisions");
+  window.history.pushState(
+    { repo, subtab: "decisions" },
+    "",
+    `${url.pathname}${url.search}#renewals`,
+  );
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
+/** A renewal decorated with its computed day-delta for render + sort. */
+interface RankedRenewal extends PortfolioRenewal {
+  diffDays: number | null;
+}
+
+/**
+ * Sort by expiry ascending (soonest first), top-5. Undated rows
+ * (`diffDays === null`) sink below every dated one. Stable tie-break by
+ * repo then name so render order is deterministic across reloads.
+ */
+function rankTop(
+  items: PortfolioRenewal[],
+  todayUtc: number,
+): RankedRenewal[] {
+  const ranked: RankedRenewal[] = items.map((r) => ({
+    ...r,
+    diffDays: daysUntil(r.expires_at, todayUtc),
+  }));
+  ranked.sort((a, b) => {
+    const aHas = a.diffDays !== null;
+    const bHas = b.diffDays !== null;
+    if (aHas && bHas) {
+      if (a.diffDays !== b.diffDays) {
+        return (a.diffDays as number) - (b.diffDays as number);
+      }
+    } else if (aHas !== bHas) {
+      return aHas ? -1 : 1;
+    }
+    return (
+      a.repo.localeCompare(b.repo, "en") ||
+      a.name.localeCompare(b.name, "ru")
+    );
+  });
+  return ranked.slice(0, MAX_ROWS);
+}
+
+export function PortfolioRenewals({ onOpenProject }: Props) {
+  const { items, loading, error, refresh } = usePortfolioRenewals();
+
+  // Today's UTC-midnight baseline, captured once at mount via a lazy
+  // state initializer (the linter forbids an impure `Date.now()` inside a
+  // render-time `useMemo`; a one-shot initializer is the sanctioned way).
+  // Date-only granularity means a session crossing midnight keeps the
+  // original baseline until a refresh — acceptable for a 1h-cached,
+  // day-resolution widget.
+  const [todayUtc] = useState(() => startOfTodayUtc(Date.now()));
+  const top = useMemo(
+    () => rankTop(items, todayUtc),
+    [items, todayUtc],
+  );
+
+  const openProject = useCallback(
+    (repo: string) => {
+      // Only repos we can map to a real project ever reach navigation —
+      // never push a bogus `?repo=` into the URL.
+      if (!VALID_REPOS.has(repo)) return;
+      if (onOpenProject) {
+        onOpenProject(repo);
+        return;
+      }
+      navigateToRenewals(repo);
+    },
+    [onOpenProject],
+  );
+
+  const showError = !!error && top.length === 0 && !loading;
+  const showSkeleton = loading && top.length === 0;
+  const showEmpty = !loading && !error && top.length === 0;
+
+  return (
+    <div className="v4-panel">
+      <div className="v4-panel-h">
+        <div className="v4-panel-t">
+          <svg
+            style={{ width: 14, height: 14, color: "var(--v4-accent-600)" }}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden
+          >
+            <path d="M12 8v4l3 3" />
+            <circle cx="12" cy="12" r="9" />
+          </svg>
+          Обновления и сроки
+          {top.length > 0 && <span className="v4-tag">{top.length}</span>}
+          {loading && top.length > 0 && (
+            <span className="v4-tag">обновляется…</span>
+          )}
+        </div>
+        <div className="v4-panel-actions">
+          <button
+            type="button"
+            className="v4-btn v4-ai-btn"
+            onClick={refresh}
+            disabled={loading}
+            title="Сбросить кэш и перечитать сроки по всем репо"
+          >
+            {loading ? "Загрузка…" : "Обновить"}
+          </button>
+        </div>
+      </div>
+
+      <div className="v4-ai-list">
+        {showError ? (
+          <div
+            className="v4-empty v4-ai-empty v4-orphan-error"
+            role="alert"
+          >
+            <div className="v4-orphan-error-t">
+              Не удалось загрузить сроки
+            </div>
+            <div className="v4-orphan-error-m">{error}</div>
+          </div>
+        ) : showSkeleton ? (
+          <RenewalsSkeleton />
+        ) : showEmpty ? (
+          <div className="v4-empty v4-ai-empty v4-promise-empty">
+            Ближайших обновлений нет
+          </div>
+        ) : (
+          top.map((r) => (
+            <RenewalRow
+              key={`${r.repo}:${r.type}:${r.name}:${r.expires_at ?? "-"}`}
+              r={r}
+              onOpen={openProject}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface RowProps {
+  r: RankedRenewal;
+  onOpen: (repo: string) => void;
+}
+
+/** Inline type icon — paired with a text label so it's not icon-only. */
+function TypeIcon({ type }: { type: RenewalType }) {
+  const common = {
+    width: 13,
+    height: 13,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 2,
+    "aria-hidden": true,
+  } as const;
+  switch (type) {
+    case "ssl":
+      return (
+        <svg {...common}>
+          <rect x="4" y="11" width="16" height="10" rx="2" />
+          <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+        </svg>
+      );
+    case "domain":
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="12" r="9" />
+          <path d="M3 12h18M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18" />
+        </svg>
+      );
+    case "contract":
+      return (
+        <svg {...common}>
+          <path d="M7 3h7l5 5v13H7z" />
+          <path d="M14 3v5h5M10 14h6M10 17h6" />
+        </svg>
+      );
+    case "license":
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="9" r="5" />
+          <path d="M9 13l-2 8 5-3 5 3-2-8" />
+        </svg>
+      );
+    case "dep":
+    default:
+      return (
+        <svg {...common}>
+          <path d="M21 16V8l-9-5-9 5v8l9 5z" />
+          <path d="M3.3 7L12 12l8.7-5M12 12v9" />
+        </svg>
+      );
+  }
+}
+
+function RenewalRow({ r, onOpen }: RowProps) {
+  const navigable = VALID_REPOS.has(r.repo);
+  const urgency: Urgency = urgencyOf(r.diffDays);
+  const label = expiryLabel(r.diffDays);
+  const typeLabel = TYPE_LABEL[r.type];
+
+  // All user/repo strings render as JSX text nodes (React auto-escapes) —
+  // no dangerouslySetInnerHTML anywhere, so no XSS surface.
+  const content = (
+    <>
+      <span
+        className={`v4-renewal-icon v4-renewal-icon--${urgency}`}
+        title={typeLabel}
+      >
+        <TypeIcon type={r.type} />
+      </span>
+      <span className="v4-promise-main">
+        <span className="v4-promise-text">
+          <span className="v4-renewal-type">{typeLabel}</span>
+          {" · "}
+          {r.name}
+        </span>
+        <span className="v4-promise-meta">
+          <span className="v4-promise-repo v4-mono">{r.repo}</span>
+          <span className="v4-renewal-client">{r.client}</span>
+          <span className={`v4-promise-due v4-renewal-due--${urgency}`}>
+            {label}
+          </span>
+        </span>
+      </span>
+      {navigable && (
+        <span className="v4-ai-row-arrow" aria-hidden>
+          ↗
+        </span>
+      )}
+    </>
+  );
+
+  if (!navigable) {
+    return (
+      <div className="v4-ai-row v4-promise-row v4-renewals-row">
+        {content}
+      </div>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className="v4-ai-row v4-promise-row v4-renewals-row"
+      onClick={() => onOpen(r.repo)}
+      title={`Открыть ${r.repo} → Decisions & Risks`}
+    >
+      {content}
+    </button>
+  );
+}
+
+/** Loading placeholder while the 12-repo fan-out is in flight. */
+function RenewalsSkeleton() {
+  return (
+    <>
+      {[0, 1, 2, 3, 4].map((i) => (
+        <div className="v4-ai-row v4-ai-skel" key={i}>
+          <span className="v4-ai-skel-sev" />
+          <span className="v4-ai-row-main">
+            <span className="v4-ai-skel-line v4-ai-skel-line--ttl" />
+            <span className="v4-ai-skel-line v4-ai-skel-line--ds" />
+          </span>
+          <span className="v4-ai-skel-meta" />
+        </div>
+      ))}
+    </>
+  );
+}

--- a/src/hooks/usePortfolioRenewals.ts
+++ b/src/hooks/usePortfolioRenewals.ts
@@ -1,0 +1,251 @@
+/**
+ * usePortfolioRenewals — cross-project renewals fetch + cache layer for
+ * the portfolio Renewals widget (Epic-010 Task-04, #346).
+ *
+ * Epic-011 Task-04 (#353) shipped the pure `scanRenewals(repo, yaml,
+ * packageJson) → Renewal[]` merge layer plus the `github-contents` REST
+ * wrapper, but no cross-repo hook. So this hook does the portfolio-wide
+ * collection itself, exactly as the issue body describes — a `Promise.all`
+ * fan-out over `PROJECTS` (config-driven, not a hardcoded repo list),
+ * reading each repo's `docs/renewals.yaml` + `package.json` via
+ * `readYaml` / `readMarkdown` and merging through `scanRenewals`.
+ *
+ * Failure model: per-repo `Promise.allSettled` + inner try/catch. One repo
+ * 500ing / missing files / corrupt yaml degrades to "no renewals for that
+ * repo", never a widget-wide crash. github-contents maps a missing file to
+ * `null`, so the empty-state path is the common case for repos that
+ * haven't adopted `docs/renewals.yaml` yet. A corrupt yaml DOES throw in
+ * `readYaml`; we catch it per-repo and fall back to a `package.json`-only
+ * scan rather than dropping the whole repo.
+ *
+ * Cache: sessionStorage `makeit_portfolio_renewals`, 1-hour TTL (renewals
+ * are slow-moving data — SSL/domain/contract dates change on the order of
+ * months; re-opening the surface inside the window does zero network I/O).
+ * sessionStorage can be disabled (Safari private mode) or quota-full —
+ * every access is guarded so the widget still works fetch-only then.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { PROJECTS } from "../utils/config";
+import { readMarkdown, readYaml } from "../utils/github-contents";
+import { scanRenewals } from "../utils/renewalsScanner";
+import type { Renewal } from "../types/hub";
+
+/** sessionStorage key for the cached cross-repo snapshot. */
+export const PORTFOLIO_RENEWALS_CACHE_KEY = "makeit_portfolio_renewals";
+
+/**
+ * Cache freshness window — 1 hour. Renewals are slow-moving (expiry dates
+ * shift on the order of months, deprecated deps change per release), so a
+ * generous TTL keeps the surface instant on re-open without going stale.
+ */
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** Repo-relative paths the scanner's two inputs live at. */
+const RENEWALS_YAML_PATH = "docs/renewals.yaml";
+const PACKAGE_JSON_PATH = "package.json";
+
+/**
+ * One renewal plus the repo + client it came from. The widget needs
+ * `repo` for navigation and `client` for the display row; `Renewal`
+ * itself carries neither.
+ */
+export interface PortfolioRenewal {
+  repo: string;
+  /** Display name of the owning client (from the project config). */
+  client: string;
+  type: Renewal["type"];
+  name: string;
+  /** ISO-8601 expiry date as captured, or `null` when undated. */
+  expires_at: string | null;
+  notes: string;
+  source: Renewal["source"];
+}
+
+/** Envelope persisted in sessionStorage. */
+interface CacheEnvelope {
+  savedAt: number;
+  items: PortfolioRenewal[];
+}
+
+export interface UsePortfolioRenewalsState {
+  /** All renewals across the portfolio (unsorted; the widget sorts). */
+  items: PortfolioRenewal[];
+  /** True while the cross-repo fan-out is in flight (cold load only). */
+  loading: boolean;
+  /** User-facing error, or null. Set only when the whole fan-out threw. */
+  error: string | null;
+  /** True when the initial render was served from a fresh cache. */
+  fromCache: boolean;
+  /** Drop the cache and re-fetch all repos. */
+  refresh: () => void;
+}
+
+/** Read a non-expired cached snapshot, or null. Never throws. */
+function readCache(): PortfolioRenewal[] | null {
+  if (typeof sessionStorage === "undefined") return null;
+  let raw: string | null;
+  try {
+    raw = sessionStorage.getItem(PORTFOLIO_RENEWALS_CACHE_KEY);
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+  try {
+    const env = JSON.parse(raw) as CacheEnvelope;
+    if (
+      env === null ||
+      typeof env !== "object" ||
+      typeof env.savedAt !== "number" ||
+      !Array.isArray(env.items)
+    ) {
+      return null;
+    }
+    if (Date.now() - env.savedAt > CACHE_TTL_MS) return null;
+    return env.items;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist a snapshot. Best-effort — disabled storage / quota is non-fatal. */
+function writeCache(items: PortfolioRenewal[]): void {
+  if (typeof sessionStorage === "undefined") return;
+  try {
+    const env: CacheEnvelope = { savedAt: Date.now(), items };
+    sessionStorage.setItem(
+      PORTFOLIO_RENEWALS_CACHE_KEY,
+      JSON.stringify(env),
+    );
+  } catch {
+    // QuotaExceededError / SecurityError (private mode): skip caching.
+  }
+}
+
+/** Clear the cached snapshot so the next load goes to the network. */
+function clearCache(): void {
+  if (typeof sessionStorage === "undefined") return;
+  try {
+    sessionStorage.removeItem(PORTFOLIO_RENEWALS_CACHE_KEY);
+  } catch {
+    // ignore — a disabled store has nothing to clear
+  }
+}
+
+/**
+ * Collect renewals for a single repo. Resolves to `[]` on any failure
+ * (auth, network, parse) so one bad repo can't reject the portfolio-wide
+ * `Promise.allSettled`.
+ *
+ * `readYaml` THROWS on a corrupt yaml (the Hub surfaces that as an error);
+ * here we don't want one malformed file to blank a portfolio row, so we
+ * catch it and still run the `package.json` auto-scan. `readMarkdown`
+ * already returns `null` for a missing/oversized manifest.
+ */
+async function collectRepo(
+  repo: string,
+  client: string,
+): Promise<PortfolioRenewal[]> {
+  try {
+    const [yamlRes, pkgRes] = await Promise.all([
+      readYaml<unknown>(repo, RENEWALS_YAML_PATH).catch(() => null),
+      readMarkdown(repo, PACKAGE_JSON_PATH).catch(() => null),
+    ]);
+    const merged = scanRenewals(
+      repo,
+      yamlRes?.data ?? null,
+      pkgRes?.content ?? null,
+    );
+    return merged.map((r) => ({
+      repo,
+      client,
+      type: r.type,
+      name: r.name,
+      expires_at: r.expires_at,
+      notes: r.notes,
+      source: r.source,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Fan out across every configured project. `allSettled` so a single
+ * rejecting repo (shouldn't happen — `collectRepo` swallows) still yields
+ * the rest. Returns the flattened renewal list.
+ */
+async function collectAll(): Promise<PortfolioRenewal[]> {
+  const results = await Promise.allSettled(
+    PROJECTS.map((p) => collectRepo(p.repo, p.client)),
+  );
+  const out: PortfolioRenewal[] = [];
+  for (const r of results) {
+    if (r.status === "fulfilled") out.push(...r.value);
+  }
+  return out;
+}
+
+export function usePortfolioRenewals(): UsePortfolioRenewalsState {
+  // Read sessionStorage once (lazy initializer) — not on every render.
+  // The result only seeds the initial state + mount effect.
+  const [cached] = useState(readCache);
+
+  const [items, setItems] = useState<PortfolioRenewal[]>(
+    () => cached ?? [],
+  );
+  const [loading, setLoading] = useState<boolean>(cached === null);
+  const [error, setError] = useState<string | null>(null);
+  const [fromCache] = useState<boolean>(cached !== null);
+
+  // Guard a late state-set after unmount and a double-fire (Strict Mode
+  // double-invoke / rapid refresh clicks).
+  const mountedRef = useRef(true);
+  const inFlightRef = useRef(false);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const load = useCallback((skipCache: boolean) => {
+    if (inFlightRef.current) return;
+    if (skipCache) clearCache();
+    inFlightRef.current = true;
+    setLoading(true);
+    setError(null);
+
+    void (async () => {
+      try {
+        const collected = await collectAll();
+        if (!mountedRef.current) return;
+        setItems(collected);
+        writeCache(collected);
+      } catch (e) {
+        if (!mountedRef.current) return;
+        setError(
+          e instanceof Error
+            ? e.message
+            : "Не удалось загрузить обновления по портфелю.",
+        );
+      } finally {
+        if (mountedRef.current) setLoading(false);
+        inFlightRef.current = false;
+      }
+    })();
+  }, []);
+
+  // Cold load only — a fresh cache satisfies the first render with zero
+  // network I/O (the issue's "re-open within 1h → no requests" rule).
+  useEffect(() => {
+    if (cached === null) load(false);
+    // `cached` is read once at mount; `load` is stable. Intentionally a
+    // mount-only effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const refresh = useCallback(() => load(true), [load]);
+
+  return { items, loading, error, fromCache, refresh };
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -1379,6 +1379,51 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 .v4-promise-due--due-week { color: var(--v4-warn-700); }
 
 /* ────────────────────────────────────────
+   PORTFOLIO RENEWALS (Epic-010 Task-04)
+   Reuses .v4-promise-* row scaffold; adds a type-icon chip whose colour
+   encodes urgency. Colour is NEVER the only signal — every row also
+   carries an explicit «через Nд» text label (WCAG 1.4.1).
+   Theme-aware via --v4-* tokens (auto dark/light).
+   ──────────────────────────────────────── */
+/* The shared .v4-promise-row grid is 8px 1fr 14px (sized for an 8px
+   dot); a renewal row leads with a 22px type-icon chip, so widen the
+   first track. .v4-renewals-row is applied alongside .v4-promise-row. */
+.v4-renewals-row {
+  grid-template-columns: 22px 1fr 14px;
+}
+.v4-renewal-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+}
+.v4-renewal-icon--red {
+  color: var(--v4-danger-700);
+  background: var(--v4-danger-50);
+}
+.v4-renewal-icon--yellow {
+  color: var(--v4-warn-700);
+  background: var(--v4-warn-50);
+}
+.v4-renewal-icon--gray {
+  color: var(--v4-ink-500);
+  background: var(--v4-line-soft);
+}
+.v4-renewal-type {
+  font-weight: 600;
+  color: var(--v4-ink-500);
+}
+.v4-renewal-client {
+  font-size: 11px;
+  color: var(--v4-ink-400);
+}
+.v4-renewal-due--red { color: var(--v4-danger-700); }
+.v4-renewal-due--yellow { color: var(--v4-warn-700); }
+.v4-renewal-due--gray { color: var(--v4-ink-500); }
+
+/* ────────────────────────────────────────
    LISTS: blocked + deadlines
    ──────────────────────────────────────── */
 .v4-list { padding: 6px 0; }


### PR DESCRIPTION
Closes #346

## Что сделано
Cross-project агрегатор предстоящих обновлений/истечений (SSL, домены, контракты, лицензии + deprecated deps).

- **`src/hooks/usePortfolioRenewals.ts`** — новый хук. `Promise.allSettled` fan-out по списку `PROJECTS` (из config, без хардкода репо), читает `docs/renewals.yaml` + `package.json` каждого репо через `github-contents`, мержит через существующий `scanRenewals` (Epic-011 Task-04, без дублирования логики). Кэш — sessionStorage `makeit_portfolio_renewals`, TTL 1 час (renewals — медленно меняющиеся данные). Per-repo try/catch + outer guard: один битый репо / corrupt yaml / 404 не роняет виджет.
- **`src/components/v4/portfolio/PortfolioRenewals.tsx`** — новый компонент. Сортировка по `expires_at` asc, top-5; rows без даты (auto-scan deps) уходят вниз. Urgency-цвет: red (≤7д) / yellow (≤30д) / gray (>30д). **Цвет не единственный носитель смысла** — каждая строка несёт явный текст «через Nд» / «истекает сегодня» / «истекло N дней назад» / «без срока» (WCAG 1.4.1). Иконка типа (SSL/домен/контракт/лицензия/зависимость) + текстовый лейбл. Клик по строке → `?tab=projects&repo=X&subtab=decisions#renewals` (`onOpenProject` если передан, иначе self-contained pushState + popstate, как в `PortfolioPromiseTracker`). `repo` валидируется против списка проектов перед попаданием в URL. Empty state «Ближайших обновлений нет».
- **`src/styles/v4.css`** — аддитивные классы `.v4-renewal-*` / `.v4-renewals-row` (переиспользуют scaffold `.v4-promise-row`, расширяют первую колонку под 22px icon-chip). Ни одно существующее правило не изменено. Theme-aware через `--v4-*` токены.

Виджет пока не смонтирован в surface — сборка Portfolio Surface это Epic-010 Task-06 (#348), как и у sibling-виджетов `PortfolioNextActions` / `PortfolioPromiseTracker`.

## Тесты
В проекте нет тест-раннера (нет `test` script, ни vitest/jest; sibling-виджеты тестов не имеют) — следую установленной конвенции. Верификация:
- `npx tsc --noEmit` — exit 0, чисто
- `npm run lint` (eslint .) — чисто
- `npm run build` — exit 0 (warning о размере чанка — pre-existing, не связан с этим изменением)

Acceptance criteria из #346 проверены вручную по коду: top-5 asc ✓; цвет red/yellow/gray + текст «in Nд» ✓; иконка типа ✓; клик → `#renewals` ✓; empty state ✓.

## Self-check / Senior review
- Self-check (13 пунктов): пройден — нет секретов/хардкода URL, нет ненумерованных TODO/FIXME, нет закомментированного кода, нет debug-логов, SQL N/A, error-handling на всех external-вызовах (per-repo catch + `Promise.allSettled` + try/catch в `load`).
- Senior review (независимый проход по diff): **P1 = 0**. Проверены secrets leak, unhandled exceptions, race на sessionStorage-кэше (guard через `inFlightRef`/`mountedRef`, паттерн зеркалит проверенный `usePortfolioPromises`), data loss (виджет read-only), backward compat (2 новых файла + аддитивный CSS, regression-поверхность нулевая). Deferred P2: нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)