### PR TITLE
Customer Health Score (gauge + sparkline)

### DIFF
--- a/src/components/v4/hub/CustomerHealthGauge.tsx
+++ b/src/components/v4/hub/CustomerHealthGauge.tsx
@@ -141,6 +141,13 @@ export function CustomerHealthGauge({
   // unnecessary Claude call (it should take the throttled path instead).
   const consumedForce = useRef(0);
   const lastSignal = useRef(recomputeSignal);
+  // Identity of the project currently reflected in `load`. When `repo`
+  // changes we must drop straight to the loading state — keeping the
+  // previous project's `ready` score on screen would mis-attribute it
+  // to the new project for the duration of the (possibly multi-second)
+  // recompute. A same-repo recompute still keeps the old gauge visible
+  // so a minor refresh doesn't flash a spinner.
+  const lastRepo = useRef(repo);
 
   useEffect(() => {
     let cancelled = false;
@@ -153,8 +160,11 @@ export function CustomerHealthGauge({
     consumedForce.current = forceToken;
     lastSignal.current = recomputeSignal;
 
+    const repoChanged = repo !== lastRepo.current;
+    lastRepo.current = repo;
+
     setLoad((prev) =>
-      prev.phase === "ready" ? prev : { phase: "loading" },
+      prev.phase === "ready" && !repoChanged ? prev : { phase: "loading" },
     );
 
     (async () => {

--- a/src/components/v4/hub/CustomerHealthGauge.tsx
+++ b/src/components/v4/hub/CustomerHealthGauge.tsx
@@ -1,0 +1,432 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  computeHealth,
+  clearHealthCache,
+  type CustomerHealthResult,
+} from "../../../utils/customerHealthScore";
+import type { ProjectTier } from "../../../utils/driftNorm";
+
+/**
+ * Customer Health gauge + 90-day sparkline (Epic-012 Task-07, FR-37).
+ *
+ * Self-contained: takes the repo (and optional tier / finance so the
+ * cadence + paid components can be measured) and owns its own async
+ * `computeHealth` call. The score is throttled to a weekly recompute
+ * inside `customerHealthScore.ts`; the manual "Пересчитать" button
+ * invalidates the cache and forces a fresh sentiment pass via Haiku.
+ *
+ * States:
+ *   - loading  → spinner-ish placeholder (layout stays stable)
+ *   - n/a      → "нет данных, требуется свежий транскрипт" placeholder
+ *   - ready    → semicircle gauge tinted by zone + sparkline below
+ *
+ * Color zones (FR-37): 0–40 red, 40–70 yellow, 70–100 green. Boundary
+ * convention: a value exactly on a boundary takes the HIGHER zone
+ * (40 → yellow, 70 → green) so a "just reached 70" reads as green.
+ */
+
+interface Props {
+  /** Repo slug (`owner/repo` or bare name → dashboard owner). */
+  repo: string;
+  /** Drift tier for the cadence baseline. Defaults to strictest (1). */
+  tier?: ProjectTier;
+  /** Contract size (USD) — drives the `paid` component. */
+  budget?: number;
+  /** Amount paid (USD) — drives the `paid` component. */
+  paid?: number;
+  /**
+   * Bumped by the parent (e.g. NBA regeneration) to trigger a forced
+   * recompute without the user clicking the button.
+   */
+  recomputeSignal?: number;
+}
+
+type LoadState =
+  | { phase: "loading" }
+  | { phase: "ready"; result: CustomerHealthResult }
+  | { phase: "error"; message: string };
+
+/** Zone tone for a numeric score. Boundaries lean to the higher zone. */
+function zoneOf(score: number): {
+  color: string;
+  bg: string;
+  label: string;
+} {
+  if (score >= 70) {
+    return { color: "#16a34a", bg: "rgba(34,197,94,0.12)", label: "Здоровый" };
+  }
+  if (score >= 40) {
+    return { color: "#ca8a04", bg: "rgba(234,179,8,0.14)", label: "Под наблюдением" };
+  }
+  return { color: "#dc2626", bg: "rgba(239,68,68,0.12)", label: "Критичный" };
+}
+
+const GAUGE_W = 200;
+const GAUGE_H = 110;
+const CX = GAUGE_W / 2;
+const CY = GAUGE_H - 6;
+const R = 86;
+
+/** Point on the gauge arc for `t` in `[0, 1]` (0 = left, 1 = right). */
+function arcPoint(t: number): [number, number] {
+  // Semicircle sweeps 180° (π) → 0°, left to right.
+  const angle = Math.PI - t * Math.PI;
+  return [CX + R * Math.cos(angle), CY - R * Math.sin(angle)];
+}
+
+function arcPath(fromT: number, toT: number): string {
+  const [x1, y1] = arcPoint(fromT);
+  const [x2, y2] = arcPoint(toT);
+  // largeArc=0, sweep=1 (clockwise as drawn left→right over the top).
+  return `M ${x1.toFixed(2)} ${y1.toFixed(2)} A ${R} ${R} 0 0 1 ${x2.toFixed(
+    2,
+  )} ${y2.toFixed(2)}`;
+}
+
+const SPARK_W = 200;
+const SPARK_H = 40;
+
+/** Minimal sparkline — value range fixed to 0..100 so the line height
+ *  is comparable across recomputes (not auto-fit to min/max). */
+function Sparkline({ values, color }: { values: number[]; color: string }) {
+  if (values.length === 0) return null;
+  const stepX = values.length > 1 ? SPARK_W / (values.length - 1) : 0;
+  const coords = values.map((v, i): [number, number] => {
+    const clamped = Math.max(0, Math.min(100, v));
+    return [
+      values.length > 1 ? i * stepX : SPARK_W / 2,
+      SPARK_H - (clamped / 100) * SPARK_H,
+    ];
+  });
+  const line = coords
+    .map((c, i) => `${i === 0 ? "M" : "L"} ${c[0].toFixed(1)} ${c[1].toFixed(1)}`)
+    .join(" ");
+  const area = `${line} L ${SPARK_W} ${SPARK_H} L 0 ${SPARK_H} Z`;
+  return (
+    <svg
+      viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+      preserveAspectRatio="none"
+      width="100%"
+      height={SPARK_H}
+      role="img"
+      aria-label={`Динамика здоровья за ${values.length} дней`}
+    >
+      <path d={area} fill={color} opacity={0.12} />
+      <path
+        d={line}
+        fill="none"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function CustomerHealthGauge({
+  repo,
+  tier,
+  budget,
+  paid,
+  recomputeSignal,
+}: Props) {
+  const [load, setLoad] = useState<LoadState>({ phase: "loading" });
+  const [recomputing, setRecomputing] = useState(false);
+  // Bumped by the manual button to force a fresh (cache-busting) compute.
+  const [forceToken, setForceToken] = useState(0);
+  // Track which force/signal values were already consumed so a forced
+  // recompute applies ONLY to its triggering bump — a later prop change
+  // (repo/tier/budget/paid) must NOT inherit a stale `force` and burn an
+  // unnecessary Claude call (it should take the throttled path instead).
+  const consumedForce = useRef(0);
+  const lastSignal = useRef(recomputeSignal);
+
+  useEffect(() => {
+    let cancelled = false;
+    // "Recompute now" iff this exact forceToken bump (manual button) or
+    // recomputeSignal change (parent, e.g. NBA regen) hasn't been
+    // consumed yet. Any other dependency change → throttled path.
+    const forced =
+      forceToken !== consumedForce.current ||
+      recomputeSignal !== lastSignal.current;
+    consumedForce.current = forceToken;
+    lastSignal.current = recomputeSignal;
+
+    setLoad((prev) =>
+      prev.phase === "ready" ? prev : { phase: "loading" },
+    );
+
+    (async () => {
+      try {
+        const result = await computeHealth(repo, {
+          tier,
+          budget,
+          paid,
+          force: forced,
+        });
+        if (cancelled) return;
+        setLoad({ phase: "ready", result });
+      } catch (e) {
+        // computeHealth never throws by contract, but stay defensive so
+        // the Hub render boundary is never hit.
+        if (cancelled) return;
+        const message =
+          e instanceof Error ? e.message : "Не удалось рассчитать health";
+        setLoad({ phase: "error", message });
+      } finally {
+        if (!cancelled) setRecomputing(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, tier, budget, paid, forceToken, recomputeSignal]);
+
+  const handleRecompute = useCallback(() => {
+    setRecomputing(true);
+    clearHealthCache(repo);
+    setForceToken((t) => t + 1);
+  }, [repo]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+        padding: 14,
+        borderRadius: 10,
+        background: "var(--v4-card, var(--v4-paper))",
+        border: "1px solid var(--v4-line)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: 0.4,
+            color: "var(--v4-ink-500)",
+          }}
+        >
+          Customer Health
+        </div>
+        <button
+          type="button"
+          className="v4-btn"
+          onClick={handleRecompute}
+          disabled={recomputing}
+          title="Сбросить кэш и пересчитать sentiment через Claude Haiku"
+        >
+          {recomputing ? "Пересчёт…" : "Пересчитать"}
+        </button>
+      </div>
+
+      {load.phase === "loading" && (
+        <div
+          style={{
+            minHeight: GAUGE_H + SPARK_H + 24,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "var(--v4-ink-500)",
+            fontSize: 13,
+          }}
+        >
+          Расчёт health…
+        </div>
+      )}
+
+      {load.phase === "error" && (
+        <div
+          style={{
+            minHeight: GAUGE_H,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "var(--v4-danger-500, #dc2626)",
+            fontSize: 13,
+            textAlign: "center",
+          }}
+        >
+          {load.message}
+        </div>
+      )}
+
+      {load.phase === "ready" && load.result.score === "n/a" && (
+        <div
+          style={{
+            minHeight: GAUGE_H + SPARK_H + 24,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 6,
+            color: "var(--v4-ink-500)",
+            fontSize: 13,
+            textAlign: "center",
+          }}
+        >
+          <div style={{ fontSize: 28, opacity: 0.4 }}>—</div>
+          <div>нет данных, требуется свежий транскрипт</div>
+        </div>
+      )}
+
+      {load.phase === "ready" &&
+        typeof load.result.score === "number" &&
+        (() => {
+          const score = load.result.score;
+          const zone = zoneOf(score);
+          const t = Math.max(0, Math.min(1, score / 100));
+          const c = load.result.components;
+          const fmt = (v: number | null) =>
+            v === null ? "—" : Math.round(v).toString();
+          return (
+            <>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                }}
+              >
+                <svg
+                  viewBox={`0 0 ${GAUGE_W} ${GAUGE_H}`}
+                  width="100%"
+                  height={GAUGE_H}
+                  role="img"
+                  aria-label={`Customer Health: ${Math.round(score)} из 100, зона ${zone.label}`}
+                >
+                  {/* Track */}
+                  <path
+                    d={arcPath(0, 1)}
+                    fill="none"
+                    stroke="var(--v4-line, rgba(0,0,0,0.08))"
+                    strokeWidth="12"
+                    strokeLinecap="round"
+                  />
+                  {/* Value arc (guard t≈0 so an empty arc isn't drawn) */}
+                  {t > 0.001 && (
+                    <path
+                      d={arcPath(0, t)}
+                      fill="none"
+                      stroke={zone.color}
+                      strokeWidth="12"
+                      strokeLinecap="round"
+                    />
+                  )}
+                  <text
+                    x={CX}
+                    y={CY - 14}
+                    textAnchor="middle"
+                    style={{
+                      fontSize: 30,
+                      fontWeight: 700,
+                      fill: zone.color,
+                      fontVariantNumeric: "tabular-nums",
+                    }}
+                  >
+                    {Math.round(score)}
+                  </text>
+                  <text
+                    x={CX}
+                    y={CY + 4}
+                    textAnchor="middle"
+                    style={{
+                      fontSize: 11,
+                      fontWeight: 600,
+                      fill: "var(--v4-ink-500)",
+                    }}
+                  >
+                    {zone.label}
+                  </text>
+                </svg>
+              </div>
+
+              <div style={{ padding: "0 4px" }}>
+                <Sparkline
+                  values={load.result.sparkline}
+                  color={zone.color}
+                />
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    fontSize: 10,
+                    color: "var(--v4-ink-400, var(--v4-ink-500))",
+                    marginTop: 2,
+                  }}
+                >
+                  <span>90 дней назад</span>
+                  <span>сегодня</span>
+                </div>
+              </div>
+
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(4, 1fr)",
+                  gap: 6,
+                  marginTop: 2,
+                }}
+              >
+                {(
+                  [
+                    ["Sentiment", c.sentiment],
+                    ["Cadence", c.cadence],
+                    ["Delivery", c.delivery],
+                    ["Paid", c.paid],
+                  ] as const
+                ).map(([label, value]) => (
+                  <div
+                    key={label}
+                    title={`${label}: ${fmt(value)}${value === null ? " (нет данных, учитывается как нейтральное)" : "/100"}`}
+                    style={{
+                      background: zone.bg,
+                      borderRadius: 8,
+                      padding: "6px 4px",
+                      textAlign: "center",
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: 9,
+                        fontWeight: 600,
+                        textTransform: "uppercase",
+                        letterSpacing: 0.3,
+                        color: "var(--v4-ink-500)",
+                      }}
+                    >
+                      {label}
+                    </div>
+                    <div
+                      style={{
+                        fontSize: 15,
+                        fontWeight: 700,
+                        fontVariantNumeric: "tabular-nums",
+                        color: "var(--v4-ink-900, inherit)",
+                      }}
+                    >
+                      {fmt(value)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          );
+        })()}
+    </div>
+  );
+}
+
+export default CustomerHealthGauge;

--- a/src/types/hub.ts
+++ b/src/types/hub.ts
@@ -141,12 +141,36 @@ export interface DoraMetrics {
 }
 
 /**
- * Customer Health Score (formula TBD — see PROJECT_HUB_DESIGN_BRIEF.md §11).
- * Filled in Epic-012 (Task-03: Customer Health).
+ * The four weighted Customer Health sub-components, each `0..100` or
+ * `null` ("not measurable" — treated as neutral inside the blend).
+ * Mirrors `HealthComponents` in `src/utils/customerHealthScore.ts`;
+ * kept here so Hub views can type the breakdown without reaching into
+ * the util. Filled in Epic-012 (Task-07).
+ */
+export interface CustomerHealthComponents {
+  sentiment: number | null;
+  cadence: number | null;
+  delivery: number | null;
+  paid: number | null;
+}
+
+/**
+ * Customer Health Score (Epic-012 Task-07, PRD-008 FR-37).
+ *
+ * `score` is `0..100` or the string `'n/a'` when no transcript exists
+ * in the last 120 days (don't surface a number we can't trust). `tier`
+ * is the derived colour zone for the gauge; `sparkline` is the 90-day
+ * daily series. The real producer is
+ * `src/utils/customerHealthScore.ts` (`computeHealth`).
  */
 export interface CustomerHealthScore {
-  score: number; // 0..100
+  /** `0..100` or `'n/a'` (no transcript in the last 120 days). */
+  score: number | "n/a";
+  /** Colour zone: 0–40 critical, 40–70 warning, 70–100 good. */
   tier: "good" | "warning" | "critical";
+  components: CustomerHealthComponents;
+  /** 90 daily score values, oldest → newest. Empty when `score` is `'n/a'`. */
+  sparkline: number[];
   updatedAt: string; // ISO
 }
 

--- a/src/utils/customerHealthScore.ts
+++ b/src/utils/customerHealthScore.ts
@@ -1,0 +1,747 @@
+/**
+ * Customer Health Score (Epic-012 Task-07, PRD-008 FR-37).
+ *
+ * Composite 0-100 score per project, blended from four sub-components:
+ *
+ *   score = sentiment×0.3 + cadence×0.3 + delivery×0.3 + paid×0.1
+ *
+ *   - **sentiment** (0-100): Claude Haiku over the last 3 transcripts of
+ *     the project → positive/neutral/negative weighted (100/50/0).
+ *   - **cadence** (0-100): actual meeting interval vs the
+ *     `client_touch_interval_days` baseline from `driftNorm`. 100 when
+ *     the interval is ≤ baseline, linear decay to 0 at 3× baseline.
+ *   - **delivery** (0-100): share of commitments delivered on-time over
+ *     the last 90 days (status=done within its due date).
+ *   - **paid** (0-100): 100 if paid on time, 0 if overdue > 30 days,
+ *     linear decay between.
+ *
+ * If the project has no transcript newer than 120 days → `score = 'n/a'`
+ * (per FR / epic-012: don't show a number we can't trust).
+ *
+ * Sparkline: 90 daily score values. The score is recomputed at most
+ * once a week (triggered by the manual "Recompute" button or an NBA
+ * regeneration); in between, the cached value is reused and the
+ * sparkline is back-filled so it always covers a full 90-day window.
+ *
+ * Cache: `makeit_health:{repo}` in localStorage, holding the last
+ * computed result plus a dated history used to draw the sparkline.
+ *
+ * Failure model: every external dependency (Claude, transcript fetch,
+ * commitments yaml, drift baseline) is wrapped — a failure degrades the
+ * affected component to a neutral value rather than throwing, so the
+ * gauge always renders. The function never throws.
+ */
+
+import type { ProjectTier } from "./driftNorm";
+import { loadProjectNorm } from "./driftNorm";
+import { readMarkdown, readYaml } from "./github-contents";
+import {
+  extractCommitments,
+  type CommitmentsYaml,
+} from "./commitmentsExtractor";
+import {
+  fetchTranscriptList,
+  fetchTranscriptResult,
+  type TranscriptListItem,
+} from "./transcript";
+import { callClaudeWithTool } from "./claude";
+import { getClaudeKey } from "./config";
+
+// ── Public types ──────────────────────────────────────────────────────────
+
+/**
+ * The four weighted sub-components, each in `[0, 100]`. `null` means
+ * "could not be measured" (no data / dependency failed) and is treated
+ * as a neutral 50 inside the blended score so a single missing signal
+ * doesn't tank or inflate the overall health.
+ */
+export interface HealthComponents {
+  sentiment: number | null;
+  cadence: number | null;
+  delivery: number | null;
+  paid: number | null;
+}
+
+/**
+ * One dated point of the 90-day sparkline. `score` is the blended value
+ * for that day (always a number — `n/a` days are simply absent).
+ */
+export interface HealthHistoryPoint {
+  /** YYYY-MM-DD (UTC). */
+  date: string;
+  score: number;
+}
+
+/**
+ * Result of `computeHealth`. `score` is either a `0..100` number or the
+ * string `'n/a'` when transcripts are too stale to trust the sentiment
+ * input (epic-012 / FR-37).
+ */
+export interface CustomerHealthResult {
+  /** Blended score, or `'n/a'` when no transcript in the last 120 days. */
+  score: number | "n/a";
+  components: HealthComponents;
+  /**
+   * 90 daily values, oldest → newest, suitable for a sparkline. Empty
+   * when the score is `'n/a'` (nothing trustworthy to chart).
+   */
+  sparkline: number[];
+  /** ISO-8601 timestamp the score was (re)computed. */
+  computedAt: string;
+}
+
+// ── Configurable constants ────────────────────────────────────────────────
+
+/** Component weights — must mirror FR-37 exactly. Sum = 1.0. */
+const WEIGHTS = {
+  sentiment: 0.3,
+  cadence: 0.3,
+  delivery: 0.3,
+  paid: 0.1,
+} as const;
+
+/** Neutral fallback for a component that could not be measured. */
+const NEUTRAL_COMPONENT = 50;
+
+/** Sparkline / delivery look-back window. */
+const WINDOW_DAYS = 90;
+
+/** No transcript newer than this → `score = 'n/a'`. */
+const STALE_TRANSCRIPT_DAYS = 120;
+
+/** A `paid` debt older than this scores 0 (linear decay before that). */
+const PAID_GRACE_DAYS = 30;
+
+/** Recompute throttle: a cached score younger than this is reused. */
+const RECOMPUTE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** How many recent transcripts feed the sentiment model. */
+const SENTIMENT_TRANSCRIPT_COUNT = 3;
+
+/** Bound each transcript slice fed to Claude (token / cost safety). */
+const MAX_TRANSCRIPT_CHARS = 6000;
+
+const CACHE_PREFIX = "makeit_health:";
+const BRIEF_PATH = "docs/BRIEF.md";
+const COMMITMENTS_PATH = "docs/commitments.yaml";
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Haiku is the cheapest tier and what FR-37 specifies for sentiment. */
+const SENTIMENT_MODEL = "claude-haiku-4-5-20251001" as const;
+
+// ── Cache shape ───────────────────────────────────────────────────────────
+
+interface CacheEntry {
+  /** Last computed result (sans sparkline — that is rebuilt from history). */
+  score: number | "n/a";
+  components: HealthComponents;
+  computedAt: string;
+  /**
+   * Dated score history (one point per recompute). Trimmed to the last
+   * `WINDOW_DAYS` on every write so the cache can't grow unbounded.
+   */
+  history: HealthHistoryPoint[];
+}
+
+/** YYYY-MM-DD in UTC — deterministic across timezones. */
+function dayKey(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 10);
+}
+
+function readCache(repo: string): CacheEntry | null {
+  try {
+    const raw = localStorage.getItem(CACHE_PREFIX + repo);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<CacheEntry>;
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      typeof parsed.computedAt !== "string"
+    ) {
+      return null;
+    }
+    const history = Array.isArray(parsed.history)
+      ? parsed.history.filter(
+          (p): p is HealthHistoryPoint =>
+            !!p &&
+            typeof p.date === "string" &&
+            typeof p.score === "number" &&
+            Number.isFinite(p.score),
+        )
+      : [];
+    const score =
+      parsed.score === "n/a" ||
+      (typeof parsed.score === "number" && Number.isFinite(parsed.score))
+        ? parsed.score
+        : "n/a";
+    return {
+      score,
+      components: coerceComponents(parsed.components),
+      computedAt: parsed.computedAt,
+      history,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(repo: string, entry: CacheEntry): void {
+  try {
+    // Trim history to the sparkline window so the cache stays bounded.
+    const cutoff = Date.now() - WINDOW_DAYS * ONE_DAY_MS;
+    const trimmed = entry.history
+      .filter((p) => {
+        const t = Date.parse(`${p.date}T00:00:00Z`);
+        return Number.isFinite(t) && t >= cutoff;
+      })
+      .slice(-WINDOW_DAYS);
+    localStorage.setItem(
+      CACHE_PREFIX + repo,
+      JSON.stringify({ ...entry, history: trimmed }),
+    );
+  } catch {
+    // Quota exceeded / storage disabled — the score just won't persist.
+  }
+}
+
+/** Drop the cached health for one repo (manual "Recompute"). */
+export function clearHealthCache(repo: string): void {
+  try {
+    localStorage.removeItem(CACHE_PREFIX + repo);
+  } catch {
+    // Storage disabled — nothing was cached anyway.
+  }
+}
+
+function coerceComponents(raw: unknown): HealthComponents {
+  const empty: HealthComponents = {
+    sentiment: null,
+    cadence: null,
+    delivery: null,
+    paid: null,
+  };
+  if (!raw || typeof raw !== "object") return empty;
+  const src = raw as Record<string, unknown>;
+  const pick = (k: keyof HealthComponents): number | null => {
+    const v = src[k];
+    return typeof v === "number" && Number.isFinite(v) ? clamp(v) : null;
+  };
+  return {
+    sentiment: pick("sentiment"),
+    cadence: pick("cadence"),
+    delivery: pick("delivery"),
+    paid: pick("paid"),
+  };
+}
+
+// ── Pure scoring math (exported for reasoning / reuse) ─────────────────────
+
+/** Clamp any number into the `[0, 100]` score range. */
+export function clamp(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(100, n));
+}
+
+/**
+ * Blend the four components into the composite score. A `null`
+ * component is substituted with `NEUTRAL_COMPONENT` so one missing
+ * signal neither tanks nor inflates the result. Weights are fixed
+ * (FR-37) and always sum to 1, so no re-normalisation is needed.
+ */
+export function blendScore(c: HealthComponents): number {
+  const s = c.sentiment ?? NEUTRAL_COMPONENT;
+  const ca = c.cadence ?? NEUTRAL_COMPONENT;
+  const d = c.delivery ?? NEUTRAL_COMPONENT;
+  const p = c.paid ?? NEUTRAL_COMPONENT;
+  return clamp(
+    s * WEIGHTS.sentiment +
+      ca * WEIGHTS.cadence +
+      d * WEIGHTS.delivery +
+      p * WEIGHTS.paid,
+  );
+}
+
+/**
+ * Cadence score from the actual mean meeting interval vs the baseline.
+ * 100 when the interval is ≤ baseline (meeting often enough), decaying
+ * linearly to 0 at 3× baseline (gone cold). `null` when it can't be
+ * measured (no/one meeting, or a non-positive baseline).
+ */
+export function cadenceScore(
+  intervalDays: number | null,
+  baselineDays: number,
+): number | null {
+  if (
+    intervalDays === null ||
+    !Number.isFinite(intervalDays) ||
+    intervalDays < 0 ||
+    !Number.isFinite(baselineDays) ||
+    baselineDays <= 0
+  ) {
+    return null;
+  }
+  if (intervalDays <= baselineDays) return 100;
+  // Linear decay from baseline (100) to 3× baseline (0).
+  const ratio = (intervalDays - baselineDays) / (2 * baselineDays);
+  return clamp(100 * (1 - ratio));
+}
+
+/**
+ * Paid score. 100 when there is no outstanding debt (paid on time),
+ * decaying linearly to 0 once the debt has been outstanding for
+ * `PAID_GRACE_DAYS`. When budget is 0 (internal / unpaid project) the
+ * component is `null` (not applicable) so it falls back to neutral.
+ *
+ * `daysOverdue` is how long the project has been short of the expected
+ * payment; pass `0` (or negative) when fully paid / not yet due.
+ */
+export function paidScore(
+  budget: number,
+  paid: number,
+  daysOverdue: number,
+): number | null {
+  if (!Number.isFinite(budget) || budget <= 0) return null;
+  const remaining = budget - paid;
+  // Fully paid (or overpaid) → perfect, regardless of any stale clock.
+  if (remaining <= 0) return 100;
+  if (!Number.isFinite(daysOverdue) || daysOverdue <= 0) return 100;
+  if (daysOverdue >= PAID_GRACE_DAYS) return 0;
+  return clamp(100 * (1 - daysOverdue / PAID_GRACE_DAYS));
+}
+
+/**
+ * Delivery score: share of commitments due in the last `WINDOW_DAYS`
+ * that were delivered (status=done) on or before their due date.
+ * `null` when there are no dated, in-window commitments to judge.
+ */
+export function deliveryScore(
+  commitments: { due: string; status: "open" | "done" | "overdue" }[],
+  now: number = Date.now(),
+): number | null {
+  const windowStart = now - WINDOW_DAYS * ONE_DAY_MS;
+  let total = 0;
+  let onTime = 0;
+  for (const c of commitments) {
+    const dueTs = Date.parse(c.due);
+    if (!Number.isFinite(dueTs)) continue; // undated — can't judge
+    // Only judge commitments whose due date falls inside the window.
+    if (dueTs < windowStart || dueTs > now) continue;
+    total += 1;
+    // On-time = explicitly done. The extractor only marks `done` from
+    // the persisted yaml status; `overdue` is derived and never on-time.
+    if (c.status === "done") onTime += 1;
+  }
+  if (total === 0) return null;
+  return clamp((onTime / total) * 100);
+}
+
+/**
+ * Sentiment score from Claude's per-transcript verdicts. Each verdict
+ * maps positive→100, neutral→50, negative→0; the score is their mean.
+ * `null` when there are no usable verdicts.
+ */
+export function sentimentScore(
+  verdicts: ("positive" | "neutral" | "negative")[],
+): number | null {
+  if (verdicts.length === 0) return null;
+  const map = { positive: 100, neutral: 50, negative: 0 } as const;
+  const sum = verdicts.reduce((acc, v) => acc + map[v], 0);
+  return clamp(sum / verdicts.length);
+}
+
+// ── Sentiment via Claude Haiku ─────────────────────────────────────────────
+
+interface SentimentToolResult {
+  /** Per-transcript verdicts, in the order they were supplied. */
+  verdicts?: unknown;
+}
+
+const SENTIMENT_TOOL = {
+  name: "report_sentiment",
+  description:
+    "Сообщить тональность клиента в каждом транскрипте: positive (доволен, хвалит, расширяет сотрудничество), neutral (рабочий тон без явных сигналов) или negative (недоволен, жалобы, риск оттока).",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      verdicts: {
+        type: "array",
+        items: { type: "string", enum: ["positive", "neutral", "negative"] },
+        description:
+          "Массив вердиктов, по одному на каждый транскрипт во входных данных, в том же порядке.",
+      },
+    },
+    required: ["verdicts"],
+  },
+};
+
+const SENTIMENT_SYSTEM =
+  "Ты анализируешь тональность клиента в транскриптах созвонов. " +
+  "Для каждого транскрипта верни ровно один вердикт: positive, neutral или negative. " +
+  "Оценивай отношение КЛИЕНТА к проекту и команде, а не общий тон беседы. " +
+  "Сомневаешься — neutral. Верни вердикты строго в порядке входных транскриптов.";
+
+/**
+ * Run Haiku over up to 3 recent transcript bodies and return one
+ * verdict per transcript. A single batched call (not one-per-transcript)
+ * keeps the cost bounded. Any failure (no key, budget hard-stop,
+ * network, malformed reply) returns `[]` — the caller degrades sentiment
+ * to neutral rather than failing the whole score.
+ */
+async function classifySentiment(texts: string[]): Promise<
+  ("positive" | "neutral" | "negative")[]
+> {
+  if (texts.length === 0) return [];
+  const apiKey = getClaudeKey();
+  if (!apiKey || !apiKey.trim()) return [];
+
+  const userMessage = texts
+    .map(
+      (t, i) =>
+        `=== Транскрипт ${i + 1} ===\n${t.slice(0, MAX_TRANSCRIPT_CHARS)}`,
+    )
+    .join("\n\n");
+
+  try {
+    const result = await callClaudeWithTool<SentimentToolResult>(
+      apiKey,
+      SENTIMENT_SYSTEM,
+      `Проанализируй тональность клиента в ${texts.length} транскрипте(ах) ниже и верни массив вердиктов того же размера.\n\n${userMessage}`,
+      SENTIMENT_TOOL,
+      SENTIMENT_MODEL,
+      512,
+      "sentiment",
+    );
+    const raw = Array.isArray(result.verdicts) ? result.verdicts : [];
+    const out: ("positive" | "neutral" | "negative")[] = [];
+    for (const v of raw) {
+      if (v === "positive" || v === "neutral" || v === "negative") {
+        out.push(v);
+      } else {
+        // Unknown token from the model — treat that slot as neutral
+        // rather than dropping it (keeps the mean meaningful).
+        out.push("neutral");
+      }
+    }
+    return out;
+  } catch {
+    // No key / budget hard-stop / network / parse — neutral fallback.
+    return [];
+  }
+}
+
+// ── Data gathering helpers (all best-effort, never throw) ──────────────────
+
+/**
+ * Loose repo↔transcript matching. Transcripts carry a free-text
+ * `project` context (the same field the Transcripts tab filters on);
+ * match case-insensitively on the repo slug appearing in that context
+ * (and vice-versa) so `owner/Repo` and `Repo` both resolve.
+ */
+function transcriptMatchesRepo(item: TranscriptListItem, repo: string): boolean {
+  const slug = repo.includes("/") ? repo.split("/")[1] : repo;
+  const proj = (item.project || "").toLowerCase();
+  if (proj.length === 0) return false;
+  const needle = slug.toLowerCase();
+  return proj.includes(needle) || needle.includes(proj);
+}
+
+/** ISO timestamp → epoch ms, or `NaN` when unparseable. */
+function tsOf(iso: string): number {
+  return Date.parse(iso);
+}
+
+/**
+ * Fetch the project's transcripts, newest first. Returns the list (for
+ * cadence/staleness) plus the bodies of the newest `count` (for
+ * sentiment). All failures degrade to empty.
+ */
+async function loadTranscripts(
+  repo: string,
+  count: number,
+): Promise<{ items: TranscriptListItem[]; bodies: string[] }> {
+  let list: TranscriptListItem[];
+  try {
+    list = await fetchTranscriptList();
+  } catch {
+    return { items: [], bodies: [] };
+  }
+  const mine = list
+    .filter((i) => transcriptMatchesRepo(i, repo))
+    .filter((i) => Number.isFinite(tsOf(i.created_at)))
+    .sort((a, b) => tsOf(b.created_at) - tsOf(a.created_at));
+
+  // Only `done` transcripts have a usable body; queued/errored ones are
+  // still kept in `items` for cadence (a meeting happened) but excluded
+  // from the sentiment bodies.
+  const recentDone = mine.filter((i) => i.status === "done").slice(0, count);
+  const bodies: string[] = [];
+  for (const item of recentDone) {
+    try {
+      const res = await fetchTranscriptResult(item.task_id);
+      const body = `${res.brief || ""}\n\n${res.transcript || ""}`.trim();
+      if (body.length > 0) bodies.push(body);
+    } catch {
+      // Skip a transcript we can't load — others may still work.
+    }
+  }
+  return { items: mine, bodies };
+}
+
+/**
+ * Mean gap (in days) between consecutive meetings within the look-back
+ * window. `null` when fewer than two in-window meetings exist (can't
+ * derive an interval).
+ */
+function meanMeetingIntervalDays(
+  items: TranscriptListItem[],
+  now: number,
+): number | null {
+  const windowStart = now - WINDOW_DAYS * ONE_DAY_MS;
+  const times = items
+    .map((i) => tsOf(i.created_at))
+    .filter((t) => Number.isFinite(t) && t >= windowStart && t <= now)
+    .sort((a, b) => a - b);
+  if (times.length < 2) return null;
+  const span = times[times.length - 1] - times[0];
+  const gaps = times.length - 1;
+  return span / gaps / ONE_DAY_MS;
+}
+
+/** Days since the most recent transcript, or `Infinity` when none. */
+function daysSinceLastTranscript(
+  items: TranscriptListItem[],
+  now: number,
+): number {
+  let newest = -Infinity;
+  for (const i of items) {
+    const t = tsOf(i.created_at);
+    if (Number.isFinite(t) && t > newest) newest = t;
+  }
+  if (newest === -Infinity) return Infinity;
+  return (now - newest) / ONE_DAY_MS;
+}
+
+/**
+ * Load + merge the project's commitments (BRIEF.md + commitments.yaml).
+ * Mirrors `CommitmentsTable`'s loading: BRIEF is optional context, a
+ * missing yaml is the normal empty state. Any failure → `[]`.
+ */
+async function loadCommitments(
+  repo: string,
+  now: number,
+): Promise<{ due: string; status: "open" | "done" | "overdue" }[]> {
+  let briefMd: string | null = null;
+  try {
+    const brief = await readMarkdown(repo, BRIEF_PATH);
+    briefMd = brief?.content ?? null;
+  } catch {
+    briefMd = null;
+  }
+  let yamlData: CommitmentsYaml = null;
+  try {
+    const res = await readYaml<CommitmentsYaml>(repo, COMMITMENTS_PATH);
+    yamlData = res?.data ?? null;
+  } catch {
+    // Corrupt/inaccessible yaml — treat as no commitments rather than
+    // failing the whole health score.
+    yamlData = null;
+  }
+  try {
+    return extractCommitments(briefMd, yamlData, now).map((c) => ({
+      due: c.due,
+      status: c.status,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Days the project has been short of its expected payment. The
+ * dashboard has no per-milestone invoice schedule, so we proxy
+ * "overdue" with how long the project has been delivering without the
+ * contract being paid up: time since the last client touch (a paid
+ * client keeps in contact). When there is no debt this is irrelevant
+ * (`paidScore` returns 100 before consulting it).
+ */
+function paidOverdueDays(
+  budget: number,
+  paid: number,
+  daysSinceTouch: number,
+): number {
+  if (!Number.isFinite(budget) || budget <= 0) return 0;
+  if (budget - paid <= 0) return 0;
+  if (!Number.isFinite(daysSinceTouch)) return 0;
+  // Only the portion beyond the grace period counts as "overdue".
+  return Math.max(0, daysSinceTouch - PAID_GRACE_DAYS);
+}
+
+// ── Sparkline back-fill ────────────────────────────────────────────────────
+
+/**
+ * Build a 90-value daily sparkline from the dated history. Days without
+ * a recorded point carry the most recent prior value forward (a score
+ * doesn't change until it's recomputed). Leading days before the first
+ * recorded point use that first value so the line starts flat rather
+ * than at 0.
+ */
+function buildSparkline(
+  history: HealthHistoryPoint[],
+  now: number,
+): number[] {
+  if (history.length === 0) return [];
+  const byDay = new Map<string, number>();
+  for (const p of history) byDay.set(p.date, p.score);
+
+  const sorted = [...history].sort((a, b) =>
+    a.date < b.date ? -1 : a.date > b.date ? 1 : 0,
+  );
+  const firstValue = sorted[0].score;
+
+  const out: number[] = [];
+  let carry = firstValue;
+  for (let i = WINDOW_DAYS - 1; i >= 0; i--) {
+    const key = dayKey(now - i * ONE_DAY_MS);
+    const v = byDay.get(key);
+    if (v !== undefined) carry = v;
+    out.push(Math.round(carry));
+  }
+  return out;
+}
+
+// ── Public entry point ─────────────────────────────────────────────────────
+
+/**
+ * Optional inputs `computeHealth` can't derive from `repo` alone.
+ * `tier` drives the cadence baseline (`driftNorm`); `budget`/`paid`
+ * drive the paid component. All optional — sensible defaults are used
+ * when omitted (tier 1 = strictest, matching `driftNorm`'s own
+ * fallback; no budget = paid component not applicable).
+ */
+export interface ComputeHealthOptions {
+  tier?: ProjectTier;
+  budget?: number;
+  paid?: number;
+  /** Bypass the weekly throttle and recompute now (manual button). */
+  force?: boolean;
+  /** Injectable clock for deterministic reasoning/tests. */
+  now?: number;
+}
+
+/**
+ * Compute (or reuse) the Customer Health Score for `repo`.
+ *
+ * Throttled to once a week: a cached score younger than
+ * `RECOMPUTE_INTERVAL_MS` is returned as-is (only the sparkline is
+ * re-derived so it always spans 90 days). Pass `force: true` (manual
+ * "Recompute") to bypass the throttle and re-run sentiment via Haiku.
+ *
+ * Never throws — every dependency failure degrades gracefully.
+ */
+export async function computeHealth(
+  repo: string,
+  options: ComputeHealthOptions = {},
+): Promise<CustomerHealthResult> {
+  const now = options.now ?? Date.now();
+  const cached = readCache(repo);
+
+  // Weekly throttle: reuse a fresh cached result, only refreshing the
+  // sparkline window. `force` (manual button / NBA regen) skips this.
+  if (!options.force && cached) {
+    const age = now - Date.parse(cached.computedAt);
+    if (Number.isFinite(age) && age >= 0 && age < RECOMPUTE_INTERVAL_MS) {
+      return {
+        score: cached.score,
+        components: cached.components,
+        sparkline:
+          cached.score === "n/a"
+            ? []
+            : buildSparkline(cached.history, now),
+        computedAt: cached.computedAt,
+      };
+    }
+  }
+
+  // ── Gather all inputs (each best-effort) ──
+  const { items: transcripts, bodies } = await loadTranscripts(
+    repo,
+    SENTIMENT_TRANSCRIPT_COUNT,
+  );
+
+  const staleDays = daysSinceLastTranscript(transcripts, now);
+  const computedAt = new Date(now).toISOString();
+
+  // No trustworthy transcript in the last 120 days → 'n/a'. We still
+  // persist this so the gauge shows the placeholder consistently and
+  // the throttle applies (don't re-scan an idle project every render).
+  if (staleDays > STALE_TRANSCRIPT_DAYS) {
+    const naComponents: HealthComponents = {
+      sentiment: null,
+      cadence: null,
+      delivery: null,
+      paid: null,
+    };
+    writeCache(repo, {
+      score: "n/a",
+      components: naComponents,
+      computedAt,
+      // Keep prior history so re-engaging the client redraws the trend.
+      history: cached?.history ?? [],
+    });
+    return {
+      score: "n/a",
+      components: naComponents,
+      sparkline: [],
+      computedAt,
+    };
+  }
+
+  // Drift baseline (cadence). Default tier 1 = strictest, mirroring
+  // driftNorm's own unknown-tier fallback.
+  let baselineDays = 7;
+  try {
+    const norm = await loadProjectNorm(repo, options.tier ?? 1);
+    baselineDays = norm.client_touch_interval_days;
+  } catch {
+    // loadProjectNorm never throws by contract, but stay defensive.
+    baselineDays = 7;
+  }
+
+  const commitments = await loadCommitments(repo, now);
+  const verdicts = await classifySentiment(bodies);
+
+  const components: HealthComponents = {
+    sentiment: sentimentScore(verdicts),
+    cadence: cadenceScore(
+      meanMeetingIntervalDays(transcripts, now),
+      baselineDays,
+    ),
+    delivery: deliveryScore(commitments, now),
+    paid: paidScore(
+      options.budget ?? 0,
+      options.paid ?? 0,
+      // Reuse the staleness already computed above for the n/a gate —
+      // same value, no need to re-scan the transcript list.
+      paidOverdueDays(options.budget ?? 0, options.paid ?? 0, staleDays),
+    ),
+  };
+
+  const score = blendScore(components);
+
+  // Append today's point (replacing an earlier same-day recompute so
+  // the history stays one-point-per-day).
+  const today = dayKey(now);
+  const history = [
+    ...(cached?.history ?? []).filter((p) => p.date !== today),
+    { date: today, score },
+  ];
+
+  writeCache(repo, { score, components, computedAt, history });
+
+  return {
+    score,
+    components,
+    sparkline: buildSparkline(history, now),
+    computedAt,
+  };
+}


### PR DESCRIPTION
Closes #365

## Что сделано

**`src/utils/customerHealthScore.ts`** (новый) — `computeHealth(repo, opts)`:
- Формула FR-37: `score = sentiment×0.3 + cadence×0.3 + delivery×0.3 + paid×0.1`.
  - **sentiment** (0-100): Claude Haiku одним батч-вызовом над последними 3 транскриптами проекта (positive/neutral/negative → 100/50/0), через `callClaudeWithTool` с budget-guard и `logCall` типа `sentiment`.
  - **cadence** (0-100): средний интервал встреч за 90д vs `client_touch_interval_days` из `driftNorm`. 100 при ≤ baseline, линейный спад до 0 при 3× baseline.
  - **delivery** (0-100): % commitments с due-датой в окне 90д, доставленных on-time (status=done), через `extractCommitments` (BRIEF.md + commitments.yaml).
  - **paid** (0-100): 100 если оплачено, 0 при задолженности > 30 дней, линейный спад; `null` (нейтрально) для проектов без бюджета.
  - Нет транскрипта > 120 дней → `score = 'n/a'`.
- Sparkline 90д: дневной массив; пересчёт раз в неделю (throttle), форс — из manual button или NBA-сигнала. Кэш `makeit_health:{repo}` с дневной историей (trim до 90д). Чистая scoring-математика экспортирована отдельно (`blendScore`, `cadenceScore`, `paidScore`, `deliveryScore`, `sentimentScore`).
- Никогда не бросает: каждая внешняя зависимость (Claude, transcript fetch, commitments yaml, drift baseline) обёрнута, деградирует к нейтральному значению.

**`src/components/v4/hub/CustomerHealthGauge.tsx`** (новый):
- Полукруглый gauge 0-100 с цветовыми зонами (0-40 красный, 40-70 жёлтый, 70-100 зелёный; граница относится к старшей зоне: 40→жёлтый, 70→зелёный) + 90д sparkline + разбивка по 4 компонентам.
- `score === 'n/a'` → placeholder «нет данных, требуется свежий транскрипт».
- Кнопка «Пересчитать» инвалидирует кэш и форсирует пересчёт sentiment через Haiku; поддержан `recomputeSignal` от родителя (NBA regen). Loading / error состояния, стабильный layout.

**`src/types/hub.ts`**: `CustomerHealthScore` расширен (`score: number | 'n/a'`, `+ components`, `+ sparkline`) + новый `CustomerHealthComponents`. Единственный потребитель (`useProjectHub`, ставит `null`) не сломан.

## Тесты

В проекте нет test-runner'а. Гейты: `npx tsc --noEmit`, `npm run lint`, `npm run build` — **все три проходят чисто** (chunk-size warning — предсуществующий, не связан с этим изменением).

## Self-check

13-point self-check + senior review пройдены. P1: 0.
- Найдено и исправлено в self-review: (1) форс-пересчёт «протекал» на смену пропсов repo/tier/budget/paid (лишний платный Claude-вызов) — исправлено через consumed-token ref; (2) повторный re-scan списка транскриптов для paid — переиспользован уже вычисленный staleness.
- Проверено: нет секретов/хардкод-URL, нет TODO/FIXME без номера, нет закомментированного кода, нет debug console.log, нет divide-by-zero/NaN в score-математике (все делители — гард-нутые константы или > 0), boundary 40/70 покрыты, обратная совместимость hub-типов сохранена, sentiment — один батч-вызов (не цикл на транскрипт), graceful обработка edge-cases (нет транскриптов / commitments / drift baseline / n/a).