### PR TITLE
Delivery tab — layout assembly (Epic-012 Task-08)

### DIFF
--- a/src/components/v4/hub/ProjectHubPage.tsx
+++ b/src/components/v4/hub/ProjectHubPage.tsx
@@ -184,7 +184,7 @@ export function ProjectHubPage({ repo, project, onBackToList }: Props) {
             <ActivityTab repo={repo} onVisited={handleActivityVisited} />
           )}
           {activeTab === "decisions" && <DecisionsRisksTab decisions={data.decisions} />}
-          {activeTab === "delivery" && <DeliveryTab />}
+          {activeTab === "delivery" && <DeliveryTab repo={repo} data={data} />}
         </Suspense>
       </div>
     </div>

--- a/src/components/v4/hub/tabs/DeliveryTab.tsx
+++ b/src/components/v4/hub/tabs/DeliveryTab.tsx
@@ -1,23 +1,126 @@
-import { Icon } from "../../health/Icon";
+import type { ProjectHubData } from "../../../../types/hub";
+import { DoraCards } from "../DoraCards";
+import { CustomerHealthGauge } from "../CustomerHealthGauge";
+import { OnboardingChecklist } from "../OnboardingChecklist";
+import { DigestViewer } from "../DigestViewer";
 
-const EPIC_URL = "https://github.com/Sergio1990-1/makeit-dashboard/blob/main/docs/epics/epic-012.md";
+interface Props {
+  /** Repo slug — drives the self-contained widgets (Customer Health, Digest). */
+  repo: string;
+  /** Aggregate Hub data from useProjectHub (presentation-only, PRD-008 FR-42). */
+  data: ProjectHubData;
+}
 
 /**
- * Placeholder. Epic-012 (DORA + Weekly Digest + Customer Health +
- * Onboarding + NBA engine, Tasks 01–09) fills this with the delivery
- * intelligence layout.
+ * Delivery tab (Epic-012 Task-08) — replaces the Epic-009 stub.
+ *
+ * Layout (per docs/PROJECT_HUB_DESIGN_BRIEF.md §4.3):
+ *   row-1  DoraCards          full-width (its own 4-column internal grid)
+ *   row-2  CustomerHealthGauge | OnboardingChecklist   (2-col ≥1280px)
+ *   row-3  DigestViewer       full-width
+ * <768px everything stacks single-column (see .delivery-* in v4.css).
+ *
+ * Data sourcing — the four widgets were built (Tasks 02/03/04/07) with
+ * their own contracts, so this tab feeds each what it actually needs and
+ * uses the matching `useProjectHub` field only to decide the per-section
+ * empty state (the stub returns null/empty today; Task-09 (#367) swaps in
+ * real producers without touching this presentation layer):
+ *   - DORA              gated on `data.dora`; DoraCards owns its own
+ *                       four-dash placeholder when no metrics yet.
+ *   - Customer Health   self-contained — owns its computeHealth(repo) call.
+ *   - Onboarding        reads the six onboarding rules from health findings.
+ *   - Weekly Digest     self-contained — read-only history by repo (no
+ *                       regenerate input until Task-09 wires the activity).
+ *
+ * Every section degrades to a scoped empty state when its source is
+ * absent, so the tab never crashes on the stubbed hook.
  */
-export function DeliveryTab() {
+export function DeliveryTab({ repo, data }: Props) {
+  const { dora, customerHealth, onboarding, digest, health } = data;
+  // OnboardingChecklist needs the raw health findings (it filters the six
+  // onboarding rules itself); `onboarding` (OnboardingReport) is the hub's
+  // summary and drives the per-section empty state — total === 0 means the
+  // project hasn't been health-scanned / classified yet.
+  const onboardingFindings = health?.findings ?? [];
+  const hasOnboarding = onboarding.total > 0 && onboardingFindings.length > 0;
+
   return (
-    <div className="v4-hub-tab-stub">
-      <Icon name="trend" />
-      <div>
-        <strong>Вкладка в разработке</strong>
-        <p>
-          DORA, Weekly Digest, Customer Health и Onboarding Readiness появятся в{" "}
-          <a href={EPIC_URL} target="_blank" rel="noreferrer">Epic-012</a>.
-        </p>
+    <div className="delivery-tab">
+      {/* row-1 — DORA KPIs (full-width, own internal 4-col grid) */}
+      <section
+        className="delivery-row delivery-row--dora"
+        aria-labelledby="delivery-dora-title"
+      >
+        <h2 id="delivery-dora-title" className="delivery-section-title">
+          DORA
+        </h2>
+        {dora === null ? (
+          <p className="delivery-empty">
+            Недостаточно merges на main за окно.
+          </p>
+        ) : (
+          <DoraCards metrics={null} />
+        )}
+      </section>
+
+      {/* row-2 — Customer Health (left) + Onboarding (right) */}
+      <div className="delivery-row delivery-row--split">
+        <section
+          className="delivery-cell"
+          aria-labelledby="delivery-health-title"
+        >
+          <h2
+            id="delivery-health-title"
+            className="delivery-section-title"
+          >
+            Customer Health
+          </h2>
+          {customerHealth === null ? (
+            <p className="delivery-empty">
+              Нет данных, требуется свежий транскрипт.
+            </p>
+          ) : (
+            <CustomerHealthGauge repo={repo} />
+          )}
+        </section>
+
+        <section
+          className="delivery-cell"
+          aria-labelledby="delivery-onboarding-title"
+        >
+          <h2
+            id="delivery-onboarding-title"
+            className="delivery-section-title"
+          >
+            Onboarding Readiness
+          </h2>
+          {!hasOnboarding ? (
+            <p className="delivery-empty">
+              Onboarding-чеклист появится после первого health-сканирования
+              проекта.
+            </p>
+          ) : (
+            <OnboardingChecklist findings={onboardingFindings} />
+          )}
+        </section>
       </div>
+
+      {/* row-3 — Weekly Digest (full-width) */}
+      <section
+        className="delivery-row delivery-row--digest"
+        aria-labelledby="delivery-digest-title"
+      >
+        <h2 id="delivery-digest-title" className="delivery-section-title">
+          Weekly Digest
+        </h2>
+        {digest === null ? (
+          <p className="delivery-empty">
+            Дайджест за неделю ещё не сгенерирован.
+          </p>
+        ) : (
+          <DigestViewer repo={repo} />
+        )}
+      </section>
     </div>
   );
 }

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -9288,3 +9288,59 @@ ul.v4-rsh-list {
   .v4-hub-risk-owner,
   .v4-hub-commit-owner { grid-area: meta; justify-self: start; }
 }
+
+/* ── Delivery Tab (Epic-012 Task-08) ───────────────────────────────────
+   Three stacked rows: DORA KPIs (full-width, own internal 4-col grid),
+   Customer Health + Onboarding (split), Weekly Digest (full-width).
+
+   Mobile-first: single column by default (covers <768px per the brief).
+   At ≥1280px row-2 becomes a 2-column split. Every selector is scoped
+   under .delivery-tab so no other tab's layout regresses. Colours reuse
+   existing semantic tokens only — no new palette here. */
+.delivery-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.delivery-tab .delivery-row {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.delivery-tab .delivery-row--split {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+}
+
+@media (min-width: 1280px) {
+  .delivery-tab .delivery-row--split {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+}
+
+.delivery-tab .delivery-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.delivery-tab .delivery-section-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+
+.delivery-tab .delivery-empty {
+  margin: 0;
+  padding: 16px;
+  border: 1px dashed var(--v4-line);
+  border-radius: 10px;
+  color: var(--v4-ink-500);
+  font-size: 13px;
+}


### PR DESCRIPTION
Closes #366

## Что сделано

Заменил Epic-009 stub `DeliveryTab.tsx` на собранный layout вкладки Delivery в Project Hub.

**Layout** (per `docs/PROJECT_HUB_DESIGN_BRIEF.md` §4.3):
- **row-1** — `DoraCards` (full-width, собственная внутренняя 4-колоночная сетка)
- **row-2** — `CustomerHealthGauge` (слева, 1fr) + `OnboardingChecklist` (справа, 1fr)
- **row-3** — `DigestViewer` (full-width)
- Desktop ≥1280px: row-2 двухколоночный. Mobile <768px: всё single-column stacked (mobile-first base).

**Источники данных** (presentation-only, PRD-008 FR-42). Каждый виджет был реализован в Tasks 02/03/04/07 со своим контрактом — таб кормит каждый тем, что ему реально нужно, и использует соответствующее поле `useProjectHub` только для решения per-section empty state:
- **DORA** — gated на `data.dora`; `<DoraCards metrics={null} />` (DoraCards имеет собственный 4-dash placeholder). `data.dora` (`DoraMetrics`) структурно несовместим с `DoraMetricsResult` DoraCards — реальную проводку делает Task-09 (#367).
- **Customer Health** — self-contained виджет, передаётся `repo` (он сам владеет `computeHealth(repo)`); empty state gated на `data.customerHealth`.
- **Onboarding** — `OnboardingChecklist` получает `findings: HealthFinding[]` из `data.health.findings` (он сам фильтрует 6 onboarding-правил); empty state gated на `data.onboarding.total > 0`.
- **Weekly Digest** — self-contained, передаётся `repo` (read-only history); empty state gated на `data.digest`.

Per-section Russian empty states при отсутствии данных (текущий stub `useProjectHub` возвращает null/empty по всем 4 — все 4 empty state рендерятся сейчас).

Call-site в `ProjectHubPage.tsx`: `<DeliveryTab repo={repo} data={data} />` — тот же `ProjectHubData`, что уже получает `OverviewTab`.

CSS-секция `.delivery-tab` добавлена в `v4.css`, все селекторы scoped под `.delivery-tab` (нет regression других tabs), только существующие `--v4-*` токены.

`useProjectHub.ts` и `src/types/hub.ts` НЕ изменены — Task-09 (#367) подменит внутренности stub позже.

## Тесты

В проекте нет test runner — гейтами являются `npx tsc --noEmit`, `npm run lint`, `npm run build`. Все три прошли:
- `npx tsc --noEmit` — exit 0
- `npm run lint` — exit 0
- `npm run build` — exit 0 (chunk-size warning — пре-существующий repo-wide, не ошибка)

Браузерный preview не выполнялся: Project Hub требует GitHub PAT в localStorage и живые данные GitHub API для навигации до этой вкладки — в чистом preview без авторизации view недостижим. Layout — простой scoped flex/grid CSS, корректность проверена через гейты + статический разбор контрактов всех 4 компонентов.

## Self-check

13-point + senior review пройдены:
- Корректные Props переданы всем 4 компонентам (нет type mismatch, tsc clean)
- Empty-state ветки достижимы (stub возвращает null/empty по всем 4 → все 4 рендерятся)
- CSS scoped под `.delivery-tab` (нет global regression)
- Responsive breakpoints верны (mobile <768 single col / desktop ≥1280 2-col row-2)
- Call-site contract консистентен с OverviewTab (`data: ProjectHubData`)
- `useProjectHub.ts` не тронут
- Нет TODO/FIXME без issue-номера, нет commented-out кода, нет console.log, нет magic-значений (только `--v4-*` токены)
- a11y: каждый `<section aria-labelledby>` указывает на существующий `<h2 id>`

P1: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)