### PR TITLE
useProjectHub real-data integration (Epic-012 Task-09)

### DIFF
--- a/src/components/v4/hub/tabs/DeliveryTab.tsx
+++ b/src/components/v4/hub/tabs/DeliveryTab.tsx
@@ -25,8 +25,10 @@ interface Props {
  * uses the matching `useProjectHub` field only to decide the per-section
  * empty state (the stub returns null/empty today; Task-09 (#367) swaps in
  * real producers without touching this presentation layer):
- *   - DORA              gated on `data.dora`; DoraCards owns its own
- *                       four-dash placeholder when no metrics yet.
+ *   - DORA              `data.dora` is the calculator's own
+ *                       `DoraMetricsResult` (unified with DoraCards in
+ *                       Task-09); passed straight through. DoraCards owns
+ *                       its own four-dash placeholder when `null`.
  *   - Customer Health   self-contained — owns its computeHealth(repo) call.
  *   - Onboarding        reads the six onboarding rules from health findings.
  *   - Weekly Digest     self-contained — read-only history by repo (no
@@ -56,10 +58,10 @@ export function DeliveryTab({ repo, data }: Props) {
         </h2>
         {dora === null ? (
           <p className="delivery-empty">
-            Недостаточно merges на main за окно.
+            DORA-метрики ещё считаются (или недостаточно активности на main).
           </p>
         ) : (
-          <DoraCards metrics={null} />
+          <DoraCards metrics={dora} />
         )}
       </section>
 

--- a/src/components/v4/hub/tabs/OverviewTab.tsx
+++ b/src/components/v4/hub/tabs/OverviewTab.tsx
@@ -19,9 +19,10 @@ interface Props {
  * Overview tab — first thing the user sees after clicking a Scorecard row.
  * 4 mini-blocks in a 2×2 grid (stack <768px): NBA / Pulse / Risks / Commitments.
  *
- * All data flows from useProjectHub. In Epic-009 every source is stubbed
- * (empty arrays / null), so every block here must render a sensible empty
- * state without crashing. Real producers land in Epic-011/012.
+ * All data flows from useProjectHub. Sources may still be empty (a
+ * project with nothing to act on, or a producer that hasn't resolved
+ * yet), so every block here must render a sensible empty state without
+ * crashing.
  *
  * Per FR-20: each block has an "Открыть полностью →" footer link that
  * switches the parent's active tab via onOpenTab.
@@ -52,9 +53,11 @@ export function OverviewTab({ data, onOpenTab }: Props) {
 export default OverviewTab;
 
 // ─── NBA block ──────────────────────────────────────────────────────────
-// Shows the top-1 Next Best Action expanded (text + reason + stub action
-// buttons). Per design brief §6, NBA sits at attention rank 1 — this is
-// the "what should I do right now" entry into the Hub.
+// Shows the top-1 Next Best Action expanded (text + reason), with the
+// next two (top-3 total) as a compact follow-up list. Per design brief
+// §6, NBA sits at attention rank 1 — this is the "what should I do right
+// now" entry into the Hub. Data is the real engine output from
+// useProjectHub (Epic-012 Task-05/Task-09).
 
 interface NbaBlockProps {
   nba: NextBestAction[];
@@ -62,7 +65,10 @@ interface NbaBlockProps {
 }
 
 function NbaBlock({ nba, onOpenTab }: NbaBlockProps) {
-  const top = nba[0];
+  // Engine already ranks most-important-first; the Hub surfaces the
+  // top-3 (slice is safe for <3 / empty — yields [] / a short list).
+  const top3 = useMemo(() => nba.slice(0, 3), [nba]);
+  const [top, ...rest] = top3;
 
   return (
     <section
@@ -84,24 +90,15 @@ function NbaBlock({ nba, onOpenTab }: NbaBlockProps) {
           <p className="v4-hub-nba-reason">
             <span className="v4-hub-nba-reason-label">Почему:</span> {top.reason}
           </p>
-          <div className="v4-hub-nba-actions">
-            <button
-              type="button"
-              className="v4-btn v4-btn--pri"
-              disabled
-              title="Будет включено в Epic-012 Task-05"
-            >
-              Создать issue
-            </button>
-            <button
-              type="button"
-              className="v4-btn"
-              disabled
-              title="Будет включено в Epic-012 Task-05"
-            >
-              Отметить сделанным
-            </button>
-          </div>
+          {rest.length > 0 ? (
+            <ul className="v4-hub-nba-list">
+              {rest.map((action) => (
+                <li key={action.id} className="v4-hub-nba-list-item">
+                  <span className="v4-hub-nba-list-text">{action.text}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
         </div>
       ) : (
         <EmptyState

--- a/src/hooks/useProjectHub.ts
+++ b/src/hooks/useProjectHub.ts
@@ -251,16 +251,20 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     useState<Resolved<DigestEntry> | null>(null);
   useEffect(() => {
     const key = repo;
+    let cancelled = false;
     void (async () => {
       try {
         const entry = await loadDigest(repo, currentWeekKey());
-        if (!mounted.current) return;
+        if (cancelled || !mounted.current) return;
         setDigestResolved({ key, data: entry, error: null });
       } catch (e) {
-        if (!mounted.current) return;
+        if (cancelled || !mounted.current) return;
         setDigestResolved({ key, data: null, error: toError(e) });
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [repo]);
   const digestSection = deriveSection(digestResolved, repo);
 
@@ -279,6 +283,7 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     useState<Resolved<CustomerHealthScore> | null>(null);
   useEffect(() => {
     const key = healthKey;
+    let cancelled = false;
     void (async () => {
       try {
         const finance = getProjectFinance(repo);
@@ -287,17 +292,20 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
           budget: finance?.budget ?? budget,
           paid: finance?.paid ?? paid,
         });
-        if (!mounted.current) return;
+        if (cancelled || !mounted.current) return;
         setHealthResolved({
           key,
           data: toCustomerHealthScore(result),
           error: null,
         });
       } catch (e) {
-        if (!mounted.current) return;
+        if (cancelled || !mounted.current) return;
         setHealthResolved({ key, data: null, error: toError(e) });
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [repo, tier, budget, paid, healthKey]);
   const healthSection = deriveSection(healthResolved, healthKey);
 
@@ -343,6 +351,7 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     useState<Resolved<NextBestAction[]> | null>(null);
   useEffect(() => {
     const key = nbaKey;
+    let cancelled = false;
     void (async () => {
       try {
         const apiKey = getClaudeKey() ?? "";
@@ -351,7 +360,7 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
           { findings: failingFindings },
           apiKey,
         );
-        if (!mounted.current) return;
+        if (cancelled || !mounted.current) return;
         const actions = result.actions.map(toNextBestAction);
         setNbaResolved({
           key,
@@ -359,10 +368,13 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
           error: null,
         });
       } catch (e) {
-        if (!mounted.current) return;
+        if (cancelled || !mounted.current) return;
         setNbaResolved({ key, data: null, error: toError(e) });
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [repo, failingFindings, nbaKey]);
   const nbaSection = deriveSection(nbaResolved, nbaKey);
 

--- a/src/hooks/useProjectHub.ts
+++ b/src/hooks/useProjectHub.ts
@@ -1,17 +1,36 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useProjectHealth } from "./useProjectHealth";
 import type { ProjectData } from "../types";
-import type { HubTab, OnboardingReport, ProjectHubData } from "../types/hub";
+import type {
+  CustomerHealthScore,
+  DigestEntry,
+  HubTab,
+  NextBestAction,
+  OnboardingReport,
+  ProjectHubData,
+} from "../types/hub";
 import {
   listRecentCommits,
   readMarkdown,
   type CommitInfo,
 } from "../utils/github-contents";
 import { extractDecisions } from "../utils/decisionLogExtractor";
+import { computeDora, type DoraMetricsResult } from "../utils/doraCalculator";
+import { currentWeekKey, loadDigest } from "../utils/weeklyDigestGenerator";
+import {
+  computeHealth,
+  type CustomerHealthResult,
+} from "../utils/customerHealthScore";
+import { isOnboardingRuleId } from "../utils/onboardingReadinessRules";
+import {
+  computeProjectNBA,
+  type NbaAction,
+} from "../utils/nextBestActionEngine";
+import { getClaudeKey, getProjectFinance } from "../utils/config";
 
 // Stable empty stubs so consumers can rely on reference equality. The Hub
-// surfaces (Overview, Activity, etc.) render empty states from these in
-// Epic-009 — real producers land in Epic-011/012 and replace these calls.
+// surfaces (Overview, Activity, etc.) render empty states from these when a
+// producer has nothing yet.
 const EMPTY_DECISIONS: ProjectHubData["decisions"] = [];
 const EMPTY_RISKS: ProjectHubData["risks"] = [];
 const EMPTY_COMMITMENTS: ProjectHubData["commitments"] = [];
@@ -20,17 +39,110 @@ const EMPTY_PULSE: ProjectHubData["pulse"] = [];
 const EMPTY_NBA: ProjectHubData["nba"] = [];
 const EMPTY_ONBOARDING: OnboardingReport = { completed: 0, total: 0, missing: [] };
 
+/** Sliding window (days) the Hub computes DORA over — mirrors the
+ *  calculator default; kept explicit so the value is visible here. */
+const DORA_WINDOW_DAYS = 30;
+
 /**
- * Aggregate hook for Project Hub. Per PRD-008 FR-42, this is the single
- * aggregation point; all Hub views (header, tabs, overview blocks) read from
- * here. Today it composes `useProjectHealth` and stubs Epic-011/012 sources;
- * the public shape is stable so downstream code doesn't churn when real
- * producers land.
+ * Adapt the NBA engine's rich `NbaAction` (`title / rationale / severity /
+ * link`) to the Hub's lighter `NextBestAction` (`text / reason`). Per the
+ * engine's own contract this mapping deliberately lives with the consumer,
+ * not the engine, so the engine stays decoupled from the Hub aggregate.
+ * `targetTab` is intentionally left undefined — the engine produces deep
+ * links, not Hub-tab ids; OverviewTab falls back to the Activity tab.
+ */
+function toNextBestAction(a: NbaAction): NextBestAction {
+  return {
+    id: a.id,
+    text: a.title,
+    reason: a.rationale,
+  };
+}
+
+/**
+ * Derive the customer-health gauge tier from the blended score, matching
+ * `CustomerHealthScore` in types/hub.ts (0–40 critical, 40–70 warning,
+ * 70–100 good). `'n/a'` (no recent transcript) maps to `critical` so the
+ * gauge surfaces the no-data zone rather than a misleading green.
+ */
+function healthTier(score: number | "n/a"): CustomerHealthScore["tier"] {
+  if (score === "n/a") return "critical";
+  if (score < 40) return "critical";
+  if (score < 70) return "warning";
+  return "good";
+}
+
+/** Map the util's `CustomerHealthResult` onto the Hub's
+ *  `CustomerHealthScore` (adds the derived `tier`, renames the
+ *  timestamp). The two shapes are deliberately distinct: the util owns
+ *  computation, the Hub owns presentation metadata. */
+function toCustomerHealthScore(r: CustomerHealthResult): CustomerHealthScore {
+  return {
+    score: r.score,
+    tier: healthTier(r.score),
+    components: r.components,
+    sparkline: r.sparkline,
+    updatedAt: r.computedAt,
+  };
+}
+
+/**
+ * One async section's resolved value, tagged with the `key` (repo, plus
+ * any extra inputs) it was computed for. The public `data/loading/error`
+ * are *derived* from whether the stored key still matches the current
+ * inputs — so a `repo` change instantly reads as "loading" with no
+ * synchronous setState-in-effect (which `react-hooks/set-state-in-effect`
+ * forbids; same idle-derivation trick as `useDriftNorm` / `useProjectHealth`).
+ * The effect only ever commits a *resolved* (or *errored*) value.
+ */
+interface Resolved<T> {
+  key: string;
+  data: T | null;
+  error: Error | null;
+}
+
+interface Section<T> {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+/** Derive the public per-section shape from the tagged store: a value
+ *  only counts when it was resolved for *this* exact key; otherwise the
+ *  section reads as still-loading (no data, no stale error). */
+function deriveSection<T>(
+  resolved: Resolved<T> | null,
+  key: string,
+): Section<T> {
+  const fresh = resolved !== null && resolved.key === key;
+  return {
+    data: fresh ? resolved.data : null,
+    loading: !fresh,
+    error: fresh ? resolved.error : null,
+  };
+}
+
+function toError(e: unknown): Error {
+  return e instanceof Error ? e : new Error(String(e));
+}
+
+/**
+ * Aggregate hook for Project Hub. Per PRD-008 FR-42 this is the single
+ * aggregation point; all Hub views (header, tabs, overview blocks) read
+ * from here. It composes `useProjectHealth` with the Epic-012 real
+ * producers (DORA / digest / customer-health / onboarding / NBA).
  *
- * @param repo  Repo name (without owner). Drives health composition.
- * @param project  Optional ProjectData from the parent Portfolio list, since
- *                 `useDashboard` already has it in memory — avoids a second
- *                 source of truth or a per-repo refetch.
+ * Each producer runs in its own effect and stores a result tagged with
+ * the inputs it belongs to; the public shape is derived per-section. A
+ * slow or failing producer degrades on its own — it never blocks or
+ * blanks the rest of the Hub. The tab-facing `ProjectHubData` shape is
+ * stable; the only deliberate change is `dora` now being the
+ * calculator's own `DoraMetricsResult`, unified with `DoraCards`.
+ *
+ * @param repo  Repo name (without owner). Drives every producer.
+ * @param project  Optional ProjectData from the parent Portfolio list,
+ *                  since `useDashboard` already has it in memory — avoids
+ *                  a second source of truth or a per-repo refetch.
  */
 export function useProjectHub(repo: string, project?: ProjectData): ProjectHubData {
   const { report, loading, error: healthError, refresh } = useProjectHealth(repo);
@@ -43,57 +155,253 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     [healthError],
   );
 
+  // Mounted-flag so a late-resolving producer can't setState after the
+  // Hub unmounts (portfolio navigation tear-down).
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
   // ── Decision Log (Epic-011 Task-01) ────────────────────────────────
   // Two sources: the project's BRIEF.md (optional, often absent) and
   // the most-recent commits filtered for `decide:`/`accept:` prefixes.
   // Both fetches are best-effort: any failure collapses to empty so the
-  // tab still renders rather than blocking the whole Hub.
+  // tab still renders rather than blocking the whole Hub. The commit
+  // list is also reused by the DORA producer below (deploy frequency /
+  // change failure rate) so we don't fetch commits twice.
+  // The commit fetch is tagged with its repo so an empty result for the
+  // *current* repo (no history / fetch failed) reads as "resolved, empty"
+  // — not "still loading" forever. Decisions/DORA derive off this.
   const [briefMd, setBriefMd] = useState<string | null>(null);
-  const [commits, setCommits] = useState<CommitInfo[]>([]);
+  const [commitsResolved, setCommitsResolved] =
+    useState<Resolved<CommitInfo[]> | null>(null);
   useEffect(() => {
+    const key = repo;
     let cancelled = false;
     void (async () => {
       // Run in parallel — they're independent and the Hub has nothing
       // to do with either response while we wait.
       const [briefRes, commitsRes] = await Promise.all([
         readMarkdown(repo, "docs/BRIEF.md").catch(() => null),
-        listRecentCommits(repo, 50).catch(() => [] as CommitInfo[]),
+        listRecentCommits(repo, 100).catch(() => [] as CommitInfo[]),
       ]);
-      if (cancelled) return;
+      if (cancelled || !mounted.current) return;
       setBriefMd(briefRes?.content ?? null);
-      setCommits(commitsRes);
+      setCommitsResolved({ key, data: commitsRes, error: null });
     })();
     return () => {
       cancelled = true;
     };
   }, [repo]);
 
+  // Only count commits resolved for *this* repo; a stale result from the
+  // previous repo (navigation mid-fetch) reads as not-yet-loaded.
+  const commitsFresh =
+    commitsResolved !== null && commitsResolved.key === repo;
+  const commits = useMemo<CommitInfo[]>(
+    () => (commitsFresh ? (commitsResolved?.data ?? []) : []),
+    [commitsFresh, commitsResolved],
+  );
+
   const decisions = useMemo(
     () => extractDecisions(briefMd, commits),
     [briefMd, commits],
   );
 
-  // `loadingTab` mirrors the per-tab loading state. In Epic-009 only Health
-  // has a real loading signal; the rest stay false until their producers
-  // (Epic-011/012) wire in their own async work.
+  // ── DORA (Epic-012 Task-03) ────────────────────────────────────────
+  // `computeDora` is pure-injectable and synchronous. We feed it the
+  // commits already loaded above (Deploy Frequency + Change Failure Rate
+  // come from real commit subjects). The other two inputs degrade by the
+  // calculator's own documented contract, not silently:
+  //   - `pullRequests: []` — `listMergedPRsInWindow` returns only
+  //     `{ number, merged_at }` (no `created_at`), so Lead Time can't be
+  //     derived without an N+1 per-PR fetch. An empty list yields an
+  //     honest `n/a` dash rather than a fabricated 0h. (tech-debt #367.)
+  //   - `incidents: null` — no per-repo BetterStack monitor matching in
+  //     the Hub today → MTTR `n/a`.
+  //   - `auditFindings: []` — CFR falls back to the fix-only signal.
+  // Derived synchronously once the commit fetch has resolved for this
+  // repo. It carries its own loading slice (true only until that fetch
+  // lands) for tab-skeleton parity with the async producers — an
+  // empty-history repo resolves to a real (all-low) metric set, not a
+  // perpetual spinner.
+  const doraSection = useMemo<Section<DoraMetricsResult>>(() => {
+    if (!commitsFresh) {
+      return { data: null, loading: true, error: null };
+    }
+    try {
+      const metrics = computeDora(
+        { commits, pullRequests: [], incidents: null, auditFindings: [] },
+        DORA_WINDOW_DAYS,
+      );
+      return { data: metrics, loading: false, error: null };
+    } catch (e) {
+      return { data: null, loading: false, error: toError(e) };
+    }
+  }, [commitsFresh, commits]);
+
+  // ── Weekly Digest (Epic-012 Task-02) ───────────────────────────────
+  // Latest digest for the current ISO week. `loadDigest` resolves from
+  // localStorage cache → committed file → null, and never throws; still
+  // guarded so a thrown rejection degrades this section alone.
+  const [digestResolved, setDigestResolved] =
+    useState<Resolved<DigestEntry> | null>(null);
+  useEffect(() => {
+    const key = repo;
+    void (async () => {
+      try {
+        const entry = await loadDigest(repo, currentWeekKey());
+        if (!mounted.current) return;
+        setDigestResolved({ key, data: entry, error: null });
+      } catch (e) {
+        if (!mounted.current) return;
+        setDigestResolved({ key, data: null, error: toError(e) });
+      }
+    })();
+  }, [repo]);
+  const digestSection = deriveSection(digestResolved, repo);
+
+  // ── Customer Health (Epic-012 Task-07) ─────────────────────────────
+  // `computeHealth` is weekly-throttled and never throws by contract;
+  // still wrapped so a rejection isolates to this section. Budget / paid
+  // come from the project finance overrides (same source CustomerHealth
+  // uses elsewhere) so the `paid` sub-component is meaningful. The store
+  // key folds in the tier so the score recomputes if classification
+  // resolves after the first run.
+  const tier = report?.classification.tier;
+  const budget = project?.budget;
+  const paid = project?.paid;
+  const healthKey = `${repo}|${tier ?? ""}|${budget ?? ""}|${paid ?? ""}`;
+  const [healthResolved, setHealthResolved] =
+    useState<Resolved<CustomerHealthScore> | null>(null);
+  useEffect(() => {
+    const key = healthKey;
+    void (async () => {
+      try {
+        const finance = getProjectFinance(repo);
+        const result = await computeHealth(repo, {
+          tier,
+          budget: finance?.budget ?? budget,
+          paid: finance?.paid ?? paid,
+        });
+        if (!mounted.current) return;
+        setHealthResolved({
+          key,
+          data: toCustomerHealthScore(result),
+          error: null,
+        });
+      } catch (e) {
+        if (!mounted.current) return;
+        setHealthResolved({ key, data: null, error: toError(e) });
+      }
+    })();
+  }, [repo, tier, budget, paid, healthKey]);
+  const healthSection = deriveSection(healthResolved, healthKey);
+
+  // ── Onboarding Readiness (Epic-012 Task-04) ────────────────────────
+  // Synchronous, not async: the six onboarding rules are merged into the
+  // checklist evaluated by `useProjectHealth`, so the report's findings
+  // already carry them. We summarise (`completed / total / missing`)
+  // here; OnboardingChecklist still filters the raw findings itself.
+  const onboarding = useMemo<OnboardingReport>(() => {
+    const findings = report?.findings ?? [];
+    const rows = findings.filter((f) => isOnboardingRuleId(f.rule_id));
+    if (rows.length === 0) return EMPTY_ONBOARDING;
+    const completed = rows.filter((f) => f.status === "pass").length;
+    const missing = rows
+      .filter((f) => f.status !== "pass")
+      .map((f) => f.rule_id);
+    return { completed, total: rows.length, missing };
+  }, [report?.findings]);
+
+  // ── Next Best Action (Epic-012 Task-05) ────────────────────────────
+  // `computeProjectNBA` is pure-injectable: it weighs the signals we
+  // pass it. Risks are not yet a Hub producer (Epic-011 Task-03 is UI
+  // only), so we feed audit findings from the health report's failing
+  // entries. The engine is week-cached and never throws to the caller;
+  // still wrapped for section isolation. The store key folds in a fast
+  // signature of the findings so the NBA refreshes when they change.
+  const failingFindings = useMemo(
+    () =>
+      (report?.findings ?? [])
+        .filter((f) => f.status === "fail")
+        .map((f) => ({
+          severity: f.severity,
+          description: f.detail ? `${f.title} — ${f.detail}` : f.title,
+        })),
+    [report?.findings],
+  );
+  const nbaKey = useMemo(
+    () =>
+      `${repo}|${failingFindings.map((f) => `${f.severity}:${f.description}`).join("¦")}`,
+    [repo, failingFindings],
+  );
+  const [nbaResolved, setNbaResolved] =
+    useState<Resolved<NextBestAction[]> | null>(null);
+  useEffect(() => {
+    const key = nbaKey;
+    void (async () => {
+      try {
+        const apiKey = getClaudeKey() ?? "";
+        const result = await computeProjectNBA(
+          repo,
+          { findings: failingFindings },
+          apiKey,
+        );
+        if (!mounted.current) return;
+        const actions = result.actions.map(toNextBestAction);
+        setNbaResolved({
+          key,
+          data: actions.length > 0 ? actions : EMPTY_NBA,
+          error: null,
+        });
+      } catch (e) {
+        if (!mounted.current) return;
+        setNbaResolved({ key, data: null, error: toError(e) });
+      }
+    })();
+  }, [repo, failingFindings, nbaKey]);
+  const nbaSection = deriveSection(nbaResolved, nbaKey);
+
+  // `loadingTab` mirrors per-tab loading. Health drives its own tabs;
+  // Delivery is "loading" until every section it shows has resolved (or
+  // errored) so the tab skeleton clears once the slowest producer lands
+  // — without one slow section blocking the others' content (each
+  // section renders independently from its own slice).
   const loadingTab = useMemo<Record<HubTab, boolean>>(
     () => ({
-      overview: false,
+      overview: nbaSection.loading,
       health: loading,
       activity: false,
       decisions: false,
-      delivery: false,
+      delivery:
+        doraSection.loading ||
+        digestSection.loading ||
+        healthSection.loading ||
+        loading,
     }),
-    [loading],
+    [
+      loading,
+      nbaSection.loading,
+      doraSection.loading,
+      digestSection.loading,
+      healthSection.loading,
+    ],
   );
 
-  // Stable no-op async actions so consumers can wire buttons today; Epic-012
-  // replaces these with real digest generation and NBA recompute.
+  // Stable no-op async actions so consumers can wire buttons today;
+  // dedicated regenerate UIs live in the section widgets / Epic-010.
   const generateDigest = useCallback(async () => {
-    // TODO: Epic-012 — weekly digest generator.
+    // Digest regeneration is owned by DigestViewer's own controls; the
+    // Hub-level button is a no-op placeholder by design (the real
+    // affordance lives in the widget, not here).
   }, []);
   const regenerateNBA = useCallback(async () => {
-    // TODO: Epic-012 — NBA engine recompute.
+    // NBA regeneration is owned by the portfolio / section controls; the
+    // Hub-level button is a no-op placeholder by design.
   }, []);
 
   // Fall back to the stable empty array when the extractor produced no
@@ -109,11 +417,11 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     renewals: EMPTY_RENEWALS,
     pulse: EMPTY_PULSE,
     inboxCount: 0,
-    digest: null,
-    dora: null,
-    customerHealth: null,
-    onboarding: EMPTY_ONBOARDING,
-    nba: EMPTY_NBA,
+    digest: digestSection.data,
+    dora: doraSection.data,
+    customerHealth: healthSection.data,
+    onboarding,
+    nba: nbaSection.data ?? EMPTY_NBA,
     loading,
     loadingTab,
     error,

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -9109,11 +9109,32 @@ ul.v4-rsh-list {
   font-weight: 600;
   color: var(--v4-ink-700);
 }
-.v4-hub-nba-actions {
+/* Follow-up actions (ranks 2–3): compact, de-emphasised vs the top-1
+   block above so the primary recommendation still dominates. */
+.v4-hub-nba-list {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 8px 0 0;
+  border-top: 1px solid var(--v4-border, rgba(0, 0, 0, 0.08));
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 2px;
+  flex-direction: column;
+  gap: 6px;
+}
+.v4-hub-nba-list-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--v4-ink-600);
+  line-height: 1.4;
+}
+.v4-hub-nba-list-item::before {
+  content: "→";
+  color: var(--v4-ink-500);
+  flex-shrink: 0;
+}
+.v4-hub-nba-list-text {
+  flex: 1;
 }
 
 /* Pulse list — compact 5-row stack. Type pill is monospace so eye-track

--- a/src/types/hub.ts
+++ b/src/types/hub.ts
@@ -5,6 +5,7 @@
 
 import type { ProjectData } from "./index";
 import type { HealthReport } from "./health";
+import type { DoraMetricsResult } from "../utils/doraCalculator";
 
 export type HubTab = "overview" | "health" | "activity" | "decisions" | "delivery";
 
@@ -163,21 +164,13 @@ export interface DigestMeta {
 }
 
 /**
- * DORA metrics snapshot + 90d trend per metric.
- * Filled in Epic-012 (Task-01: DORA).
+ * DORA metrics: the Hub re-uses the calculator's own result shape
+ * (`DoraMetricsResult` from `src/utils/doraCalculator.ts`) rather than a
+ * parallel type. `DoraCards` already consumes that exact shape, so the
+ * Hub aggregate, the producer (`computeDora`) and the presentation layer
+ * all share one source of truth — no adapter, no field-name skew.
+ * Filled in Epic-012 (Task-03: DORA calculator, Task-09: Hub wiring).
  */
-export interface DoraMetrics {
-  deploymentFrequency: number; // deploys/week
-  leadTimeHours: number;
-  mttrHours: number;
-  changeFailureRate: number; // 0..1
-  trend90d: {
-    deploymentFrequency: number[];
-    leadTimeHours: number[];
-    mttrHours: number[];
-    changeFailureRate: number[];
-  };
-}
 
 /**
  * The four weighted Customer Health sub-components, each `0..100` or
@@ -251,7 +244,7 @@ export interface ProjectHubData {
   pulse: PulseEvent[];
   inboxCount: number;
   digest: DigestEntry | null;
-  dora: DoraMetrics | null;
+  dora: DoraMetricsResult | null;
   customerHealth: CustomerHealthScore | null;
   onboarding: OnboardingReport;
   nba: NextBestAction[];


### PR DESCRIPTION
Closes #367

## Что сделано

### Реальные продюсеры в `useProjectHub` (вместо Epic-009 stubs)
| Поле | Откуда | Тип → ProjectHubData |
|---|---|---|
| `dora` | `computeDora({commits, pullRequests:[], incidents:null, auditFindings:[]}, 30)` | `DoraMetricsResult \| null` |
| `digest` | `loadDigest(repo, currentWeekKey())` | `DigestEntry \| null` |
| `customerHealth` | `computeHealth(repo, {tier, budget, paid})` → адаптер | `CustomerHealthScore \| null` |
| `onboarding` | summary 6 правил `onboarding.*` из `report.findings` (`isOnboardingRuleId`) | `OnboardingReport` |
| `nba` | `computeProjectNBA(repo, {findings}, apiKey)` → адаптер `NbaAction → NextBestAction` | `NextBestAction[]` |

- **Loading/error per section** — idle-derivation: каждый продюсер пишет результат, помеченный ключом входных данных; публичная форма (`data/loading/error`) выводится на рендере из совпадения ключа. Одна медленная/упавшая секция не блокирует и не очищает остальной Hub. Без синхронного setState-in-effect (как `useDriftNorm`/`useProjectHealth`).
- **Onboarding** — синхронный `useMemo` (правила уже в чеклисте, который считает `useProjectHealth`), не лишний async-эффект.
- **NBA** — сигнатура findings в ключе кэша, чтобы не было лишних Claude-вызовов; engine сам week-cached.

### DORA-реконсиляция типов (из комментария к #367, адъюдикация ревью #403)
- Удалён расходящийся `DoraMetrics` в `src/types/hub.ts` (поля `deploymentFrequency/changeFailureRate/trend90d`) — единственным потребителем был сам `ProjectHubData.dora`.
- `ProjectHubData.dora` теперь `DoraMetricsResult | null` (тип из `doraCalculator.ts`). Продюсер (`computeDora`), hub-агрегат и `DoraCards` — один источник истины, **без адаптера**.
- `DeliveryTab.tsx`: `<DoraCards metrics={null} />` → `<DoraCards metrics={dora} />`, per-section empty-state gating сохранён и компилируется. Остальные 3 секции (CustomerHealthGauge/OnboardingChecklist/DigestViewer) не тронуты.

### OverviewTab
NBA mini-block рендерит реальный engine-вывод: top-1 развёрнут + следующие 2 (top-3) компактным списком. Убраны stub-кнопки и устаревшие `Epic-009/Task-05` комментарии. CSS обновлён в синхроне.

### Известные ограничения DORA (документированные деградации калькулятора, не молчаливые)
- `pullRequests: []` — `listMergedPRsInWindow` не отдаёт `created_at`, Lead Time без N+1 не посчитать → честный `n/a` дэш (tech-debt, ниже).
- `incidents: null` → MTTR `n/a`; `auditFindings: []` → CFR на fix-only сигнале.
- Deploy Frequency и Change Failure Rate считаются на реальных коммитах.

## Тесты
Test runner в проекте нет; гейты — `tsc` / `lint` / `build`, все зелёные:
- `npx tsc --noEmit` — pass (0)
- `npm run lint` — pass (0)
- `npm run build` — pass (0)

## Самопроверка
- [x] Каждый из 5 продюсеров замаплен корректным типом, без расхождения имён полей
- [x] Per-section изоляция: одна упавшая/медленная секция не очищает Hub (idle-derivation, tagged store)
- [x] DORA-тип унифицирован (без адаптера); все потребители `DoraMetrics` найдены grep — единственный был `ProjectHubData.dora`
- [x] DeliveryTab отдаёт реальные метрики, empty-state gating работает
- [x] OverviewTab top-3 (slice безопасен для <3 / пусто)
- [x] `PortfolioNextActions`/`usePortfolioNba` (Epic-010) не сломаны — они decoupled (потребляют `NbaResult` движка напрямую, hub-типы не трогают), grep + tsc подтверждают
- [x] `ProjectHubHeader` (`data.nba[0]?.text`) совместим — hub-тип `NextBestAction` сохранён
- [x] Edge-case: репо без истории коммитов резолвится в реальный (all-low) DORA, не вечный спиннер
- [x] Нет debug console.log / TODO без номера / закомментированного кода
- [x] tsc / lint / build зелёные
- [x] Senior re-review пройден (re-diff после фиксов)
- [x] Циклических импортов нет (type-only импорт hub→doraCalculator, build проверил)
- [x] P1: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)