### PR TITLE
feat(hub): Risk extraction from transcripts (Epic-011 Task-09)

### DIFF
--- a/src/components/v4/hub/RiskRegisterTable.tsx
+++ b/src/components/v4/hub/RiskRegisterTable.tsx
@@ -4,6 +4,10 @@ import {
   readYaml,
   writeYaml,
 } from "../../../utils/github-contents";
+import {
+  extractRisks,
+  type ProposedRisk,
+} from "../../../utils/extractRisksFromTranscripts";
 import type {
   Risk,
   RiskProbability,
@@ -434,6 +438,92 @@ export function RiskRegisterTable({ repo }: Props) {
     await persist([], "chore(hub): create docs/risks.yaml");
   };
 
+  // ── risk extraction from transcripts (Epic-011 Task-09) ────────────
+
+  /**
+   * Extraction lifecycle. `idle` ⇒ no modal. While `extracting` we show
+   * a loading state on the button. `done` opens the review modal with
+   * `proposals` (possibly empty → "nothing found" state inside modal).
+   */
+  const [extractPhase, setExtractPhase] = useState<
+    "idle" | "extracting" | "done"
+  >("idle");
+  const [proposals, setProposals] = useState<ProposedRisk[]>([]);
+  const [extractError, setExtractError] = useState<string | null>(null);
+
+  const runExtraction = useCallback(async () => {
+    setExtractPhase("extracting");
+    setExtractError(null);
+    setProposals([]);
+    try {
+      const found = await extractRisks(repo);
+      setProposals(found);
+      setExtractPhase("done");
+    } catch (e) {
+      // extractRisks is contracted never to throw, but stay defensive
+      // so a future regression can't wedge the button in "extracting".
+      setExtractError(errorMessage(e));
+      setExtractPhase("idle");
+    }
+  }, [repo]);
+
+  const closeExtraction = () => {
+    setExtractPhase("idle");
+    setProposals([]);
+  };
+
+  /**
+   * Approve one proposed risk: convert it to a real `Risk` (forcing
+   * `source: 'transcript-extracted'`) and append it through the
+   * component's EXISTING `persist()` path — same sha/ConflictError flow
+   * as manual add, so there is exactly one writer to risks.yaml. On a
+   * successful write the row is dropped from the modal list; on conflict
+   * the standard ConflictDialog takes over (the proposal stays in the
+   * list so it can be retried after the user resolves the conflict).
+   */
+  const approveProposal = useCallback(
+    async (p: ProposedRisk): Promise<void> => {
+      const rand =
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID().slice(0, 8)
+          : Math.random().toString(36).slice(2, 10);
+      const risk: Risk = {
+        id: `risk-${Date.now().toString(36)}-${rand}`,
+        title: p.title.trim(),
+        severity: p.severity,
+        probability: p.probability,
+        mitigation: p.mitigation.trim(),
+        owner: "",
+        due: null,
+        status: "open",
+        source: "transcript-extracted",
+      };
+      const ok = await persist(
+        [...risks, risk],
+        `chore(hub): add risk "${risk.title}" from transcript to risks.yaml`,
+      );
+      if (ok) {
+        setProposals((prev) => prev.filter((x) => x !== p));
+      }
+    },
+    [persist, risks],
+  );
+
+  const rejectProposal = useCallback((p: ProposedRisk) => {
+    // Reject = forget it. Nothing is written to risks.yaml.
+    setProposals((prev) => prev.filter((x) => x !== p));
+  }, []);
+
+  /** Replace a proposal in-place after an inline edit (no write yet). */
+  const editProposal = useCallback(
+    (index: number, next: ProposedRisk) => {
+      setProposals((prev) =>
+        prev.map((x, i) => (i === index ? next : x)),
+      );
+    },
+    [],
+  );
+
   // ── render ────────────────────────────────────────────────────────
 
   if (phase === "loading") {
@@ -516,15 +606,47 @@ export function RiskRegisterTable({ repo }: Props) {
           {risks.length}{" "}
           {risks.length === 1 ? "риск" : "рисков"} · сортировка по severity
         </span>
-        <button
-          type="button"
-          style={btnPrimary}
-          disabled={busy || adding || editingId !== null}
-          onClick={startAdd}
-        >
-          + Добавить риск
-        </button>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button
+            type="button"
+            style={btn}
+            disabled={
+              busy ||
+              adding ||
+              editingId !== null ||
+              extractPhase === "extracting"
+            }
+            onClick={() => void runExtraction()}
+          >
+            {extractPhase === "extracting"
+              ? "Извлечение…"
+              : "Extract from transcripts"}
+          </button>
+          <button
+            type="button"
+            style={btnPrimary}
+            disabled={busy || adding || editingId !== null}
+            onClick={startAdd}
+          >
+            + Добавить риск
+          </button>
+        </div>
       </div>
+
+      {extractError && (
+        <div
+          role="alert"
+          style={{
+            fontSize: 12,
+            padding: "8px 10px",
+            borderRadius: 8,
+            background: "var(--v4-danger-bg, rgba(220,38,38,0.1))",
+            color: "var(--v4-danger, #dc2626)",
+          }}
+        >
+          Не удалось извлечь риски: {extractError}
+        </div>
+      )}
 
       {writeError && (
         <div
@@ -676,6 +798,17 @@ export function RiskRegisterTable({ repo }: Props) {
         />
       )}
 
+      {extractPhase === "done" && (
+        <ExtractReviewModal
+          proposals={proposals}
+          busy={busy}
+          onApprove={(p) => void approveProposal(p)}
+          onReject={rejectProposal}
+          onEdit={editProposal}
+          onClose={closeExtraction}
+        />
+      )}
+
       {conflict && (
         <ConflictDialog
           busy={busy}
@@ -684,6 +817,309 @@ export function RiskRegisterTable({ repo }: Props) {
           onDismiss={() => setConflict(null)}
         />
       )}
+    </div>
+  );
+}
+
+// ─── transcript-extraction review modal ─────────────────────────────────
+
+interface ExtractReviewProps {
+  proposals: ProposedRisk[];
+  busy: boolean;
+  onApprove: (p: ProposedRisk) => void;
+  onReject: (p: ProposedRisk) => void;
+  onEdit: (index: number, next: ProposedRisk) => void;
+  onClose: () => void;
+}
+
+function ExtractReviewModal({
+  proposals,
+  busy,
+  onApprove,
+  onReject,
+  onEdit,
+  onClose,
+}: ExtractReviewProps) {
+  const [editingIdx, setEditingIdx] = useState<number | null>(null);
+
+  // The proposals array is index-keyed for the edit toggle. When a row
+  // is approved/rejected the array shifts, so a stale `editingIdx`
+  // would attach the edit form to the wrong card. Reset it during
+  // render (the React-recommended "adjust state on prop change"
+  // pattern) whenever the list length changes — no effect needed.
+  const count = proposals.length;
+  const [seenCount, setSeenCount] = useState(count);
+  if (seenCount !== count) {
+    setSeenCount(count);
+    setEditingIdx(null);
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Риски из транскриптов"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.45)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          background: "var(--v4-surface, #fff)",
+          color: "var(--v4-ink-900, inherit)",
+          borderRadius: 12,
+          padding: 20,
+          width: "min(640px, 100%)",
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+          maxHeight: "90vh",
+          overflowY: "auto",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
+          <h3 style={{ margin: 0, fontSize: 16 }}>Риски из транскриптов</h3>
+          <button type="button" style={btn} onClick={onClose}>
+            Закрыть
+          </button>
+        </div>
+
+        {proposals.length === 0 ? (
+          <div
+            style={{
+              padding: 16,
+              border: "1px dashed var(--v4-border, rgba(0,0,0,0.1))",
+              borderRadius: 10,
+              color: "var(--v4-ink-500)",
+              fontSize: 13,
+            }}
+          >
+            В последних транскриптах проекта риски не найдены (или нет
+            обработанных транскриптов). Закройте это окно.
+          </div>
+        ) : (
+          <>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 12,
+                color: "var(--v4-ink-500)",
+              }}
+            >
+              {proposals.length}{" "}
+              {proposals.length === 1
+                ? "предложенный риск"
+                : "предложенных рисков"}
+              . «Одобрить» добавит риск в risks.yaml (источник: Transcript).
+              «Отклонить» ничего не записывает.
+            </p>
+            <div
+              style={{ display: "flex", flexDirection: "column", gap: 10 }}
+            >
+              {proposals.map((p, idx) => {
+                const isEditing = editingIdx === idx;
+                return (
+                  <div
+                    key={`${p.source}-${idx}`}
+                    style={{
+                      border:
+                        "1px solid var(--v4-border, rgba(0,0,0,0.12))",
+                      borderRadius: 10,
+                      padding: 12,
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 8,
+                    }}
+                  >
+                    {isEditing ? (
+                      <ProposalEditForm
+                        value={p}
+                        onChange={(next) => onEdit(idx, next)}
+                      />
+                    ) : (
+                      <>
+                        <div style={{ fontWeight: 600, fontSize: 14 }}>
+                          {p.title || "—"}
+                        </div>
+                        <div
+                          style={{
+                            display: "flex",
+                            gap: 6,
+                            flexWrap: "wrap",
+                          }}
+                        >
+                          <span
+                            style={{
+                              ...pillStyle,
+                              background: severityBg(p.severity),
+                              color: "#fff",
+                            }}
+                          >
+                            {SEVERITY_LABEL[p.severity]}
+                          </span>
+                          <span style={pillStyle}>
+                            Вероятность:{" "}
+                            {PROBABILITY_LABEL[p.probability]}
+                          </span>
+                        </div>
+                        {p.mitigation && (
+                          <div
+                            style={{
+                              fontSize: 13,
+                              color: "var(--v4-ink-700)",
+                            }}
+                          >
+                            Митигация: {p.mitigation}
+                          </div>
+                        )}
+                      </>
+                    )}
+                    <div
+                      style={{
+                        display: "flex",
+                        gap: 6,
+                        justifyContent: "flex-end",
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      {isEditing ? (
+                        <button
+                          type="button"
+                          style={btn}
+                          disabled={busy}
+                          onClick={() => setEditingIdx(null)}
+                        >
+                          Готово
+                        </button>
+                      ) : (
+                        <button
+                          type="button"
+                          style={btn}
+                          disabled={busy}
+                          onClick={() => setEditingIdx(idx)}
+                        >
+                          Изм.
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        style={btn}
+                        disabled={busy}
+                        onClick={() => onReject(p)}
+                      >
+                        Отклонить
+                      </button>
+                      <button
+                        type="button"
+                        style={btnPrimary}
+                        disabled={busy || p.title.trim() === ""}
+                        onClick={() => onApprove(p)}
+                      >
+                        {busy ? "…" : "Одобрить"}
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface ProposalEditFormProps {
+  value: ProposedRisk;
+  onChange: (next: ProposedRisk) => void;
+}
+
+function ProposalEditForm({ value, onChange }: ProposalEditFormProps) {
+  const field: React.CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+    fontSize: 12,
+    color: "var(--v4-ink-500)",
+  };
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <label style={field}>
+        Название
+        <input
+          aria-label="Название риска"
+          style={inputStyle}
+          value={value.title}
+          onChange={(e) => onChange({ ...value, title: e.target.value })}
+        />
+      </label>
+      <div style={{ display: "flex", gap: 12 }}>
+        <label style={{ ...field, flex: 1 }}>
+          Severity
+          <select
+            aria-label="Severity"
+            style={inputStyle}
+            value={value.severity}
+            onChange={(e) =>
+              onChange({
+                ...value,
+                severity: e.target.value as RiskSeverity,
+              })
+            }
+          >
+            {SEVERITIES.map((s) => (
+              <option key={s} value={s}>
+                {SEVERITY_LABEL[s]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={{ ...field, flex: 1 }}>
+          Вероятность
+          <select
+            aria-label="Вероятность"
+            style={inputStyle}
+            value={value.probability}
+            onChange={(e) =>
+              onChange({
+                ...value,
+                probability: e.target.value as RiskProbability,
+              })
+            }
+          >
+            {PROBABILITIES.map((pr) => (
+              <option key={pr} value={pr}>
+                {PROBABILITY_LABEL[pr]}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <label style={field}>
+        Митигация
+        <input
+          aria-label="Митигация"
+          style={inputStyle}
+          value={value.mitigation}
+          onChange={(e) =>
+            onChange({ ...value, mitigation: e.target.value })
+          }
+        />
+      </label>
     </div>
   );
 }

--- a/src/utils/extractRisksFromTranscripts.ts
+++ b/src/utils/extractRisksFromTranscripts.ts
@@ -1,0 +1,301 @@
+/**
+ * Risk extraction from transcripts (Epic-011 Task-09, PRD-008 FR-30).
+ *
+ * `extractRisks(repo)` pulls the BRIEF.md of the project's last 5 *done*
+ * transcripts, hands them to Claude Haiku, and returns a structured list
+ * of proposed risks for the operator to approve / reject / edit in the
+ * Risk Register UI.
+ *
+ * Design notes:
+ *  - Reuses the existing transcript client (`transcript.ts`) and the
+ *    Claude helper (`callClaudeWithTool` in `claude.ts`). No API key,
+ *    endpoint or model id is hardcoded here — the key comes from
+ *    `getClaudeKey()` (localStorage) and the budget guard / model
+ *    downgrade live inside `callClaudeWithTool`.
+ *  - The repo↔transcript match mirrors `customerHealthScore.ts` so the
+ *    same "owner/Repo" ↔ free-text project-context heuristic is used
+ *    everywhere (one source of truth for that fuzzy join).
+ *  - A forced tool call is used instead of free-form JSON: Anthropic
+ *    validates the model output against `input_schema`, so we get a
+ *    typed payload instead of regex-scraping a fenced code block. We
+ *    still defensively re-validate every field (an LLM can return an
+ *    out-of-enum severity, a number where a string is expected, etc.)
+ *    and silently drop unusable rows rather than throwing.
+ *  - Failure model: every external call (transcript list, transcript
+ *    body, Claude) is wrapped. No key / no transcripts / network error /
+ *    malformed reply all degrade to `[]` — the function never throws so
+ *    the UI can show a graceful empty state.
+ */
+
+import {
+  fetchTranscriptList,
+  fetchTranscriptResult,
+  type TranscriptListItem,
+} from "./transcript";
+import { callClaudeWithTool } from "./claude";
+import { getClaudeKey } from "./config";
+import type { RiskProbability, RiskSeverity } from "../types/hub";
+
+/** How many of the most recent *done* transcripts to feed the model. */
+const MAX_TRANSCRIPTS = 5;
+
+/** Per-transcript BRIEF char cap so the prompt size stays bounded. */
+const MAX_BRIEF_CHARS = 6000;
+
+/** Haiku is appropriate here (browser-side, cheap, structured output). */
+const RISK_MODEL = "claude-haiku-4-5-20251001" as const;
+
+const SEVERITIES: readonly RiskSeverity[] = ["low", "med", "high", "critical"];
+const PROBABILITIES: readonly RiskProbability[] = ["low", "med", "high"];
+
+/**
+ * One model-proposed risk, pre-validated. `source` is the transcript id
+ * the risk was derived from (kept for traceability in the approve UI;
+ * the persisted `Risk.source` enum value is set to `transcript-extracted`
+ * by the caller when the operator approves).
+ */
+export interface ProposedRisk {
+  title: string;
+  severity: RiskSeverity;
+  probability: RiskProbability;
+  mitigation: string;
+  /** Transcript task id the risk was extracted from (provenance). */
+  source: string;
+}
+
+const RISK_TOOL = {
+  name: "report_risks",
+  description:
+    "Сообщить список проектных рисков, извлечённых из транскриптов созвонов. " +
+    "Возвращай только реальные риски проекта (сроки, бюджет, технический долг, " +
+    "зависимость от внешних сторон, неясные требования, риск оттока клиента и т.п.), " +
+    "не общие наблюдения. Если рисков нет — верни пустой массив.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      risks: {
+        type: "array",
+        description:
+          "Список извлечённых рисков. Пустой массив, если рисков не обнаружено.",
+        items: {
+          type: "object",
+          properties: {
+            title: {
+              type: "string",
+              description: "Краткая формулировка риска (одно предложение).",
+            },
+            severity: {
+              type: "string",
+              enum: ["low", "med", "high", "critical"],
+              description: "Серьёзность последствий, если риск реализуется.",
+            },
+            probability: {
+              type: "string",
+              enum: ["low", "med", "high"],
+              description: "Вероятность того, что риск реализуется.",
+            },
+            mitigation: {
+              type: "string",
+              description:
+                "Предлагаемая мера по снижению риска (может быть пустой строкой).",
+            },
+            transcript_index: {
+              type: "number",
+              description:
+                "Номер транскрипта (1-based), из которого извлечён риск, как указано во входных данных.",
+            },
+          },
+          required: ["title", "severity", "probability", "transcript_index"],
+        },
+      },
+    },
+    required: ["risks"],
+  },
+};
+
+const RISK_SYSTEM =
+  "Ты — технический директор, который вычитывает транскрипты созвонов с клиентом " +
+  "и фиксирует проектные риски. Извлекай только конкретные риски проекта, а не " +
+  "общие рассуждения. Для каждого риска укажи серьёзность, вероятность и, если " +
+  "возможно, меру снижения. Не выдумывай риски, которых нет в тексте. " +
+  "Сомневаешься, риск это или нет — не включай его.";
+
+/**
+ * Loose repo↔transcript match. Mirrors `customerHealthScore.ts`:
+ * transcripts carry a free-text `project` context (the same field the
+ * Transcripts tab filters on); match case-insensitively on the repo slug
+ * appearing in that context (or vice-versa) so `owner/Repo` and `Repo`
+ * both resolve.
+ */
+function transcriptMatchesRepo(
+  item: TranscriptListItem,
+  repo: string,
+): boolean {
+  const slug = repo.includes("/") ? repo.split("/")[1] : repo;
+  const proj = (item.project || "").toLowerCase();
+  if (proj.length === 0) return false;
+  const needle = slug.toLowerCase();
+  return proj.includes(needle) || needle.includes(proj);
+}
+
+/** ISO timestamp → epoch ms, or `NaN` when unparseable. */
+function tsOf(iso: string): number {
+  return Date.parse(iso);
+}
+
+/** Trim an arbitrary value to a string (tolerates null/number/missing). */
+function asString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+/** Coerce an arbitrary value to a valid enum member, or `null`. */
+function coerceEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+): T | null {
+  return typeof value === "string" && (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : null;
+}
+
+interface RawRisk {
+  title?: unknown;
+  severity?: unknown;
+  probability?: unknown;
+  mitigation?: unknown;
+  transcript_index?: unknown;
+}
+
+interface RiskToolResult {
+  risks?: unknown;
+}
+
+/**
+ * Normalise one raw model row into a `ProposedRisk`, or `null` when the
+ * row is unusable (no title, or an out-of-enum severity/probability we
+ * can't safely guess). We never trust the model payload — even with a
+ * forced tool call Anthropic only loosely validates, so a missing field
+ * or a hallucinated enum is possible.
+ */
+function normaliseProposed(
+  raw: RawRisk,
+  transcripts: { id: string }[],
+): ProposedRisk | null {
+  const title = asString(raw.title).trim();
+  if (title === "") return null;
+
+  const severity = coerceEnum<RiskSeverity>(raw.severity, SEVERITIES);
+  const probability = coerceEnum<RiskProbability>(
+    raw.probability,
+    PROBABILITIES,
+  );
+  // A risk with an uninterpretable severity/probability is dropped
+  // rather than silently defaulted — the operator should not approve a
+  // risk whose level the model never actually expressed.
+  if (severity === null || probability === null) return null;
+
+  // `transcript_index` is 1-based in the prompt. Map it back to a task
+  // id for provenance; fall back to the first transcript if the model
+  // returned an out-of-range index (still a real transcript id).
+  const idxRaw = raw.transcript_index;
+  const idx =
+    typeof idxRaw === "number" && Number.isFinite(idxRaw)
+      ? Math.trunc(idxRaw) - 1
+      : -1;
+  const source =
+    idx >= 0 && idx < transcripts.length
+      ? transcripts[idx].id
+      : (transcripts[0]?.id ?? "");
+
+  return {
+    title,
+    severity,
+    probability,
+    mitigation: asString(raw.mitigation).trim(),
+    source,
+  };
+}
+
+/**
+ * Extract proposed risks from the project's most recent transcripts.
+ *
+ * Returns `[]` (never throws) when: no Claude key is set, the transcript
+ * service is unreachable, the project has no usable transcripts, the
+ * Claude call fails / is budget-stopped, or the model returns an
+ * unparseable payload. The caller treats `[]` as the graceful empty
+ * state.
+ */
+export async function extractRisks(repo: string): Promise<ProposedRisk[]> {
+  const apiKey = getClaudeKey();
+  if (!apiKey || !apiKey.trim()) return [];
+
+  let list: TranscriptListItem[];
+  try {
+    list = await fetchTranscriptList();
+  } catch {
+    return [];
+  }
+
+  const recentDone = list
+    .filter((i) => transcriptMatchesRepo(i, repo))
+    .filter((i) => i.status === "done")
+    .filter((i) => Number.isFinite(tsOf(i.created_at)))
+    .sort((a, b) => tsOf(b.created_at) - tsOf(a.created_at))
+    .slice(0, MAX_TRANSCRIPTS);
+
+  if (recentDone.length === 0) return [];
+
+  // Fetch each BRIEF; skip the ones we can't load (others may work).
+  const transcripts: { id: string; brief: string }[] = [];
+  for (const item of recentDone) {
+    try {
+      const res = await fetchTranscriptResult(item.task_id);
+      const brief = (res.brief || "").trim();
+      if (brief.length > 0) {
+        transcripts.push({ id: item.task_id, brief });
+      }
+    } catch {
+      // Skip an unreadable transcript.
+    }
+  }
+  if (transcripts.length === 0) return [];
+
+  const userMessage = transcripts
+    .map(
+      (t, i) =>
+        `=== Транскрипт ${i + 1} (id: ${t.id}) ===\n${t.brief.slice(0, MAX_BRIEF_CHARS)}`,
+    )
+    .join("\n\n");
+
+  let result: RiskToolResult;
+  try {
+    result = await callClaudeWithTool<RiskToolResult>(
+      apiKey,
+      RISK_SYSTEM,
+      `Извлеки проектные риски из ${transcripts.length} транскрипт(ов) ниже. ` +
+        `Для каждого риска укажи transcript_index (1-based) того транскрипта, ` +
+        `из которого он извлечён.\n\n${userMessage}`,
+      RISK_TOOL,
+      RISK_MODEL,
+      2048,
+      "other",
+    );
+  } catch {
+    // No key / budget hard-stop / network / model-didn't-call-tool.
+    return [];
+  }
+
+  const rawList = Array.isArray(result.risks) ? result.risks : [];
+  const out: ProposedRisk[] = [];
+  for (const raw of rawList) {
+    if (raw && typeof raw === "object") {
+      const norm = normaliseProposed(raw as RawRisk, transcripts);
+      if (norm) out.push(norm);
+    }
+  }
+  return out;
+}

--- a/src/utils/extractRisksFromTranscripts.ts
+++ b/src/utils/extractRisksFromTranscripts.ts
@@ -8,10 +8,11 @@
  *
  * Design notes:
  *  - Reuses the existing transcript client (`transcript.ts`) and the
- *    Claude helper (`callClaudeWithTool` in `claude.ts`). No API key,
- *    endpoint or model id is hardcoded here — the key comes from
- *    `getClaudeKey()` (localStorage) and the budget guard / model
- *    downgrade live inside `callClaudeWithTool`.
+ *    Claude helper (`callClaudeWithTool` in `claude.ts`). No API key or
+ *    endpoint is hardcoded — the key comes from `getClaudeKey()`
+ *    (localStorage) and the budget guard / model downgrade live inside
+ *    `callClaudeWithTool`. The model is pinned to Haiku via `RISK_MODEL`
+ *    (extraction is a cheap, structured-output task).
  *  - The repo↔transcript match mirrors `customerHealthScore.ts` so the
  *    same "owner/Repo" ↔ free-text project-context heuristic is used
  *    everywhere (one source of truth for that fuzzy join).


### PR DESCRIPTION
Closes #358

## Что сделано
- `src/utils/extractRisksFromTranscripts.ts` — `extractRisks(repo)`: последние 5 *done* BRIEF.md проекта → Claude Haiku (forced tool call, schema-validated) → `ProposedRisk[]` с defensive per-field validation. Reuse `transcript.ts` + `callClaudeWithTool` (`claude.ts`); ключ из `getClaudeKey()`, бюджет-гард внутри хелпера. Никогда не бросает: нет ключа / нет транскриптов / сеть / malformed reply → `[]`.
- `RiskRegisterTable.tsx` — кнопка «Extract from transcripts» + loading + modal со списком предложенных рисков, у каждого Approve / Reject / Edit. Approve конвертирует в `Risk` (`source: 'transcript-extracted'`) и пишет через СУЩЕСТВУЮЩИЙ `persist()` (тот же sha/ConflictError flow — один писатель в risks.yaml). Reject ничего не пишет. Пустая история / все отклонены → graceful empty state. Публичный API компонента (`{ repo }`, default export) не изменён.

## Out of scope (follow-up)
- Bootstrap templates в makeit-knowledge (cross-repo) → отдельная задача #406

## Тесты
- `npx tsc --noEmit` / `npm run lint` / `npm run build` — чистые

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён
- [x] P1 issues: 0 (P2: stale edit-index after approve/reject — исправлено render-time reset, без effect)