### PR TITLE
feat(hub): ActivityTab assembly (Epic-011 Task-07)

### DIFF
--- a/src/components/v4/hub/tabs/ActivityTab.tsx
+++ b/src/components/v4/hub/tabs/ActivityTab.tsx
@@ -1,8 +1,14 @@
-import { useEffect } from "react";
-import { Icon } from "../../health/Icon";
-import { markVisited } from "../../../../utils/lastVisitedStore";
-
-const EPIC_URL = "https://github.com/Sergio1990-1/makeit-dashboard/blob/main/docs/epics/epic-011.md";
+import { useEffect, useMemo, useState } from "react";
+import type { PulseEvent, PulseSource } from "../../../../types/hub";
+import { Icon, type IconName } from "../../health/Icon";
+import { markVisited, getLastVisited } from "../../../../utils/lastVisitedStore";
+import { aggregatePulse } from "../../../../utils/activityPulseAggregator";
+import {
+  fetchOpenPullRequests,
+  type OpenPullRequest,
+} from "../../../../utils/github";
+import { usePipeline } from "../../../../hooks/usePipeline";
+import { PulseTimeline } from "../PulseTimeline";
 
 interface Props {
   /** Repo whose Activity is being viewed — keys the lastVisited store. */
@@ -11,32 +17,428 @@ interface Props {
   onVisited: () => void;
 }
 
+/** All pulse sources, in chip display order. */
+const SOURCES: readonly PulseSource[] = [
+  "github",
+  "pipeline",
+  "transcript",
+  "audit",
+] as const;
+
+const SOURCE_LABEL: Record<PulseSource, string> = {
+  github: "GitHub",
+  pipeline: "Pipeline",
+  transcript: "Транскрипт",
+  audit: "Аудит",
+};
+
 /**
- * Placeholder. Epic-011 (Activity Pulse aggregator + ActivityTab assembly,
- * Tasks 06–07) fills this with the real timeline + inbox + open PRs/runs.
+ * Pulse window matches the aggregator's own 30-day floor. `aggregatePulse`
+ * clamps `since` to `max(since, now − 30d)` regardless, so this is just an
+ * explicit, honest lower bound rather than a magic `""`.
+ */
+const PULSE_WINDOW_DAYS = 30;
+
+/**
+ * One async section's resolved value, tagged with the `repo` it was loaded
+ * for. The public `data` / `loading` are *derived* from whether the stored
+ * key still matches the current `repo` — so a `repo` change instantly reads
+ * as "loading" with no synchronous setState-in-effect (forbidden by
+ * `react-hooks/set-state-in-effect`). Same idle-derivation pattern as
+ * `useProjectHub`'s `Resolved<T>` / `deriveSection`.
+ */
+interface Resolved<T> {
+  key: string;
+  data: T;
+}
+
+/**
+ * Activity tab (Epic-011 Task-07) — final assembly. Four stacked sections:
  *
- * Epic-011 Task-05 wires the lastVisited tracking: opening this tab marks
- * `repo` as visited (per-device sessionStorage) and notifies the parent so
- * the inbox badge clears.
+ *   1. Inbox        — pulse events newer than this device's last Activity
+ *                     visit for `repo`, highlighted. Computed against the
+ *                     last-visited timestamp captured *before* the
+ *                     markVisited effect runs (see `visitCutoff`), so the
+ *                     unread set is stable for this open.
+ *   2. Pulse        — `<PulseTimeline>` with source filter chips. Chips are
+ *                     tab-local state (NOT persisted) and filter the already
+ *                     loaded events client-side — no refetch.
+ *   3. Open PRs     — open pull requests from GitHub (≤20, newest-updated).
+ *   4. Open Runs    — currently-*running* pipeline tasks (via usePipeline).
+ *
+ * Data is fetched here (self-contained, like HealthTab) rather than through
+ * useProjectHub: `aggregatePulse` owns its own 5-min sessionStorage cache
+ * and `usePipeline` owns its own polling lifecycle, so threading either
+ * through the Hub aggregate would duplicate that machinery for no gain.
+ *
+ * The markVisited/onVisited effect is preserved verbatim from the Epic-009
+ * stub: on mount we `markVisited(repo)` then `onVisited()` so the Inbox
+ * renders its unread set at least once before the badge clears.
  */
 export function ActivityTab({ repo, onVisited }: Props) {
+  // Capture "last visited" ONCE, synchronously at mount, before the
+  // markVisited effect overwrites it — this is the cutoff the Inbox unread
+  // set is computed against, so the section is stable for the whole visit
+  // and doesn't empty itself the instant the effect fires. A lazy useState
+  // initializer (not a ref read in render) keeps this lint-clean and the
+  // value frozen for the component's lifetime; `repo` does not change for a
+  // mounted Hub (a different project remounts ProjectHubPage's subtree).
+  const [visitCutoff] = useState<string | null>(() => getLastVisited(repo));
+
   useEffect(() => {
     markVisited(repo);
     onVisited();
   }, [repo, onVisited]);
 
+  // ── Pulse ────────────────────────────────────────────────────────────
+  // aggregatePulse never throws (per its contract: a failing source
+  // degrades to empty); still guarded so a rejected promise can't escape
+  // into render. The effect only ever commits a *resolved* value tagged
+  // with the `repo` it loaded for; `loading` is derived (key mismatch =
+  // still loading) so there's no synchronous setState in the effect.
+  // `cancelled` drops a late resolve after repo-change / unmount.
+  const [pulseResolved, setPulseResolved] =
+    useState<Resolved<PulseEvent[]> | null>(null);
+  useEffect(() => {
+    const key = repo;
+    let cancelled = false;
+    const since = new Date(
+      Date.now() - PULSE_WINDOW_DAYS * 86_400_000,
+    ).toISOString();
+    void aggregatePulse(repo, since)
+      .then((events) => {
+        if (cancelled) return;
+        setPulseResolved({ key, data: events });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setPulseResolved({ key, data: [] });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo]);
+  const pulseFresh = pulseResolved !== null && pulseResolved.key === repo;
+  const pulse = useMemo<PulseEvent[]>(
+    () => (pulseFresh ? (pulseResolved?.data ?? []) : []),
+    [pulseFresh, pulseResolved],
+  );
+  const pulseLoading = !pulseFresh;
+
+  // ── Open PRs ─────────────────────────────────────────────────────────
+  // fetchOpenPullRequests degrades to [] on any failure (no token / network
+  // / GraphQL error), so the section just shows its empty state. Same
+  // tagged-store / derived-loading pattern as pulse above.
+  const [prsResolved, setPrsResolved] =
+    useState<Resolved<OpenPullRequest[]> | null>(null);
+  useEffect(() => {
+    const key = repo;
+    let cancelled = false;
+    void fetchOpenPullRequests(repo)
+      .then((list) => {
+        if (cancelled) return;
+        setPrsResolved({ key, data: list });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setPrsResolved({ key, data: [] });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo]);
+  const prsFresh = prsResolved !== null && prsResolved.key === repo;
+  const prs = useMemo<OpenPullRequest[]>(
+    () => (prsFresh ? (prsResolved?.data ?? []) : []),
+    [prsFresh, prsResolved],
+  );
+  const prsLoading = !prsFresh;
+
+  // ── Open pipeline runs ───────────────────────────────────────────────
+  // usePipeline owns its own polling + backoff; we only read its status and
+  // filter to in-flight runs. The feed is global (not repo-scoped), so this
+  // mirrors the aggregator's pipeline source: surface runs whose status is
+  // "running" (a running task genuinely is happening now).
+  const { status: pipelineStatus } = usePipeline();
+  const runningRuns = useMemo(
+    () =>
+      (pipelineStatus?.results ?? []).filter((r) => r.status === "running"),
+    [pipelineStatus],
+  );
+
+  // ── Inbox (unread) ───────────────────────────────────────────────────
+  // Events strictly newer than the pre-visit cutoff. Never-visited
+  // (`null`) → empty inbox, NOT the whole history (mirrors
+  // lastVisitedStore.unreadCount's first-open contract).
+  const unread = useMemo<PulseEvent[]>(() => {
+    if (visitCutoff === null) return [];
+    const cutoffMs = Date.parse(visitCutoff);
+    if (Number.isNaN(cutoffMs)) return [];
+    return pulse.filter((ev) => {
+      const t = Date.parse(ev.timestamp);
+      return !Number.isNaN(t) && t > cutoffMs;
+    });
+  }, [pulse, visitCutoff]);
+
+  // ── Source filter chips (tab-local, not persisted) ───────────────────
+  // `null` = "all"; otherwise the single selected source. The timeline is
+  // filtered client-side from the already-loaded `pulse` — toggling a chip
+  // never refetches.
+  const [sourceFilter, setSourceFilter] = useState<PulseSource | null>(null);
+  const filteredPulse = useMemo(
+    () =>
+      sourceFilter === null
+        ? pulse
+        : pulse.filter((ev) => ev.source === sourceFilter),
+    [pulse, sourceFilter],
+  );
+
   return (
-    <div className="v4-hub-tab-stub">
-      <Icon name="clock" />
-      <div>
-        <strong>Вкладка в разработке</strong>
-        <p>
-          Activity Pulse, Inbox, Open PRs и Open Pipeline Runs появятся в{" "}
-          <a href={EPIC_URL} target="_blank" rel="noreferrer">Epic-011</a>.
-        </p>
-      </div>
+    <div className="v4-hub-activity">
+      {/* 1 ── Inbox ─────────────────────────────────────────────────── */}
+      <section
+        className="v4-hub-activity-section v4-hub-activity-inbox"
+        aria-labelledby="v4-hub-activity-inbox-title"
+      >
+        <header className="v4-hub-activity-head">
+          <span className="v4-hub-activity-ic" aria-hidden="true">
+            <Icon name="bell" />
+          </span>
+          <h2
+            className="v4-hub-activity-title"
+            id="v4-hub-activity-inbox-title"
+          >
+            Inbox
+            {unread.length > 0 ? (
+              <span className="v4-hub-activity-count">{unread.length}</span>
+            ) : null}
+          </h2>
+        </header>
+        {unread.length > 0 ? (
+          <ul className="v4-hub-activity-inbox-list">
+            {unread.map((ev) => (
+              <li
+                key={`${ev.source}:${ev.id}`}
+                className="v4-hub-activity-inbox-item"
+              >
+                <span className="v4-hub-activity-inbox-src">
+                  {SOURCE_LABEL[ev.source]}
+                </span>
+                <span className="v4-hub-activity-inbox-title">
+                  {ev.title}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <ActivityEmpty
+            icon="check-big"
+            text={
+              pulseLoading
+                ? "Загрузка событий…"
+                : "Новых событий с прошлого визита нет."
+            }
+          />
+        )}
+      </section>
+
+      {/* 2 ── Pulse Timeline + source chips ──────────────────────────── */}
+      <section
+        className="v4-hub-activity-section"
+        aria-labelledby="v4-hub-activity-pulse-title"
+      >
+        <header className="v4-hub-activity-head">
+          <span className="v4-hub-activity-ic" aria-hidden="true">
+            <Icon name="trend" />
+          </span>
+          <h2
+            className="v4-hub-activity-title"
+            id="v4-hub-activity-pulse-title"
+          >
+            Активность
+          </h2>
+        </header>
+        <div
+          className="v4-hub-activity-chips"
+          role="group"
+          aria-label="Фильтр по источнику"
+        >
+          <button
+            type="button"
+            className={`v4-hub-activity-chip${
+              sourceFilter === null ? " v4-hub-activity-chip--on" : ""
+            }`}
+            aria-pressed={sourceFilter === null}
+            onClick={() => setSourceFilter(null)}
+          >
+            Все
+          </button>
+          {SOURCES.map((src) => (
+            <button
+              key={src}
+              type="button"
+              className={`v4-hub-activity-chip${
+                sourceFilter === src ? " v4-hub-activity-chip--on" : ""
+              }`}
+              aria-pressed={sourceFilter === src}
+              onClick={() =>
+                setSourceFilter((cur) => (cur === src ? null : src))
+              }
+            >
+              {SOURCE_LABEL[src]}
+            </button>
+          ))}
+        </div>
+        {pulseLoading ? (
+          <ActivityEmpty icon="clock" text="Загрузка активности…" />
+        ) : (
+          <PulseTimeline events={filteredPulse} />
+        )}
+      </section>
+
+      {/* 3 ── Open PRs ───────────────────────────────────────────────── */}
+      <section
+        className="v4-hub-activity-section"
+        aria-labelledby="v4-hub-activity-prs-title"
+      >
+        <header className="v4-hub-activity-head">
+          <span className="v4-hub-activity-ic" aria-hidden="true">
+            <Icon name="git-branch" />
+          </span>
+          <h2
+            className="v4-hub-activity-title"
+            id="v4-hub-activity-prs-title"
+          >
+            Открытые PR
+            {prs.length > 0 ? (
+              <span className="v4-hub-activity-count">{prs.length}</span>
+            ) : null}
+          </h2>
+        </header>
+        {prs.length > 0 ? (
+          <ul className="v4-hub-activity-pr-list">
+            {prs.map((pr) => (
+              <li key={pr.number} className="v4-hub-activity-pr-item">
+                <a
+                  className="v4-hub-activity-pr-link"
+                  href={pr.url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <span className="v4-hub-activity-pr-num">
+                    #{pr.number}
+                  </span>
+                  <span className="v4-hub-activity-pr-title">
+                    {pr.title}
+                  </span>
+                  {pr.isDraft ? (
+                    <span className="v4-hub-activity-pr-badge">draft</span>
+                  ) : null}
+                  {pr.author ? (
+                    <span className="v4-hub-activity-pr-author">
+                      @{pr.author}
+                    </span>
+                  ) : null}
+                </a>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <ActivityEmpty
+            icon="check"
+            text={
+              prsLoading ? "Загрузка PR…" : "Открытых PR нет."
+            }
+          />
+        )}
+      </section>
+
+      {/* 4 ── Open pipeline runs ─────────────────────────────────────── */}
+      <section
+        className="v4-hub-activity-section"
+        aria-labelledby="v4-hub-activity-runs-title"
+      >
+        <header className="v4-hub-activity-head">
+          <span className="v4-hub-activity-ic" aria-hidden="true">
+            <Icon name="cpu" />
+          </span>
+          <h2
+            className="v4-hub-activity-title"
+            id="v4-hub-activity-runs-title"
+          >
+            Pipeline в работе
+            {runningRuns.length > 0 ? (
+              <span className="v4-hub-activity-count">
+                {runningRuns.length}
+              </span>
+            ) : null}
+          </h2>
+        </header>
+        {runningRuns.length > 0 ? (
+          <ul className="v4-hub-activity-run-list">
+            {runningRuns.map((run) => {
+              const verdict =
+                run.outcome ?? run.phase_status ?? run.status;
+              return (
+                <li
+                  key={run.issue_number}
+                  className="v4-hub-activity-run-item"
+                >
+                  {run.pr_url ? (
+                    <a
+                      className="v4-hub-activity-run-link"
+                      href={run.pr_url}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      <span className="v4-hub-activity-run-num">
+                        #{run.issue_number}
+                      </span>
+                      <span className="v4-hub-activity-run-status">
+                        {verdict}
+                      </span>
+                    </a>
+                  ) : (
+                    <span className="v4-hub-activity-run-plain">
+                      <span className="v4-hub-activity-run-num">
+                        #{run.issue_number}
+                      </span>
+                      <span className="v4-hub-activity-run-status">
+                        {verdict}
+                      </span>
+                    </span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <ActivityEmpty
+            icon="check"
+            text="Сейчас pipeline-задач в работе нет."
+          />
+        )}
+      </section>
     </div>
   );
 }
 
 export default ActivityTab;
+
+interface ActivityEmptyProps {
+  icon: IconName;
+  text: string;
+}
+
+/** Scoped per-section empty state — keeps a section visible (never collapses
+ *  to nothing) even when its source is empty or still loading. */
+function ActivityEmpty({ icon, text }: ActivityEmptyProps) {
+  return (
+    <div className="v4-hub-activity-empty">
+      <span className="v4-hub-activity-empty-ic" aria-hidden="true">
+        <Icon name={icon} />
+      </span>
+      <p className="v4-hub-activity-empty-text">{text}</p>
+    </div>
+  );
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -9365,3 +9365,202 @@ ul.v4-rsh-list {
   color: var(--v4-ink-500);
   font-size: 13px;
 }
+
+/* ── Activity Tab (Epic-011 Task-07) ───────────────────────────────────
+   Four stacked sections: Inbox / Pulse (+ source chips) / Open PRs /
+   Open pipeline runs. Single-column on every breakpoint (the timeline is
+   inherently vertical). Every selector is scoped under .v4-hub-activity
+   and reuses existing semantic tokens only — no new palette. */
+.v4-hub-activity {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.v4-hub-activity .v4-hub-activity-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* Inbox sits at the top and is visually highlighted (accent-tinted card)
+   so unread events read as the priority surface. */
+.v4-hub-activity .v4-hub-activity-inbox {
+  padding: 16px 18px;
+  border: 1px solid var(--v4-accent-100);
+  border-radius: 12px;
+  background: var(--v4-accent-50);
+}
+
+.v4-hub-activity .v4-hub-activity-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.v4-hub-activity .v4-hub-activity-ic {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  font-size: 16px;
+  background: var(--v4-sky-50);
+  color: var(--v4-sky-700);
+}
+.v4-hub-activity .v4-hub-activity-inbox .v4-hub-activity-ic {
+  background: var(--v4-accent-100);
+  color: var(--v4-accent-700);
+}
+.v4-hub-activity .v4-hub-activity-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+.v4-hub-activity .v4-hub-activity-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--v4-accent-600);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+/* Source filter chips — toggle buttons, tab-local state. */
+.v4-hub-activity .v4-hub-activity-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.v4-hub-activity .v4-hub-activity-chip {
+  padding: 4px 12px;
+  border: 1px solid var(--v4-line);
+  border-radius: 999px;
+  background: var(--v4-paper);
+  color: var(--v4-ink-700);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.v4-hub-activity .v4-hub-activity-chip:hover {
+  border-color: var(--v4-accent-600);
+}
+.v4-hub-activity .v4-hub-activity-chip--on {
+  background: var(--v4-accent-600);
+  border-color: var(--v4-accent-600);
+  color: #fff;
+}
+.v4-hub-activity .v4-hub-activity-chip:focus-visible {
+  outline: 2px solid var(--v4-accent-500);
+  outline-offset: 2px;
+}
+
+/* Inbox / PR / run lists — compact rows, same rhythm as the hub minis. */
+.v4-hub-activity .v4-hub-activity-inbox-list,
+.v4-hub-activity .v4-hub-activity-pr-list,
+.v4-hub-activity .v4-hub-activity-run-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v4-hub-activity .v4-hub-activity-inbox-item,
+.v4-hub-activity .v4-hub-activity-pr-item,
+.v4-hub-activity .v4-hub-activity-run-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--v4-ink-900);
+}
+.v4-hub-activity .v4-hub-activity-inbox-item {
+  padding: 8px 10px;
+  border: 1px solid var(--v4-accent-100);
+  border-radius: 8px;
+  background: var(--v4-paper);
+}
+.v4-hub-activity .v4-hub-activity-inbox-src,
+.v4-hub-activity .v4-hub-activity-pr-num,
+.v4-hub-activity .v4-hub-activity-run-num {
+  flex-shrink: 0;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--v4-line-soft);
+  color: var(--v4-ink-700);
+  font-size: 11px;
+  font-weight: 600;
+}
+.v4-hub-activity .v4-hub-activity-inbox-title,
+.v4-hub-activity .v4-hub-activity-pr-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.v4-hub-activity .v4-hub-activity-pr-link,
+.v4-hub-activity .v4-hub-activity-run-link,
+.v4-hub-activity .v4-hub-activity-run-plain {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--v4-line);
+  border-radius: 8px;
+  background: var(--v4-paper);
+  color: inherit;
+  text-decoration: none;
+}
+.v4-hub-activity .v4-hub-activity-pr-link:hover,
+.v4-hub-activity .v4-hub-activity-run-link:hover {
+  border-color: var(--v4-accent-600);
+}
+.v4-hub-activity .v4-hub-activity-pr-badge {
+  flex-shrink: 0;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--v4-warn-50);
+  color: var(--v4-warn-700);
+  font-size: 11px;
+  font-weight: 600;
+}
+.v4-hub-activity .v4-hub-activity-pr-author,
+.v4-hub-activity .v4-hub-activity-run-status {
+  flex-shrink: 0;
+  color: var(--v4-ink-500);
+  font-size: 12px;
+}
+
+/* Per-section empty state — keeps a section visible (never collapses). */
+.v4-hub-activity .v4-hub-activity-empty {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 16px;
+  border: 1px dashed var(--v4-line);
+  border-radius: 10px;
+  color: var(--v4-ink-500);
+  font-size: 13px;
+}
+.v4-hub-activity .v4-hub-activity-empty-ic {
+  display: inline-flex;
+  font-size: 16px;
+  color: var(--v4-ink-400);
+}
+.v4-hub-activity .v4-hub-activity-empty-text {
+  margin: 0;
+}

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,5 +1,5 @@
 import type { Issue, IssueStatus, Priority, Phase, ProjectData, Milestone, CommitActivity } from "../types";
-import { getProjects, GITHUB_OWNER, GITHUB_PROJECT_NUMBER, DEFAULT_PROJECTS, loadFinances } from "./config";
+import { getProjects, GITHUB_OWNER, GITHUB_PROJECT_NUMBER, DEFAULT_PROJECTS, loadFinances, getToken } from "./config";
 import { dispatchExternalAuthLost } from "./external-auth-events";
 
 function getCacheUrl(): string {
@@ -764,4 +764,95 @@ export async function fetchDashboardData(
   const now = new Date();
   writeLocalCache(result, now);
   return { projects: result, lastSync: now };
+}
+
+// ── Open Pull Requests (Epic-011 Task-07: ActivityTab) ─────────────────────
+//
+// The Activity tab lists a project's currently-open PRs. This is a focused,
+// single-repo GraphQL query (≤ 20 newest open PRs) — distinct from the bulk
+// Projects-V2 sync above and from the REST `/events` feed the Pulse
+// aggregator uses (events surface *activity*, this surfaces *open state*).
+
+const OPEN_PRS_QUERY = `
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(first: 20, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        number
+        title
+        url
+        isDraft
+        updatedAt
+        author { login }
+      }
+    }
+  }
+}
+`;
+
+interface OpenPrsResponse {
+  repository: {
+    pullRequests: {
+      nodes: Array<{
+        number: number;
+        title: string;
+        url: string;
+        isDraft: boolean;
+        updatedAt: string;
+        author: { login: string } | null;
+      }>;
+    };
+  } | null;
+}
+
+/** One open PR as surfaced on the Activity tab. */
+export interface OpenPullRequest {
+  number: number;
+  title: string;
+  url: string;
+  isDraft: boolean;
+  updatedAt: string; // ISO
+  /** Login of the PR author, or `null` for a deleted/ghost account. */
+  author: string | null;
+}
+
+/**
+ * Open PRs for one repo, newest-updated first (≤ 20). Accepts either a
+ * bare `repo-name` (resolved against the dashboard `GITHUB_OWNER`) or a
+ * fully-qualified `owner/name` slug, matching the convention used by the
+ * other Hub utils (github-contents, activityPulseAggregator).
+ *
+ * Best-effort: with no token, or on any GraphQL/network failure, resolves
+ * to `[]` so the caller renders an empty state rather than crashing the
+ * tab (PRD-008 §"Каскадирование ошибок").
+ */
+export async function fetchOpenPullRequests(
+  repo: string,
+): Promise<OpenPullRequest[]> {
+  const token = getToken();
+  if (!token) return [];
+
+  const [owner, name] = repo.includes("/")
+    ? (repo.split("/") as [string, string])
+    : [GITHUB_OWNER, repo];
+
+  try {
+    const data = await graphql<OpenPrsResponse>(token, OPEN_PRS_QUERY, {
+      owner,
+      repo: name,
+    });
+    const nodes = data.repository?.pullRequests.nodes ?? [];
+    return nodes.map((pr) => ({
+      number: pr.number,
+      title: pr.title,
+      url: pr.url,
+      isDraft: pr.isDraft,
+      updatedAt: pr.updatedAt,
+      author: pr.author?.login ?? null,
+    }));
+  } catch {
+    // Auth-lost is already dispatched inside `graphql()`; here we degrade
+    // to an empty list so the Activity tab shows its empty state.
+    return [];
+  }
 }


### PR DESCRIPTION
Closes #356

## Что сделано
- ActivityTab: 4 секции в порядке Inbox / Pulse Timeline (+ source filter chips) / Open PRs / Open Pipeline Runs, у каждой секции свой scoped empty/loading state (не схлопывается в ничто)
- markVisited-once на mount сохранён дословно из заглушки (effect deps `[repo, onVisited]`, `onVisited` стабилен через `useCallback([])` в родителе); `onVisited()` сбрасывает inbox-badge в 0
- Inbox = pulse-события с `timestamp > lastVisited`, причём cutoff захватывается лениво при mount (`useState(() => getLastVisited(repo))`) ДО того как effect перезапишет lastVisited — секция стабильна весь визит
- Filter chips — локальный непостоянный стейт; фильтрация client-side из уже загруженного `pulse` (`.filter`, исходный массив не мутируется), без рефетча
- Данные: `aggregatePulse(repo, since)` (свой 5-мин sessionStorage-кэш), `usePipeline()` (свой polling) для running-задач, и **новый** `fetchOpenPullRequests(repo)` в `src/utils/github.ts` (focused GraphQL, ≤20 открытых PR, newest-updated; degrade → `[]` при no-token/ошибке)
- Данные грузятся в самой вкладке (self-contained, как HealthTab), а не через useProjectHub — у aggregatePulse/usePipeline своя машинерия кэша/поллинга. **ProjectHubPage.tsx и useProjectHub.ts НЕ тронуты**, пропсы ActivityTab без изменений (backward-compatible)
- Async-загрузка через паттерн `Resolved<T>` tagged-store + derived loading (как в useProjectHub) — без синхронного setState в effect

## Файлы
- `src/components/v4/hub/tabs/ActivityTab.tsx` — заглушка → сборка
- `src/utils/github.ts` — additive: импорт `getToken` + `fetchOpenPullRequests` / `OpenPullRequest`
- `src/styles/v4.css` — additive: scoped `.v4-hub-activity*` стили (только существующие токены)

## Тесты
- `npx tsc --noEmit` — чисто
- `npm run lint` — чисто
- `npm run build` — чисто

## Самопроверка
- [x] 13 пунктов
- [x] Senior review, P1: 1 исправлен (react-hooks/refs: чтение ref в render → ленивый useState; связанные set-state-in-effect → tagged-store паттерн)