### PR TITLE
feat(hub): DecisionsRisksTab assembly (Epic-011 Task-08)

### DIFF
--- a/src/components/v4/hub/CommitmentsTable.tsx
+++ b/src/components/v4/hub/CommitmentsTable.tsx
@@ -46,6 +46,14 @@ const COMMIT_MESSAGE = "chore(hub): update commitments";
 interface Props {
   /** Repo slug (`owner/repo` or bare name → dashboard owner). */
   repo: string;
+  /**
+   * Optional observer for the rendered row count. Fired with the
+   * number of commitment rows currently in the table (after load and
+   * on every local add/delete) so a parent (DecisionsRisksTab) can
+   * show an accurate section counter from the SAME data this table
+   * renders — no divergent second fetch.
+   */
+  onCount?: (count: number) => void;
 }
 
 /** A row plus a stable client-side key (Commitment has no id). */
@@ -222,7 +230,7 @@ function DraftForm({ initial, submitLabel, onSubmit, onCancel }: DraftFormProps)
   );
 }
 
-export function CommitmentsTable({ repo }: Props) {
+export function CommitmentsTable({ repo, onCount }: Props) {
   const [load, setLoad] = useState<LoadState>({ phase: "loading" });
   const [rows, setRows] = useState<Row[]>([]);
   /** sha of docs/commitments.yaml at load; undefined ⇒ file absent. */
@@ -298,6 +306,16 @@ export function CommitmentsTable({ repo }: Props) {
       ? { ...r, status: "overdue" as const }
       : r,
   );
+
+  // Report the rendered row count to an interested parent. Effect (not
+  // render) so it's a parent notification, not a synchronous local
+  // setState — fires after commit, only when the count or callback
+  // identity changes. `decorated` is a 1:1 map of `rows`, so
+  // `rows.length` is exactly what the table renders. Callers pass a
+  // stable `useCallback` per the standard effect-dependency contract.
+  useEffect(() => {
+    onCount?.(rows.length);
+  }, [rows.length, onCount]);
 
   function mutate(next: Row[]) {
     setRows(next);

--- a/src/components/v4/hub/ProjectHubPage.tsx
+++ b/src/components/v4/hub/ProjectHubPage.tsx
@@ -183,7 +183,9 @@ export function ProjectHubPage({ repo, project, onBackToList }: Props) {
           {activeTab === "activity" && (
             <ActivityTab repo={repo} onVisited={handleActivityVisited} />
           )}
-          {activeTab === "decisions" && <DecisionsRisksTab decisions={data.decisions} />}
+          {activeTab === "decisions" && (
+            <DecisionsRisksTab repo={repo} decisions={data.decisions} />
+          )}
           {activeTab === "delivery" && <DeliveryTab repo={repo} data={data} />}
         </Suspense>
       </div>

--- a/src/components/v4/hub/RenewalsTable.tsx
+++ b/src/components/v4/hub/RenewalsTable.tsx
@@ -148,12 +148,22 @@ const btnPrimary: React.CSSProperties = {
 interface Props {
   /** Repo slug (`owner/repo` or bare name → dashboard owner). */
   repo: string;
+  /**
+   * Optional observer for the tracked-record count. Fired with the
+   * total renewals (manual + non-shadowed auto-scan, BEFORE the
+   * in-table type filter) so a parent (DecisionsRisksTab) can show an
+   * accurate, stable section counter from the SAME data this table
+   * derives — no divergent second fetch. Deliberately the unfiltered
+   * total: the type filter is a local view control, not the section's
+   * record count.
+   */
+  onCount?: (count: number) => void;
 }
 
 type Phase = "loading" | "ready" | "error";
 type TypeFilter = RenewalType | "all";
 
-export function RenewalsTable({ repo }: Props) {
+export function RenewalsTable({ repo, onCount }: Props) {
   const [phase, setPhase] = useState<Phase>("loading");
   const [loadError, setLoadError] = useState<string | null>(null);
   /** `false` ⇒ docs/renewals.yaml does not exist yet (empty-state). */
@@ -221,7 +231,10 @@ export function RenewalsTable({ repo }: Props) {
   // expiry. `now` is read fresh every render (urgency colouring) — no
   // memo: the input changes every tick so a memo would never hit.
   const now = Date.now();
-  const visible = useMemo(() => {
+  // Full tracked set (manual + non-shadowed auto-scan), sorted by
+  // expiry, BEFORE the local type filter. This is the section's true
+  // record count; the type filter is only a view control.
+  const allTracked = useMemo(() => {
     const manualKeys = new Set(
       manual.map((r) => `${r.type}::${r.name.trim().toLowerCase()}`),
     );
@@ -231,11 +244,24 @@ export function RenewalsTable({ repo }: Props) {
         (r) => !manualKeys.has(`${r.type}::${r.name.trim().toLowerCase()}`),
       ),
     ];
-    const sorted = sortByExpiry(merged);
-    return filter === "all"
-      ? sorted
-      : sorted.filter((r) => r.type === filter);
-  }, [manual, autoScan, filter]);
+    return sortByExpiry(merged);
+  }, [manual, autoScan]);
+  const visible = useMemo(
+    () =>
+      filter === "all"
+        ? allTracked
+        : allTracked.filter((r) => r.type === filter),
+    [allTracked, filter],
+  );
+
+  // Report the tracked-record count to an interested parent. Effect
+  // (not render) so it's a parent notification, not a synchronous
+  // local setState — fires after commit, only when the count or
+  // callback identity changes. Unfiltered on purpose (see `onCount`
+  // doc). Callers pass a stable `useCallback`.
+  useEffect(() => {
+    onCount?.(allTracked.length);
+  }, [allTracked.length, onCount]);
 
   /**
    * Persist `next` manual list to renewals.yaml. Auto-scan rows are

--- a/src/components/v4/hub/RiskRegisterTable.tsx
+++ b/src/components/v4/hub/RiskRegisterTable.tsx
@@ -219,11 +219,18 @@ const btnPrimary: React.CSSProperties = {
 
 interface Props {
   repo: string;
+  /**
+   * Optional observer for the rendered record count. Fired with
+   * `risks.length` whenever it changes (after load / CRUD). Lets a
+   * parent (DecisionsRisksTab) show an accurate section counter from
+   * the SAME data this table renders — no divergent second fetch.
+   */
+  onCount?: (count: number) => void;
 }
 
 type Phase = "loading" | "ready" | "error";
 
-export function RiskRegisterTable({ repo }: Props) {
+export function RiskRegisterTable({ repo, onCount }: Props) {
   const [phase, setPhase] = useState<Phase>("loading");
   const [loadError, setLoadError] = useState<string | null>(null);
   /** `null` ⇒ file does not exist yet (empty-state with "create"). */
@@ -275,6 +282,15 @@ export function RiskRegisterTable({ repo }: Props) {
   }, [load]);
 
   const sorted = useMemo(() => sortBySeverityDesc(risks), [risks]);
+
+  // Report the rendered count to an interested parent. Effect (not
+  // render) so it's a parent notification, not a synchronous local
+  // setState — fires after commit, only when the count or callback
+  // identity changes. Callers pass a stable `useCallback` per the
+  // standard effect-dependency contract.
+  useEffect(() => {
+    onCount?.(risks.length);
+  }, [risks.length, onCount]);
 
   /**
    * Persist `next` to the repo. On a sha conflict we DON'T silently

--- a/src/components/v4/hub/tabs/DecisionsRisksTab.tsx
+++ b/src/components/v4/hub/tabs/DecisionsRisksTab.tsx
@@ -1,45 +1,330 @@
-import { Icon } from "../../health/Icon";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Icon, type IconName } from "../../health/Icon";
 import { DecisionLog } from "../DecisionLog";
+import { RiskRegisterTable } from "../RiskRegisterTable";
+import { CommitmentsTable } from "../CommitmentsTable";
+import { RenewalsTable } from "../RenewalsTable";
 import type { Decision } from "../../../../types/hub";
 
-const EPIC_URL = "https://github.com/Sergio1990-1/makeit-dashboard/blob/main/docs/epics/epic-011.md";
+/**
+ * Decisions & Risks tab — final four-section assembly (Epic-011
+ * Task-08, FR-23..FR-32, PRD-008 §4.3).
+ *
+ * Layout: a sticky in-tab nav (horizontal on narrow screens) plus four
+ * anchored sections in this fixed order:
+ *
+ *   1. Decision Log    (#decisions) — read-only, fed from BRIEF.md +
+ *                       conventional commits via useProjectHub.
+ *   2. Risk Register   (#risks)     — repo-driven CRUD over risks.yaml.
+ *   3. Commitments     (#commitments) — repo-driven CRUD over
+ *                       commitments.yaml (+ BRIEF merge).
+ *   4. Renewals        (#renewals)  — repo-driven CRUD over
+ *                       renewals.yaml (+ package.json auto-scan).
+ *
+ * Deep-link: OverviewTab's NBA / Risks / Commitments summaries switch
+ * to this tab via the parent's `?subtab=decisions`. FR-14 wants those
+ * to land on the right section, so this tab reads `location.hash` on
+ * mount and smooth-scrolls to the matching `<section id>` once the
+ * sections are mounted (their containers render synchronously; the
+ * self-fetching tables show their own loading state in place, so the
+ * anchor target exists and resolves at the correct offset immediately).
+ *
+ * Active-section highlight in the nav is driven by a single
+ * IntersectionObserver created once and disconnected on unmount — no
+ * scroll listener, no per-render observer churn.
+ *
+ * Counts: the Decision Log count is `decisions.length` (the array this
+ * component renders). The three self-fetching tables each report their
+ * rendered record count through an `onCount` callback — the SAME data
+ * they render, never a divergent second fetch. `useProjectHub` still
+ * returns EMPTY_* placeholders for risks/commitments/renewals, so it is
+ * deliberately NOT used as a count source (it would show wrong 0s). A
+ * table's badge is shown only once it has reported a real count, so a
+ * section never flashes a knowingly-wrong 0 while its table loads.
+ *
+ * Empty states are delegated entirely to the underlying components
+ * (DecisionLog / the three tables each own theirs) — this assembly
+ * never reimplements them.
+ */
 
 interface Props {
+  /** Decisions for the read-only Decision Log (from useProjectHub). */
   decisions: Decision[];
+  /**
+   * Repo slug — required by the three self-fetching CRUD tables
+   * (risks/commitments/renewals all read & write their own yaml).
+   */
+  repo: string;
 }
 
-/**
- * Decision Log lives here today (Epic-011 Task-01). Risk Register,
- * Commitments, and Renewals get their own sections in Tasks 02–04 and
- * the four-section assembly + anchors lands in Task-08.
- */
-export function DecisionsRisksTab({ decisions }: Props) {
-  return (
-    <div className="v4-hub-decisions-tab" style={{ display: "flex", flexDirection: "column", gap: 24 }}>
-      <section aria-labelledby="hub-decision-log-heading">
-        <h2
-          id="hub-decision-log-heading"
-          style={{
-            margin: "0 0 12px",
-            fontSize: 16,
-            fontWeight: 600,
-          }}
-        >
-          Decision Log
-        </h2>
-        <DecisionLog decisions={decisions} />
-      </section>
+type SectionId = "decisions" | "risks" | "commitments" | "renewals";
 
-      <div className="v4-hub-tab-stub">
-        <Icon name="book" />
-        <div>
-          <strong>Risk Register, Commitments, Renewals — в разработке</strong>
-          <p>
-            Появятся в{" "}
-            <a href={EPIC_URL} target="_blank" rel="noreferrer">Epic-011</a>{" "}
-            (Tasks 02–04, 08).
-          </p>
-        </div>
+interface SectionDef {
+  id: SectionId;
+  title: string;
+  icon: IconName;
+}
+
+/** Fixed order — Decision Log → Risk Register → Commitments → Renewals. */
+const SECTIONS: readonly SectionDef[] = [
+  { id: "decisions", title: "Decision Log", icon: "book" },
+  { id: "risks", title: "Risk Register", icon: "alert" },
+  { id: "commitments", title: "Commitments", icon: "clock" },
+  { id: "renewals", title: "Renewals", icon: "shield" },
+] as const;
+
+function isSectionId(value: string): value is SectionId {
+  return SECTIONS.some((s) => s.id === value);
+}
+
+export function DecisionsRisksTab({ decisions, repo }: Props) {
+  // Per-section record counts. Decision Log is known synchronously
+  // (the array we render). The three tables report through onCount;
+  // `null` ⇒ "not reported yet" so we suppress the badge rather than
+  // flash a wrong 0 while a table is still loading.
+  const [riskCount, setRiskCount] = useState<number | null>(null);
+  const [commitCount, setCommitCount] = useState<number | null>(null);
+  const [renewalCount, setRenewalCount] = useState<number | null>(null);
+
+  // Stable callbacks: the tables depend on `onCount` identity in their
+  // count-reporting effect, so an inline lambda would re-fire it every
+  // render. useCallback keeps it firing only on real count changes.
+  const onRiskCount = useCallback((n: number) => setRiskCount(n), []);
+  const onCommitCount = useCallback((n: number) => setCommitCount(n), []);
+  const onRenewalCount = useCallback((n: number) => setRenewalCount(n), []);
+
+  const counts = useMemo<Record<SectionId, number | null>>(
+    () => ({
+      decisions: decisions.length,
+      risks: riskCount,
+      commitments: commitCount,
+      renewals: renewalCount,
+    }),
+    [decisions.length, riskCount, commitCount, renewalCount],
+  );
+
+  // ── Active section (scroll-spy) ──────────────────────────────────────
+  const [activeId, setActiveId] = useState<SectionId>("decisions");
+  const sectionRefs = useRef<Partial<Record<SectionId, HTMLElement | null>>>(
+    {},
+  );
+
+  const setSectionRef = useCallback(
+    (id: SectionId) => (el: HTMLElement | null) => {
+      sectionRefs.current[id] = el;
+    },
+    [],
+  );
+
+  // One IntersectionObserver for all four sections, created once on
+  // mount and disconnected on unmount (no leak, no stale-node observe).
+  // The most "in view" section (largest intersection ratio, tie-broken
+  // by document order) wins the active highlight.
+  useEffect(() => {
+    const els = SECTIONS.map((s) => sectionRefs.current[s.id]).filter(
+      (el): el is HTMLElement => el != null,
+    );
+    if (els.length === 0) return;
+
+    const ratios = new Map<SectionId, number>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const id = entry.target.getAttribute("data-section-id");
+          if (id && isSectionId(id)) {
+            ratios.set(id, entry.isIntersecting ? entry.intersectionRatio : 0);
+          }
+        }
+        let best: SectionId | null = null;
+        let bestRatio = -1;
+        for (const s of SECTIONS) {
+          const r = ratios.get(s.id) ?? 0;
+          if (r > bestRatio) {
+            bestRatio = r;
+            best = s.id;
+          }
+        }
+        if (best !== null && bestRatio > 0) setActiveId(best);
+      },
+      // Several thresholds so the active item tracks smoothly as a
+      // section scrolls through the viewport.
+      { threshold: [0, 0.25, 0.5, 0.75, 1] },
+    );
+
+    for (const el of els) observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // ── Hash deep-link on mount ──────────────────────────────────────────
+  // OverviewTab switches to this tab via `?subtab=decisions` (state, not
+  // hash), but FR-14 deep-links carry a `#section` so the tab can land
+  // on the right block. Scroll once, after first paint, when a matching
+  // hash is present. Section containers render synchronously (tables
+  // show their own loading state in place), so the anchor target exists
+  // at the correct offset — we don't wait on async table data.
+  const didHashScrollRef = useRef(false);
+  useEffect(() => {
+    if (didHashScrollRef.current) return;
+    didHashScrollRef.current = true;
+    if (typeof window === "undefined") return;
+    const raw = window.location.hash.replace(/^#/, "");
+    if (!raw || !isSectionId(raw)) return;
+    const el = sectionRefs.current[raw];
+    if (!el) return;
+    // Scroll only. The active-nav highlight is owned by the
+    // IntersectionObserver — it fires as this scroll lands and sets
+    // `activeId`, so we must NOT setState here (that would be a
+    // synchronous effect setState; the observer is the single source
+    // of truth for the active section).
+    el.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
+  const handleNavClick = useCallback(
+    (id: SectionId) => () => {
+      const el = sectionRefs.current[id];
+      if (!el) return;
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+      setActiveId(id);
+      // Reflect the section in the URL hash without a history entry so
+      // a refresh / share lands back on the same section.
+      if (typeof window !== "undefined") {
+        const url = new URL(window.location.href);
+        url.hash = id;
+        window.history.replaceState(null, "", url.toString());
+      }
+    },
+    [],
+  );
+
+  return (
+    <div className="v4-hub-decisions">
+      <nav
+        className="v4-hub-decisions-nav"
+        aria-label="Разделы Decisions & Risks"
+      >
+        {SECTIONS.map((s) => {
+          const count = counts[s.id];
+          return (
+            <button
+              key={s.id}
+              type="button"
+              className={`v4-hub-decisions-navlink${
+                activeId === s.id ? " v4-hub-decisions-navlink--on" : ""
+              }`}
+              aria-current={activeId === s.id ? "true" : undefined}
+              onClick={handleNavClick(s.id)}
+            >
+              <span className="v4-hub-decisions-nav-ic" aria-hidden="true">
+                <Icon name={s.icon} />
+              </span>
+              <span className="v4-hub-decisions-nav-label">{s.title}</span>
+              {count !== null ? (
+                <span className="v4-hub-decisions-nav-count">{count}</span>
+              ) : null}
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="v4-hub-decisions-main">
+        <section
+          id="decisions"
+          data-section-id="decisions"
+          ref={setSectionRef("decisions")}
+          className="v4-hub-decisions-section"
+          aria-labelledby="v4-hub-decisions-decisions-title"
+        >
+          <header className="v4-hub-decisions-head">
+            <span className="v4-hub-decisions-ic" aria-hidden="true">
+              <Icon name="book" />
+            </span>
+            <h2
+              className="v4-hub-decisions-title"
+              id="v4-hub-decisions-decisions-title"
+            >
+              Decision Log
+              <span className="v4-hub-decisions-count">
+                {decisions.length}
+              </span>
+            </h2>
+          </header>
+          <DecisionLog decisions={decisions} />
+        </section>
+
+        <section
+          id="risks"
+          data-section-id="risks"
+          ref={setSectionRef("risks")}
+          className="v4-hub-decisions-section"
+          aria-labelledby="v4-hub-decisions-risks-title"
+        >
+          <header className="v4-hub-decisions-head">
+            <span className="v4-hub-decisions-ic" aria-hidden="true">
+              <Icon name="alert" />
+            </span>
+            <h2
+              className="v4-hub-decisions-title"
+              id="v4-hub-decisions-risks-title"
+            >
+              Risk Register
+              {riskCount !== null ? (
+                <span className="v4-hub-decisions-count">{riskCount}</span>
+              ) : null}
+            </h2>
+          </header>
+          {/* Add affordance is provided by RiskRegisterTable itself. */}
+          <RiskRegisterTable repo={repo} onCount={onRiskCount} />
+        </section>
+
+        <section
+          id="commitments"
+          data-section-id="commitments"
+          ref={setSectionRef("commitments")}
+          className="v4-hub-decisions-section"
+          aria-labelledby="v4-hub-decisions-commitments-title"
+        >
+          <header className="v4-hub-decisions-head">
+            <span className="v4-hub-decisions-ic" aria-hidden="true">
+              <Icon name="clock" />
+            </span>
+            <h2
+              className="v4-hub-decisions-title"
+              id="v4-hub-decisions-commitments-title"
+            >
+              Commitments
+              {commitCount !== null ? (
+                <span className="v4-hub-decisions-count">{commitCount}</span>
+              ) : null}
+            </h2>
+          </header>
+          {/* Add affordance is provided by CommitmentsTable itself. */}
+          <CommitmentsTable repo={repo} onCount={onCommitCount} />
+        </section>
+
+        <section
+          id="renewals"
+          data-section-id="renewals"
+          ref={setSectionRef("renewals")}
+          className="v4-hub-decisions-section"
+          aria-labelledby="v4-hub-decisions-renewals-title"
+        >
+          <header className="v4-hub-decisions-head">
+            <span className="v4-hub-decisions-ic" aria-hidden="true">
+              <Icon name="shield" />
+            </span>
+            <h2
+              className="v4-hub-decisions-title"
+              id="v4-hub-decisions-renewals-title"
+            >
+              Renewals
+              {renewalCount !== null ? (
+                <span className="v4-hub-decisions-count">{renewalCount}</span>
+              ) : null}
+            </h2>
+          </header>
+          {/* Add affordance is provided by RenewalsTable itself. */}
+          <RenewalsTable repo={repo} onCount={onRenewalCount} />
+        </section>
       </div>
     </div>
   );

--- a/src/components/v4/hub/tabs/DecisionsRisksTab.tsx
+++ b/src/components/v4/hub/tabs/DecisionsRisksTab.tsx
@@ -21,13 +21,16 @@ import type { Decision } from "../../../../types/hub";
  *   4. Renewals        (#renewals)  — repo-driven CRUD over
  *                       renewals.yaml (+ package.json auto-scan).
  *
- * Deep-link: OverviewTab's NBA / Risks / Commitments summaries switch
- * to this tab via the parent's `?subtab=decisions`. FR-14 wants those
- * to land on the right section, so this tab reads `location.hash` on
- * mount and smooth-scrolls to the matching `<section id>` once the
- * sections are mounted (their containers render synchronously; the
+ * Deep-link: on mount this tab reads `location.hash` and, if it is one
+ * of `#decisions|#risks|#commitments|#renewals`, smooth-scrolls to the
+ * matching `<section id>` (containers render synchronously — the
  * self-fetching tables show their own loading state in place, so the
- * anchor target exists and resolves at the correct offset immediately).
+ * anchor exists at the correct offset immediately). This satisfies an
+ * externally-supplied `…#risks` URL. NOTE: the in-app OverviewTab
+ * summaries currently switch tabs via the parent's `?subtab=decisions`
+ * (state, no hash), so that path lands at the top of the tab, not on
+ * the originating section — wiring OverviewTab→section for the in-app
+ * path is tracked separately (FR-14 follow-up, issue #413).
  *
  * Active-section highlight in the nav is driven by a single
  * IntersectionObserver created once and disconnected on unmount — no

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -9564,3 +9564,157 @@ ul.v4-rsh-list {
 .v4-hub-activity .v4-hub-activity-empty-text {
   margin: 0;
 }
+
+/* ── Decisions & Risks tab (Epic-011 Task-08) ──────────────────────────
+   Four anchored sections (Decision Log / Risk Register / Commitments /
+   Renewals) plus an in-tab nav with scroll-spy active state. At ≥960px
+   the nav is a sticky left rail; below that it collapses to a sticky
+   horizontal bar above the content (degrades, never overflows). Every
+   selector is scoped under .v4-hub-decisions and reuses existing
+   semantic tokens only — no new palette. */
+.v4-hub-decisions {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  align-items: start;
+}
+@media (min-width: 960px) {
+  .v4-hub-decisions {
+    grid-template-columns: 200px minmax(0, 1fr);
+    gap: 24px;
+  }
+}
+
+/* Nav: sticky horizontal scroller on narrow screens, sticky vertical
+   rail at ≥960px. position:sticky degrades to static where unsupported
+   without breaking the layout. */
+.v4-hub-decisions .v4-hub-decisions-nav {
+  position: sticky;
+  top: 8px;
+  z-index: 1;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: 6px;
+  padding: 6px;
+  overflow-x: auto;
+  border: 1px solid var(--v4-line);
+  border-radius: 12px;
+  background: var(--v4-paper);
+}
+@media (min-width: 960px) {
+  .v4-hub-decisions .v4-hub-decisions-nav {
+    flex-direction: column;
+    flex-wrap: nowrap;
+    overflow-x: visible;
+    top: 16px;
+  }
+}
+
+.v4-hub-decisions .v4-hub-decisions-navlink {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--v4-ink-700);
+  font-size: 13px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.v4-hub-decisions .v4-hub-decisions-navlink:hover {
+  background: var(--v4-line-soft);
+}
+.v4-hub-decisions .v4-hub-decisions-navlink--on {
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
+}
+.v4-hub-decisions .v4-hub-decisions-navlink:focus-visible {
+  outline: 2px solid var(--v4-accent-500);
+  outline-offset: 2px;
+}
+.v4-hub-decisions .v4-hub-decisions-nav-ic {
+  display: inline-flex;
+  font-size: 15px;
+}
+.v4-hub-decisions .v4-hub-decisions-nav-label {
+  flex: 1;
+  min-width: 0;
+}
+.v4-hub-decisions .v4-hub-decisions-nav-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--v4-line-soft);
+  color: var(--v4-ink-700);
+  font-size: 11px;
+  font-weight: 700;
+}
+.v4-hub-decisions .v4-hub-decisions-navlink--on .v4-hub-decisions-nav-count {
+  background: var(--v4-accent-100);
+  color: var(--v4-accent-700);
+}
+
+.v4-hub-decisions .v4-hub-decisions-main {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  min-width: 0;
+}
+
+/* scroll-margin-top so a hash / nav scroll lands the heading below the
+   sticky nav rather than flush against the viewport top. */
+.v4-hub-decisions .v4-hub-decisions-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  scroll-margin-top: 16px;
+}
+
+.v4-hub-decisions .v4-hub-decisions-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.v4-hub-decisions .v4-hub-decisions-ic {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  font-size: 16px;
+  background: var(--v4-sky-50);
+  color: var(--v4-sky-700);
+}
+.v4-hub-decisions .v4-hub-decisions-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+.v4-hub-decisions .v4-hub-decisions-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--v4-line-soft);
+  color: var(--v4-ink-700);
+  font-size: 12px;
+  font-weight: 700;
+}


### PR DESCRIPTION
Closes #357

## Что сделано
- DecisionsRisksTab: 4 секции (Decision Log / Risk Register / Commitments / Renewals) в фиксированном порядке с якорями `#decisions` / `#risks` / `#commitments` / `#renewals`
- Sticky in-tab nav + IntersectionObserver active-section (один observer, создаётся один раз, disconnect на unmount); `location.hash` → `scrollIntoView({ behavior: 'smooth' })` один раз на mount
- Заголовки секций: title + count badge; empty state полностью делегирован компонентам (DecisionLog / 3 таблицы); Add-кнопки НЕ дублируются — каждая из 3 таблиц рендерит свою, DecisionLog read-only
- ProjectHubPage: `<DecisionsRisksTab repo={repo} decisions={data.decisions} />` — добавлен backward-compatible `repo` prop (нужен 3 self-fetching таблицам); другие табы не затронуты
- Counts wiring: Decision Log = `decisions.length` (массив, который рендерит компонент). Risk/Commitments/Renewals — через новый optional `onCount?: (n) => void` callback на каждой таблице (репортит ровно тот счётчик, что отрендерен — без дивергентного второго fetch). `useProjectHub` отдаёт EMPTY_* плейсхолдеры для risks/commitments/renewals, поэтому он НЕ используется как источник счётчиков (дал бы неверные 0). Badge таблицы показывается только после реального репорта (`null`-guard) — секция не мигает заведомо неверным 0 во время загрузки. Renewals: счётчик = полный tracked-набор (manual + non-shadowed auto-scan) ДО локального type-фильтра (фильтр — view-control, не record count)
- Anchors → OverviewTab deep-links: OverviewTab переключает таб через `?subtab=decisions` (state, не hash); section IDs совпадают с issue-спекой и FR-14 (`#section`), hash-scroll срабатывает когда таб монтируется с присутствующим hash

## Тесты
- type-check / lint / build чистые

## Самопроверка
- [x] 13 пунктов
- [x] Senior review, P1: 0