### PR TITLE
feat(portfolio): Sidebar NBA badge — Epic-010 Task-07 Part 1 (#349)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { useDashboard } from "./hooks/useDashboard";
 import { useMonitors } from "./hooks/useMonitors";
 import { usePortfolioHealth } from "./hooks/usePortfolioHealth";
 import { usePortfolioOrphans } from "./hooks/usePortfolioOrphans";
+import { usePortfolioNbaBadge } from "./hooks/usePortfolioNbaBadge";
 import { fetchPipelineStatus, fetchPipelineLimits } from "./utils/pipeline";
 import type { PipelineAbortReason, PipelineLimits } from "./utils/pipeline";
 import { getToken, clearToken, getAuth, clearAuth, clearClaudeKey, MONITOR_MATCH, PROJECTS } from "./utils/config";
@@ -475,6 +476,10 @@ function AppInner({ onFirstFetchDone }: AppInnerProps = {}) {
     orphansRefresh();
   }, [refresh, refreshMonitors, portfolioRefresh, orphansRefresh]);
 
+  // Passive portfolio-NBA count for the «Проекты» sidebar pill. Reads only
+  // the cache PortfolioNextActions wrote — never triggers a Claude compute.
+  const nbaBadge = usePortfolioNbaBadge(tab);
+
   const hasToken = !!getToken();
 
   const allMilestones = projects.flatMap((p) => p.milestones);
@@ -542,6 +547,7 @@ function AppInner({ onFirstFetchDone }: AppInnerProps = {}) {
         monitorsCount={monitors.length}
         auditAlerts={auditAlerts}
         criticalFails={criticalFails}
+        nbaBadge={nbaBadge}
         pulses={pulses}
         isOpen={sideOpen}
         onClose={() => setSideOpen(false)}

--- a/src/components/v4/Sidebar.tsx
+++ b/src/components/v4/Sidebar.tsx
@@ -9,6 +9,9 @@ interface NavItem {
   label: string;
   count?: number;
   badge?: number;
+  /** Portfolio NBA count pill (Epic-010 Task-07, FR-10). undefined/0 → no
+   *  pill. Distinct from `badge` (red danger) — this is a warn-tone pill. */
+  nba?: number;
   /** Optional pulsing dot for "new activity since last visit". */
   pulse?: PulseKind;
   icon: ReactElement;
@@ -29,6 +32,9 @@ interface Props {
   /** Number of portfolio-wide critical health fails. Shown as a red badge
    *  on the «Дашборд» nav item. 0/undefined → no badge rendered. */
   criticalFails?: number;
+  /** Portfolio NBA action count for the «Проекты» pill (Epic-010 Task-07,
+   *  FR-10). undefined/0 → no pill (no cache or empty portfolio NBA). */
+  nbaBadge?: number;
   /** Per-tab activity pulses (null = no dot). */
   pulses?: Partial<Record<TabId, PulseKind>>;
   user?: { initials: string; name: string; role: string };
@@ -106,6 +112,7 @@ export function Sidebar({
   monitorsCount,
   auditAlerts,
   criticalFails,
+  nbaBadge,
   pulses,
   user = { initials: "SM", name: "Сергей М.", role: "owner · MakeIT" },
   isOpen,
@@ -126,7 +133,7 @@ export function Sidebar({
           // count down so we don't double-mount the hook here.
           badge: criticalFails && criticalFails > 0 ? criticalFails : undefined,
         },
-        { id: "projects", label: "Проекты", count: projectsCount, icon: ICON_LIST, pulse: p.projects },
+        { id: "projects", label: "Проекты", count: projectsCount, nba: nbaBadge, icon: ICON_LIST, pulse: p.projects },
         { id: "milestones", label: "Milestones", count: milestonesCount, icon: ICON_CLOCK, pulse: p.milestones },
         { id: "uptime", label: "Мониторинг", count: monitorsCount || undefined, icon: ICON_MONITOR, pulse: p.uptime },
       ],
@@ -192,6 +199,14 @@ export function Sidebar({
                   {item.icon}
                   {item.label}
                   {item.count !== undefined && <span className="v4-nav-count">{item.count}</span>}
+                  {item.nba !== undefined && item.nba > 0 && (
+                    <span
+                      className="sidebar-badge"
+                      title={`${item.nba} рекомендованных действий по портфелю`}
+                    >
+                      {item.nba}
+                    </span>
+                  )}
                   {item.badge !== undefined && item.badge > 0 && (
                     <span className="v4-nav-badge">{item.badge}</span>
                   )}

--- a/src/components/v4/Sidebar.tsx
+++ b/src/components/v4/Sidebar.tsx
@@ -202,6 +202,8 @@ export function Sidebar({
                   {item.nba !== undefined && item.nba > 0 && (
                     <span
                       className="sidebar-badge"
+                      role="status"
+                      aria-label={`${item.nba} рекомендованных действий по портфелю`}
                       title={`${item.nba} рекомендованных действий по портфелю`}
                     >
                       {item.nba}

--- a/src/hooks/usePortfolioNba.ts
+++ b/src/hooks/usePortfolioNba.ts
@@ -100,6 +100,17 @@ function readCachedEnvelope(): { actions: NbaResult["actions"]; weekStartMs: num
   }
 }
 
+/**
+ * Read-only count of cached portfolio NBA actions for the sidebar badge
+ * (Epic-010 Task-07, #349, FR-10). Returns null when there is no usable
+ * cache — deliberately distinct from 0 so the badge stays hidden rather than
+ * rendering «0». Never triggers a compute / Claude call.
+ */
+export function readPortfolioNbaCount(): number | null {
+  const env = readCachedEnvelope();
+  return env === null ? null : env.actions.length;
+}
+
 export interface UsePortfolioNbaState {
   /** Top-5 portfolio actions (empty array = clean / no cache). */
   actions: NbaResult["actions"];

--- a/src/hooks/usePortfolioNbaBadge.ts
+++ b/src/hooks/usePortfolioNbaBadge.ts
@@ -1,0 +1,51 @@
+/**
+ * usePortfolioNbaBadge — passive sidebar badge count for the «Проекты» nav
+ * item (Epic-010 Task-07, #349, FR-10).
+ *
+ * Reads ONLY the cache `PortfolioNextActions` already wrote
+ * (`localStorage[PORTFOLIO_NBA_CACHE_KEY]`); it never computes or calls
+ * Claude just to feed a badge. Returns `undefined` (badge hidden) when there
+ * is no cache or the cached portfolio has zero actions; otherwise the action
+ * count. Refreshes on cross-tab `storage` events and whenever the user
+ * switches to the «Проекты» tab (same-document writes emit no storage event,
+ * so the tab switch is the in-tab refresh trigger).
+ */
+
+import { useEffect, useState } from "react";
+import type { TabId } from "../types";
+import { PORTFOLIO_NBA_CACHE_KEY, readPortfolioNbaCount } from "./usePortfolioNba";
+
+export function usePortfolioNbaBadge(activeTab: TabId): number | undefined {
+  const [count, setCount] = useState<number | null>(() =>
+    readPortfolioNbaCount(),
+  );
+
+  // Re-read when the user lands on «Проекты». A same-document cache write
+  // (PortfolioNextActions regenerate) fires no `storage` event, so the tab
+  // switch is the in-tab refresh point. This is React's documented "adjust
+  // state during render when a prop changes" pattern (prev-value in state +
+  // setState during render) — it re-renders before commit with no effect /
+  // cascading-render cost, and unlike a ref-guard it satisfies the strict
+  // react-hooks lint rules.
+  const [prevTab, setPrevTab] = useState(activeTab);
+  if (prevTab !== activeTab) {
+    setPrevTab(activeTab);
+    if (activeTab === "projects") {
+      setCount(readPortfolioNbaCount());
+    }
+  }
+
+  // Subscribe to cross-tab cache writes (another browser tab regenerated).
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      // e.key === null → localStorage.clear(); re-read in that case too.
+      if (e.key === null || e.key === PORTFOLIO_NBA_CACHE_KEY) {
+        setCount(readPortfolioNbaCount());
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  return count !== null && count > 0 ? count : undefined;
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -219,6 +219,23 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   border-radius: 4px;
   padding: 1px 6px;
 }
+/* Portfolio NBA pill on the «Проекты» nav item (Epic-010 Task-07, FR-10).
+   Warn tone, distinct from the red danger .v4-nav-badge. Sits after the
+   gray .v4-nav-count (which holds margin-left:auto) on the right edge. */
+.sidebar-badge {
+  margin-left: 6px;
+  font-family: var(--v4-mono);
+  font-size: 9px;
+  font-weight: 700;
+  background: var(--v4-warn-50);
+  color: var(--v4-warn-700);
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+.v4-nav-item.is-active .sidebar-badge {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
 
 .v4-side-foot {
   padding: 14px 16px;


### PR DESCRIPTION
Closes #349

## Что сделано
**Part 1 — Sidebar NBA badge (FR-10):**
- `readPortfolioNbaCount()` in `usePortfolioNba.ts` — read-only count from the existing `localStorage[makeit_portfolio_nba]` cache (reuses the private envelope parser; cache key imported, not inlined). Returns `null` (≠ 0) when no cache so the badge stays hidden rather than showing «0».
- `usePortfolioNbaBadge(activeTab)` hook — returns the count, or `undefined` when no cache / zero actions. Refreshes on cross-tab `storage` events and when switching to the «Проекты» tab. **Never triggers a Claude compute** — purely passive.
- `Sidebar.tsx` — new optional `nbaBadge?` prop renders a warn-tone `.sidebar-badge` pill on the «Проекты» item (distinct from the red danger `.v4-nav-badge`). Hidden at 0/undefined.
- CSS pill + `is-active` legibility override (mirrors the existing `.v4-nav-count` active override).
- Wired in `App.tsx` (hook mounted once, count passed down — same single-source pattern as `criticalFails`).

**Part 2 — E2E test:** split into #417. The project has no Playwright/test harness; standing one up (deps + CI job + GitHub GraphQL fixtures) is distinct infra work, not part of this polish-sized task.

## Тесты
No automated tests added — the project has zero test infrastructure (tracked in #417). Verified via `npm run lint` + `npx tsc --noEmit` + `npm run build` (all clean, exit 0) and a full manual senior code review of the diff.

Note: full in-browser render of the pill could not be exercised here — the dashboard sits behind a React-controlled password gate and then requires a live GitHub PAT (no-backend SPA) to render the sidebar.

## Самопроверка
- [x] 13 пунктов пройдены (no hardcoded secrets, no debug logs, no dead code, read-only, listener cleaned up)
- [x] Senior review проведён
- [x] P1 issues: 0 · P2 issues: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)