### PR TITLE
fix(portfolio): resolve Portfolio Surface review leftovers (#392)

### DIFF
--- a/src/components/v4/portfolio/DriftDots.tsx
+++ b/src/components/v4/portfolio/DriftDots.tsx
@@ -1,4 +1,5 @@
 import type { ProjectNorm } from "../../../utils/driftNorm";
+import { SEVERITY_COLORS, DRIFT_WARN_MULT, DRIFT_STALE_MULT } from "./constants";
 
 /**
  * DriftDots — four colored dots showing how stale each project signal is
@@ -42,12 +43,12 @@ interface DotStyle {
   word: string;
 }
 
-// Tints carry their own readable color (not a theme var) so the dot is
-// legible on both light and dark Scorecards; the glyph adds a non-color cue.
+// Shared severity palette (see ./constants) so dot color can't drift apart
+// from ProjectScorecard's grade tone; the glyph adds a non-color cue.
 const DOT_STYLE: Record<DriftSeverity, DotStyle> = {
-  ok: { bg: "#16a34a", glyph: "●", word: "в норме" },
-  warn: { bg: "#ca8a04", glyph: "◐", word: "отставание" },
-  stale: { bg: "#dc2626", glyph: "▲", word: "просрочено" },
+  ok: { bg: SEVERITY_COLORS.ok, glyph: "●", word: "в норме" },
+  warn: { bg: SEVERITY_COLORS.warn, glyph: "◐", word: "отставание" },
+  stale: { bg: SEVERITY_COLORS.danger, glyph: "▲", word: "просрочено" },
   unknown: { bg: "var(--v4-ink-300, #C5CCDA)", glyph: "○", word: "нет данных" },
 };
 
@@ -67,8 +68,8 @@ function classifyDrift(
   if (norm === undefined || !Number.isFinite(norm) || norm <= 0) {
     return "unknown";
   }
-  if (days >= norm * 3) return "stale";
-  if (days >= norm * 1.5) return "warn";
+  if (days >= norm * DRIFT_STALE_MULT) return "stale";
+  if (days >= norm * DRIFT_WARN_MULT) return "warn";
   return "ok";
 }
 

--- a/src/components/v4/portfolio/PortfolioNextActions.tsx
+++ b/src/components/v4/portfolio/PortfolioNextActions.tsx
@@ -93,6 +93,13 @@ export function PortfolioNextActions({
   const { actions, loading, error, ageDays, hasCache, budgetFallback, regenerate } =
     usePortfolioNba(perProjectActions);
 
+  // Regenerate invalidates the cache *before* recomputing, so firing it with
+  // no per-project input would compute an empty result and silently wipe the
+  // actions currently on screen. Until live cross-portfolio collection lands
+  // (Epic-012 Task-09, #367) the mounting surface passes `undefined` — keep
+  // the button disabled in that state rather than letting it erase the cache.
+  const canRegenerate = !!perProjectActions?.length;
+
   const openProject = useCallback(
     (repo: string | undefined) => {
       // Engine rows carry an optional `repo`; ignore anything we can't map
@@ -156,8 +163,12 @@ export function PortfolioNextActions({
             type="button"
             className="v4-btn v4-ai-btn"
             onClick={regenerate}
-            disabled={loading}
-            title="Сбросить кэш и пересчитать действия по портфелю"
+            disabled={loading || !canRegenerate}
+            title={
+              canRegenerate
+                ? "Сбросить кэш и пересчитать действия по портфелю"
+                : "Нет данных по проектам для пересчёта — кэш не трогаем"
+            }
           >
             {loading ? "Генерация…" : "Регенерировать"}
           </button>

--- a/src/components/v4/portfolio/ProjectScorecard.tsx
+++ b/src/components/v4/portfolio/ProjectScorecard.tsx
@@ -4,6 +4,7 @@ import type { HealthScore } from "../../../types/health";
 import type { ProjectTier } from "../../../utils/driftNorm";
 import { useDriftNorm } from "../../../hooks/useDriftNorm";
 import { DriftDots, type DriftDaysInput } from "./DriftDots";
+import { SEVERITY_COLORS } from "./constants";
 
 /**
  * ProjectScorecard — preview card for the Portfolio Surface
@@ -68,20 +69,26 @@ const PHASE_BADGE: Record<Phase, { icon: string; label: string; color: string }>
   "pre-dev": { icon: "◻", label: "pre-dev", color: "var(--v4-purple-700, #5B21B6)" },
 };
 
-// Grade → tone. Colors carry their own readable value (kept off pure theme
-// vars) and the letter itself is the primary, non-color signal.
+// Grade → tone. Shared severity palette (see ./constants) so this can't
+// drift apart from DriftDots; the letter itself is the primary, non-color
+// signal.
 const GRADE_TONE: Record<HealthGrade, string> = {
-  A: "#16a34a",
-  B: "#65a30d",
-  C: "#ca8a04",
-  D: "#ea580c",
-  F: "#dc2626",
+  A: SEVERITY_COLORS.ok,
+  B: SEVERITY_COLORS.strong,
+  C: SEVERITY_COLORS.warn,
+  D: SEVERITY_COLORS.elevated,
+  F: SEVERITY_COLORS.danger,
 };
 
+/** Numeric tier (1|2|3), accepting either the numeric or `tier-N` form. */
+function tierNumber(tier: ProjectTier): 1 | 2 | 3 {
+  if (tier === 1 || tier === "tier-1") return 1;
+  if (tier === 2 || tier === "tier-2") return 2;
+  return 3;
+}
+
 function tierLabel(tier: ProjectTier): string {
-  if (tier === 1 || tier === "tier-1") return "T1";
-  if (tier === 2 || tier === "tier-2") return "T2";
-  return "T3";
+  return `T${tierNumber(tier)}`;
 }
 
 /** Days → short relative RU string. `null`/invalid → "—". */
@@ -93,14 +100,22 @@ function relativeDays(days: number | null | undefined): string {
   return `${d}д назад`;
 }
 
-/** Compact USD ($1,2k / $940). Non-finite → null (footer skips it). */
+/**
+ * Compact USD ($940 / $1,2k / $3,5M). Non-finite/negative → null (footer
+ * skips it). Uses Intl `ru-RU` formatting (decimal comma + thousands
+ * grouping) and an M tier so large sums no longer fall back to an ungrouped
+ * `$1250k`-style string.
+ */
 function compactUsd(n: number | null | undefined): string | null {
   if (n === null || n === undefined || !Number.isFinite(n) || n < 0) return null;
-  if (n >= 1000) {
-    const k = n / 1000;
-    return `$${k.toFixed(k % 1 === 0 ? 0 : 1).replace(".", ",")}k`;
-  }
-  return `$${Math.round(n)}`;
+  const ru = (v: number, maxFrac: number): string =>
+    new Intl.NumberFormat("ru-RU", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: maxFrac,
+    }).format(v);
+  if (n >= 1_000_000) return `$${ru(n / 1_000_000, 1)}M`;
+  if (n >= 1000) return `$${ru(n / 1000, 1)}k`;
+  return `$${ru(Math.round(n), 0)}`;
 }
 
 interface KpiItemProps {
@@ -121,7 +136,7 @@ function KpiItem({ icon, value, label, danger }: KpiItemProps) {
         alignItems: "baseline",
         gap: 4,
         fontSize: 12,
-        color: isAlert ? "#dc2626" : "var(--v4-ink-800, #1B2235)",
+        color: isAlert ? SEVERITY_COLORS.danger : "var(--v4-ink-800, #1B2235)",
         fontWeight: isAlert ? 700 : 500,
       }}
     >
@@ -152,7 +167,7 @@ export function ProjectScorecard({
   // thresholds (issue: "Берёт … norm из useDriftNorm(repo)").
   const { norm, loading: normLoading } = useDriftNorm(repo, tier);
 
-  const phaseBadge = PHASE_BADGE[phase] ?? PHASE_BADGE["pre-dev"];
+  const phaseBadge = PHASE_BADGE[phase];
   const gradeTone = grade ? GRADE_TONE[grade] : "var(--v4-ink-400, #94A0B8)";
   const cost = compactUsd(costMtdUsd);
 
@@ -205,7 +220,7 @@ export function ProjectScorecard({
               {repo}
             </span>
             <span
-              title={`Tier ${tierLabel(tier).slice(1)}`}
+              title={`Tier ${tierNumber(tier)}`}
               style={{
                 fontSize: 10,
                 fontWeight: 700,

--- a/src/components/v4/portfolio/constants.ts
+++ b/src/components/v4/portfolio/constants.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared Portfolio Surface palette + drift thresholds (Epic-010, #392).
+ *
+ * `ProjectScorecard` (grade tone, KPI alert) and `DriftDots` (dot color,
+ * classify thresholds) previously hard-coded the same severity hexes and
+ * drift multipliers in two separate files — a palette-drift risk flagged in
+ * review as the surface grows. This is the single source for both.
+ *
+ * Tones are self-contained readable hexes (deliberately NOT theme vars) so
+ * they read on light AND dark Scorecards; the grade letter / dot glyph is
+ * always the primary, non-color signal.
+ */
+
+export const SEVERITY_COLORS = {
+  /** A grade · in-norm drift */
+  ok: "#16a34a",
+  /** B grade */
+  strong: "#65a30d",
+  /** C grade · lagging drift */
+  warn: "#ca8a04",
+  /** D grade */
+  elevated: "#ea580c",
+  /** F grade · overdue drift · KPI alert */
+  danger: "#dc2626",
+} as const;
+
+/**
+ * Drift severity bands as a multiple of the per-project norm
+ * (epic-010.md color rule: warn ≥ 1.5×, stale ≥ 3×).
+ */
+export const DRIFT_WARN_MULT = 1.5;
+export const DRIFT_STALE_MULT = 3;


### PR DESCRIPTION
Closes #392

## Что сделано
Non-blocking review findings from PR #391 (Task-01) / #390 (Task-02), all Low:

1. **Shared palette/thresholds** — new `src/components/v4/portfolio/constants.ts` with `SEVERITY_COLORS` + `DRIFT_WARN_MULT`/`DRIFT_STALE_MULT`. `ProjectScorecard` (`GRADE_TONE`, KPI alert) and `DriftDots` (`DOT_STYLE`, `classifyDrift`) now consume it instead of duplicating the same hexes / `1.5`·`3` literals across two files. **Color & threshold values are byte-identical — zero visual change.**
2. **`compactUsd`** — `Intl.NumberFormat('ru-RU')` (decimal comma + thousands grouping) + an `M` tier, replacing the brittle `.replace(".", ",")`. Large sums no longer degrade to an ungrouped `$1250k`.
3. **Tier tooltip** — uses `tierNumber(tier)` directly instead of `tierLabel(tier).slice(1)` double conversion.
4. **Dead branch** — removed the unreachable `?? PHASE_BADGE["pre-dev"]` fallback (`Phase` is a closed 3-member union exactly matching `PHASE_BADGE`'s keys).
5. **Regenerate cache-wipe** — «Регенерировать» is now disabled (with an explanatory tooltip) when there is no per-project input. `regenerate` invalidates the cache *before* recomputing, so firing it with empty input (the current `ProjectsView` mount, until Epic-012 #367) silently wiped the on-screen actions.

## Тесты
No automated tests (project has no test harness — tracked in #417). Verified via `npm run lint` + `npx tsc --noEmit` + `npm run build` (all clean, exit 0) and a full senior code review confirming findings 1/3/4 are behavior-preserving and only 2/5 change behavior (the intended fixes).

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён
- [x] P1 issues: 0 · P2 issues: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)