### PR TITLE
fix(portfolio): dedupe weekEndMs + thread force in digest panel (#415)

### DIFF
--- a/src/components/v4/portfolio/PortfolioDigestPanel.tsx
+++ b/src/components/v4/portfolio/PortfolioDigestPanel.tsx
@@ -44,6 +44,7 @@ import { renderMarkdownHtml } from "../../../utils/transcript-markdown";
 import {
   currentWeekKey,
   generatePortfolioDigest,
+  weekEndMs,
 } from "../../../utils/weeklyDigestGenerator";
 import { readFile } from "../../../utils/github-contents";
 
@@ -63,33 +64,6 @@ function portfolioDigestPath(weekKey: string): string {
 
 function cacheKey(weekKey: string): string {
   return `${CACHE_PREFIX}_${weekKey}`;
-}
-
-/**
- * Epoch ms at which a cached digest for `weekKey` stops being
- * authoritative: the end (Sunday 23:59:59.999 UTC) of that ISO week.
- *
- * Identical algorithm to the generator's internal `weekEndMs` (which is
- * not exported): ISO week 1 is the week containing Jan 4th; Monday of
- * week N is `week1Monday + (N-1)*7`; the week ends end-of-Sunday. A past
- * week's timestamp is already in the past, but the cache reader keeps a
- * cached past-week value anyway (the underlying activity is frozen).
- */
-function weekEndMs(weekKey: string): number {
-  const m = weekKey.match(/^(\d{4})-(\d{2})$/);
-  if (!m) return 0;
-  const year = Number(m[1]);
-  const week = Number(m[2]);
-  const jan4 = new Date(Date.UTC(year, 0, 4));
-  const jan4Day = jan4.getUTCDay() || 7; // Sun=7
-  const week1Monday = new Date(jan4);
-  week1Monday.setUTCDate(jan4.getUTCDate() - (jan4Day - 1));
-  const weekMonday = new Date(week1Monday);
-  weekMonday.setUTCDate(week1Monday.getUTCDate() + (week - 1) * 7);
-  const weekSundayEnd = new Date(weekMonday);
-  weekSundayEnd.setUTCDate(weekMonday.getUTCDate() + 6);
-  weekSundayEnd.setUTCHours(23, 59, 59, 999);
-  return weekSundayEnd.getTime();
 }
 
 interface CachedDigest {
@@ -220,12 +194,10 @@ export function PortfolioDigestPanel({ week }: Props) {
     const reqId = ++reqRef.current;
     try {
       // The real Epic-012 Task-02 generator: rebuilds + re-persists
-      // `digests/{weekKey}-portfolio.md` and returns the entry. NOTE: the
-      // portfolio path currently ignores `force` — it re-stitches from
-      // the per-project digest caches and always re-persists the
-      // portfolio file, but does not force-refresh the per-project
-      // inputs. `{ force: true }` is passed for intent / forward-compat;
-      // threading it to per-project loadDigest is tracked in #415.
+      // `digests/{weekKey}-portfolio.md` and returns the entry. `force`
+      // is now threaded to each per-project `loadDigest` (#415), so a
+      // Regenerate re-reads the committed per-project digests instead of
+      // stitching from possibly-stale localStorage caches.
       const entry = await generatePortfolioDigest(weekKey, { force: true });
       if (reqRef.current !== reqId) return;
       // Refresh preview in place (no page reload) and overwrite the

--- a/src/utils/weeklyDigestGenerator.ts
+++ b/src/utils/weeklyDigestGenerator.ts
@@ -172,7 +172,7 @@ export function recentWeekKeys(count: number, from: Date = new Date()): string[]
  * already in the past and any cached value is still served (we only
  * treat *missing* as stale for closed weeks — see `readCache`).
  */
-function weekEndMs(weekKey: string): number {
+export function weekEndMs(weekKey: string): number {
   const m = weekKey.match(/^(\d{4})-(\d{2})$/);
   if (!m) return 0;
   const year = Number(m[1]);
@@ -630,6 +630,7 @@ export async function generateDigest(
 export async function loadDigest(
   repo: string,
   weekISO: string | Date,
+  force = false,
 ): Promise<DigestEntry | null> {
   let weekKey: string;
   try {
@@ -638,8 +639,14 @@ export async function loadDigest(
     return null;
   }
 
-  const cached = readCache(repo, weekKey);
-  if (cached !== null) return cached;
+  // `force` bypasses the localStorage cache so a forced portfolio
+  // regenerate re-reads the committed per-project digest (source of
+  // truth) instead of a possibly-stale cached copy. The committed file
+  // re-seeds the cache below either way (#415).
+  if (!force) {
+    const cached = readCache(repo, weekKey);
+    if (cached !== null) return cached;
+  }
 
   try {
     const file = await readFile(DIGEST_REPO, digestPath(repo, weekKey));
@@ -696,6 +703,10 @@ export async function loadDigestHistory(
  * "No digest" note rather than omitted silently, so the roll-up makes
  * coverage gaps visible. Never throws — a failed per-project read is
  * counted as "no digest".
+ *
+ * `options.force` (Regenerate) is threaded into each per-project
+ * `loadDigest` so the roll-up re-reads committed per-project digests
+ * instead of stitching from possibly-stale localStorage caches (#415).
  */
 export async function generatePortfolioDigest(
   weekISO: string | Date,
@@ -707,7 +718,7 @@ export async function generatePortfolioDigest(
   const loaded = await Promise.all(
     repos.map(async (repo) => ({
       repo,
-      entry: await loadDigest(repo, weekKey).catch(() => null),
+      entry: await loadDigest(repo, weekKey, options.force).catch(() => null),
     })),
   );
 

--- a/src/utils/weeklyDigestGenerator.ts
+++ b/src/utils/weeklyDigestGenerator.ts
@@ -166,11 +166,15 @@ export function recentWeekKeys(count: number, from: Date = new Date()): string[]
 }
 
 /**
- * Epoch ms at which a digest for `weekKey` should expire from cache:
- * the end (Sunday 23:59:59.999 UTC) of that ISO week. A past week's
- * digest never needs refreshing (the week is closed), so its TTL is
+ * Epoch ms of the end (Sunday 23:59:59.999 UTC) of ISO week `weekKey` —
+ * the point a digest for that week stops being authoritative. A past
+ * week never needs refreshing (the week is closed), so its value is
  * already in the past and any cached value is still served (we only
  * treat *missing* as stale for closed weeks — see `readCache`).
+ *
+ * Exported as the single source of this cutoff: `PortfolioDigestPanel`
+ * uses it for its own sessionStorage cache TTL so the two cache layers
+ * can't drift apart (#415).
  */
 export function weekEndMs(weekKey: string): number {
   const m = weekKey.match(/^(\d{4})-(\d{2})$/);


### PR DESCRIPTION
Closes #415

## Что сделано
Two non-blocking Medium findings from code review of PR #414 (Epic-010 Task-05):

1. **Duplicated ISO-week-end algorithm** — `PortfolioDigestPanel.tsx` had a byte-identical copy of the generator's private `weekEndMs`. Exported `weekEndMs` from `weeklyDigestGenerator.ts`, imported it in the panel, deleted the local copy. The panel's sessionStorage TTL can no longer silently diverge from the generator's week notion. Behavior-preserving (same algorithm).
2. **`generatePortfolioDigest` ignored `force`** — «Сгенерировать новый» re-stitched the portfolio digest from possibly-stale per-project `loadDigest` localStorage caches, so it could appear to "do nothing new" within a week. Added an optional `force = false` param to `loadDigest` (default false → **backward-compatible**; `loadDigestHistory` / `DigestViewer` / `useProjectHub` callers unaffected) and threaded `options.force` from `generatePortfolioDigest` into it. A forced regenerate now bypasses the per-project localStorage cache and re-reads the committed digest (source of truth), which then re-seeds the cache.

Updated the panel's now-stale inline comment that said "portfolio path currently ignores force".

## Тесты
No automated tests (project has no test harness — tracked in #417). Verified via `npm run lint` + `npx tsc --noEmit` + `npm run build` (all clean, exit 0) and a senior code review (backward-compat of the new optional param, behavior-preserving dedup, edge case: missing committed file → "no digest").

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён
- [x] P1 issues: 0 · P2 issues: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)