### PR TITLE
fix(hub): onboarding readiness review leftovers

### DIFF
--- a/src/components/v4/hub/OnboardingChecklist.tsx
+++ b/src/components/v4/hub/OnboardingChecklist.tsx
@@ -1,4 +1,4 @@
-import type { HealthFinding } from "../../../types/health";
+import type { FindingStatus, HealthFinding } from "../../../types/health";
 import { isOnboardingRuleId } from "../../../utils/onboardingReadinessRules";
 
 /**
@@ -34,6 +34,17 @@ const ICON_LABEL: Record<IconKind, string> = {
   fail: "Не выполнено",
   unknown: "Не удалось проверить",
   skipped: "Пропущено",
+};
+
+// Explicit, exhaustive FindingStatus → IconKind map. The two unions are
+// identical today, but keying by `FindingStatus` makes a new status member a
+// compile error here until it's deliberately mapped, rather than silently
+// passing through an implicit cross-type assignment.
+const STATUS_ICON: Record<FindingStatus, IconKind> = {
+  pass: "pass",
+  fail: "fail",
+  unknown: "unknown",
+  skipped: "skipped",
 };
 
 export function OnboardingChecklist({ findings }: Props) {
@@ -100,16 +111,18 @@ export function OnboardingChecklist({ findings }: Props) {
         }}
       >
         {onboarding.map((f) => {
-          const kind: IconKind = f.status;
+          const kind: IconKind = STATUS_ICON[f.status];
           // Compose a tooltip: detail (always) + remediation (only when
           // failing — pass / skipped don't need a fix). Falsy guard so we
           // never render the literal string «undefined» in `title`.
+          // Native `title` collapses whitespace and ignores `\n`, so join
+          // with a visible inline separator instead of blank lines.
           const tooltipParts: string[] = [];
           if (f.detail) tooltipParts.push(f.detail);
           if (f.status === "fail" && f.remediation) {
             tooltipParts.push(`Как починить: ${f.remediation}`);
           }
-          const tooltip = tooltipParts.join("\n\n");
+          const tooltip = tooltipParts.join(" — ");
 
           return (
             <li

--- a/src/utils/checklist.ts
+++ b/src/utils/checklist.ts
@@ -48,14 +48,29 @@ export async function loadChecklist(
   // than the YAML source of truth (Epic-012 Task-04: Onboarding Readiness).
   // Dedup by `id` so a future mirror-PR into makeit-knowledge can't
   // double-count the same rule — the YAML version wins if present.
+  //
+  // Build a NEW immutable document instead of mutating `parsed` in place, so
+  // the cached doc that future readers see is internally consistent rather
+  // than a half-patched copy of the parsed YAML.
   const existingIds = new Set(parsed.rules.map((r) => r.id));
-  for (const rule of ONBOARDING_READINESS_RULES) {
-    if (!existingIds.has(rule.id)) {
-      parsed.rules.push(rule);
-    }
+  const mergedRules = ONBOARDING_READINESS_RULES.filter(
+    (rule) => !existingIds.has(rule.id),
+  );
+  // Keep `check_types_supported` self-consistent: any check type introduced
+  // by a merged-in rule (e.g. `deploy_doc_present`, `audit_fresh`) must be
+  // listed so a future validator doesn't flag those rules as unsupported.
+  // Dedup against whatever the YAML already declares.
+  const supportedTypes = new Set(parsed.check_types_supported);
+  for (const rule of mergedRules) {
+    supportedTypes.add(rule.check.type);
   }
-  cached = { doc: parsed, loaded_at: Date.now() };
-  return parsed;
+  const doc: ChecklistDocument = {
+    ...parsed,
+    check_types_supported: [...supportedTypes],
+    rules: [...parsed.rules, ...mergedRules],
+  };
+  cached = { doc, loaded_at: Date.now() };
+  return doc;
 }
 
 export function clearChecklistCache(): void {


### PR DESCRIPTION
Closes #384

Code-review leftovers deferred from PR #380 (Epic-012 Task-04: Onboarding Readiness). Scope: `src/utils/checklist.ts` и `src/components/v4/hub/OnboardingChecklist.tsx` — два файла, без новых абстракций.

## Что сделано

1. **(Medium) `check_types_supported` теперь обновляется при runtime-merge** — при слиянии in-code onboarding-правил типы их проверок (`deploy_doc_present`, `audit_fresh` и т.д.) добавляются в `check_types_supported` кэшированного документа с дедупликацией против списка из YAML. Будущий валидатор больше не пометит эти правила как «unsupported».
2. **(Medium) Убрана мутация распарсенного YAML на месте** — `loadChecklist` строит новый неизменяемый `ChecklistDocument` (`{ ...parsed, check_types_supported, rules }`) и кэширует/возвращает его вместо патчинга `parsed.rules`. Дедуп по `id` и инвалидация кэша через `force` сохранены.
3. **(Low) Разделитель тултипа** — нативный `title` схлопывает пробелы и игнорирует `\n`, поэтому части тултипа соединяются видимым inline-разделителем ` — ` вместо `\n\n`.
4. **(Low) Явная исчерпывающая карта `FindingStatus` → `IconKind`** — неявное cross-type присваивание `const kind: IconKind = f.status` заменено на `STATUS_ICON: Record<FindingStatus, IconKind>`. Новый член `FindingStatus` теперь даёт ошибку компиляции, пока его не обработают.

## Тесты

- `npx tsc --noEmit` — exit 0
- `npm run lint` — exit 0
- `npm run build` — exit 0

## Self-check

- [x] Нет debug `console.log`
- [x] Нет хардкод-секретов
- [x] Нет TODO/FIXME без номера issue
- [x] Нет закомментированного кода
- [x] Обработка ошибок не нарушена (`validate`, dedup, force-reload сохранены)
- [x] Русские строки консистентны (не менялись)
- [x] Только 2 файла в скоупе

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>