### PR TITLE
fix(portfolio): promise tracker + renewals review leftovers

### DIFF
--- a/src/components/v4/hub/RenewalsTable.tsx
+++ b/src/components/v4/hub/RenewalsTable.tsx
@@ -8,7 +8,6 @@ import {
 import {
   parseRenewalsYaml,
   scanRenewals,
-  sortByExpiry,
   toRenewalsYaml,
   type RenewalsYaml,
 } from "../../../utils/renewalsScanner";
@@ -86,6 +85,41 @@ function urgencyOf(iso: string | null, now: number): Urgency {
   if (t < now) return "expired";
   if (t - now <= SOON_MS) return "soon";
   return "ok";
+}
+
+/**
+ * A renewal paired with its stable identity for the table. `manualIndex`
+ * is the row's index in the `manual` state array (or -1 for a virtual
+ * auto-scan row). Edit/save/delete and the React `key` target a row by
+ * this index, never by `manual.indexOf(r)` (which returns the FIRST
+ * match when two manual rows share type+name → editing the 2nd row would
+ * mutate the 1st) or by a name-derived key (which would collide).
+ */
+interface TrackedRow {
+  r: Renewal;
+  manualIndex: number;
+}
+
+/**
+ * Sort tracked rows by `expires_at` ascending (soonest first); undated
+ * rows sink to the bottom. Mirrors `sortByExpiry`'s comparator exactly,
+ * but on the wrapper so each row keeps its stable `manualIndex` through
+ * the sort (sorting `Renewal[]` and re-deriving the index by name would
+ * reintroduce the duplicate-name collision this wrapper exists to fix).
+ */
+function sortTrackedByExpiry(rows: TrackedRow[]): TrackedRow[] {
+  return [...rows].sort((a, b) => {
+    const ta = a.r.expires_at ? Date.parse(a.r.expires_at) : NaN;
+    const tb = b.r.expires_at ? Date.parse(b.r.expires_at) : NaN;
+    const aHas = !Number.isNaN(ta);
+    const bHas = !Number.isNaN(tb);
+    if (aHas && bHas) {
+      return ta !== tb ? ta - tb : a.r.name.localeCompare(b.r.name);
+    }
+    if (aHas) return -1;
+    if (bHas) return 1;
+    return a.r.name.localeCompare(b.r.name);
+  });
 }
 
 /** A new blank manual renewal. */
@@ -227,30 +261,37 @@ export function RenewalsTable({ repo, onCount }: Props) {
     void load();
   }, [load]);
 
-  // Merge for display: manual + non-shadowed auto-scan, sorted by
-  // expiry. `now` is read fresh every render (urgency colouring) — no
-  // memo: the input changes every tick so a memo would never hit.
+  // `now` is read fresh every render for urgency colouring; the table
+  // is a register (not a live timer), so an already-open table does not
+  // repaint an expired row until the next re-render — acceptable here.
   const now = Date.now();
   // Full tracked set (manual + non-shadowed auto-scan), sorted by
   // expiry, BEFORE the local type filter. This is the section's true
-  // record count; the type filter is only a view control.
-  const allTracked = useMemo(() => {
+  // record count; the type filter is only a view control. Each row
+  // carries `manualIndex` — its index in the `manual` array, or -1 for
+  // an auto-scan row — so edit/save/delete and the React key target a
+  // row by its stable position, never by `indexOf` (which collides when
+  // two manual rows share type+name) or a name-derived key.
+  const allTracked = useMemo<TrackedRow[]>(() => {
     const manualKeys = new Set(
       manual.map((r) => `${r.type}::${r.name.trim().toLowerCase()}`),
     );
-    const merged = [
-      ...manual,
-      ...autoScan.filter(
-        (r) => !manualKeys.has(`${r.type}::${r.name.trim().toLowerCase()}`),
-      ),
-    ];
-    return sortByExpiry(merged);
+    const rows: TrackedRow[] = manual.map((r, manualIndex) => ({
+      r,
+      manualIndex,
+    }));
+    autoScan.forEach((r) => {
+      if (!manualKeys.has(`${r.type}::${r.name.trim().toLowerCase()}`)) {
+        rows.push({ r, manualIndex: -1 });
+      }
+    });
+    return sortTrackedByExpiry(rows);
   }, [manual, autoScan]);
   const visible = useMemo(
     () =>
       filter === "all"
         ? allTracked
-        : allTracked.filter((r) => r.type === filter),
+        : allTracked.filter((row) => row.r.type === filter),
     [allTracked, filter],
   );
 
@@ -643,9 +684,16 @@ export function RenewalsTable({ repo, onCount }: Props) {
               </tr>
             </thead>
             <tbody>
-              {visible.map((r) => {
-                const manualIndex =
-                  r.source === "manual" ? manual.indexOf(r) : -1;
+              {visible.map(({ r, manualIndex }) => {
+                // Stable, collision-free row key: manual rows key by
+                // their `manual`-array index (unique even when two rows
+                // share type+name); auto-scan rows have no index but are
+                // already unique by type+name (scanner dedup), so a
+                // composite is safe and stable for them.
+                const rowKey =
+                  manualIndex !== -1
+                    ? `m-${manualIndex}`
+                    : `a-${r.type}-${r.name}`;
                 const isEditing =
                   manualIndex !== -1 &&
                   editingIndex === manualIndex &&
@@ -653,7 +701,7 @@ export function RenewalsTable({ repo, onCount }: Props) {
                 if (isEditing && draft) {
                   return (
                     <RenewalEditRow
-                      key={`edit-${manualIndex}`}
+                      key={rowKey}
                       draft={draft}
                       busy={busy}
                       onChange={setDraft}
@@ -669,10 +717,10 @@ export function RenewalsTable({ repo, onCount }: Props) {
                     : urg === "soon"
                       ? "var(--v4-caution, #ca8a04)"
                       : undefined;
-                const isAuto = r.source === "auto-scan";
+                const isAuto = manualIndex === -1;
                 return (
                   <tr
-                    key={`${r.source}-${r.type}-${r.name}`}
+                    key={rowKey}
                     title={
                       isAuto
                         ? "Auto-detected, fix in package.json"
@@ -856,6 +904,35 @@ function RenewalFormModal({
   onSave,
   onCancel,
 }: EditProps) {
+  // Minimal a11y for the add modal: Escape closes it and focus returns
+  // to the element that opened it (the "+ Добавить" button). A full
+  // focus-trap (Tab cycling within the dialog) is intentionally NOT done
+  // here — it's the same gap as tech-debt #395 (RiskRegister) and is to
+  // be solved once by a shared modal extraction there, not duplicated.
+  const onCancelRef = useRef(onCancel);
+  useEffect(() => {
+    onCancelRef.current = onCancel;
+  }, [onCancel]);
+  useEffect(() => {
+    const trigger =
+      typeof document !== "undefined"
+        ? (document.activeElement as HTMLElement | null)
+        : null;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onCancelRef.current();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      // Restore focus to the trigger so keyboard users aren't dropped at
+      // the top of the document after the dialog unmounts.
+      if (trigger && typeof trigger.focus === "function") trigger.focus();
+    };
+  }, []);
+
   const field: React.CSSProperties = {
     display: "flex",
     flexDirection: "column",

--- a/src/hooks/usePortfolioPromises.ts
+++ b/src/hooks/usePortfolioPromises.ts
@@ -69,8 +69,6 @@ export interface UsePortfolioPromisesState {
   loading: boolean;
   /** User-facing error, or null. Set only when every repo failed. */
   error: string | null;
-  /** True when the initial render was served from a fresh cache. */
-  fromCache: boolean;
   /** Drop the cache and re-fetch all repos. */
   refresh: () => void;
 }
@@ -191,7 +189,6 @@ export function usePortfolioPromises(): UsePortfolioPromisesState {
   );
   const [loading, setLoading] = useState<boolean>(cached === null);
   const [error, setError] = useState<string | null>(null);
-  const [fromCache] = useState<boolean>(cached !== null);
 
   // Guard a late state-set after unmount and a double-fire (Strict Mode
   // double-invoke / rapid refresh clicks).
@@ -242,5 +239,5 @@ export function usePortfolioPromises(): UsePortfolioPromisesState {
 
   const refresh = useCallback(() => load(true), [load]);
 
-  return { items, loading, error, fromCache, refresh };
+  return { items, loading, error, refresh };
 }

--- a/src/hooks/usePortfolioRenewals.ts
+++ b/src/hooks/usePortfolioRenewals.ts
@@ -75,8 +75,6 @@ export interface UsePortfolioRenewalsState {
   loading: boolean;
   /** User-facing error, or null. Set only when the whole fan-out threw. */
   error: string | null;
-  /** True when the initial render was served from a fresh cache. */
-  fromCache: boolean;
   /** Drop the cache and re-fetch all repos. */
   refresh: () => void;
 }
@@ -196,7 +194,6 @@ export function usePortfolioRenewals(): UsePortfolioRenewalsState {
   );
   const [loading, setLoading] = useState<boolean>(cached === null);
   const [error, setError] = useState<string | null>(null);
-  const [fromCache] = useState<boolean>(cached !== null);
 
   // Guard a late state-set after unmount and a double-fire (Strict Mode
   // double-invoke / rapid refresh clicks).
@@ -247,5 +244,5 @@ export function usePortfolioRenewals(): UsePortfolioRenewalsState {
 
   const refresh = useCallback(() => load(true), [load]);
 
-  return { items, loading, error, fromCache, refresh };
+  return { items, loading, error, refresh };
 }

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -1353,6 +1353,13 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   grid-template-columns: 8px 1fr 14px;
   align-items: center;
 }
+/* .v4-ai-row sets an unconditional cursor:pointer (it's normally a
+   clickable row). A promise/renewal row for an unknown repo renders as
+   a non-interactive <div>, not a <button>, so it must not look
+   clickable — genuine <button> rows still get the pointer. */
+.v4-promise-row:not(button) {
+  cursor: default;
+}
 .v4-promise-dot {
   width: 8px;
   height: 8px;
@@ -1384,7 +1391,7 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 .v4-promise-repo {
   font-size: 11px;
   color: var(--v4-ink-500);
-  background: var(--v4-line-soft, #eef0f4);
+  background: var(--v4-line-soft);
   padding: 1px 6px;
   border-radius: 4px;
 }


### PR DESCRIPTION
Closes #398

Deferred non-blocking findings from code review of PR #396
(PortfolioPromiseTracker) and PR #397 (Renewals). Milestone:
**Epic-011: New Data Sources**.

## Что сделано

**#396 PortfolioPromiseTracker**

1. **(Low) Unused `fromCache`** — *исправлено: удалено.* `fromCache`
   возвращался из `usePortfolioPromises` и `usePortfolioRenewals`, но ни
   один компонент его не читал, и ни один соседний portfolio-хук не
   показывает индикатор кэша. Убрал из типа, `useState` и возвращаемого
   объекта в обоих хуках — мёртвая часть публичного API устранена,
   хуки остались консистентны.

2. **(Low) Хардкод `#eef0f4` в `.v4-promise-repo`** — *исправлено.*
   Теперь `background: var(--v4-line-soft)` без fallback, как у соседа
   `.v4-promise-grp` (токен определён в теме).

3. **(Low) `cursor:pointer` на ненавигируемой строке** — *исправлено.*
   Добавлен `.v4-promise-row:not(button){cursor:default}`. Ненавигируемая
   строка рендерится как `<div>`, навигируемая — как `<button>`, так что
   настоящие кнопки сохраняют pointer.

**#397 Renewals**

4. **(Medium, ключевой фикс) Идентичность строки через
   `manual.indexOf(r)` + key по имени** — *исправлено.* Введён враппер
   `TrackedRow { r, manualIndex }`, который проносит стабильный индекс
   строки в массиве `manual` (или `-1` для auto-scan) через
   merge/сортировку. React `key`, определение редактируемой строки,
   `startEdit`/`saveDraft`/`deleteRenewal` теперь адресуют строку по
   индексу. Две manual-записи с одинаковыми `type`+`name` больше не
   коллидируют (раньше редактирование 2-й строки мутировало 1-ю, а
   React-ключ `manual-<type>-<name>` совпадал). `sortTrackedByExpiry`
   повторяет компаратор `sortByExpiry` на враппере, чтобы индексы
   пережили сортировку. Прогнал в голове create/edit/save/delete для
   дублирующей пары — корректная строка, ключи уникальны и стабильны.

5. **(Low a11y) Нет Esc / focus-trap / focus-restore у модалки** —
   *частично исправлено локально; полный focus-trap осознанно оставлен
   за #395.* В add-модалку (`RenewalFormModal`) добавлены
   Escape-to-close и возврат фокуса на триггер при размонтировании —
   маленькое безопасное улучшение. Полноценный focus-trap (циклирование
   Tab) — тот же пробел, что и в RiskRegister (#395), и решается там
   общим shared-modal; здесь НЕ дублирую (scope creep / коллизия с
   #395). Новый issue не заводил — #395 уже трекает это.

6. **(Low) Вводящий в заблуждение комментарий про "changes every
   tick"** — *исправлено.* Комментарий заменён на корректное описание:
   таблица — это register, а не live-таймер; открытая таблица
   перерисует истёкшую строку при следующем re-render. Таймер НЕ
   добавлялся.

## Тесты

- `npx tsc --noEmit` — чисто (exit 0)
- `npm run lint` — чисто (exit 0)
- `npm run build` — успешно (предупреждение про размер чанка
  пре-существующее, не связано с изменениями)
- Юнит-тестов в проекте нет — изменения проверены tsc / lint / build
  и ручной трассировкой сценария с дублирующимися строками.

## Self-check

- [x] Нет debug `console.log`
- [x] Нет хардкод-секретов
- [x] Нет TODO/FIXME без номера issue
- [x] Нет закомментированного кода
- [x] Внешние вызовы сохраняют обработку ошибок (не трогались)
- [x] Русские строки UI консистентны (не менялись)
- [x] Минимальный диф, без спекулятивных абстракций и scope creep
- [x] Finding 4 проверен ментально: create/edit/save/delete
      дубль-строки адресуют верную строку, React-ключи уникальны/стабильны

🤖 Generated with [Claude Code](https://claude.com/claude-code)