### PR TITLE
fix(dora): DORA calculator review leftovers (#385)

### DIFF
--- a/src/components/v4/hub/DoraCards.tsx
+++ b/src/components/v4/hub/DoraCards.tsx
@@ -54,7 +54,8 @@ function formatHours(hours: number | null): string {
 /** Fraction in `[0, 1]` → percentage string. `null` → `—`. */
 function formatPercent(value: number | null): string {
   if (value === null || Number.isNaN(value)) return "—";
-  const pct = Math.round(value * 1000) / 10; // one decimal
+  // value is a [0,1] fraction → ×100 to a percent, then round to 1 decimal.
+  const pct = Math.round(value * 100 * 10) / 10;
   const text = Number.isInteger(pct) ? pct.toString() : pct.toFixed(1);
   return `${text}%`;
 }

--- a/src/utils/doraCalculator.ts
+++ b/src/utils/doraCalculator.ts
@@ -169,8 +169,10 @@ const CFR_ELITE = 0.05;      // ≤ 5%
 const CFR_HIGH = 0.10;       // ≤ 10%
 const CFR_MEDIUM = 0.15;     // ≤ 15%
 
-function tierForDeployFreq(perDay: number | null): DoraTier {
-  if (perDay === null) return "na";
+// Note: unlike the other tierFor* helpers, deployFreq is never null at the
+// call site (it's `deploys.length / windowDays`, guarded by windowDays > 0),
+// so the parameter is `number` and there is no `na` branch here.
+function tierForDeployFreq(perDay: number): DoraTier {
   if (perDay >= DF_ELITE) return "elite";
   if (perDay >= DF_HIGH) return "high";
   if (perDay >= DF_MEDIUM) return "medium";


### PR DESCRIPTION
Closes #385

Non-blocking code-review leftovers from PR #381 (Epic-012 Task-03). All Low, did not block merge.

## Что сделано

**1. `formatPercent` читаемость** (`src/components/v4/hub/DoraCards.tsx`)
`Math.round(value * 1000) / 10` переписан как `Math.round(value * 100 * 10) / 10` + однострочный комментарий, раскрывающий намерение (`value` — доля `[0,1]` → ×100 в проценты → округление до 1 знака). Выражения математически идентичны (`value * 100 * 10` вычисляется слева направо = `value * 1000`), числовой результат **не изменился**.

**2. Мёртвая null-ветка в `tierForDeployFreq`** (`src/utils/doraCalculator.ts`)
Ветка `if (perDay === null) return "na"` **удалена**, а тип параметра ужесточён до `number`.

_Решение — удалить (вариант a), не оставлять (вариант b)._ Обоснование: единственный call site — `tierForDeployFreq(deployFreq)`, где `deployFreq = deploys.length / windowDays` (конечное число ≥ 0, путь `windowDays <= 0` отсекается ранним guard'ом), так что `null` недостижим. Sibling-функции `tierForLeadTime`/`tierForMttr`/`tierForCfr` реально принимают `null` (их метрики типизированы `number | null`), но **общей сигнатуры/типа-таблицы между ними нет** — каждая `tierFor*` имеет независимую сигнатуру, поэтому удаление ветки ничего не ломает по симметрии. Проектное правило self-check «нет мёртвого кода» применяется. Ужесточение типа до `number` даёт компилятору гарантию на будущее.

## Намеренно отложено (по тексту issue)

- **Пункт 3 — CFR O(deploys × (fixCommits + criticalAudits))**: на текущем масштабе ОК, фикс только если перфоманс станет проблемой. Логика CFR не тронута.
- **Пункт 4 — MTTR `incidents === []` → `na`**: текущее поведение задокументировано в `docs/DELIVERY.md`, требует решения команды, не баг. Логика MTTR не тронута.

## Проверка

- `npm run lint` — чисто, без ошибок
- `npx tsc --noEmit` — чисто, без ошибок типов (подтверждает корректность ужесточённой сигнатуры `number`)
- `npm run build` — успешно (warning о размере чанка — pre-existing, не связан)

## Самопроверка: P1 issues: 0

- Числовой вывод `formatPercent` доказуемо не изменился (та же операнда `Math.round`, тот же `/ 10`).
- `tierForDeployFreq` возвращает корректные значения для всех входов: 0 деплоев → `0` → `"low"`; высокая частота → `"elite"`.
- Других затронутых путей нет (единственный call site type-compatible, tsc чист).
- Нет лишних комментариев / `console.log`. CFR и MTTR не затронуты.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>