### PR TITLE
fix(hub): in-app Overview→Decisions/Risks section deep-link

### DIFF
--- a/src/components/v4/hub/ProjectHubPage.tsx
+++ b/src/components/v4/hub/ProjectHubPage.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ProjectData } from "../../../types";
-import type { HubTab } from "../../../types/hub";
+import type { HubSection, HubTab } from "../../../types/hub";
 import { useProjectHub } from "../../../hooks/useProjectHub";
 import { unreadCount } from "../../../utils/lastVisitedStore";
 import { ProjectHubHeader } from "./ProjectHubHeader";
@@ -82,6 +82,18 @@ export function ProjectHubPage({ repo, project, onBackToList }: Props) {
     return isHubTab(raw) ? raw : "overview";
   });
 
+  // In-app deep-link target for the Decisions tab (FR-14, issue #413).
+  // OverviewTab's Risks/Commitments summaries call `onOpenTab("decisions",
+  // "<section>")`; this carries the originating section down to
+  // DecisionsRisksTab so it scrolls there instead of opening at the top.
+  // The `nonce` makes each request a fresh object even when the same
+  // section is re-requested, so the child's scroll effect re-fires.
+  const [pendingSection, setPendingSection] = useState<{
+    section: HubSection;
+    nonce: number;
+  } | null>(null);
+  const sectionNonceRef = useRef(0);
+
   // Mount cleanup: if the URL arrived with an invalid `subtab=foo`, strip
   // it now so subsequent pushState from the change-effect can't push a
   // history entry with the bogus value. replaceState (not pushState) — the
@@ -102,6 +114,10 @@ export function ProjectHubPage({ repo, project, onBackToList }: Props) {
   }, []);
 
   // Push URL whenever activeTab changes (skipping re-syncs from mount/popstate).
+  // Single writer of the `#section` hash too: an in-app Overview→Decisions
+  // deep-link carries `pendingSection`, so the pushed entry lands on the
+  // right section after refresh/share; every other tab switch drops any
+  // stale hash so a later non-Decisions tab can't keep `#risks` around.
   useEffect(() => {
     if (!didMountPushRef.current) {
       didMountPushRef.current = true;
@@ -111,7 +127,20 @@ export function ProjectHubPage({ repo, project, onBackToList }: Props) {
     lastSyncedSubtabRef.current = activeTab;
     const url = new URL(window.location.href);
     url.searchParams.set("subtab", activeTab);
-    window.history.pushState({ subtab: activeTab }, "", url.pathname + url.search);
+    const hash =
+      activeTab === "decisions" && pendingSection
+        ? `#${pendingSection.section}`
+        : "";
+    window.history.pushState(
+      { subtab: activeTab },
+      "",
+      url.pathname + url.search + hash,
+    );
+    // `pendingSection` is set together with `activeTab` in `openTab`, so
+    // this effect already sees the latest value on the same render; it is
+    // intentionally not a dependency (a later standalone section change
+    // must not push a second history entry on its own).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab]);
 
   // Popstate: re-read URL and sync activeTab. Reading `location.search`
@@ -131,6 +160,22 @@ export function ProjectHubPage({ repo, project, onBackToList }: Props) {
     };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  // Tab switch with an optional target section (FR-14 in-app deep-link).
+  // Plain tab switches (Tabs bar, NBA/Pulse footers) pass no section and
+  // clear any stale pending one. Risks/Commitments footers pass their
+  // originating section so DecisionsRisksTab lands there. The URL hash is
+  // written by the subtab pushState effect below (single writer) so the
+  // pushed history entry already carries `#<section>` for refresh/share.
+  const openTab = useCallback((tab: HubTab, section?: HubSection) => {
+    if (tab === "decisions" && section) {
+      sectionNonceRef.current += 1;
+      setPendingSection({ section, nonce: sectionNonceRef.current });
+    } else {
+      setPendingSection(null);
+    }
+    setActiveTab(tab);
   }, []);
 
   // Back-to-list: strip `subtab` from URL with replaceState (no extra history
@@ -159,7 +204,7 @@ export function ProjectHubPage({ repo, project, onBackToList }: Props) {
       <ProjectHubHeader data={data} />
       <ProjectHubTabs
         active={activeTab}
-        onChange={setActiveTab}
+        onChange={openTab}
         inboxCount={inboxCount}
       />
       <div
@@ -178,13 +223,17 @@ export function ProjectHubPage({ repo, project, onBackToList }: Props) {
             />
           }
         >
-          {activeTab === "overview" && <OverviewTab data={data} onOpenTab={setActiveTab} />}
+          {activeTab === "overview" && <OverviewTab data={data} onOpenTab={openTab} />}
           {activeTab === "health" && <HealthTab repo={repo} project={project} />}
           {activeTab === "activity" && (
             <ActivityTab repo={repo} onVisited={handleActivityVisited} />
           )}
           {activeTab === "decisions" && (
-            <DecisionsRisksTab repo={repo} decisions={data.decisions} />
+            <DecisionsRisksTab
+              repo={repo}
+              decisions={data.decisions}
+              scrollTo={pendingSection}
+            />
           )}
           {activeTab === "delivery" && <DeliveryTab repo={repo} data={data} />}
         </Suspense>

--- a/src/components/v4/hub/tabs/DecisionsRisksTab.tsx
+++ b/src/components/v4/hub/tabs/DecisionsRisksTab.tsx
@@ -4,7 +4,7 @@ import { DecisionLog } from "../DecisionLog";
 import { RiskRegisterTable } from "../RiskRegisterTable";
 import { CommitmentsTable } from "../CommitmentsTable";
 import { RenewalsTable } from "../RenewalsTable";
-import type { Decision } from "../../../../types/hub";
+import type { Decision, HubSection } from "../../../../types/hub";
 
 /**
  * Decisions & Risks tab — final four-section assembly (Epic-011
@@ -21,16 +21,18 @@ import type { Decision } from "../../../../types/hub";
  *   4. Renewals        (#renewals)  — repo-driven CRUD over
  *                       renewals.yaml (+ package.json auto-scan).
  *
- * Deep-link: on mount this tab reads `location.hash` and, if it is one
- * of `#decisions|#risks|#commitments|#renewals`, smooth-scrolls to the
- * matching `<section id>` (containers render synchronously — the
- * self-fetching tables show their own loading state in place, so the
- * anchor exists at the correct offset immediately). This satisfies an
- * externally-supplied `…#risks` URL. NOTE: the in-app OverviewTab
- * summaries currently switch tabs via the parent's `?subtab=decisions`
- * (state, no hash), so that path lands at the top of the tab, not on
- * the originating section — wiring OverviewTab→section for the in-app
- * path is tracked separately (FR-14 follow-up, issue #413).
+ * Deep-link (FR-14): two entry paths, both honoured.
+ *  - External URL: on mount this tab reads `location.hash` and, if it
+ *    is one of `#decisions|#risks|#commitments|#renewals`,
+ *    smooth-scrolls to the matching `<section id>` (containers render
+ *    synchronously — the self-fetching tables show their own loading
+ *    state in place, so the anchor exists at the correct offset
+ *    immediately). Satisfies an externally-pasted `…#risks` URL.
+ *  - In-app: OverviewTab's Risks/Commitments summaries call
+ *    `onOpenTab("decisions", "<section>")`; ProjectHubPage threads that
+ *    down as the `scrollTo` prop (with a bump nonce). A dedicated effect
+ *    scrolls on each new request — so clicking a summary lands on the
+ *    originating section, not the top of the tab (issue #413).
  *
  * Active-section highlight in the nav is driven by a single
  * IntersectionObserver created once and disconnected on unmount — no
@@ -58,9 +60,17 @@ interface Props {
    * (risks/commitments/renewals all read & write their own yaml).
    */
   repo: string;
+  /**
+   * In-app deep-link target (FR-14, issue #413). Set by ProjectHubPage
+   * when the user clicks an Overview Risks/Commitments summary. `nonce`
+   * is bumped per request so re-selecting the same section still
+   * re-fires the scroll. `null` when arrived via a plain tab switch /
+   * external URL (the mount-time `location.hash` read handles that).
+   */
+  scrollTo?: { section: HubSection; nonce: number } | null;
 }
 
-type SectionId = "decisions" | "risks" | "commitments" | "renewals";
+type SectionId = HubSection;
 
 interface SectionDef {
   id: SectionId;
@@ -80,7 +90,7 @@ function isSectionId(value: string): value is SectionId {
   return SECTIONS.some((s) => s.id === value);
 }
 
-export function DecisionsRisksTab({ decisions, repo }: Props) {
+export function DecisionsRisksTab({ decisions, repo, scrollTo }: Props) {
   // Per-section record counts. Decision Log is known synchronously
   // (the array we render). The three tables report through onCount;
   // `null` ⇒ "not reported yet" so we suppress the badge rather than
@@ -158,13 +168,22 @@ export function DecisionsRisksTab({ decisions, repo }: Props) {
     return () => observer.disconnect();
   }, []);
 
-  // ── Hash deep-link on mount ──────────────────────────────────────────
-  // OverviewTab switches to this tab via `?subtab=decisions` (state, not
-  // hash), but FR-14 deep-links carry a `#section` so the tab can land
-  // on the right block. Scroll once, after first paint, when a matching
-  // hash is present. Section containers render synchronously (tables
-  // show their own loading state in place), so the anchor target exists
-  // at the correct offset — we don't wait on async table data.
+  // Smooth-scroll to a section's anchor. Scroll only — the active-nav
+  // highlight is owned by the IntersectionObserver, which fires as this
+  // scroll lands and sets `activeId`; calling setActiveId here would be a
+  // competing source of truth. No-op if the ref isn't attached yet.
+  const scrollToSection = useCallback((id: SectionId) => {
+    const el = sectionRefs.current[id];
+    if (!el) return;
+    el.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
+  // ── Hash deep-link on mount (external URL) ───────────────────────────
+  // An externally-pasted `…#risks` URL: read `location.hash` once after
+  // first paint and scroll. Section containers render synchronously
+  // (tables show their own loading state in place), so the anchor target
+  // exists at the correct offset — we don't wait on async table data.
+  // The in-app path is handled by the `scrollTo` effect below instead.
   const didHashScrollRef = useRef(false);
   useEffect(() => {
     if (didHashScrollRef.current) return;
@@ -172,21 +191,25 @@ export function DecisionsRisksTab({ decisions, repo }: Props) {
     if (typeof window === "undefined") return;
     const raw = window.location.hash.replace(/^#/, "");
     if (!raw || !isSectionId(raw)) return;
-    const el = sectionRefs.current[raw];
-    if (!el) return;
-    // Scroll only. The active-nav highlight is owned by the
-    // IntersectionObserver — it fires as this scroll lands and sets
-    // `activeId`, so we must NOT setState here (that would be a
-    // synchronous effect setState; the observer is the single source
-    // of truth for the active section).
-    el.scrollIntoView({ behavior: "smooth", block: "start" });
-  }, []);
+    scrollToSection(raw);
+  }, [scrollToSection]);
+
+  // ── In-app deep-link (Overview→section, issue #413) ──────────────────
+  // ProjectHubPage bumps `scrollTo.nonce` each time an Overview summary
+  // requests this tab+section, so this scrolls on every request — even
+  // when the same section is re-selected. Distinct from the mount-hash
+  // effect: that one fires once for external URLs; this one tracks live
+  // in-app navigation. Scrolling twice to the same anchor is a harmless
+  // no-op, so the two effects need no cross-guard.
+  useEffect(() => {
+    if (!scrollTo) return;
+    scrollToSection(scrollTo.section);
+  }, [scrollTo, scrollToSection]);
 
   const handleNavClick = useCallback(
     (id: SectionId) => () => {
-      const el = sectionRefs.current[id];
-      if (!el) return;
-      el.scrollIntoView({ behavior: "smooth", block: "start" });
+      if (!sectionRefs.current[id]) return;
+      scrollToSection(id);
       setActiveId(id);
       // Reflect the section in the URL hash without a history entry so
       // a refresh / share lands back on the same section.
@@ -196,7 +219,7 @@ export function DecisionsRisksTab({ decisions, repo }: Props) {
         window.history.replaceState(null, "", url.toString());
       }
     },
-    [],
+    [scrollToSection],
   );
 
   return (

--- a/src/components/v4/hub/tabs/OverviewTab.tsx
+++ b/src/components/v4/hub/tabs/OverviewTab.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import type {
   Commitment,
+  HubSection,
   HubTab,
   NextBestAction,
   ProjectHubData,
@@ -10,9 +11,17 @@ import type {
 import { Icon } from "../../health/Icon";
 import type { IconName } from "../../health/Icon";
 
+/**
+ * Open a Hub tab, optionally landing on a specific anchored section
+ * (FR-14 in-app deep-link). The Risks/Commitments summaries pass a
+ * `section` so the Decisions tab scrolls to the originating block
+ * instead of opening at the top.
+ */
+type OpenTab = (tab: HubTab, section?: HubSection) => void;
+
 interface Props {
   data: ProjectHubData;
-  onOpenTab: (tab: HubTab) => void;
+  onOpenTab: OpenTab;
 }
 
 /**
@@ -61,7 +70,7 @@ export default OverviewTab;
 
 interface NbaBlockProps {
   nba: NextBestAction[];
-  onOpenTab: (tab: HubTab) => void;
+  onOpenTab: OpenTab;
 }
 
 function NbaBlock({ nba, onOpenTab }: NbaBlockProps) {
@@ -124,7 +133,7 @@ function NbaBlock({ nba, onOpenTab }: NbaBlockProps) {
 
 interface PulseSummaryProps {
   events: PulseEvent[];
-  onOpenTab: (tab: HubTab) => void;
+  onOpenTab: OpenTab;
 }
 
 function PulseSummary({ events, onOpenTab }: PulseSummaryProps) {
@@ -188,7 +197,7 @@ function PulseSummary({ events, onOpenTab }: PulseSummaryProps) {
 
 interface RisksSummaryProps {
   risks: Risk[];
-  onOpenTab: (tab: HubTab) => void;
+  onOpenTab: OpenTab;
 }
 
 function RisksSummary({ risks, onOpenTab }: RisksSummaryProps) {
@@ -242,7 +251,7 @@ function RisksSummary({ risks, onOpenTab }: RisksSummaryProps) {
         <EmptyState icon="check" text="Активных рисков нет" />
       )}
 
-      <FooterLink onClick={() => onOpenTab("decisions")} />
+      <FooterLink onClick={() => onOpenTab("decisions", "risks")} />
     </section>
   );
 }
@@ -253,7 +262,7 @@ function RisksSummary({ risks, onOpenTab }: RisksSummaryProps) {
 
 interface CommitmentsSummaryProps {
   commitments: Commitment[];
-  onOpenTab: (tab: HubTab) => void;
+  onOpenTab: OpenTab;
 }
 
 function CommitmentsSummary({
@@ -315,7 +324,7 @@ function CommitmentsSummary({
         <EmptyState icon="check-big" text="Все обещания в срок" />
       )}
 
-      <FooterLink onClick={() => onOpenTab("decisions")} />
+      <FooterLink onClick={() => onOpenTab("decisions", "commitments")} />
     </section>
   );
 }

--- a/src/types/hub.ts
+++ b/src/types/hub.ts
@@ -10,6 +10,16 @@ import type { DoraMetricsResult } from "../utils/doraCalculator";
 export type HubTab = "overview" | "health" | "activity" | "decisions" | "delivery";
 
 /**
+ * Anchored sections inside the Decisions & Risks tab, in render order.
+ * Doubles as the `#section` deep-link hash (FR-14): an external
+ * `…#risks` URL and the in-app Overview→section navigation both target
+ * one of these. Shared here so OverviewTab (source), ProjectHubPage
+ * (URL/prop wiring) and DecisionsRisksTab (scroll target) agree on one
+ * vocabulary instead of a local copy per file.
+ */
+export type HubSection = "decisions" | "risks" | "commitments" | "renewals";
+
+/**
  * Decision Log entry — institutional memory captured from transcripts.
  * Filled in Epic-011 (Task-01: Decision Log extractor + UI).
  */


### PR DESCRIPTION
Closes #413

## Что сделано

In-app навигация (клик по сводке Риски/Обещания в OverviewTab) теперь ведёт на нужную секцию Decisions-вкладки, а не на её верх. До этого FR-14 deep-link работал только для внешне вставленного `…#risks` URL.

- **`src/types/hub.ts`** — добавлен общий тип `HubSection` (`decisions | risks | commitments | renewals`), чтобы OverviewTab, ProjectHubPage и DecisionsRisksTab использовали один словарь секций вместо локальной копии.
- **`OverviewTab.tsx`** — `onOpenTab` расширен до `(tab, section?)`; футеры Риски/Обещания передают свою секцию (`"risks"` / `"commitments"`). NBA/Pulse футеры без изменений (без секции).
- **`ProjectHubPage.tsx`** — новый `openTab(tab, section?)`: ставит `activeTab` и nonced `pendingSection`; этот же колбэк теперь у таб-бара (сброс stale-секции при обычном переключении). Effect `pushState` остался единственным писателем URL: для Decisions добавляет `#<section>`, для остальных вкладок hash пустой → `?subtab=` персистентность и поведение не меняются; stale `#risks` корректно сбрасывается при уходе с Decisions.
- **`DecisionsRisksTab.tsx`** — новый prop `scrollTo` ({ section, nonce }); выделен общий `scrollToSection`; добавлен effect, реагирующий на `scrollTo` (in-app навигация), при этом одноразовое чтение `location.hash` на mount сохранено для внешних URL. `SectionId` теперь алиас `HubSection`.

## Проверка

- `npm install` — OK (exit 0)
- `npm run lint` — PASS (чисто)
- `npx tsc --noEmit` — PASS (без ошибок)
- `npm run build` — PASS (сборка успешна; warning про размер чанка — pre-existing, не связан с изменением)
- Browser-проверка **не проводилась**: в изолированном worktree надёжный preview недоступен. Вместо неё выполнен строгий статический разбор: внешние `#section` URL и `?subtab=` персистентность не сломаны, popstate/back-forward не повреждены, edge-cases (нет hash, неизвестная секция, повторные/быстрые переключения, stale hash при уходе с Decisions) разобраны.

## Самопроверка: P1 issues: 0