### PR TITLE
fix(pipeline): adapt fetchTimeline to backend timeline contract

### DIFF
--- a/src/utils/pipeline.ts
+++ b/src/utils/pipeline.ts
@@ -672,21 +672,90 @@ export interface TimelineEntry {
   status: string;
   ts: number;
   detail?: string;
-  elapsed?: number;
   cost_usd?: number;
   duration_seconds?: number;
+}
+
+/**
+ * Raw per-entry shape returned by `GET /pipeline/timeline/{repo:path}/{issue}`
+ * (backend `TimelineEntry` Pydantic model in makeit-pipeline `api.py`).
+ * Field names/types here mirror the backend exactly; `fetchTimeline` adapts
+ * them to the dashboard's `TimelineEntry`.
+ */
+interface BackendTimelineEntry {
+  timestamp: string; // ISO-8601
+  phase: string;
+  event: string; // phase_start | phase_complete | phase_failed | retry | escalation | merge | cleanup
+  status?: string | null; // PhaseStatus value or "in_progress"
+  cost_usd?: number | null;
+  duration_seconds?: number | null;
+  detail?: string | null;
+}
+
+interface BackendTimelineResponse {
+  repo: string;
+  issue_number: number;
+  entries: BackendTimelineEntry[];
+}
+
+/**
+ * Map the backend's `event`/`status` pair onto the small status vocabulary
+ * `IssueTimeline`'s `dotColor` understands (`completed` / `failed` /
+ * `in_progress` / `partial`). The `event` field is the richest signal; the
+ * `status` (`PhaseStatus` value or `"in_progress"`) refines completion into
+ * success vs. partial.
+ */
+function normalizeTimelineStatus(event: string, status?: string | null): string {
+  if (event === "phase_failed" || event === "escalation") return "failed";
+  if (event === "phase_start" || event === "retry") return "in_progress";
+  if (event === "phase_complete" || event === "merge" || event === "cleanup") {
+    if (status === "partial") return "partial";
+    if (
+      status === "retryable_failure" ||
+      status === "terminal_failure" ||
+      status === "blocked" ||
+      status === "timeout" ||
+      status === "timeout_with_pr"
+    ) {
+      return "failed";
+    }
+    return "completed";
+  }
+  if (status === "in_progress") return "in_progress";
+  return status ?? event;
 }
 
 export async function fetchTimeline(
   repo: string,
   issue: number,
 ): Promise<TimelineEntry[]> {
+  // `repo` is an `owner/name` slug. The backend route captures it via a
+  // FastAPI `{repo:path}` converter (it must keep the `/`), so split + encode
+  // each segment — same approach as `fetchBudget` — rather than
+  // `encodeURIComponent(repo)` which would emit `%2F` and miss the route.
+  const [owner, name] = repo.split("/", 2);
+  const repoPath = name
+    ? `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`
+    : encodeURIComponent(repo);
   const res = await fetch(
-    `${PIPELINE_BASE_URL}/pipeline/timeline/${encodeURIComponent(repo)}/${issue}`,
+    `${PIPELINE_BASE_URL}/pipeline/timeline/${repoPath}/${issue}`,
     { cache: "no-store" },
   );
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json() as Promise<TimelineEntry[]>;
+  const data = (await res.json()) as BackendTimelineResponse;
+  const entries = Array.isArray(data?.entries) ? data.entries : [];
+  return entries.map((e) => {
+    const parsedMs = Date.parse(e.timestamp);
+    return {
+      stage: e.phase,
+      status: normalizeTimelineStatus(e.event, e.status),
+      // Backend sends ISO-8601; the UI expects Unix seconds (it `* 1000`s it).
+      ts: Number.isNaN(parsedMs) ? 0 : parsedMs / 1000,
+      detail: e.detail ?? undefined,
+      cost_usd: e.cost_usd ?? undefined,
+      duration_seconds: e.duration_seconds ?? undefined,
+    };
+  });
 }
 
 /** Backend list-item shape returned by /research/list and /discovery/list. */


### PR DESCRIPTION
Closes #434

## What

`IssueTimeline` modal was **always silently empty**. Two bugs in `src/utils/pipeline.ts` `fetchTimeline`:

1. **Wrong response shape.** `fetchTimeline` cast the response to `TimelineEntry[]`, but the backend route `GET /pipeline/timeline/{repo:path}/{issue_number}` returns a `TimelineResponse` **object** `{repo, issue_number, entries[]}`. So `Array.isArray(data) ? data : []` in `IssueTimeline.tsx` was always false → empty list, no error.
2. **Broken path.** The URL used `encodeURIComponent(repo)`, turning the `/` in `owner/repo` into `%2F`, which never matches the FastAPI `{repo:path}` converter (backend also validates against an `owner/name` regex).

## Why

The two consumers (`PipelineControlPanel`, `PipelineView`) pass `selectedProject` (an `owner/repo` slug) as `repo`. The timeline endpoint exists and works; the dashboard was simply talking to it incorrectly.

## Fix (frontend-only — per locked decision: backend is the source of truth, makeit-pipeline untouched)

- Build the repo path by split + per-segment `encodeURIComponent` joined with a literal `/` (same pattern as the existing `fetchBudget` `{project:path}` client), so the `/` is preserved.
- Parse `data.entries` from the object response.
- Map backend per-entry fields → the `TimelineEntry` fields the UI actually renders:
  - `phase` → `stage`
  - `timestamp` (ISO-8601) → `ts` (Unix seconds; the component does `* 1000`), with a `NaN` guard
  - `event` + `status` → `status`, normalized to the `completed`/`failed`/`in_progress`/`partial` vocabulary `dotColor` understands (backend `status` is a `PhaseStatus` value like `success`/`terminal_failure` or `"in_progress"`, which would otherwise all render gray)
  - `cost_usd` / `duration_seconds` / `detail` passthrough (`null` → `undefined`)
- Removed the unused `elapsed` field from the `TimelineEntry` interface (never read by `IssueTimeline.tsx`, no backend equivalent).

`IssueTimeline.tsx` is unchanged — it still consumes the same `TimelineEntry` shape; `fetchTimeline` now always returns a real array.

## Verification

- `npx tsc --noEmit` — pass
- `npx eslint src/utils/pipeline.ts src/components/IssueTimeline.tsx` — pass
- `npm run build` — pass (only the pre-existing chunk-size warning)
- No other consumers: `fetchTimeline`/`TimelineEntry` are only used by `IssueTimeline.tsx` (grep-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)