### PR TITLE
fix(pipeline): normalize /pipeline/stats backend shape (#435)

### DIFF
--- a/src/utils/pipeline.ts
+++ b/src/utils/pipeline.ts
@@ -194,6 +194,21 @@ export interface PipelineStats {
   cost_per_task_usd?: number;
 }
 
+/**
+ * Raw `GET /pipeline/stats` payload (backend `AgentStatsResponse` in
+ * makeit-pipeline `api.py`). The backend is the source of truth; two
+ * fields differ in representation from the dashboard's `PipelineStats`
+ * and are converted at the boundary in `fetchPipelineStats`:
+ *   - `model_usage` is a `{model: count}` map, not a `ModelUsage[]`.
+ *   - `first_pass_rate` is a 0–1 fraction (`round(fp/len, 3)`), not the
+ *     0–100 percentage the UI renders.
+ */
+interface BackendPipelineStats
+  extends Omit<PipelineStats, "model_usage" | "first_pass_rate"> {
+  model_usage?: Record<string, number> | null;
+  first_pass_rate?: number | null;
+}
+
 /* ── Live phase constants (new /pipeline/status format) ── */
 
 export const PHASE_ORDER = [
@@ -463,7 +478,25 @@ export async function fetchPipelineStats(project: string): Promise<PipelineStats
     { cache: "no-store" },
   );
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json() as Promise<PipelineStats>;
+  const raw = (await res.json()) as BackendPipelineStats;
+  const { model_usage, first_pass_rate, ...rest } = raw;
+  return {
+    ...rest,
+    // dict → array the UI iterates; absent/null → undefined.
+    model_usage:
+      model_usage && typeof model_usage === "object"
+        ? Object.entries(model_usage).map(([model, count]) => ({
+            model,
+            count,
+          }))
+        : undefined,
+    // fraction (0–1) → percentage (0–100) the UI renders. Keep 0 (a real
+    // 0% rate) distinct from absent — gate on the number type, not truthiness.
+    first_pass_rate:
+      typeof first_pass_rate === "number"
+        ? first_pass_rate * 100
+        : undefined,
+  };
 }
 
 export async function startPipeline(req: PipelineStartRequest): Promise<string> {


### PR DESCRIPTION
Closes #435. **Stacked on #440** (base = `fix/issue-434-pipeline-timeline`, shares `pipeline.ts`). GitHub auto-retargets this PR to `main` when #440 merges.

## Проблема
`GET /pipeline/stats` (backend `AgentStatsResponse` — source of truth):
- `model_usage: dict[str,int] | None` — фронт ждал `ModelUsage[]` → `.length`/`.map` по объекту → блок model-usage мёртв
- `first_pass_rate: float` = `round(fp/len, 3)` (дробь 0–1) — фронт рендерит как 0–100% → всегда ~0–1%, всегда красный

## Решение (frontend-only, по зафиксированному решению: backend = SoT)
Anti-corruption layer **только на границе** `fetchPipelineStats`:
- `model_usage` dict → `ModelUsage[]` (`Object.entries`); null/absent → undefined
- `first_pass_rate` дробь → процент (`*100`); гейт по `typeof === number` (0% сохраняется, не путается с absent)

`PipelineStats` тип и **все консьюмеры не тронуты** — они уже ожидали ровно эту форму (`!= null`-гейты, `.length`/`.map`, `Math.round(x)%`, пороги `>=80/>=60`). Минимальный blast radius, не расширяет конфликт с #440.

## Проверка
- `npx tsc --noEmit` ✅ · `npx eslint src/utils/pipeline.ts` ✅ · `npm run build` ✅
- Regression-скан консьюмеров (`PipelineControlPanel` 766/775/777/778/839/845, `PipelineKpiStrip` 15, `PipelineComplexityPanel` 11/39/43): все совместимы с нормализованной формой
- 1 файл, +34/-1

## Самопроверка
- [x] Senior review (типы, 0%-кейс, extra-keys поведение = как было, no new throw)
- [x] P1 issues: 0
- [x] Не мержить без явной команды

🤖 Generated with [Claude Code](https://claude.com/claude-code)