### PR TITLE
fix(transcript): align client with backend status/result contract

### DIFF
--- a/src/components/TranscriptProgress.tsx
+++ b/src/components/TranscriptProgress.tsx
@@ -174,12 +174,10 @@ export function TranscriptProgress({ taskId, onDone, onRetry }: Props) {
       {/* Stepper timeline */}
       <div className="tpc-stepper">
         {STAGES.map((s, i) => {
-          // Use stages_completed for precise state when available (new pipeline),
-          // otherwise fall back to index-based comparison (legacy)
-          const hasCompletedData = status && status.stages_completed.length > 0;
-          const stepDone = hasCompletedData
-            ? status.stages_completed.includes(s.key) || (s.key === "done" && isDone)
-            : i < currentIdx || (i === currentIdx && isDone);
+          // Backend exposes only a coarse status string (no per-stage
+          // completion list), so step state is derived purely from the
+          // current stage index.
+          const stepDone = i < currentIdx || (i === currentIdx && isDone);
           const isActive = i === currentIdx && !hasError && !isDone;
           const isFailed = i === currentIdx && hasError;
 

--- a/src/components/v4/transcripts/TranscriptProgressV4.tsx
+++ b/src/components/v4/transcripts/TranscriptProgressV4.tsx
@@ -176,10 +176,10 @@ export function TranscriptProgressV4({ taskId, onDone, onRetry }: Props) {
       {/* Phase stepper */}
       <div className="v4-tpc-stepper">
         {STAGES.map((s, i) => {
-          const hasCompletedData = status && status.stages_completed.length > 0;
-          const stepDone = hasCompletedData
-            ? status.stages_completed.includes(s.key) || (s.key === "done" && isDone)
-            : i < currentIdx || (i === currentIdx && isDone);
+          // Backend exposes only a coarse status string (no per-stage
+          // completion list), so step state is derived purely from the
+          // current stage index.
+          const stepDone = i < currentIdx || (i === currentIdx && isDone);
           const isActive = i === currentIdx && !hasError && !isDone;
           const isFailed = i === currentIdx && hasError;
           const dotCls = stepDone

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -21,22 +21,14 @@ export interface TranscriptStatus {
   started_at: string | null;
   duration_seconds: number;
   speaker_count: number;
-  current_stage: string | null;
-  stages_completed: string[];
 }
 
-const VALID_STAGES = new Set<TranscriptStage>(["intake", "stt", "enrichment", "structuring", "synthesis", "done"]);
-
-/** Map backend status/current_stage to frontend TranscriptStage.
- *  If `currentStage` is provided (new pipeline), use it directly.
- *  Otherwise fall back to legacy status string mapping. */
-function mapStatusToStage(status: string, backendStage?: string, currentStage?: string): TranscriptStage {
-  // New pipeline: use current_stage directly if valid
-  if (currentStage && VALID_STAGES.has(currentStage as TranscriptStage)) {
-    return currentStage as TranscriptStage;
-  }
-
-  // Legacy fallback
+/** Map backend `status` (queued|transcribing|processing|done|error) to the
+ *  frontend TranscriptStage. The backend `TranscriptStatusResponse` exposes
+ *  `status` + `stage`/`stage_detail` only — there is no per-stage progress
+ *  field, so the stepper is driven entirely off the coarse status string
+ *  (`stage` is used only to refine the bucket on error). */
+function mapStatusToStage(status: string, backendStage?: string): TranscriptStage {
   switch (status) {
     case "queued":
       return "intake";
@@ -69,7 +61,7 @@ export async function fetchTranscriptStatus(taskId: string): Promise<TranscriptS
   const data = await res.json();
   return {
     task_id: data.job_id,
-    stage: mapStatusToStage(data.status, data.stage, data.current_stage),
+    stage: mapStatusToStage(data.status, data.stage),
     stage_detail: data.stage_detail || data.stage || "",
     progress: data.progress ?? 0,
     error: data.error || null,
@@ -78,8 +70,6 @@ export async function fetchTranscriptStatus(taskId: string): Promise<TranscriptS
     started_at: data.started_at || null,
     duration_seconds: data.duration_seconds ?? 0,
     speaker_count: data.speaker_count ?? 0,
-    current_stage: data.current_stage || null,
-    stages_completed: Array.isArray(data.stages_completed) ? data.stages_completed : [],
   };
 }
 
@@ -94,6 +84,21 @@ export interface QualityCheck {
 export interface QualityReport {
   checks: QualityCheck[];
   score: number;
+}
+
+const QUALITY_VERDICTS = new Set<TranscriptQuality>(["pass", "warning", "needs_review"]);
+
+/** Pull the overall quality verdict out of the backend `quality_report.json`.
+ * The result endpoint (`TranscriptResultResponse`) carries no standalone
+ * `quality` field — the verdict lives at `quality_report.status`
+ * (`pass`/`warning`/`needs_review`, see `_build_quality_report_dict` in
+ * makeit-pipeline). Returns null when absent/unknown. */
+function extractQuality(raw: unknown): TranscriptQuality | null {
+  if (!raw || typeof raw !== "object") return null;
+  const s = (raw as { status?: unknown }).status;
+  return typeof s === "string" && QUALITY_VERDICTS.has(s as TranscriptQuality)
+    ? (s as TranscriptQuality)
+    : null;
 }
 
 /** Backend `quality_report.json` ships `checks` as a dict keyed by check
@@ -147,7 +152,7 @@ export async function fetchTranscriptResult(taskId: string): Promise<TranscriptR
     task_id: data.job_id,
     brief: data.brief_content || "",
     transcript: data.transcript_text || "",
-    quality: data.quality || null,
+    quality: extractQuality(data.quality_report),
     quality_report: adaptQualityReport(data.quality_report),
   };
 }
@@ -199,16 +204,12 @@ export async function saveTranscriptBrief(
     },
   );
   if (!res.ok) {
-    if (res.status === 405) {
-      // Backend doesn't expose PUT /transcript/result/{id} yet — FastAPI
-      // returns 405 Method Not Allowed because GET on this path exists
-      // but PUT does not. Tracked in makeit-pipeline#790. Surface a humane
-      // message so users know the editor change is local-only.
-      // NOTE: 404 is deliberately NOT included here — once the PUT route
-      // ships, a real "task not found" 404 must surface as such, not as
-      // "save not supported".
+    if (res.status === 409) {
+      // Backend PUT /transcript/result/{id} rejects edits while the job is
+      // not yet `done` (api.py: status != "done" → 409). Surface a clear,
+      // actionable message instead of a raw status code.
       throw new Error(
-        "Сохранение пока не поддерживается на сервере. Изменения остались только локально (черновик в браузере).",
+        "Бриф можно сохранить только когда транскрипция завершена (статус «done»). Дождитесь окончания обработки и повторите.",
       );
     }
     const text = await res.text().catch(() => "");


### PR DESCRIPTION
Closes #438

## Что и почему

Transcript-клиент дашборда читал три поля, которые backend (makeit-pipeline) никогда не присылает — код работал «по удаче»:

1. **`current_stage` / `stages_completed`** — `TranscriptStatusResponse` (`api.py:904-919`) их не содержит, есть только `stage`/`stage_detail`. Ветка «new pipeline» в `mapStatusToStage` и `stages_completed`-ветка в обоих степперах были мёртвыми (`hasCompletedData` всегда `false`). Удалены; степпер работает по реальному `status` (legacy-путь — ровно то, что и так выполнялось). Поведение для пользователя не меняется, убран мёртвый код.
2. **`quality` vs `quality_report`** — `TranscriptResultResponse` (`api.py:921-938`) содержит `quality_report` (его top-level `status` = pass/warning/needs_review, см. `_build_quality_report_dict`), но не отдельное `quality`. Вердикт теперь выводится из `quality_report.status` вместо всегда-`undefined` `data.quality`. Побочно чинит скрытый баг: бейдж качества в `TranscriptBrief`/`TranscriptBriefV4` был постоянно скрыт (`result.quality` всегда `null`).
3. **`saveTranscriptBrief` 409 / stale 405** — PUT `/transcript/result/{job_id}` (`api.py:3725`) существует и при статусе job != `done` возвращает **409**; 405 недостижим. Мёртвая 405-ветка заменена на понятное сообщение для 409. 404/500 по-прежнему уходят в общий обработчик (корректно — разные ошибки не маскируются).

`TranscriptListItem.current_stage`/`quality` (отдельный интерфейс, `fetchTranscriptList`) намеренно не тронут — вне scope 3 находок issue #438.

## Решение
Frontend-only adaptation per locked decision: **backend (makeit-pipeline) — source of truth**, изменений в makeit-pipeline нет. Дашборд приведён к фактическому контракту backend.

## Verification
- `npx tsc --noEmit` — clean
- `npx eslint src/utils/transcript.ts src/components/TranscriptProgress.tsx src/components/v4/transcripts/TranscriptProgressV4.tsx` — clean
- `npm run build` — clean (chunk-size warning pre-existing, не связан)

Файлы: `src/utils/transcript.ts`, `src/components/TranscriptProgress.tsx`, `src/components/v4/transcripts/TranscriptProgressV4.tsx`