### PR TITLE
fix(pipeline): align /research/* client contract with backend (#436)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5040,6 +5040,9 @@ body::after {
   color: var(--color-text-muted);
   font-weight: 400;
 }
+.srm-hint--error {
+  color: var(--color-danger);
+}
 .srm-info {
   font-size: var(--text-xs);
   color: var(--color-text-muted);

--- a/src/components/ResearchTab.tsx
+++ b/src/components/ResearchTab.tsx
@@ -378,7 +378,9 @@ export function ResearchTab({ repos }: Props) {
     setShowModal(false);
     await agent.launchResearch({
       project,
-      product_description: description || undefined,
+      // Modal guarantees a non-empty description before calling onStart;
+      // backend requires it (Field(..., min_length=1)).
+      product_description: description,
       region: region || undefined,
     });
   };

--- a/src/components/StartResearchModal.tsx
+++ b/src/components/StartResearchModal.tsx
@@ -22,10 +22,15 @@ export function StartResearchModal({ defaultRepo, onClose, onStart, starting }: 
   const [description, setDescription] = useState("");
   const [region, setRegion] = useState("");
 
-  const canSubmit = project.trim() !== "" && !starting;
+  const [touched, setTouched] = useState(false);
+  // Backend requires a non-empty product_description (Field(..., min_length=1)).
+  // Block submit instead of sending undefined → 422.
+  const descMissing = description.trim() === "";
+  const canSubmit = project.trim() !== "" && !descMissing && !starting;
 
   const handleSubmit = () => {
-    if (!canSubmit) return;
+    setTouched(true);
+    if (project.trim() === "" || descMissing || starting) return;
     onStart(project, description.trim(), region);
   };
 
@@ -53,15 +58,23 @@ export function StartResearchModal({ defaultRepo, onClose, onStart, starting }: 
           </label>
 
           <label className="srm-label">
-            Описание продукта
+            Описание продукта <span className="srm-required">*</span>
             <textarea
               className="srm-textarea"
               placeholder="Кратко опишите продукт и целевую аудиторию для более точного анализа..."
               value={description}
               onChange={(e) => setDescription(e.target.value)}
+              onBlur={() => setTouched(true)}
               rows={3}
+              aria-invalid={touched && descMissing}
             />
-            <span className="srm-hint">Необязательно. Помогает агенту точнее определить конкурентов.</span>
+            {touched && descMissing ? (
+              <span className="srm-hint srm-hint--error" role="alert">
+                Укажите описание продукта — без него агент не может запуститься.
+              </span>
+            ) : (
+              <span className="srm-hint">Обязательно. Помогает агенту точнее определить конкурентов.</span>
+            )}
           </label>
 
           <label className="srm-label">

--- a/src/components/v4/research/ResearchView.tsx
+++ b/src/components/v4/research/ResearchView.tsx
@@ -69,7 +69,9 @@ export function ResearchView({ repos }: Props) {
       setShowModal(false);
       agent.launchResearch({
         project,
-        product_description: description || undefined,
+        // Modal guarantees a non-empty description before calling onStart;
+        // backend requires it (Field(..., min_length=1)).
+        product_description: description,
         region: region || undefined,
       });
     },

--- a/src/hooks/useResearchAgent.ts
+++ b/src/hooks/useResearchAgent.ts
@@ -9,6 +9,7 @@ import {
 import type {
   ResearchStartRequest,
   ResearchAgentStatus,
+  ResearchAgentKind,
   ResearchHistoryItem,
 } from "../utils/pipeline";
 
@@ -55,11 +56,11 @@ export function useResearchAgent(): UseResearchAgentReturn {
   // Cleanup on unmount.
   useEffect(() => () => stopPolling(), [stopPolling]);
 
-  const startPolling = useCallback((id: string) => {
+  const startPolling = useCallback((id: string, agent: ResearchAgentKind) => {
     stopPolling();
     pollRef.current = setInterval(async () => {
       try {
-        const status = await fetchResearchStatus(id);
+        const status = await fetchResearchStatus(id, agent);
         setActiveRun(status);
         if (status.status === "done" || status.status === "error") {
           stopPolling();
@@ -82,9 +83,9 @@ export function useResearchAgent(): UseResearchAgentReturn {
     setError(null);
     try {
       const { id } = await startResearchAgent(req);
-      const status = await fetchResearchStatus(id);
+      const status = await fetchResearchStatus(id, "research");
       setActiveRun(status);
-      startPolling(id);
+      startPolling(id, "research");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to start Research agent");
     } finally {
@@ -98,9 +99,9 @@ export function useResearchAgent(): UseResearchAgentReturn {
     setError(null);
     try {
       const { id } = await startDiscoveryAgent(project);
-      const status = await fetchResearchStatus(id);
+      const status = await fetchResearchStatus(id, "discovery");
       setActiveRun(status);
-      startPolling(id);
+      startPolling(id, "discovery");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to start Discovery agent");
     } finally {

--- a/src/utils/pipeline.ts
+++ b/src/utils/pipeline.ts
@@ -535,20 +535,51 @@ export async function stopPipeline(): Promise<string> {
 
 export interface ResearchStartRequest {
   project: string;
-  product_description?: string;
+  /** Backend requires a non-empty description (Field(..., min_length=1)). */
+  product_description: string;
   region?: string;
 }
 
+/** Job-type discriminator. The backend does NOT expose this on the
+ *  status endpoint — only /research/list & /discovery/list carry
+ *  `agent_type`. The dashboard threads the known type from the caller. */
+export type ResearchAgentKind = "research" | "discovery";
+
+/** Backend AgentStatusResponse status values (api.py): research emits
+ *  queued/searching/done/error, discovery emits queued/analyzing/done/error.
+ *  Kept loose so an unknown value degrades gracefully instead of crashing. */
+export type ResearchAgentStatusValue =
+  | "queued"
+  | "searching"
+  | "analyzing"
+  | "done"
+  | "error"
+  | (string & {});
+
 export interface ResearchAgentStatus {
   id: string;
-  agent: "research" | "discovery";
+  /** Set client-side from the launching call — backend status payload
+   *  has no agent discriminator. */
+  agent: ResearchAgentKind;
   project: string;
-  status: "queued" | "running" | "done" | "error";
+  status: ResearchAgentStatusValue;
   progress: number;
   stage: string;
   error?: string;
   started_at: string;
   finished_at?: string;
+}
+
+/** Raw shape returned by GET /research/status and /discovery/status. */
+interface AgentStatusResponse {
+  job_id: string;
+  status: string;
+  stage?: string;
+  progress?: number;
+  error?: string;
+  project?: string;
+  created_at?: string;
+  started_at?: string;
 }
 
 export interface ResearchHistoryItem {
@@ -591,12 +622,35 @@ export async function startDiscoveryAgent(project: string): Promise<{ id: string
   return res.json() as Promise<{ id: string }>;
 }
 
-export async function fetchResearchStatus(id: string): Promise<ResearchAgentStatus> {
-  const res = await fetch(`${PIPELINE_BASE_URL}/research/status/${encodeURIComponent(id)}`, {
+export async function fetchResearchStatus(
+  id: string,
+  /** The kind of agent that was launched. Backend status payload has no
+   *  discriminator, so the caller (hook) supplies what it already knows.
+   *  It also selects the correct endpoint: the backend keeps research and
+   *  discovery jobs in separate stores (`/research/status` only knows
+   *  research jobs, `/discovery/status` only discovery). */
+  agent: ResearchAgentKind = "research",
+): Promise<ResearchAgentStatus> {
+  const path = agent === "discovery" ? "discovery" : "research";
+  const res = await fetch(`${PIPELINE_BASE_URL}/${path}/status/${encodeURIComponent(id)}`, {
     cache: "no-store",
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json() as Promise<ResearchAgentStatus>;
+  const raw = (await res.json()) as AgentStatusResponse;
+  // Adapt AgentStatusResponse → ResearchAgentStatus. The backend uses
+  // `job_id` and exposes no `agent`/`finished_at`; status is preserved
+  // as-is (consumers treat anything other than done/error as in-progress).
+  return {
+    id: raw.job_id,
+    agent,
+    project: raw.project ?? "",
+    status: raw.status,
+    progress: raw.progress ?? 0,
+    stage: raw.stage ?? "",
+    error: raw.error ? raw.error : undefined,
+    started_at: raw.started_at || raw.created_at || "",
+    finished_at: undefined,
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #436

## Что и почему

Контракт-дрейф фронт↔бэк во флоу Research/Discovery. **Frontend-only по locked decision: backend (makeit-pipeline) — source of truth и не меняется.** Дашборд адаптирован под фактический контракт бэкенда.

Бэкенд (`makeit-pipeline/src/makeit_pipeline/api.py`):
- `AgentStatusResponse` (api.py:1002-1012): поля `job_id, status, stage, progress, error, project, created_at, started_at`. **Нет `agent`.**
- Статусы: research → `queued/searching/done/error` (api.py:5611/5654/5667/5674), discovery → `queued/analyzing/done/error` (api.py:5696/5750). Нет `running`.
- Дискриминатор `agent_type` (`research`/`discovery`) есть только на `AgentListItem` (`/research/list`, `/discovery/list`, api.py:1025-1032).
- `ResearchStartRequest.product_description = Field(..., min_length=1)` (api.py:973) — **required, non-empty**.

### 3 гэпа

1. **`status.agent`**: бэкенд не возвращает `agent`. `fetchResearchStatus` теперь принимает вид агента от вызывающего (хук `useResearchAgent` его знает: `launchResearch`→`research`, `launchDiscovery`→`discovery`) и проставляет в адаптированный `ResearchAgentStatus`. Лейбл баннера/прогресса теперь корректен для research vs discovery (раньше всегда «Discovery»).
2. **Status enum drift**: клиентский union расширен до `queued|searching|analyzing|done|error|(string & {})`. Консьюмеры спец-кейсят только `done`/`error`, остальное (включая неизвестное) → in-progress, без краша.
3. **`product_description` 422**: тип сделан обязательным `string`; в `StartResearchModal` добавлена валидация (блок submit + inline-ошибка при пустом); оба call-site больше не шлют `description || undefined`.

Доп. корректность: discovery-поллинг теперь идёт на `/discovery/status` (бэкенд хранит research/discovery в раздельных стораджах — `/research/status` 404-ит на discovery job). Следует естественно из проброса вида агента, без новых абстракций.

## Verification
- `npx tsc --noEmit` — clean
- `npx eslint <changed files>` — clean
- `npm run build` — clean (chunk-size warning pre-existing, unrelated)

## Изменённые файлы
src/utils/pipeline.ts, src/hooks/useResearchAgent.ts, src/components/StartResearchModal.tsx, src/components/ResearchTab.tsx, src/components/v4/research/ResearchView.tsx, src/App.css