### PR TITLE
fix(pipeline): align complexity_filter with backend literal + expose manual (#437)

### DIFF
--- a/src/components/PipelineControlPanel.tsx
+++ b/src/components/PipelineControlPanel.tsx
@@ -18,6 +18,7 @@ const COMPLEXITY_OPTIONS: { value: ComplexityFilter; label: string; hint: string
   { value: "all", label: "All", hint: "Все задачи" },
   { value: "auto", label: "Auto", hint: "Sonnet — простые" },
   { value: "assisted", label: "Assisted", hint: "Opus — сложные" },
+  { value: "manual", label: "Manual", hint: "Ручной режим" },
 ];
 
 const COMPLEXITY_STYLE: Record<string, { label: string; color: string; bg: string }> = {
@@ -278,7 +279,7 @@ export function PipelineControlPanel({ projects }: PipelineControlPanelProps) {
   });
   const [complexityFilter, setComplexityFilter] = useState<ComplexityFilter>(() => {
     const stored = localStorage.getItem("pipeline_complexity");
-    const valid: ComplexityFilter[] = ["auto", "assisted", "all"];
+    const valid: ComplexityFilter[] = ["auto", "assisted", "manual", "all"];
     return stored && valid.includes(stored as ComplexityFilter) ? (stored as ComplexityFilter) : "all";
   });
   const [selectedMilestone, setSelectedMilestone] = useState<string>(() => {

--- a/src/components/v4/pipeline/ConfigPanel.tsx
+++ b/src/components/v4/pipeline/ConfigPanel.tsx
@@ -15,6 +15,7 @@ const COMPLEXITY_OPTIONS: { value: ComplexityFilter; label: string; hint: string
   { value: "all", label: "All", hint: "Все задачи" },
   { value: "auto", label: "Auto", hint: "Sonnet — простые" },
   { value: "assisted", label: "Assisted", hint: "Opus — сложные" },
+  { value: "manual", label: "Manual", hint: "Ручной режим" },
 ];
 
 interface Props {

--- a/src/components/v4/pipeline/PipelineView.tsx
+++ b/src/components/v4/pipeline/PipelineView.tsx
@@ -76,7 +76,7 @@ export function PipelineView({
   const [limit, setLimit] = useState<number>(() => Number(localStorage.getItem(STORAGE.limit)) || 4);
   const [complexityFilter, setComplexityFilter] = useState<ComplexityFilter>(() => {
     const stored = localStorage.getItem(STORAGE.complexity);
-    const valid: ComplexityFilter[] = ["auto", "assisted", "all"];
+    const valid: ComplexityFilter[] = ["auto", "assisted", "manual", "all"];
     return stored && valid.includes(stored as ComplexityFilter)
       ? (stored as ComplexityFilter)
       : "all";

--- a/src/utils/pipeline.ts
+++ b/src/utils/pipeline.ts
@@ -2,13 +2,21 @@
 
 import { PIPELINE_BASE_URL } from "./config";
 
-export type ComplexityFilter = "auto" | "assisted" | "all";
+/**
+ * UI selection for the complexity filter. `auto`/`assisted`/`manual` are
+ * the backend's literals (`StartRequest.complexity_filter`); `all` is a
+ * UI-only sentinel meaning "no filter" — it is never sent on the wire
+ * (the send sites map it to `undefined`).
+ */
+export type ComplexityFilter = "auto" | "assisted" | "manual" | "all";
 
 export interface PipelineStartRequest {
   project?: string;
   labels?: string[];
   limit?: number;
-  complexity_filter?: ComplexityFilter;
+  /** Backend `Literal["auto","assisted","manual"] | None` — the UI-only
+   *  `"all"` is stripped to `undefined` before the request is built. */
+  complexity_filter?: "auto" | "assisted" | "manual";
   /** Open-milestone title to filter issues by (AND with labels). Backend
    * accepts the title string, normalises whitespace-only to "no filter", and
    * passes through the special tokens `*` and `none` unchanged. */


### PR DESCRIPTION
Closes #437. Frontend-only per locked decision (backend = source of truth).

## Проблема
Backend `StartRequest.complexity_filter: Literal["auto","assisted","manual"] | None` (api.py:374). Фронт:
- предлагал `all|auto|assisted` — режим **`manual`** недостижим из UI (фича backend без доступа с фронта)
- типизировал wire-поле через UI-only `"all"`

(Отправка `"all"` фактически 422 НЕ вызывала — оба send-site уже стрипают `complexityFilter !== "all" ? : undefined`; реальный gap — недостижимый `manual` + нечестный wire-тип.)

## Решение
- `ComplexityFilter` += `"manual"` (UI-тип; `"all"` остаётся UI-сентинелом «без фильтра», на провод не идёт)
- `PipelineStartRequest.complexity_filter` сужен до backend-литерала `"auto"|"assisted"|"manual"` → **tsc теперь enforce-ит** существующий `"all"`→`undefined` стрип на обоих send-site
- `COMPLEXITY_OPTIONS` (ConfigPanel + PipelineControlPanel) += кнопка Manual
- localStorage `valid`-массивы (PipelineView, PipelineControlPanel) += `"manual"` (восстановление сохранённого выбора)

## Проверка
- `npx tsc --noEmit` ✅ (сужение wire-типа подтверждает корректность strip — иначе была бы type-error)
- `npx eslint <4 files>` ✅ · `npm run build` ✅
- 4 файла, +14/−4. Других потребителей `ComplexityFilter` нет (нет exhaustive switch / `Record<ComplexityFilter,_>`)
- Полный e2e (выбрать Manual → POST /pipeline/start без 422) требует живого pipeline-бэкенда (отдельный Mac) — не триггерил side-effect; контракт гарантирован типами

## Самопроверка
- [x] Senior review (strip tsc-enforced, "all" не уходит, manual проходит, persisted restore)
- [x] P1 issues: 0