### PR TITLE
fix(transcript): drop dead quality/current_stage from list contract (#446)

### DIFF
--- a/src/components/TranscriptHistory.tsx
+++ b/src/components/TranscriptHistory.tsx
@@ -3,7 +3,6 @@ import {
   fetchTranscriptList,
   deleteTranscript,
   type TranscriptListItem,
-  type TranscriptQuality,
   type TranscriptionModel,
 } from "../utils/transcript";
 
@@ -35,26 +34,6 @@ const STATUS_CLASS: Record<string, string> = {
 };
 
 const ACTIVE_STATUSES = new Set(["queued", "transcribing", "processing"]);
-
-const STAGE_LABELS: Record<string, string> = {
-  intake: "Приём",
-  stt: "Транскрипция",
-  enrichment: "Обогащение",
-  structuring: "Структуризация",
-  synthesis: "Синтез",
-};
-
-const QUALITY_LABEL: Record<TranscriptQuality, string> = {
-  pass: "ОК",
-  warning: "Замечания",
-  needs_review: "Проверить",
-};
-
-const QUALITY_CLASS: Record<TranscriptQuality, string> = {
-  pass: "pass",
-  warning: "warning",
-  needs_review: "needs-review",
-};
 
 export function TranscriptHistory({ onOpen, onResume, onRetry, refreshKey }: Props) {
   const [items, setItems] = useState<TranscriptListItem[]>([]);
@@ -240,23 +219,10 @@ export function TranscriptHistory({ onOpen, onResume, onRetry, refreshKey }: Pro
                       <span className={`tpc-status ${STATUS_CLASS[item.status] ?? ""}`}>
                         {isActive && <span className="tpc-status-pulse" />}
                         {STATUS_LABELS[item.status] ?? item.status}
-                        {item.status === "error" && item.current_stage && STAGE_LABELS[item.current_stage] && (
-                          <span className="tpc-status-stage"> ({STAGE_LABELS[item.current_stage]})</span>
-                        )}
                       </span>
                     </td>
                     <td className="tpc-history-quality">
-                      {item.status === "done" ? (
-                        item.quality ? (
-                          <span className={`tpc-quality-badge tpc-quality-badge--${QUALITY_CLASS[item.quality]} tpc-quality-badge--static tpc-quality-badge--sm`}>
-                            {QUALITY_LABEL[item.quality]}
-                          </span>
-                        ) : (
-                          <span className="tpc-text-muted">—</span>
-                        )
-                      ) : (
-                        <span className="tpc-text-muted">—</span>
-                      )}
+                      <span className="tpc-text-muted">—</span>
                     </td>
                     <td className="tpc-history-actions">
                       {item.status === "done" && (

--- a/src/components/v4/transcripts/TranscriptHistoryV4.tsx
+++ b/src/components/v4/transcripts/TranscriptHistoryV4.tsx
@@ -36,7 +36,6 @@ const STATUS_CLASS: Record<string, string> = {
 
 const ACTIVE_STATUSES = new Set(["queued", "transcribing", "processing"]);
 
-
 type StatusFilter = "all" | "active" | "done" | "error";
 
 const FILTER_LABELS: Record<StatusFilter, string> = {

--- a/src/components/v4/transcripts/TranscriptHistoryV4.tsx
+++ b/src/components/v4/transcripts/TranscriptHistoryV4.tsx
@@ -3,7 +3,6 @@ import {
   fetchTranscriptList,
   deleteTranscript,
   type TranscriptListItem,
-  type TranscriptQuality,
   type TranscriptionModel,
 } from "../../../utils/transcript";
 
@@ -37,25 +36,6 @@ const STATUS_CLASS: Record<string, string> = {
 
 const ACTIVE_STATUSES = new Set(["queued", "transcribing", "processing"]);
 
-const STAGE_LABELS: Record<string, string> = {
-  intake: "Приём",
-  stt: "Транскрипция",
-  enrichment: "Обогащение",
-  structuring: "Структуризация",
-  synthesis: "Синтез",
-};
-
-const QUALITY_LABEL: Record<TranscriptQuality, string> = {
-  pass: "ОК",
-  warning: "Замечания",
-  needs_review: "Проверить",
-};
-
-const QUALITY_CLASS: Record<TranscriptQuality, string> = {
-  pass: "v4-tpc-quality--pass",
-  warning: "v4-tpc-quality--warn",
-  needs_review: "v4-tpc-quality--review",
-};
 
 type StatusFilter = "all" | "active" | "done" | "error";
 
@@ -487,19 +467,10 @@ export function TranscriptHistoryV4({ onOpen, onResume, onRetry, refreshKey, onI
                   <span className={`v4-tpc-status ${STATUS_CLASS[item.status] ?? ""}`}>
                     {isActive && <span className="v4-tpc-status-pulse" />}
                     {STATUS_LABELS[item.status] ?? item.status}
-                    {item.status === "error" && item.current_stage && STAGE_LABELS[item.current_stage] && (
-                      <span className="v4-tpc-text-muted"> ({STAGE_LABELS[item.current_stage]})</span>
-                    )}
                   </span>
                 </div>
                 <div className="v4-tpc-history-cell v4-tpc-history-quality">
-                  {item.status === "done" && item.quality ? (
-                    <span className={`v4-tpc-quality-chip v4-tpc-quality-chip--static v4-tpc-quality-chip--sm ${QUALITY_CLASS[item.quality]}`}>
-                      {QUALITY_LABEL[item.quality]}
-                    </span>
-                  ) : (
-                    <span className="v4-tpc-text-muted">—</span>
-                  )}
+                  <span className="v4-tpc-text-muted">—</span>
                 </div>
                 <div className="v4-tpc-history-cell v4-tpc-history-actions">
                   {item.status === "done" && (

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -166,8 +166,6 @@ export interface TranscriptListItem {
   status: "done" | "queued" | "transcribing" | "processing" | "error";
   created_at: string; // ISO timestamp
   transcription_model?: TranscriptionModel;
-  quality?: TranscriptQuality;
-  current_stage?: string; // for error display: stage where job failed
 }
 
 export async function fetchTranscriptList(): Promise<TranscriptListItem[]> {
@@ -186,8 +184,6 @@ export async function fetchTranscriptList(): Promise<TranscriptListItem[]> {
     status: item.status as TranscriptListItem["status"],
     created_at: item.created_at || "",
     transcription_model: (item.transcription_model as TranscriptionModel) || undefined,
-    quality: (item.quality as TranscriptQuality) || undefined,
-    current_stage: item.current_stage || undefined,
   }));
 }
 


### PR DESCRIPTION
Closes #446. Frontend-only (backend = source of truth).

## Проблема
Backend `/transcript/list` → `TranscriptListItem` (api.py:952; handler api.py:3786, `-> list[TranscriptListItem]`) шлёт только job_id/status/file_name/project/created_at/file_type/transcription_model. Фронт-тип объявлял `quality?`/`current_stage?`, `fetchTranscriptList` их маппил → всегда undefined → quality-чип и подпись стадии ошибки в обоих History-компонентах = мёртвые ветки, никогда не рендерились.

## Решение
Убраны поля из `TranscriptListItem`, 2 строки маппинга, мёртвые UI-ветки, и ставшие unused `QUALITY_LABEL`/`QUALITY_CLASS`/`STAGE_LABELS` + импорт `TranscriptQuality` в обоих компонентах. Структура `<td>`/grid-ячейки сохранена (показывает `—` как и раньше) → **поведенчески нейтрально, без table/grid-CSS изменений, без визуальной регрессии**. `TranscriptQuality` тип остаётся в transcript.ts (используется TranscriptResult/extractQuality).

## Проверка
- tsc/eslint/build ✅; residual-ref скан пуст; diff +2/−69 (чистое удаление dead-кода)
- Браузер-проверка неинформативна: по построению ничего визуально не меняется (backend никогда не слал эти поля — UI всегда рендерил `—`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)