### PR TITLE
fix: подключить риски в useProjectHub (Hub Overview топ-3)

### DIFF
--- a/src/hooks/useProjectHub.ts
+++ b/src/hooks/useProjectHub.ts
@@ -8,10 +8,16 @@ import type {
   NextBestAction,
   OnboardingReport,
   ProjectHubData,
+  Risk,
+  RiskProbability,
+  RiskSeverity,
+  RiskSource,
+  RiskStatus,
 } from "../types/hub";
 import {
   listRecentCommits,
   readMarkdown,
+  readYaml,
   resolveRepoSlug,
   type CommitInfo,
 } from "../utils/github-contents";
@@ -75,6 +81,164 @@ async function fetchDoraPRs(repo: string): Promise<DoraPullRequest[]> {
       createdAt: pr.created_at,
       mergedAt: pr.merged_at,
     }));
+  } catch {
+    return [];
+  }
+}
+
+// ── Risk Register read (Epic-011 Task-03 → Hub Overview wiring, #450) ──
+// The Overview "Риски — топ-3" card must show the SAME risks the
+// DecisionsRisks tab's RiskRegisterTable renders. That table's displayed
+// list is the persisted register `docs/risks.yaml`, read via `readYaml`,
+// normalised per-row, and sorted severity-desc (its `extractRisks` path
+// is a separate Claude-powered *write* flow that only feeds the approval
+// modal — it never sources the rendered list). RiskRegisterTable keeps
+// its normalise/sort helpers module-private; we mirror them here exactly
+// (same enum tables, same `coerceEnum` repair, same `isIsoCalendarDate`
+// `due` coercion, same severity rank + id tie-break) rather than widen
+// that component's API. Kept byte-for-byte aligned so the Overview top-3
+// can never diverge from the table's row order.
+const RISKS_PATH = "docs/risks.yaml";
+
+/** On-disk shape of `docs/risks.yaml`: `{ risks: Risk[] }`. */
+interface RisksFile {
+  risks: Risk[];
+}
+
+const RISK_SEVERITIES: RiskSeverity[] = ["low", "med", "high", "critical"];
+const RISK_PROBABILITIES: RiskProbability[] = ["low", "med", "high"];
+const RISK_STATUSES: RiskStatus[] = [
+  "open",
+  "mitigated",
+  "accepted",
+  "closed",
+];
+const RISK_SOURCES: RiskSource[] = [
+  "manual",
+  "transcript-extracted",
+  "audit-promoted",
+];
+
+/** Worst→best ordering so the top-3 puts critical first (mirrors
+ *  RiskRegisterTable's `SEVERITY_RANK`). */
+const RISK_SEVERITY_RANK: Record<RiskSeverity, number> = {
+  critical: 3,
+  high: 2,
+  med: 1,
+  low: 0,
+};
+
+/** Coerce an arbitrary yaml value to a valid member of `allowed`. */
+function coerceRiskEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  return typeof value === "string" &&
+    (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : fallback;
+}
+
+/**
+ * Strict `YYYY-MM-DD` calendar check for a risk `due` — mirrors
+ * RiskRegisterTable's `isIsoCalendarDate`. A non-ISO value is coerced to
+ * `null` at read time so the Overview card never shows a junk date.
+ */
+function isIsoCalendarDate(value: string): boolean {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!m) return false;
+  const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  const dt = new Date(Date.UTC(y, mo - 1, d));
+  return (
+    dt.getUTCFullYear() === y &&
+    dt.getUTCMonth() === mo - 1 &&
+    dt.getUTCDate() === d
+  );
+}
+
+/** Trim to a string, tolerating `null`/`number`/missing yaml values. */
+function riskAsString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+/**
+ * Normalise one raw yaml row into a valid `Risk` — mirrors
+ * RiskRegisterTable's `normaliseRisk`. A hand-edited or extractor-written
+ * file can carry an invalid `severity`, a missing `owner`, a numeric
+ * `due`, etc.; we never trust it, we repair it so the Overview card
+ * can't crash on bad input.
+ */
+function normaliseRisk(raw: unknown, index: number): Risk {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  const id = riskAsString(r.id).trim() || `risk-${index + 1}`;
+  const dueRaw = riskAsString(r.due).trim();
+  const due =
+    dueRaw !== "" && isIsoCalendarDate(dueRaw) ? dueRaw : null;
+  return {
+    id,
+    title: riskAsString(r.title).trim(),
+    severity: coerceRiskEnum<RiskSeverity>(
+      r.severity,
+      RISK_SEVERITIES,
+      "med",
+    ),
+    probability: coerceRiskEnum<RiskProbability>(
+      r.probability,
+      RISK_PROBABILITIES,
+      "med",
+    ),
+    mitigation: riskAsString(r.mitigation).trim(),
+    owner: riskAsString(r.owner).trim(),
+    due,
+    status: coerceRiskEnum<RiskStatus>(r.status, RISK_STATUSES, "open"),
+    source: coerceRiskEnum<RiskSource>(r.source, RISK_SOURCES, "manual"),
+  };
+}
+
+/** Pull a `Risk[]` out of whatever `readYaml` returned — mirrors
+ *  RiskRegisterTable's `parseRisksFile`. */
+function parseRisksFile(data: unknown): Risk[] {
+  const list = Array.isArray(data)
+    ? data
+    : Array.isArray((data as RisksFile | null)?.risks)
+      ? (data as RisksFile).risks
+      : [];
+  return list.map(normaliseRisk);
+}
+
+/** Stable severity-desc sort (tie-break by id) — mirrors
+ *  RiskRegisterTable's `sortBySeverityDesc`, so the Overview top-3 is
+ *  exactly the first three rows the register table would render. */
+function sortBySeverityDesc(risks: Risk[]): Risk[] {
+  return [...risks].sort((a, b) => {
+    const d =
+      RISK_SEVERITY_RANK[b.severity] - RISK_SEVERITY_RANK[a.severity];
+    return d !== 0 ? d : a.id.localeCompare(b.id);
+  });
+}
+
+/** How many top risks the Overview "Риски — топ-3" card shows. */
+const RISKS_TOP_N = 3;
+
+/**
+ * Read the project's `docs/risks.yaml`, normalise + severity-desc sort
+ * exactly like RiskRegisterTable, and return the top-N. Best-effort:
+ *  - file absent (`readYaml` → null on 404) → `[]`, never an error;
+ *  - corrupt yaml (`readYaml` throws on parse) is swallowed → `[]`,
+ *    so a single bad register file degrades this section alone and
+ *    never crashes the rest of the Hub (the register tab still
+ *    surfaces the parse error with its own retry affordance).
+ */
+async function fetchTopRisks(repo: string): Promise<Risk[]> {
+  try {
+    const res = await readYaml<RisksFile>(repo, RISKS_PATH);
+    if (res === null) return [];
+    return sortBySeverityDesc(parseRisksFile(res.data)).slice(0, RISKS_TOP_N);
   } catch {
     return [];
   }
@@ -220,21 +384,31 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
   // while one input lags the other. #405.
   const [prsResolved, setPrsResolved] =
     useState<Resolved<DoraPullRequest[]> | null>(null);
+  // Risk Register (Epic-011 Task-03) top-3 for the Overview card (#450).
+  // Same repo-keyed effect as commits/PRs: risks.yaml is also a per-repo
+  // read with nothing for the Hub to do while it loads, so it rides the
+  // existing Promise.all rather than introducing a second uncoordinated
+  // fetch. `fetchTopRisks` is best-effort (absent/corrupt file → []),
+  // so this resolves to a real (possibly empty) list, never an error.
+  const [risksResolved, setRisksResolved] =
+    useState<Resolved<Risk[]> | null>(null);
   useEffect(() => {
     const key = repo;
     let cancelled = false;
     void (async () => {
       // Run in parallel — they're independent and the Hub has nothing
       // to do with either response while we wait.
-      const [briefRes, commitsRes, prsRes] = await Promise.all([
+      const [briefRes, commitsRes, prsRes, risksRes] = await Promise.all([
         readMarkdown(repo, "docs/BRIEF.md").catch(() => null),
         listRecentCommits(repo, 100).catch(() => [] as CommitInfo[]),
         fetchDoraPRs(repo),
+        fetchTopRisks(repo),
       ]);
       if (cancelled || !mounted.current) return;
       setBriefMd(briefRes?.content ?? null);
       setCommitsResolved({ key, data: commitsRes, error: null });
       setPrsResolved({ key, data: prsRes, error: null });
+      setRisksResolved({ key, data: risksRes, error: null });
     })();
     return () => {
       cancelled = true;
@@ -255,6 +429,18 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     () => (prsFresh ? (prsResolved?.data ?? []) : []),
     [prsFresh, prsResolved],
   );
+
+  // Only surface risks resolved for *this* repo; a stale result from
+  // the previous repo (navigation mid-fetch) reads as not-yet-loaded
+  // (empty), never as the old repo's risks. Falls back to the stable
+  // `EMPTY_RISKS` so downstream memo deps keep reference equality and
+  // the Overview empty state appears only when there are genuinely no
+  // risks (file absent / corrupt / register empty).
+  const risksFresh = risksResolved !== null && risksResolved.key === repo;
+  const risks = useMemo<ProjectHubData["risks"]>(() => {
+    const list = risksFresh ? (risksResolved?.data ?? []) : [];
+    return list.length > 0 ? list : EMPTY_RISKS;
+  }, [risksFresh, risksResolved]);
 
   const decisions = useMemo(
     () => extractDecisions(briefMd, commits),
@@ -475,7 +661,7 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     project: project ?? null,
     health: report,
     decisions: finalDecisions,
-    risks: EMPTY_RISKS,
+    risks,
     commitments: EMPTY_COMMITMENTS,
     renewals: EMPTY_RENEWALS,
     pulse: EMPTY_PULSE,


### PR DESCRIPTION
Closes #450

## Что сделано
- useProjectHub формирует risks из того же источника, что отображает RiskRegisterTable: docs/risks.yaml через readYaml
- Нормализация строк и сортировка по severity (desc, tie-break по id) зеркалят приватные хелперы RiskRegisterTable один-в-один; берётся топ-3
- Встроено в тот же repo-keyed Promise.all (commits/PRs) и выводится через существующий Resolved<T> + freshness паттерн — без второго фетча
- Изменён только useProjectHub.ts (+ импорт); продюсер и типы переиспользованы как есть

## Самопроверка
- [x] 13 пунктов / senior review; P1: 0, P2: 0
- [x] lint + tsc --noEmit + build чисто
- [x] Репо без docs/risks.yaml (404→null) или с повреждённым yaml → пустые риски, без ошибки хука; пустое состояние только когда рисков реально нет

## Примечание
extractRisks — это отдельный Claude-write-path для модалки одобрения предложений (требует API-ключ, интерактивен); отображаемый список RiskRegisterTable формируется из docs/risks.yaml. Для пассивной карточки топ-3 единственный корректный источник — persisted-реестр risks.yaml; зеркалим именно его pipeline чтения/нормализации/сортировки.

🤖 Generated with Claude Code