### PR TITLE
refactor: общий risksRegister — устранить дублирование RiskRegisterTable/useProjectHub

### DIFF
--- a/src/components/v4/hub/RiskRegisterTable.tsx
+++ b/src/components/v4/hub/RiskRegisterTable.tsx
@@ -17,6 +17,16 @@ import type {
   RiskSource,
   RiskStatus,
 } from "../../../types/hub";
+import {
+  PROBABILITIES,
+  parseRisksFile,
+  RISKS_PATH,
+  type RisksFile,
+  SEVERITIES,
+  SOURCES,
+  sortBySeverityDesc,
+  STATUSES,
+} from "../../../utils/risksRegister";
 
 /**
  * Risk Register CRUD table over `docs/risks.yaml` (Epic-011 Task-03,
@@ -34,30 +44,6 @@ import type {
  * `writeYaml`, so a title like `<img onerror>` or a yaml control
  * sequence is inert both on screen and on disk.
  */
-
-const RISKS_PATH = "docs/risks.yaml";
-
-/** On-disk shape of `docs/risks.yaml`: `{ risks: Risk[] }`. */
-interface RisksFile {
-  risks: Risk[];
-}
-
-const SEVERITIES: RiskSeverity[] = ["low", "med", "high", "critical"];
-const PROBABILITIES: RiskProbability[] = ["low", "med", "high"];
-const STATUSES: RiskStatus[] = ["open", "mitigated", "accepted", "closed"];
-const SOURCES: RiskSource[] = [
-  "manual",
-  "transcript-extracted",
-  "audit-promoted",
-];
-
-/** Worst→best ordering so the default sort puts critical on top. */
-const SEVERITY_RANK: Record<RiskSeverity, number> = {
-  critical: 3,
-  high: 2,
-  med: 1,
-  low: 0,
-};
 
 const SEVERITY_LABEL: Record<RiskSeverity, string> = {
   low: "Low",
@@ -103,97 +89,6 @@ const EXTRACT_ERROR_MESSAGE: Record<
   "claude-failed":
     "Не удалось обратиться к Claude API (сеть, ключ или ответ модели). Попробуйте ещё раз.",
 };
-
-/** Coerce an arbitrary yaml value to a valid member of `allowed`. */
-function coerceEnum<T extends string>(
-  value: unknown,
-  allowed: readonly T[],
-  fallback: T,
-): T {
-  return typeof value === "string" && (allowed as readonly string[]).includes(value)
-    ? (value as T)
-    : fallback;
-}
-
-/**
- * Strict `YYYY-MM-DD` calendar check for a risk `due`. `Date.parse`
- * rolls invalid days over (`2026-02-30` → Mar 2) and accepts loose
- * formats the `<input type="date">` can't render, so we require the
- * exact ISO shape AND a round-tripping UTC date.
- */
-function isIsoCalendarDate(value: string): boolean {
-  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  if (!m) return false;
-  const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
-  const dt = new Date(Date.UTC(y, mo - 1, d));
-  return (
-    dt.getUTCFullYear() === y &&
-    dt.getUTCMonth() === mo - 1 &&
-    dt.getUTCDate() === d
-  );
-}
-
-/** Trim to a string, tolerating `null`/`number`/missing yaml values. */
-function asString(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  return "";
-}
-
-/**
- * Normalise one raw yaml row into a valid `Risk`. A hand-edited or
- * extractor-produced file can carry an invalid `severity`, a missing
- * `owner`, a numeric `due`, etc. — we never trust it, we repair it so
- * the table can't crash on bad input.
- */
-function normaliseRisk(raw: unknown, index: number): Risk {
-  const r = (raw ?? {}) as Record<string, unknown>;
-  const id = asString(r.id).trim() || `risk-${index + 1}`;
-  const dueRaw = asString(r.due).trim();
-  // Normalise `due` to either a real ISO `YYYY-MM-DD` or `null` at READ
-  // time. A non-ISO value (e.g. "Q3") can't render in the `type="date"`
-  // input — it would show blank and the first unrelated edit would
-  // silently overwrite it with null. Coercing it to null here makes the
-  // loss deterministic and visible (the row shows "—" immediately)
-  // instead of a hidden data-loss path on the next edit.
-  const due =
-    dueRaw !== "" && isIsoCalendarDate(dueRaw) ? dueRaw : null;
-  return {
-    id,
-    title: asString(r.title).trim(),
-    severity: coerceEnum<RiskSeverity>(r.severity, SEVERITIES, "med"),
-    probability: coerceEnum<RiskProbability>(
-      r.probability,
-      PROBABILITIES,
-      "med",
-    ),
-    mitigation: asString(r.mitigation).trim(),
-    owner: asString(r.owner).trim(),
-    due,
-    status: coerceEnum<RiskStatus>(r.status, STATUSES, "open"),
-    source: coerceEnum<RiskSource>(r.source, SOURCES, "manual"),
-  };
-}
-
-/** Pull a `Risk[]` out of whatever `readYaml` returned. */
-function parseRisksFile(data: unknown): Risk[] {
-  const list = Array.isArray(data)
-    ? data
-    : Array.isArray((data as RisksFile | null)?.risks)
-      ? (data as RisksFile).risks
-      : [];
-  return list.map(normaliseRisk);
-}
-
-/** Stable severity-desc sort (tie-break by id) for deterministic rows. */
-function sortBySeverityDesc(risks: Risk[]): Risk[] {
-  return [...risks].sort((a, b) => {
-    const d = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
-    return d !== 0 ? d : a.id.localeCompare(b.id);
-  });
-}
 
 /** A new blank risk seeded with a collision-resistant id. */
 function blankRisk(): Risk {

--- a/src/hooks/useProjectHub.ts
+++ b/src/hooks/useProjectHub.ts
@@ -9,10 +9,6 @@ import type {
   OnboardingReport,
   ProjectHubData,
   Risk,
-  RiskProbability,
-  RiskSeverity,
-  RiskSource,
-  RiskStatus,
 } from "../types/hub";
 import {
   listRecentCommits,
@@ -21,6 +17,12 @@ import {
   resolveRepoSlug,
   type CommitInfo,
 } from "../utils/github-contents";
+import {
+  parseRisksFile,
+  RISKS_PATH,
+  type RisksFile,
+  sortBySeverityDesc,
+} from "../utils/risksRegister";
 import { extractDecisions } from "../utils/decisionLogExtractor";
 import {
   computeDora,
@@ -87,140 +89,12 @@ async function fetchDoraPRs(repo: string): Promise<DoraPullRequest[]> {
 }
 
 // ── Risk Register read (Epic-011 Task-03 → Hub Overview wiring, #450) ──
-// The Overview "Риски — топ-3" card must show the SAME risks the
-// DecisionsRisks tab's RiskRegisterTable renders. That table's displayed
-// list is the persisted register `docs/risks.yaml`, read via `readYaml`,
-// normalised per-row, and sorted severity-desc (its `extractRisks` path
-// is a separate Claude-powered *write* flow that only feeds the approval
-// modal — it never sources the rendered list). RiskRegisterTable keeps
-// its normalise/sort helpers module-private; we mirror them here exactly
-// (same enum tables, same `coerceEnum` repair, same `isIsoCalendarDate`
-// `due` coercion, same severity rank + id tie-break) rather than widen
-// that component's API. Kept byte-for-byte aligned so the Overview top-3
-// can never diverge from the table's row order.
-const RISKS_PATH = "docs/risks.yaml";
-
-/** On-disk shape of `docs/risks.yaml`: `{ risks: Risk[] }`. */
-interface RisksFile {
-  risks: Risk[];
-}
-
-const RISK_SEVERITIES: RiskSeverity[] = ["low", "med", "high", "critical"];
-const RISK_PROBABILITIES: RiskProbability[] = ["low", "med", "high"];
-const RISK_STATUSES: RiskStatus[] = [
-  "open",
-  "mitigated",
-  "accepted",
-  "closed",
-];
-const RISK_SOURCES: RiskSource[] = [
-  "manual",
-  "transcript-extracted",
-  "audit-promoted",
-];
-
-/** Worst→best ordering so the top-3 puts critical first (mirrors
- *  RiskRegisterTable's `SEVERITY_RANK`). */
-const RISK_SEVERITY_RANK: Record<RiskSeverity, number> = {
-  critical: 3,
-  high: 2,
-  med: 1,
-  low: 0,
-};
-
-/** Coerce an arbitrary yaml value to a valid member of `allowed`. */
-function coerceRiskEnum<T extends string>(
-  value: unknown,
-  allowed: readonly T[],
-  fallback: T,
-): T {
-  return typeof value === "string" &&
-    (allowed as readonly string[]).includes(value)
-    ? (value as T)
-    : fallback;
-}
-
-/**
- * Strict `YYYY-MM-DD` calendar check for a risk `due` — mirrors
- * RiskRegisterTable's `isIsoCalendarDate`. A non-ISO value is coerced to
- * `null` at read time so the Overview card never shows a junk date.
- */
-function isIsoCalendarDate(value: string): boolean {
-  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  if (!m) return false;
-  const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
-  const dt = new Date(Date.UTC(y, mo - 1, d));
-  return (
-    dt.getUTCFullYear() === y &&
-    dt.getUTCMonth() === mo - 1 &&
-    dt.getUTCDate() === d
-  );
-}
-
-/** Trim to a string, tolerating `null`/`number`/missing yaml values. */
-function riskAsString(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  return "";
-}
-
-/**
- * Normalise one raw yaml row into a valid `Risk` — mirrors
- * RiskRegisterTable's `normaliseRisk`. A hand-edited or extractor-written
- * file can carry an invalid `severity`, a missing `owner`, a numeric
- * `due`, etc.; we never trust it, we repair it so the Overview card
- * can't crash on bad input.
- */
-function normaliseRisk(raw: unknown, index: number): Risk {
-  const r = (raw ?? {}) as Record<string, unknown>;
-  const id = riskAsString(r.id).trim() || `risk-${index + 1}`;
-  const dueRaw = riskAsString(r.due).trim();
-  const due =
-    dueRaw !== "" && isIsoCalendarDate(dueRaw) ? dueRaw : null;
-  return {
-    id,
-    title: riskAsString(r.title).trim(),
-    severity: coerceRiskEnum<RiskSeverity>(
-      r.severity,
-      RISK_SEVERITIES,
-      "med",
-    ),
-    probability: coerceRiskEnum<RiskProbability>(
-      r.probability,
-      RISK_PROBABILITIES,
-      "med",
-    ),
-    mitigation: riskAsString(r.mitigation).trim(),
-    owner: riskAsString(r.owner).trim(),
-    due,
-    status: coerceRiskEnum<RiskStatus>(r.status, RISK_STATUSES, "open"),
-    source: coerceRiskEnum<RiskSource>(r.source, RISK_SOURCES, "manual"),
-  };
-}
-
-/** Pull a `Risk[]` out of whatever `readYaml` returned — mirrors
- *  RiskRegisterTable's `parseRisksFile`. */
-function parseRisksFile(data: unknown): Risk[] {
-  const list = Array.isArray(data)
-    ? data
-    : Array.isArray((data as RisksFile | null)?.risks)
-      ? (data as RisksFile).risks
-      : [];
-  return list.map(normaliseRisk);
-}
-
-/** Stable severity-desc sort (tie-break by id) — mirrors
- *  RiskRegisterTable's `sortBySeverityDesc`, so the Overview top-3 is
- *  exactly the first three rows the register table would render. */
-function sortBySeverityDesc(risks: Risk[]): Risk[] {
-  return [...risks].sort((a, b) => {
-    const d =
-      RISK_SEVERITY_RANK[b.severity] - RISK_SEVERITY_RANK[a.severity];
-    return d !== 0 ? d : a.id.localeCompare(b.id);
-  });
-}
+// The Overview "Риски — топ-3" card must show the SAME first three rows
+// the DecisionsRisks tab's RiskRegisterTable renders. Both now share the
+// single read model in `utils/risksRegister` (parse/normalise/sort), so
+// the top-3 can never drift from the register's row order (#467). The
+// `extractRisks` path is a separate Claude-powered *write* flow that
+// only feeds the approval modal — it never sources the rendered list.
 
 /** How many top risks the Overview "Риски — топ-3" card shows. */
 const RISKS_TOP_N = 3;

--- a/src/utils/risksRegister.ts
+++ b/src/utils/risksRegister.ts
@@ -1,0 +1,140 @@
+import type {
+  Risk,
+  RiskProbability,
+  RiskSeverity,
+  RiskSource,
+  RiskStatus,
+} from "../types/hub";
+
+/**
+ * Shared risk-register read model over `docs/risks.yaml` (Epic-011
+ * Task-03). The normalise/parse/sort helpers here are the single source
+ * of truth for two consumers that MUST agree on row order:
+ *  - `RiskRegisterTable` (DecisionsRisks tab) — the CRUD register, and
+ *  - `useProjectHub` — the Overview "Риски — топ-3" card (#450), which
+ *    must show exactly the first three rows the register renders.
+ *
+ * Previously each kept a private byte-faithful copy; editing one
+ * silently desynced the Overview top-3 from the table (#467). Keep all
+ * read-model logic in this module so the two can never drift again.
+ */
+
+export const RISKS_PATH = "docs/risks.yaml";
+
+/** On-disk shape of `docs/risks.yaml`: `{ risks: Risk[] }`. */
+export interface RisksFile {
+  risks: Risk[];
+}
+
+export const SEVERITIES: RiskSeverity[] = ["low", "med", "high", "critical"];
+export const PROBABILITIES: RiskProbability[] = ["low", "med", "high"];
+export const STATUSES: RiskStatus[] = [
+  "open",
+  "mitigated",
+  "accepted",
+  "closed",
+];
+export const SOURCES: RiskSource[] = [
+  "manual",
+  "transcript-extracted",
+  "audit-promoted",
+];
+
+/** Worst→best ordering so the default sort puts critical on top. */
+export const SEVERITY_RANK: Record<RiskSeverity, number> = {
+  critical: 3,
+  high: 2,
+  med: 1,
+  low: 0,
+};
+
+/** Coerce an arbitrary yaml value to a valid member of `allowed`. */
+export function coerceEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  return typeof value === "string" && (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : fallback;
+}
+
+/**
+ * Strict `YYYY-MM-DD` calendar check for a risk `due`. `Date.parse`
+ * rolls invalid days over (`2026-02-30` → Mar 2) and accepts loose
+ * formats the `<input type="date">` can't render, so we require the
+ * exact ISO shape AND a round-tripping UTC date.
+ */
+export function isIsoCalendarDate(value: string): boolean {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!m) return false;
+  const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  const dt = new Date(Date.UTC(y, mo - 1, d));
+  return (
+    dt.getUTCFullYear() === y &&
+    dt.getUTCMonth() === mo - 1 &&
+    dt.getUTCDate() === d
+  );
+}
+
+/** Trim to a string, tolerating `null`/`number`/missing yaml values. */
+export function asString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+/**
+ * Normalise one raw yaml row into a valid `Risk`. A hand-edited or
+ * extractor-produced file can carry an invalid `severity`, a missing
+ * `owner`, a numeric `due`, etc. — we never trust it, we repair it so
+ * the table can't crash on bad input.
+ */
+export function normaliseRisk(raw: unknown, index: number): Risk {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  const id = asString(r.id).trim() || `risk-${index + 1}`;
+  const dueRaw = asString(r.due).trim();
+  // Normalise `due` to either a real ISO `YYYY-MM-DD` or `null` at READ
+  // time. A non-ISO value (e.g. "Q3") can't render in the `type="date"`
+  // input — it would show blank and the first unrelated edit would
+  // silently overwrite it with null. Coercing it to null here makes the
+  // loss deterministic and visible (the row shows "—" immediately)
+  // instead of a hidden data-loss path on the next edit.
+  const due =
+    dueRaw !== "" && isIsoCalendarDate(dueRaw) ? dueRaw : null;
+  return {
+    id,
+    title: asString(r.title).trim(),
+    severity: coerceEnum<RiskSeverity>(r.severity, SEVERITIES, "med"),
+    probability: coerceEnum<RiskProbability>(
+      r.probability,
+      PROBABILITIES,
+      "med",
+    ),
+    mitigation: asString(r.mitigation).trim(),
+    owner: asString(r.owner).trim(),
+    due,
+    status: coerceEnum<RiskStatus>(r.status, STATUSES, "open"),
+    source: coerceEnum<RiskSource>(r.source, SOURCES, "manual"),
+  };
+}
+
+/** Pull a `Risk[]` out of whatever `readYaml` returned. */
+export function parseRisksFile(data: unknown): Risk[] {
+  const list = Array.isArray(data)
+    ? data
+    : Array.isArray((data as RisksFile | null)?.risks)
+      ? (data as RisksFile).risks
+      : [];
+  return list.map(normaliseRisk);
+}
+
+/** Stable severity-desc sort (tie-break by id) for deterministic rows. */
+export function sortBySeverityDesc(risks: Risk[]): Risk[] {
+  return [...risks].sort((a, b) => {
+    const d = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+    return d !== 0 ? d : a.id.localeCompare(b.id);
+  });
+}


### PR DESCRIPTION
Closes #467

## Проблема
PR #466 добавил byte-faithful копии приватных хелперов `RiskRegisterTable` в `useProjectHub` (переименованы `coerceEnum→coerceRiskEnum`, `asString→riskAsString`, массивы с префиксом `RISK_`). Правка одной копии молча рассинхронизировала Overview «Риски — топ-3» с порядком строк реестра.

## Что сделано
- Новый `src/utils/risksRegister.ts` — единый read-model: `RISKS_PATH`, `RisksFile`, `SEVERITIES/PROBABILITIES/STATUSES/SOURCES`, `SEVERITY_RANK`, `coerceEnum`, `isIsoCalendarDate`, `asString`, `normaliseRisk`, `parseRisksFile`, `sortBySeverityDesc`.
- `RiskRegisterTable.tsx` и `useProjectHub.ts` импортируют из него; локальные копии удалены.
- Каноническая реализация = оригинал `RiskRegisterTable` (порядок строк реестра — source of truth, который Overview обязан зеркалить). Поведение идентично: те же enum-таблицы, тот же severity rank + tie-break по `id`, та же строгость `isIsoCalendarDate`.
- Нетто: **+162 / −253** (3 файла), дублирование устранено.

## Тесты
- `npm run lint` — чисто
- `npx tsc --noEmit` — чисто
- `npm run build` — успешно (только pre-existing chunk-size advisory)
- Рефакторинг без функциональных изменений; нет регресса в порядке строк (общий `sortBySeverityDesc`).

## Самопроверка
- [x] Senior review: нет ссылок на удалённые/переименованные символы (grep по src/ чисто); `fetchTopRisks` цел и использует импортируемые символы; `RiskRegisterTable` больше не самоопределяет перенесённые символы
- [x] P1: 0

🤖 Generated with Claude Code
