### PR TITLE
fix: сбор per-project NBA в портфельный вход (Что делать дальше)

### DIFF
--- a/src/components/v4/ProjectsView.tsx
+++ b/src/components/v4/ProjectsView.tsx
@@ -10,6 +10,8 @@ import { PortfolioRenewals } from "./portfolio/PortfolioRenewals";
 import { PortfolioPromiseTracker } from "./portfolio/PortfolioPromiseTracker";
 import { PortfolioDigestPanel } from "./portfolio/PortfolioDigestPanel";
 import { calcRiskScore } from "../../utils/riskScore";
+import { usePortfolioNbaCollection } from "../../hooks/usePortfolioNbaCollection";
+import { collectCachedPerProjectNba } from "../../utils/portfolioNbaCollector";
 import { useToast } from "./toastContext";
 
 interface Props {
@@ -419,6 +421,20 @@ export function ProjectsView({
     [onSelectRepo],
   );
 
+  // Portfolio NBA collection (#453). The render path is a pure read of the
+  // per-project engine caches (populated for free as hubs are opened) — no
+  // N+1 Claude calls block this list. `refreshLive` runs the on-demand
+  // per-project recompute only when the user clicks «Регенерировать».
+  const { perProjectActions, refreshLive } =
+    usePortfolioNbaCollection(projects);
+  const handleNbaRegenerate = useCallback(async () => {
+    await refreshLive();
+    // refreshLive resolved → the per-project engine caches are now fresh;
+    // re-read them so the portfolio aggregate (and sidebar badge cache)
+    // recomputes from the just-written per-project results.
+    return collectCachedPerProjectNba(projects.map((p) => p.repo));
+  }, [refreshLive, projects]);
+
   if (selectedRepo) {
     return (
       <ProjectHubPage
@@ -470,8 +486,9 @@ export function ProjectsView({
           (no self-contained URL-navigation fallback fires). */}
       <div className="v4-portfolio-widgets">
         <PortfolioNextActions
-          perProjectActions={undefined}
+          perProjectActions={perProjectActions}
           onOpenProject={openProject}
+          onBeforeRegenerate={handleNbaRegenerate}
         />
         <PortfolioRenewals onOpenProject={openProject} />
         <PortfolioPromiseTracker onOpenProject={openProject} />

--- a/src/components/v4/portfolio/PortfolioNextActions.tsx
+++ b/src/components/v4/portfolio/PortfolioNextActions.tsx
@@ -18,7 +18,7 @@
  * malformed engine row can't inject an arbitrary query value.
  */
 
-import { useCallback } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { HealthSeverity } from "../../../types/health";
 import { PROJECTS } from "../../../utils/config";
 import type { NbaAction, NbaResult } from "../../../utils/nextBestActionEngine";
@@ -38,6 +38,16 @@ interface Props {
    * itself (see file header).
    */
   onOpenProject?: (repo: string) => void;
+  /**
+   * Live per-project collection (#453). Awaited on «Регенерировать»
+   * BEFORE the portfolio aggregate recomputes; resolves to the freshly
+   * collected per-project `NbaResult[]`. The async result can't be in the
+   * `perProjectActions` prop yet, so it is passed straight into
+   * `regenerate(override)`. When supplied the button is enabled even with
+   * an empty/undefined `perProjectActions` (a regenerate can now actually
+   * produce input instead of only wiping the cache).
+   */
+  onBeforeRegenerate?: () => Promise<NbaResult[]>;
 }
 
 // Whole row is one visual line; the rationale clamps to 1-2 lines in CSS
@@ -89,16 +99,53 @@ function navigateToProjectOverview(repo: string): void {
 export function PortfolioNextActions({
   perProjectActions,
   onOpenProject,
+  onBeforeRegenerate,
 }: Props) {
   const { actions, loading, error, ageDays, hasCache, budgetFallback, regenerate } =
     usePortfolioNba(perProjectActions);
 
+  // Guards a double-fire of the async regenerate (the in-flight live
+  // collection has no `loading` flag of its own until usePortfolioNba's
+  // recompute starts).
+  const collectingRef = useRef(false);
+  const [collecting, setCollecting] = useState(false);
+
   // Regenerate invalidates the cache *before* recomputing, so firing it with
   // no per-project input would compute an empty result and silently wipe the
-  // actions currently on screen. Until live cross-portfolio collection lands
-  // (Epic-012 Task-09, #367) the mounting surface passes `undefined` — keep
-  // the button disabled in that state rather than letting it erase the cache.
-  const canRegenerate = !!perProjectActions?.length;
+  // actions currently on screen. Two ways to have real input now (#453):
+  // already-collected per-project results in the prop, OR a live collector
+  // (`onBeforeRegenerate`) that produces them on demand. With neither, keep
+  // the button disabled rather than letting it erase the cache.
+  const canRegenerate = !!perProjectActions?.length || !!onBeforeRegenerate;
+
+  // Run the live collection (if provided) THEN recompute the portfolio
+  // aggregate with its fresh result. `regenerate` reads its `perProjectActions`
+  // from a closure captured before the async collection resolved, so the
+  // freshly-collected list must be passed in explicitly as the override.
+  const handleRegenerate = useCallback(() => {
+    if (collectingRef.current || loading) return;
+    if (!onBeforeRegenerate) {
+      regenerate();
+      return;
+    }
+    collectingRef.current = true;
+    setCollecting(true);
+    void (async () => {
+      try {
+        const fresh = await onBeforeRegenerate();
+        regenerate(fresh);
+      } catch {
+        // Collection failed — still recompute from whatever the prop has
+        // so the button isn't a silent no-op (engine degrades internally).
+        regenerate();
+      } finally {
+        collectingRef.current = false;
+        setCollecting(false);
+      }
+    })();
+  }, [onBeforeRegenerate, regenerate, loading]);
+
+  const busy = loading || collecting;
 
   const openProject = useCallback(
     (repo: string | undefined) => {
@@ -124,9 +171,10 @@ export function PortfolioNextActions({
       : null;
 
   // Loading shows for the regenerate request only — the initial render is
-  // synchronous from cache (or empty), there is no cold fetch here.
-  const showError = !!error && actions.length === 0 && !loading;
-  const showEmpty = !loading && !error && actions.length === 0;
+  // synchronous from cache (or empty), there is no cold fetch here. `busy`
+  // also covers the in-flight live collection that precedes the recompute.
+  const showError = !!error && actions.length === 0 && !busy;
+  const showEmpty = !busy && !error && actions.length === 0;
 
   return (
     <div className="v4-panel">
@@ -144,7 +192,7 @@ export function PortfolioNextActions({
           </svg>
           Что делать дальше
           <span className="v4-tag">{actions.length}</span>
-          {loading && <span className="v4-tag">обновляется…</span>}
+          {busy && <span className="v4-tag">обновляется…</span>}
           {budgetFallback && (
             <span
               className="v4-tag v4-tag--warn"
@@ -156,21 +204,21 @@ export function PortfolioNextActions({
           )}
         </div>
         <div className="v4-panel-actions">
-          {freshnessLabel && !loading && (
+          {freshnessLabel && !busy && (
             <span className="v4-panel-meta">{freshnessLabel}</span>
           )}
           <button
             type="button"
             className="v4-btn v4-ai-btn"
-            onClick={regenerate}
-            disabled={loading || !canRegenerate}
+            onClick={handleRegenerate}
+            disabled={busy || !canRegenerate}
             title={
               canRegenerate
                 ? "Сбросить кэш и пересчитать действия по портфелю"
                 : "Нет данных по проектам для пересчёта — кэш не трогаем"
             }
           >
-            {loading ? "Генерация…" : "Регенерировать"}
+            {busy ? "Генерация…" : "Регенерировать"}
           </button>
         </div>
       </div>

--- a/src/hooks/usePortfolioNba.ts
+++ b/src/hooks/usePortfolioNba.ts
@@ -128,11 +128,17 @@ export interface UsePortfolioNbaState {
   /** Engine flagged a Claude budget downgrade for a contributing project. */
   budgetFallback: boolean;
   /**
-   * Drop the cache and recompute from `perProjectActions`. No-ops while a
+   * Drop the cache and recompute the portfolio aggregate. No-ops while a
    * previous regenerate is still running (button is disabled in the UI too,
    * this is the belt-and-braces guard against a double-fire).
+   *
+   * `override` lets the caller hand in freshly-collected per-project
+   * results computed *just before* this call (#453): the live collector
+   * resolves asynchronously, so its result can't be in the closed-over
+   * `perProjectActions` prop yet. When omitted we fall back to the prop —
+   * preserving the original (override-less) behaviour.
    */
-  regenerate: () => void;
+  regenerate: (override?: NbaResult[]) => void;
 }
 
 /**
@@ -168,7 +174,8 @@ export function usePortfolioNba(
     };
   }, []);
 
-  const regenerate = useCallback(() => {
+  const regenerate = useCallback(
+    (override?: NbaResult[]) => {
     if (inFlightRef.current) return;
     inFlightRef.current = true;
     setLoading(true);
@@ -182,7 +189,10 @@ export function usePortfolioNba(
       // best-effort — a disabled localStorage just means no cache to clear
     }
 
-    const input = perProjectActions ?? [];
+    // Prefer freshly-collected input handed in by the caller (#453); the
+    // live per-project collection resolves after this closure was created,
+    // so the prop alone would be stale on the first regenerate.
+    const input = override ?? perProjectActions ?? [];
 
     void (async () => {
       try {
@@ -208,7 +218,59 @@ export function usePortfolioNba(
         inFlightRef.current = false;
       }
     })();
-  }, [perProjectActions]);
+    },
+    [perProjectActions],
+  );
+
+  // Passive auto-aggregate (#453). `computePortfolioNBA` is LOCAL-ONLY
+  // (sorts the per-project top-1s, no Claude / network call) and the
+  // engine itself short-circuits on a fresh week-cache. So once the
+  // caller has collected per-project results we run it once per distinct
+  // input to (a) surface aggregated actions without requiring a manual
+  // «Регенерировать», and (b) write the `makeit_portfolio_nba` cache the
+  // sidebar badge reads — which nothing wrote before. A content signature
+  // + ref guard makes this idempotent (no render loop): re-running with
+  // the same input is skipped, and a same-signature recompute would be a
+  // no-op cache hit anyway. Not triggered while a manual regenerate is in
+  // flight, and never overrides a regenerate's fresher result.
+  const autoSig =
+    perProjectActions === undefined
+      ? null
+      : JSON.stringify(
+          perProjectActions.map((p) => ({
+            f: p.budgetFallback,
+            a: p.actions.map((x) => `${x.id}|${x.severity}|${x.title}`),
+          })),
+        );
+  const lastAutoSigRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (autoSig === null) return;
+    // Empty input → nothing to aggregate; leave the cache untouched so an
+    // earlier good portfolio cache (and its badge) survives.
+    if (perProjectActions !== undefined && perProjectActions.length === 0) {
+      return;
+    }
+    if (lastAutoSigRef.current === autoSig) return;
+    if (inFlightRef.current) return;
+    lastAutoSigRef.current = autoSig;
+    void (async () => {
+      try {
+        const result = await computePortfolioNBA(perProjectActions ?? []);
+        if (!mountedRef.current) return;
+        // A concurrent manual regenerate is the source of truth — don't
+        // clobber its (fresher) result with this passive pass.
+        if (inFlightRef.current) return;
+        setActions(result.actions);
+        setBudgetFallback(result.budgetFallback);
+        const fresh = readCachedEnvelope();
+        setWeekStartMs(fresh?.weekStartMs ?? null);
+        setHasCache(fresh !== null);
+      } catch {
+        // Local aggregation effectively never throws; on the off chance
+        // it does, keep whatever (cache-seeded) state we already have.
+      }
+    })();
+  }, [autoSig, perProjectActions]);
 
   const ageDays =
     weekStartMs === null

--- a/src/hooks/usePortfolioNba.ts
+++ b/src/hooks/usePortfolioNba.ts
@@ -142,6 +142,22 @@ export interface UsePortfolioNbaState {
 }
 
 /**
+ * Stable content signature of a per-project NBA input list. Used to
+ * dedupe the passive auto-aggregate (and to mark a manual regenerate's
+ * input as already-aggregated so it doesn't redundantly re-fire).
+ * `undefined` → `null` (no input collected yet).
+ */
+function nbaInputSignature(list: NbaResult[] | undefined): string | null {
+  if (list === undefined) return null;
+  return JSON.stringify(
+    list.map((p) => ({
+      f: p.budgetFallback,
+      a: p.actions.map((x) => `${x.id}|${x.severity}|${x.title}`),
+    })),
+  );
+}
+
+/**
  * @param perProjectActions  Per-project `NbaResult[]` the caller already
  *   computed. The engine aggregates these locally. Undefined/empty →
  *   graceful empty state (full live collection is Task-09, out of scope).
@@ -167,6 +183,10 @@ export function usePortfolioNba(
   // resolves late.
   const inFlightRef = useRef(false);
   const mountedRef = useRef(true);
+  // Signature of the input last aggregated (manually or passively) so the
+  // passive auto-aggregate skips a redundant recompute after a manual
+  // regenerate already produced the result for that same input.
+  const lastAutoSigRef = useRef<string | null>(null);
   useEffect(() => {
     mountedRef.current = true;
     return () => {
@@ -206,6 +226,9 @@ export function usePortfolioNba(
         const fresh = readCachedEnvelope();
         setWeekStartMs(fresh?.weekStartMs ?? null);
         setHasCache(fresh !== null);
+        // This input is now aggregated — when the prop settles to the
+        // same content the passive effect must not redundantly recompute.
+        lastAutoSigRef.current = nbaInputSignature(input);
       } catch (e) {
         if (!mountedRef.current) return;
         setError(
@@ -233,16 +256,7 @@ export function usePortfolioNba(
   // the same input is skipped, and a same-signature recompute would be a
   // no-op cache hit anyway. Not triggered while a manual regenerate is in
   // flight, and never overrides a regenerate's fresher result.
-  const autoSig =
-    perProjectActions === undefined
-      ? null
-      : JSON.stringify(
-          perProjectActions.map((p) => ({
-            f: p.budgetFallback,
-            a: p.actions.map((x) => `${x.id}|${x.severity}|${x.title}`),
-          })),
-        );
-  const lastAutoSigRef = useRef<string | null>(null);
+  const autoSig = nbaInputSignature(perProjectActions);
   useEffect(() => {
     if (autoSig === null) return;
     // Empty input → nothing to aggregate; leave the cache untouched so an

--- a/src/hooks/usePortfolioNbaCollection.ts
+++ b/src/hooks/usePortfolioNbaCollection.ts
@@ -1,0 +1,107 @@
+/**
+ * usePortfolioNbaCollection — owns the per-project NBA input feeding the
+ * portfolio widget (#453).
+ *
+ * Render path (zero cost): on mount / when the project list changes it
+ * synchronously reads the engine's already-computed per-project caches
+ * (`collectCachedPerProjectNba`). No Claude, no network — those caches are
+ * populated for free as the user browses project hubs.
+ *
+ * Regenerate path (on-demand): `refreshLive()` is awaited by the widget's
+ * «Регенерировать» click BEFORE the portfolio aggregate recomputes. It
+ * derives lightweight signals from the already-loaded `ProjectData` and
+ * calls the per-project engine (fresh week-caches short-circuit, so it is
+ * mostly cache reuse). The freshly-collected results replace state, so the
+ * subsequent `usePortfolioNba` recompute aggregates the new input and
+ * re-writes the `makeit_portfolio_nba` cache the sidebar badge reads.
+ *
+ * `perProjectActions` is `undefined` until the first collection so the
+ * widget's "no input" guard (disabled regenerate) holds correctly when
+ * nothing is cached AND no key is configured; once we have collected
+ * (even an empty array) it becomes a real array so the aggregate can run.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ProjectData } from "../types";
+import { getClaudeKey } from "../utils/config";
+import {
+  collectCachedPerProjectNba,
+  collectLivePerProjectNba,
+} from "../utils/portfolioNbaCollector";
+import type { NbaResult } from "../utils/nextBestActionEngine";
+
+export interface UsePortfolioNbaCollectionState {
+  /**
+   * Per-project `NbaResult[]` for `usePortfolioNba`. `undefined` only
+   * before the first (synchronous) cache collection — never after, so the
+   * widget's regenerate guard enables once there is real input.
+   */
+  perProjectActions: NbaResult[] | undefined;
+  /**
+   * Recompute per-project NBAs live from the loaded projects, then update
+   * `perProjectActions`. Awaited by the widget before it recomputes the
+   * portfolio aggregate. No-ops (returns cheaply) when no projects.
+   */
+  refreshLive: () => Promise<void>;
+}
+
+export function usePortfolioNbaCollection(
+  projects: ProjectData[],
+): UsePortfolioNbaCollectionState {
+  const [perProjectActions, setPerProjectActions] = useState<
+    NbaResult[] | undefined
+  >(undefined);
+
+  // Stable list of repos; recompute the cheap cached collection whenever
+  // the set of repos changes (not on every ProjectData field churn).
+  const repoKey = projects
+    .map((p) => p.repo)
+    .sort()
+    .join("|");
+
+  // Latest projects in a ref so `refreshLive` stays referentially stable
+  // (it must not change identity on every projects refresh — the widget
+  // memoises around it).
+  const projectsRef = useRef(projects);
+  useEffect(() => {
+    projectsRef.current = projects;
+  }, [projects]);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // RENDER PATH: pure cached collection. The read is synchronous and a
+  // pure function of `repoKey`, so this uses React's documented "adjust
+  // state during render when a prop changes" pattern (prev-value in state
+  // + setState during render) — same pattern as `usePortfolioNbaBadge`'s
+  // tab guard. It re-renders before commit with no effect / cascading
+  // render, and (unlike a setState-in-effect) satisfies the strict
+  // react-hooks lint rules. A live `refreshLive` later writes the same
+  // state; the next repo-set change re-syncs from caches again.
+  const [syncedRepoKey, setSyncedRepoKey] = useState<string | null>(null);
+  if (syncedRepoKey !== repoKey) {
+    setSyncedRepoKey(repoKey);
+    const repos = repoKey.length > 0 ? repoKey.split("|") : [];
+    setPerProjectActions(collectCachedPerProjectNba(repos));
+  }
+
+  const refreshLive = useCallback(async () => {
+    const current = projectsRef.current;
+    if (current.length === 0) {
+      // Nothing to compute — fall back to the cached collection so the
+      // aggregate at least re-reads any per-project caches.
+      if (mountedRef.current) setPerProjectActions([]);
+      return;
+    }
+    const apiKey = getClaudeKey() ?? "";
+    const collected = await collectLivePerProjectNba(current, apiKey);
+    if (mountedRef.current) setPerProjectActions(collected);
+  }, []);
+
+  return { perProjectActions, refreshLive };
+}

--- a/src/utils/portfolioNbaCollector.ts
+++ b/src/utils/portfolioNbaCollector.ts
@@ -1,0 +1,196 @@
+/**
+ * portfolioNbaCollector — collects per-project NBA results into the input
+ * the portfolio aggregate (`computePortfolioNBA` / `usePortfolioNba`)
+ * expects (#453, was Epic-012 Task-09 / #367 "not done").
+ *
+ * The per-project engine (`computeProjectNBA`) is real but every miss is a
+ * Claude call. Computing it for the whole portfolio on every render would
+ * be an N+1 of model calls blocking the Projects view — explicitly
+ * forbidden. So collection is split in two:
+ *
+ *   1. `collectCachedPerProjectNba(repos)` — RENDER PATH, zero cost.
+ *      A pure synchronous read of the engine's own per-project week-cache
+ *      (`makeit_nba:{repo}`). Those entries are populated for free as the
+ *      user opens project hubs (`useProjectHub` already calls
+ *      `computeProjectNBA`). No Claude, no network, no fetch — just
+ *      `localStorage.getItem` per repo. Projects without a fresh cache
+ *      simply don't contribute (graceful, never a false signal).
+ *
+ *   2. `collectLivePerProjectNba(projects, apiKey)` — REGENERATE PATH,
+ *      on-demand only (fires from the user's «Регенерировать» click, never
+ *      on render). For each project it derives lightweight NBA signals
+ *      from data ProjectsView already holds (blocked / stale-open issues —
+ *      no extra fetch) and calls `computeProjectNBA`. Fresh week-cache
+ *      hits short-circuit inside the engine, so a regenerate right after a
+ *      browse session mostly reuses caches and only spends a Claude call
+ *      on projects that actually changed or were never opened.
+ *
+ * The engine does not export its per-project cache key shape, so the
+ * read-only reader mirrors it here (`makeit_nba:{repo}`, `{week, result}`
+ * envelope, ISO-week scoped). Kept as the single mirror-point with a
+ * comment so a future engine rename has one place to update.
+ */
+
+import type { ProjectData } from "../types";
+import {
+  computeProjectNBA,
+  type NbaInputs,
+  type NbaResult,
+} from "./nextBestActionEngine";
+
+/**
+ * Engine per-project cache key prefix. Mirrors
+ * `PROJECT_KEY_PREFIX` in nextBestActionEngine.ts (`makeit_nba`); the
+ * engine does not export it. If the engine renames it, update here.
+ */
+const PROJECT_NBA_KEY_PREFIX = "makeit_nba";
+
+/** Cap so a regenerate never fans out an unbounded number of model calls. */
+const MAX_LIVE_PROJECTS = 20;
+
+/** Shape the engine writes per project: `{ week, result: NbaResult }`. */
+interface RawProjectCacheEnvelope {
+  week?: unknown;
+  result?: unknown;
+}
+
+function projectCacheKey(repo: string): string {
+  return `${PROJECT_NBA_KEY_PREFIX}:${repo}`;
+}
+
+/**
+ * Read-only peek at one project's engine cache. Returns its `NbaResult`
+ * regardless of which ISO week wrote it (the portfolio aggregate is
+ * itself week-scoped downstream, and a slightly stale per-project entry
+ * is still a far better portfolio signal than nothing). Returns null for
+ * a missing / corrupt / empty-storage entry so a bad cache degrades to
+ * "this project doesn't contribute" instead of throwing.
+ */
+function readProjectNbaCache(repo: string): NbaResult | null {
+  if (typeof localStorage === "undefined") return null;
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(projectCacheKey(repo));
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+  try {
+    const env = JSON.parse(raw) as RawProjectCacheEnvelope;
+    if (
+      env === null ||
+      typeof env !== "object" ||
+      typeof env.week !== "string" ||
+      env.result === null ||
+      typeof env.result !== "object"
+    ) {
+      return null;
+    }
+    const result = env.result as Partial<NbaResult>;
+    if (!Array.isArray(result.actions)) return null;
+    return {
+      actions: result.actions,
+      budgetFallback: result.budgetFallback === true,
+      warning: typeof result.warning === "string" ? result.warning : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * RENDER PATH — pure synchronous collection of whatever per-project NBA
+ * results the engine already cached. One `localStorage` read per repo, no
+ * Claude / network. The result is the `perProjectActions` input
+ * `usePortfolioNba` aggregates; an all-empty portfolio (nothing cached
+ * yet) yields `[]` → the widget's graceful empty state, never a crash or
+ * a false badge.
+ */
+export function collectCachedPerProjectNba(repos: string[]): NbaResult[] {
+  const out: NbaResult[] = [];
+  for (const repo of repos) {
+    const cached = readProjectNbaCache(repo);
+    if (cached !== null) out.push(cached);
+  }
+  return out;
+}
+
+/**
+ * Derive lightweight per-project NBA signals from data ProjectsView
+ * already holds — NO extra fetch. We surface blocked and stale-open
+ * issues as `drift` indicators (the engine's free-form norm-violation
+ * channel). This is intentionally a coarse signal: the rich per-project
+ * inputs (audit findings, risks) belong to the Project Hub
+ * (`useProjectHub`), which already computes the high-fidelity per-project
+ * NBA cached entries this collector's render path reuses. The live path
+ * exists so «Регенерировать» still produces *something* for projects the
+ * user never opened.
+ */
+function deriveProjectSignals(p: ProjectData): NbaInputs {
+  const drift: NonNullable<NbaInputs["drift"]> = [];
+
+  const blocked = p.issues.filter((i) => i.isBlocked && i.status !== "Done");
+  if (blocked.length > 0) {
+    drift.push({
+      label: `${blocked.length} заблокированных задач: ${blocked
+        .slice(0, 3)
+        .map((i) => i.title)
+        .join("; ")}`,
+      severity: "high",
+    });
+  }
+
+  const isStaleOpen =
+    p.daysSinceActivity !== null &&
+    p.daysSinceActivity >= 7 &&
+    p.openCount > 0;
+  if (isStaleOpen) {
+    drift.push({
+      label: `Нет активности ${p.daysSinceActivity} дней при ${p.openCount} открытых задачах`,
+      severity: "medium",
+    });
+  }
+
+  const p1 = p.priorityCounts.P1 ?? 0;
+  if (p1 > 0) {
+    drift.push({
+      label: `${p1} задач приоритета P1 в работе`,
+      severity: "high",
+    });
+  }
+
+  return { drift };
+}
+
+/**
+ * REGENERATE PATH — on-demand per-project collection. For each project
+ * (capped at `MAX_LIVE_PROJECTS`) it derives signals and calls
+ * `computeProjectNBA`. A fresh per-project week-cache short-circuits
+ * inside the engine (no Claude call); projects with no actionable signal
+ * also short-circuit to an empty cached result. The engine never throws
+ * to us (it degrades to stale cache + warning), but each call is still
+ * isolated so one project's failure can't abort the whole collection.
+ *
+ * Returns the per-project `NbaResult[]` for `computePortfolioNBA` to
+ * aggregate. Caller passes this to `usePortfolioNba`, which invalidates
+ * the portfolio cache and recomputes — so after this resolves the
+ * `makeit_portfolio_nba` cache (sidebar badge) reflects fresh data.
+ */
+export async function collectLivePerProjectNba(
+  projects: ProjectData[],
+  apiKey: string,
+): Promise<NbaResult[]> {
+  const slice = projects.slice(0, MAX_LIVE_PROJECTS);
+  const results = await Promise.all(
+    slice.map(async (p) => {
+      try {
+        return await computeProjectNBA(p.repo, deriveProjectSignals(p), apiKey);
+      } catch {
+        // Engine already degrades internally; this is belt-and-braces so
+        // one rejected project never sinks the portfolio regenerate.
+        return null;
+      }
+    }),
+  );
+  return results.filter((r): r is NbaResult => r !== null);
+}


### PR DESCRIPTION
Closes #453

## Проблема

`ProjectsView` хардкодил `perProjectActions={undefined}` → виджет «Что делать дальше» всегда показывал «Действия не требуются», кнопка «Регенерировать» была `disabled`, а sidebar-бейдж не появлялся (кэш `makeit_portfolio_nba` никто не писал). Per-project движок (`computeProjectNBA`) был реальным — отсутствовал только сбор результатов в портфельный вход.

## Что сделано

Сбор разделён на два слоя ради cost-discipline (никакого N+1 вызовов Claude на рендере портфеля):

- **Путь рендера (ноль стоимости)** — `collectCachedPerProjectNba` (новый `src/utils/portfolioNbaCollector.ts`): чистое синхронное чтение per-project кэшей движка `makeit_nba:{repo}`. Эти кэши наполняются бесплатно, когда пользователь открывает хабы проектов (`useProjectHub` уже вызывает `computeProjectNBA`). Ноль Claude / сети / fetch.
- **Путь регенерации (по требованию)** — `collectLivePerProjectNba`: только по клику «Регенерировать». Выводит лёгкие сигналы из уже загруженных `ProjectData` (blocked / stale-open / P1 задачи — без доп. запросов) и вызывает per-project движок; свежие недельные кэши short-circuit'ятся внутри движка.

`usePortfolioNba` получил пассивную авто-агрегацию: `computePortfolioNBA` локальна (сортирует per-project top-1, без Claude), поэтому она запускается один раз на распознанный вход → пишет кэш `makeit_portfolio_nba`, который читает sidebar-бейдж (раньше его никто не писал). `regenerate(override)` теперь принимает свежесобранный вход — фикс staleness замыкания (live-сбор резолвится после создания замыкания). Кнопка активна, когда есть собранный вход ИЛИ доступен live-коллектор.

Новый тонкий хук `src/hooks/usePortfolioNbaCollection.ts` владеет собранным входом (читает кэши через render-time state-sync паттерн, как `usePortfolioNbaBadge`).

## Cost trade-off (документировано умышленно)

Свежезагруженный портфель без предыдущих визитов в хабы покажет пустой виджет до первой регенерации — это сознательный выбор cost-discipline (не делать N+1 Claude-вызовов на рендере списка). Live-путь через кнопку покрывает этот случай. Это минимально-корректная версия; отдельный tech-debt issue не требуется — трейд-офф присущ ограничению стоимости, а не архитектурный долг.

## Параллельная безопасность

НЕ затрагивает `src/hooks/useProjectHub.ts` (параллельно редактируется другим агентом). Изменены только разрешённые файлы + 2 новых util/hook.

## Self-check

- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm run build` — clean (chunk-size warning pre-existing, unrelated)
- Senior self-review: cache shape (badge reads engine envelope мы пишем), no render loop (content-signature ref guard + render-time state-sync), no N+1 blocking render, empty/edge cases (нет кэша → пустое состояние, нет ложного бейджа; пустой вход не затирает хороший кэш), backward-compatible signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)