### PR TITLE
fix: DriftDots — честная семантика для неподдержанных точек (без вечно-серых)

### DIFF
--- a/src/components/v4/portfolio/DriftDots.tsx
+++ b/src/components/v4/portfolio/DriftDots.tsx
@@ -19,6 +19,17 @@ import { SEVERITY_COLORS, DRIFT_WARN_MULT, DRIFT_STALE_MULT } from "./constants"
  * («commit: 4д назад, норма 2д»), an `aria-label` with the same text plus
  * the severity word, and a glyph (●/◐/▲) so red/green is distinguishable
  * without color perception. `role="img"` so SR announces the label.
+ *
+ * Grounded-only rendering (issue #457): a signal is "supplied at the
+ * portfolio level" only when the caller passes its `daysSinceX` prop with
+ * a value (a number, or `null` meaning "tracked but no measurement yet").
+ * When the prop is absent / `undefined` the signal is simply not wired in
+ * this surface — we render NO dot for it rather than a perpetual grey
+ * "нет данных", which read as broken. Today only commit is supplied; the
+ * rest stay hidden until their data path lands (separate cost decision,
+ * #456/#462). Explicit `null` is still shown as the honest grey
+ * "нет данных" so a tracked-but-empty signal (e.g. a repo with zero
+ * commits) is NOT silently dropped.
  */
 
 export type DriftSeverity = "ok" | "warn" | "stale" | "unknown";
@@ -115,6 +126,18 @@ export function DriftDots({
     client_touch_interval_days: daysSinceClientTouch,
   };
 
+  // Render only signals actually supplied by this surface. `undefined`
+  // means the caller does not wire this signal here at all (vs. `null` =
+  // tracked but no measurement yet) — hiding it avoids the misleading
+  // perpetual grey "нет данных" dot (issue #457).
+  const groundedKeys = DRIFT_KEYS.filter(
+    ({ key }) => daysByKey[key] !== undefined,
+  );
+
+  // Nothing wired (shouldn't happen — commit is always supplied) → render
+  // nothing rather than an empty labelled group.
+  if (groundedKeys.length === 0) return null;
+
   return (
     <div
       className="v4-drift-dots"
@@ -122,7 +145,7 @@ export function DriftDots({
       aria-label="Drift-индикаторы"
       style={{ display: "flex", alignItems: "center", gap: 8 }}
     >
-      {DRIFT_KEYS.map(({ key, label }) => {
+      {groundedKeys.map(({ key, label }) => {
         const days = daysByKey[key];
         const normValue = norm ? norm[key] : undefined;
         // While the norm is still loading we can't classify — show muted.


### PR DESCRIPTION
Closes #457.

## Проблема
`DriftDots` рендерил 4 точки (commit / deploy / audit / client-touch), но `ProjectsView` пробрасывает только `daysSinceCommit`. Остальные 3 prop'а приходили `undefined` → `classifyDrift` возвращал `unknown` → на каждой карточке портфеля 3 из 4 точек всегда серые «○ нет данных», читаясь как сломанный UI.

## Что сделано (bounded путь)
Из двух путей в acceptance выбран bounded — «осознанно скрыть недоступные точки» (вариант **(a)** — hide):

- Рендерим только сигналы, **реально проброшенные на этом surface**.
- Чёткое различие двух состояний:
  - prop **отсутствует / `undefined`** → сигнал здесь не подключён вообще → **точка скрыта** (нет шумной вечно-серой точки);
  - prop **явный `null`** → сигнал отслеживается, но измерения ещё нет → остаётся честная серая «нет данных» (так репо без коммитов по commit-точке НЕ теряется молча).
- Если ни один сигнал не проброшен (на практике не бывает — commit всегда есть) → `return null` вместо пустой labelled-группы.

Сегодня проброшен только `commit`; deploy/audit/client-touch скрыты, пока их data-path не приземлится.

## Почему bounded, а не полная проводка
Реальная проводка deploy/audit/client-touch требует новых fetch'ей / хуков / per-project async (Pipeline/Auditor/commitments) — это отдельное **cost-решение (#456 / #462)** и вне scope #457. Здесь — только остановить вводящую в заблуждение вечную серость.

## Почему выбран hide (а не honest-label)
Honest-label добавил бы 4-е визуальное состояние, занимающее место и требующее новой пояснительной подсказки — для сигналов, не несущих информации на уровне портфеля. Скрытие честнее и минимальнее: показываем только то, что обосновано.

## Commit-точка не регрессировала
`daysSinceCommit` всегда поставляется `ProjectsView` (число, либо `null` для репо без коммитов) → всегда проходит фильтр `!== undefined` → классифицируется через `useDriftNorm` ровно как раньше, тултип «commit: Nд назад, норма Nд» без изменений.

## Scope
- Изменён только `src/components/v4/portfolio/DriftDots.tsx` (24 insert / 1 delete).
- `ProjectsView.tsx` правок не требовал — он уже корректно опускает 3 ключа (`undefined` = «не подключён») и пробрасывает `daysSinceCommit` явно.
- `src/hooks/useProjectHub.ts` **не затронут**.

## Self-check
- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm run build` — success (chunk-size warning pre-existing, unrelated)
- Новых fetch / data-path не добавлено; pure presentation.
- Edge cases покрыты: `norm` undefined/loading, `days` `null` vs `undefined`, пустой набор сигналов.
- UI-текст без изменений; добавленные комментарии — code-internal English (по конвенции).
- Без debug-логов и магических констант.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>