### PR TITLE
fix: подключить DigestInput в DigestViewer — Weekly Digest генерируется (#454)

### DIFF
--- a/src/components/v4/hub/tabs/DeliveryTab.tsx
+++ b/src/components/v4/hub/tabs/DeliveryTab.tsx
@@ -1,4 +1,9 @@
-import type { ProjectHubData } from "../../../../types/hub";
+import { useMemo } from "react";
+import type { DigestInput, ProjectHubData } from "../../../../types/hub";
+import {
+  currentWeekKey,
+  normalizeWeekKey,
+} from "../../../../utils/weeklyDigestGenerator";
 import { DoraCards } from "../DoraCards";
 import { CustomerHealthGauge } from "../CustomerHealthGauge";
 import { OnboardingChecklist } from "../OnboardingChecklist";
@@ -31,20 +36,57 @@ interface Props {
  *                       its own four-dash placeholder when `null`.
  *   - Customer Health   self-contained — owns its computeHealth(repo) call.
  *   - Onboarding        reads the six onboarding rules from health findings.
- *   - Weekly Digest     self-contained — read-only history by repo (no
- *                       regenerate input until Task-09 wires the activity).
+ *   - Weekly Digest     fed a best-effort `DigestInput` (this week's
+ *                       activity from the now-wired hub) so its Regenerate
+ *                       control is live and the first digest can be
+ *                       created from an empty state (#454).
  *
  * Every section degrades to a scoped empty state when its source is
  * absent, so the tab never crashes on the stubbed hook.
  */
 export function DeliveryTab({ repo, data }: Props) {
-  const { dora, customerHealth, onboarding, digest, health } = data;
+  const { dora, customerHealth, onboarding, health } = data;
   // OnboardingChecklist needs the raw health findings (it filters the six
   // onboarding rules itself); `onboarding` (OnboardingReport) is the hub's
   // summary and drives the per-section empty state — total === 0 means the
   // project hasn't been health-scanned / classified yet.
   const onboardingFindings = health?.findings ?? [];
   const hasOnboarding = onboarding.total > 0 && onboardingFindings.length > 0;
+
+  // Best-effort DigestInput for the current ISO week, fed to DigestViewer
+  // so its Regenerate control is live (#454). Week-scoping reuses the
+  // generator's own `normalizeWeekKey` (pass a Date — the string overload
+  // would mis-read a full ISO timestamp) so this can never drift from the
+  // key DigestViewer regenerates under. Fields the hub aggregate doesn't
+  // carry (audit findings — separate useAudit, #461) are omitted;
+  // `generateDigest` degrades gracefully on a partial input.
+  const digestInput = useMemo<DigestInput>(() => {
+    const wk = currentWeekKey();
+    const inCurrentWeek = (iso: string): boolean => {
+      const d = new Date(iso);
+      if (Number.isNaN(d.getTime())) return false;
+      return normalizeWeekKey(d) === wk;
+    };
+    const weekPulse = data.pulse.filter((e) => inCurrentWeek(e.timestamp));
+    const mergedPRs = weekPulse
+      .filter((e) => e.type === "pr_merged")
+      .map((e) => ({ title: e.title, url: e.url }));
+    const closedIssues = weekPulse
+      .filter((e) => e.type === "issue_closed")
+      .map((e) => ({ title: e.title, url: e.url }));
+    // No per-commitment delivered-date in the model — surface the ones
+    // currently marked done as this week's deliveries (best-effort).
+    const commitmentsDelivered = data.commitments.filter(
+      (c) => c.status === "done",
+    );
+    return {
+      pulse: weekPulse,
+      closedIssues,
+      mergedPRs,
+      commitmentsDelivered,
+      auditFindings: [],
+    };
+  }, [data.pulse, data.commitments]);
 
   return (
     <div className="delivery-tab">
@@ -115,13 +157,11 @@ export function DeliveryTab({ repo, data }: Props) {
         <h2 id="delivery-digest-title" className="delivery-section-title">
           Weekly Digest
         </h2>
-        {digest === null ? (
-          <p className="delivery-empty">
-            Дайджест за неделю ещё не сгенерирован.
-          </p>
-        ) : (
-          <DigestViewer repo={repo} />
-        )}
+        {/* Always mount: DigestViewer owns its own per-week empty state
+            («…ещё не сгенерирован. Нажмите «Regenerate».») which is now
+            actionable since `input` is supplied — so the FIRST digest can
+            be created, not just regenerated. */}
+        <DigestViewer repo={repo} input={digestInput} />
       </section>
     </div>
   );


### PR DESCRIPTION
Closes #454

## Проблема
`DeliveryTab` монтировал `<DigestViewer repo={repo} />` без пропа `input` → `canRegenerate = Boolean(input) && selectedWeek===currentWeekKey()` всегда false → кнопка «Regenerate» не появлялась, дайджест никогда не создавался (портфельный «Дайджест 0/12» — следствие). Хуже: при `digest === null` вкладка показывала тупиковое сообщение и **вообще не монтировала** DigestViewer — первый дайджест создать было нельзя в принципе.

## Что сделано (regression-safe, по issue, ничего не сломано)
- `DeliveryTab` формирует **best-effort `DigestInput`** за текущую ISO-неделю из уже подключённых данных хаба: `pulse` (#452, week-filtered), `mergedPRs`/`closedIssues` из pulse по `type` в пределах недели, `commitmentsDelivered` = `data.commitments` со `status==="done"` (#451), `auditFindings: []` (аудит не в hub-агрегате — отдельный useAudit/#461; генератор деградирует gracefully).
- Week-scoping переиспользует **`normalizeWeekKey(Date)`** самого генератора (Date-перегрузка, не string — строковая мис-парсила бы полный ISO-таймстамп) → ключ недели не может разойтись с тем, под которым DigestViewer регенерирует.
- DigestViewer монтируется **всегда** (его собственное per-week пустое состояние «…ещё не сгенерирован. Нажмите «Regenerate».» теперь actionable) — первый дайджест создаётся, не только регенерируется.
- `useProjectHub.generateDigest` оставлен задокументированным no-op: grep показал, что **никто его не вызывает** (только DigestViewer импортирует реальный `generateDigest` из `weeklyDigestGenerator` и зовёт сам). Вшивать его = спящий второй writer, ничего не даёт — намеренно не трогал.

## Тесты
- `npm run lint` — чисто
- `npx tsc --noEmit` — чисто
- `npm run build` — успешно (pre-existing chunk-size advisory, не связано)
- Live UI прогон требует аутентифицированной Hub-сессии (token в localStorage) + реального Claude-расхода на regenerate — в sandbox невыполнимо; корректность покрыта tsc/build + анализом (логика `canRegenerate`/persist в DigestViewer уже отревьюена в прошлых PR).

## Самопроверка
- [x] Senior review: P1=0, P2=0. Один файл, минимальный диф, без второго writer-а, генератор деградирует на частичном input
- [x] Edge: пустые pulse/commitments → пустой DigestInput → детерминированный fallback-дайджест (не падает)

🤖 Generated with Claude Code
