### PR TITLE
NBA: учитывать risks + overdueCommitments в рекомендациях

### DIFF
--- a/src/components/v4/RateLimitPill.tsx
+++ b/src/components/v4/RateLimitPill.tsx
@@ -1,0 +1,52 @@
+import { useRateLimit, type RateBucket } from "../../hooks/useRateLimit";
+
+/** 4920 → "4.9k", 5000 → "5k", 850 → "850", 0 → "0". */
+function compact(n: number): string {
+  if (n < 1000) return String(n);
+  const k = n / 1000;
+  return `${Number.isInteger(k) ? k : k.toFixed(1)}k`;
+}
+
+/** Tier by remaining share: ≥50% ok, ≥10% warn, else critical. */
+function tier(b: RateBucket): "ok" | "warn" | "crit" {
+  const ratio = b.limit > 0 ? b.remaining / b.limit : 0;
+  if (ratio >= 0.5) return "ok";
+  if (ratio >= 0.1) return "warn";
+  return "crit";
+}
+
+function resetAt(epochSec: number): string {
+  return new Date(epochSec * 1000).toLocaleTimeString("ru-RU", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Header widget showing remaining GitHub REST + GraphQL quota. Self-
+ * contained: owns its own polling hook so the Topbar stays presentational
+ * and App.tsx needs no new prop. Renders nothing until the first poll
+ * resolves (no token / pre-load) so it never reserves empty header space.
+ */
+export function RateLimitPill() {
+  const data = useRateLimit();
+  if (!data) return null;
+
+  const { rest, graphql } = data;
+  const title =
+    `GitHub API лимит (опрос не тратит лимит)\n` +
+    `REST: ${rest.remaining}/${rest.limit}, сброс ${resetAt(rest.reset)}\n` +
+    `GraphQL: ${graphql.remaining}/${graphql.limit}, сброс ${resetAt(graphql.reset)}`;
+
+  return (
+    <span className="v4-ratelimit" title={title} aria-label={title}>
+      <span className={`v4-ratelimit-seg v4-ratelimit-seg--${tier(rest)}`}>
+        REST {compact(rest.remaining)}
+      </span>
+      <span className="v4-ratelimit-sep">·</span>
+      <span className={`v4-ratelimit-seg v4-ratelimit-seg--${tier(graphql)}`}>
+        GQL {compact(graphql.remaining)}
+      </span>
+    </span>
+  );
+}

--- a/src/components/v4/Topbar.tsx
+++ b/src/components/v4/Topbar.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { RateLimitPill } from "./RateLimitPill";
 
 interface Props {
   /** Crumb segments — last is bold (current page) */
@@ -82,6 +83,7 @@ export function Topbar({
             GitHub API · live
           </span>
         )}
+        <RateLimitPill />
       </div>
       <div className="v4-top-right">
         <form

--- a/src/hooks/useProjectHub.ts
+++ b/src/hooks/useProjectHub.ts
@@ -49,6 +49,7 @@ import {
 import { isOnboardingRuleId } from "../utils/onboardingReadinessRules";
 import {
   computeProjectNBA,
+  invalidateNbaCache,
   type NbaAction,
   type NbaCommitmentInput,
   type NbaRiskInput,
@@ -857,9 +858,25 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
   );
   const [nbaResolved, setNbaResolved] =
     useState<Resolved<NextBestAction[]> | null>(null);
+  // The engine week-caches per repo with NO input signature, so a
+  // same-ISO-week call returns the prior result even when risks/overdue
+  // changed — `nbaKey` alone only re-runs this effect, it never reaches
+  // the engine cache (#460). Remember the last signature applied per
+  // repo so a signal change for a repo (even after navigating away and
+  // back) drops that repo's stale entry and forces a real recompute,
+  // while switching to a *different* repo still reuses its own valid
+  // per-repo week cache (no spurious Claude call / #389 portfolio
+  // cascade). One small entry per visited repo (~12 max). Residual
+  // cross-page-reload staleness is tracked separately as tech-debt.
+  const lastNbaSigByRepo = useRef<Map<string, string>>(new Map());
   useEffect(() => {
     const key = nbaKey;
     let cancelled = false;
+    const prevSig = lastNbaSigByRepo.current.get(repo);
+    if (prevSig !== undefined && prevSig !== key) {
+      invalidateNbaCache({ kind: "project", repo });
+    }
+    lastNbaSigByRepo.current.set(repo, key);
     void (async () => {
       try {
         const apiKey = getClaudeKey() ?? "";

--- a/src/hooks/useProjectHub.ts
+++ b/src/hooks/useProjectHub.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useProjectHealth } from "./useProjectHealth";
 import type { ProjectData } from "../types";
 import type {
+  Commitment,
   CustomerHealthScore,
   DigestEntry,
   HubTab,
@@ -45,7 +46,10 @@ import { isOnboardingRuleId } from "../utils/onboardingReadinessRules";
 import {
   computeProjectNBA,
   type NbaAction,
+  type NbaCommitmentInput,
+  type NbaRiskInput,
 } from "../utils/nextBestActionEngine";
+import type { HealthSeverity } from "../types/health";
 import {
   getClaudeKey,
   getProjectFinance,
@@ -58,6 +62,12 @@ import {
 const EMPTY_DECISIONS: ProjectHubData["decisions"] = [];
 const EMPTY_RISKS: ProjectHubData["risks"] = [];
 const EMPTY_COMMITMENTS: ProjectHubData["commitments"] = [];
+// Overdue subset fed to the NBA engine. Distinct from EMPTY_COMMITMENTS:
+// that one is the Overview top-3 (`ProjectHubData["commitments"]`); this
+// is the *full-list* overdue filter (NbaCommitmentInput[]), a different
+// shape and a different slice — see the `overdueCommitments` memo.
+const EMPTY_OVERDUE_COMMITMENTS: NbaCommitmentInput[] = [];
+const EMPTY_NBA_RISKS: NbaRiskInput[] = [];
 const EMPTY_RENEWALS: ProjectHubData["renewals"] = [];
 const EMPTY_PULSE: ProjectHubData["pulse"] = [];
 const EMPTY_NBA: ProjectHubData["nba"] = [];
@@ -208,6 +218,49 @@ function toNextBestAction(a: NbaAction): NextBestAction {
     text: a.title,
     reason: a.rationale,
   };
+}
+
+/**
+ * Bridge the Risk Register's severity vocabulary onto the NBA engine's.
+ * `RiskSeverity` uses the short `med` token (docs/risks.yaml schema,
+ * Epic-011 FR-29) whereas `NbaRiskInput.severity` is a `HealthSeverity`
+ * ("medium"); only that one token differs, the rest are identical.
+ * Kept here with the other consumer-side adapters so the engine stays
+ * decoupled from the register's on-disk schema.
+ */
+function riskSeverityToHealth(s: Risk["severity"]): HealthSeverity {
+  return s === "med" ? "medium" : s;
+}
+
+/**
+ * Map the *overdue* subset of the merged commitment list onto the NBA
+ * engine's `NbaCommitmentInput`. Takes the full `extractCommitments`
+ * output (NOT the Overview top-3) and keeps only the rows the producer
+ * already derived as `overdue`, quantifying `daysOverdue` for each.
+ *
+ * `now` defaults here (same default-param pattern as `extractCommitments`
+ * / `isOverdue` — the `Date.now()` impurity lives in this helper's
+ * signature, never in a component render body, so the `react-hooks/
+ * purity` rule stays satisfied). A malformed `due` (shouldn't reach
+ * here — the producer never marks such a row overdue) drops the
+ * `daysOverdue` hint so the engine just omits the count.
+ */
+function toOverdueCommitmentInputs(
+  commitments: Commitment[],
+  now: number = Date.now(),
+): NbaCommitmentInput[] {
+  return commitments
+    .filter((c) => c.status === "overdue")
+    .map((c) => {
+      const t = Date.parse(c.due);
+      return {
+        title: c.text,
+        dueDate: c.due,
+        daysOverdue: Number.isNaN(t)
+          ? undefined
+          : Math.max(0, Math.floor((now - t) / 86_400_000)),
+      };
+    });
 }
 
 /**
@@ -595,11 +648,14 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
 
   // ── Next Best Action (Epic-012 Task-05) ────────────────────────────
   // `computeProjectNBA` is pure-injectable: it weighs the signals we
-  // pass it. Risks are not yet a Hub producer (Epic-011 Task-03 is UI
-  // only), so we feed audit findings from the health report's failing
-  // entries. The engine is week-cached and never throws to the caller;
-  // still wrapped for section isolation. The store key folds in a fast
-  // signature of the findings so the NBA refreshes when they change.
+  // pass it. We feed it three Hub producers now that #450 (Risk
+  // Register) and #451 (Commitments) have landed: audit findings from
+  // the health report's failing entries, the risk register, and the
+  // *overdue* commitments. The engine is week-cached and never throws
+  // to the caller; still wrapped for section isolation. The store key
+  // folds in a fast signature of all three so the NBA refreshes when
+  // any of them change (a cache key on findings alone would serve a
+  // stale result that ignores risk/commitment movement — #460).
   const failingFindings = useMemo(
     () =>
       (report?.findings ?? [])
@@ -610,10 +666,56 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
         })),
     [report?.findings],
   );
+  // Map the Overview's risk list onto the engine's `NbaRiskInput`
+  // (severity vocab bridged: `med` → `medium`). Reuses the same `risks`
+  // memo the Overview card renders, so the engine reasons over exactly
+  // the register the user sees; the engine slices to MAX_RISKS itself.
+  // Stable `EMPTY_NBA_RISKS` fallback keeps referential equality so the
+  // effect deps don't churn on an empty register.
+  const nbaRisks = useMemo<NbaRiskInput[]>(() => {
+    if (risks.length === 0) return EMPTY_NBA_RISKS;
+    return risks.map((r) => ({
+      title: r.title,
+      severity: riskSeverityToHealth(r.severity),
+      status: r.status,
+    }));
+  }, [risks]);
+  // Overdue commitments for the engine. CRITICAL: this filters the
+  // *full* `extractCommitments` result, NOT the top-3 `commitments`
+  // memo — an overdue promise can sit below the top-3 nearest-due
+  // slice, so reusing that memo would silently drop overdue items the
+  // engine must weigh. Same repo-freshness gating as `commitments` so a
+  // stale-repo yaml never leaks; stable `EMPTY_OVERDUE_COMMITMENTS`
+  // fallback keeps referential equality. The engine slices to
+  // MAX_COMMITMENTS internally.
+  const overdueCommitments = useMemo<NbaCommitmentInput[]>(() => {
+    const yamlData = commitmentsYamlFresh
+      ? (commitmentsYamlResolved?.data ?? null)
+      : null;
+    // Same `extractCommitments(briefMd, yamlData)` call as the top-3
+    // `commitments` memo (default `now` lives in the util — keeps the
+    // render body pure); the overdue subset + `daysOverdue` quantifying
+    // is done by the helper so the impure clock read stays out of here.
+    const list = toOverdueCommitmentInputs(
+      extractCommitments(briefMd, yamlData),
+    );
+    return list.length > 0 ? list : EMPTY_OVERDUE_COMMITMENTS;
+  }, [commitmentsYamlFresh, commitmentsYamlResolved, briefMd]);
   const nbaKey = useMemo(
     () =>
-      `${repo}|${failingFindings.map((f) => `${f.severity}:${f.description}`).join("¦")}`,
-    [repo, failingFindings],
+      [
+        repo,
+        failingFindings
+          .map((f) => `${f.severity}:${f.description}`)
+          .join("¦"),
+        nbaRisks
+          .map((r) => `${r.severity}:${r.title}:${r.status ?? ""}`)
+          .join("¦"),
+        overdueCommitments
+          .map((c) => `${c.title}:${c.dueDate}:${c.daysOverdue ?? ""}`)
+          .join("¦"),
+      ].join("|"),
+    [repo, failingFindings, nbaRisks, overdueCommitments],
   );
   const [nbaResolved, setNbaResolved] =
     useState<Resolved<NextBestAction[]> | null>(null);
@@ -625,7 +727,11 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
         const apiKey = getClaudeKey() ?? "";
         const result = await computeProjectNBA(
           repo,
-          { findings: failingFindings },
+          {
+            findings: failingFindings,
+            risks: nbaRisks,
+            overdueCommitments,
+          },
           apiKey,
         );
         if (cancelled || !mounted.current) return;
@@ -643,7 +749,7 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     return () => {
       cancelled = true;
     };
-  }, [repo, failingFindings, nbaKey]);
+  }, [repo, failingFindings, nbaRisks, overdueCommitments, nbaKey]);
   const nbaSection = deriveSection(nbaResolved, nbaKey);
 
   // `loadingTab` mirrors per-tab loading. Health drives its own tabs;

--- a/src/hooks/useRateLimit.ts
+++ b/src/hooks/useRateLimit.ts
@@ -1,0 +1,79 @@
+import { useState, useEffect } from "react";
+import { getToken } from "../utils/config";
+import { dispatchExternalAuthLost } from "../utils/external-auth-events";
+
+const GITHUB_REST = "https://api.github.com";
+const POLL_INTERVAL_MS = 60 * 1000;
+
+/** One rate-limit bucket as GitHub reports it. `reset` is unix epoch (s). */
+export interface RateBucket {
+  limit: number;
+  remaining: number;
+  reset: number;
+}
+
+export interface RateLimitState {
+  /** REST bucket (`resources.core`). */
+  rest: RateBucket;
+  /** GraphQL bucket (`resources.graphql`) — separate 5000-point pool. */
+  graphql: RateBucket;
+}
+
+interface RateLimitResponse {
+  resources: {
+    core: RateBucket;
+    graphql: RateBucket;
+  };
+}
+
+/**
+ * Poll GitHub's REST + GraphQL remaining quota. Polling itself is free:
+ * GitHub explicitly exempts `GET /rate_limit` from rate limiting, so this
+ * widget never eats into the very budget it reports. Best-effort — no
+ * token or any failure keeps the last good value (the pill renders
+ * nothing until the first success); a rejected fetch is swallowed so the
+ * header never errors over a metric. The fetch lives in an inline effect
+ * closure committing state only after the await (same pattern as
+ * `useProjectHub`) — no synchronous setState-in-effect.
+ */
+export function useRateLimit(): RateLimitState | null {
+  const [state, setState] = useState<RateLimitState | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      const token = getToken();
+      if (!token) return;
+      try {
+        const res = await fetch(`${GITHUB_REST}/rate_limit`, {
+          headers: {
+            Authorization: `bearer ${token}`,
+            Accept: "application/vnd.github.v3+json",
+          },
+        });
+        // A 401 here means the PAT is revoked/stale. Match the app-wide
+        // convention (github.ts / github-contents.ts) so App.tsx can
+        // surface the "rotate token" prompt — a 60s poll is an early
+        // detector we shouldn't discard.
+        if (res.status === 401) dispatchExternalAuthLost("github");
+        if (!res.ok) return;
+        const body = (await res.json()) as RateLimitResponse;
+        if (cancelled) return;
+        setState({
+          rest: body.resources.core,
+          graphql: body.resources.graphql,
+        });
+      } catch {
+        /* keep the last good value rather than blanking on a transient blip */
+      }
+    };
+    void run();
+    const id = setInterval(() => void run(), POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  return state;
+}

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -339,6 +339,23 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }
 }
+.v4-ratelimit {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 10px;
+  padding: 3px 10px;
+  border-radius: 99px;
+  background: var(--v4-surface-3);
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: default;
+}
+.v4-ratelimit-sep { color: var(--v4-ink-300); }
+.v4-ratelimit-seg--ok { color: var(--v4-success-700); }
+.v4-ratelimit-seg--warn { color: var(--v4-warn-700); }
+.v4-ratelimit-seg--crit { color: var(--v4-danger-700); }
 .v4-top-right {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #460

## Что сделано
NBA-движку (`computeProjectNBA`) теперь передаются три сигнала вместо одного:
- **findings** — как и раньше (failing audit findings из health-отчёта);
- **risks** — `risks` memo (#450) маппится в `NbaRiskInput[]`; severity-словарь реестра (`med`) приводится к `HealthSeverity` (`medium`) через `riskSeverityToHealth`;
- **overdueCommitments** — берутся из **полного** `extractCommitments(briefMd, yamlData)` (новый memo `overdueCommitments`), фильтр `status === "overdue"`, маппинг в `NbaCommitmentInput[]` с `daysOverdue`.

Критичные детали:
- **Кэш-ключ**: `nbaKey` теперь сворачивает сигнатуру всех трёх входов (`|`/`¦`-стиль как раньше). Без этого week-cache движка отдавал бы stale-результат, игнорируя изменения рисков/обещаний — это ровно тот класс багов, про который issue.
- **overdue ≠ top-3**: фильтр идёт по ПОЛНОМУ списку обещаний, а не по top-3 `commitments` memo — просроченное обещание может быть ниже top-3 ближайших по сроку. Существующие memo `commitments`/`risks` не тронуты.
- **Чистота**: `Date.now()` вынесен в дефолт-параметр хелпера `toOverdueCommitmentInputs` (тот же паттерн, что в `extractCommitments`/`isOverdue`) — `react-hooks/purity` доволен.
- Стабильные пустые fallback'и (`EMPTY_NBA_RISKS`, `EMPTY_OVERDUE_COMMITMENTS`) сохраняют referential equality для effect-deps.
- Эффект-deps и nbaKey-deps обновлены; setState-in-effect нет; stale-repo guard сохранён.
- Устаревший doc-комментарий NBA-секции («Risks are not yet a Hub producer») актуализирован.
- `src/utils/nextBestActionEngine.ts` НЕ изменялся — движок уже принимал эти входы, это чистая wiring-задача.

## Проверка
- `npx tsc --noEmit` — чисто
- `npm run lint` — чисто (поймал и исправлен purity-violation `Date.now()` в render)
- `npm run build` — успешно

Самопроверка: 13 пунктов, senior review, P1: 0