### PR TITLE
NBA cache: гейт свежести по сигнатуре входов (#476)

### DIFF
--- a/src/hooks/useProjectHub.ts
+++ b/src/hooks/useProjectHub.ts
@@ -49,7 +49,6 @@ import {
 import { isOnboardingRuleId } from "../utils/onboardingReadinessRules";
 import {
   computeProjectNBA,
-  invalidateNbaCache,
   type NbaAction,
   type NbaCommitmentInput,
   type NbaRiskInput,
@@ -858,25 +857,21 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
   );
   const [nbaResolved, setNbaResolved] =
     useState<Resolved<NextBestAction[]> | null>(null);
-  // The engine week-caches per repo with NO input signature, so a
-  // same-ISO-week call returns the prior result even when risks/overdue
-  // changed — `nbaKey` alone only re-runs this effect, it never reaches
-  // the engine cache (#460). Remember the last signature applied per
-  // repo so a signal change for a repo (even after navigating away and
-  // back) drops that repo's stale entry and forces a real recompute,
-  // while switching to a *different* repo still reuses its own valid
-  // per-repo week cache (no spurious Claude call / #389 portfolio
-  // cascade). One small entry per visited repo (~12 max). Residual
-  // cross-page-reload staleness is tracked separately as tech-debt.
-  const lastNbaSigByRepo = useRef<Map<string, string>>(new Map());
+  // The engine week-caches per repo and (since #476) keys the entry by
+  // the input signature, so we pass `nbaKey` straight through as that
+  // signature: a same-ISO-week call recomputes when risks/findings/
+  // overdue changed and serves the cache otherwise — including across a
+  // full page reload, since the gate lives in the stored envelope, not a
+  // hook-side ref. This supersedes the #460 `lastNbaSigByRepo` ref +
+  // its invalidate-on-change workaround (removed here): the engine now
+  // owns same-week staleness end to end. Switching to a *different* repo
+  // still reuses that repo's own valid week+sig cache (no spurious
+  // Claude call / #389 portfolio cascade). `invalidateNbaCache` is no
+  // longer imported here (the engine sig replaced its only use in this
+  // hook); it remains in the engine module for the Regenerate flow.
   useEffect(() => {
     const key = nbaKey;
     let cancelled = false;
-    const prevSig = lastNbaSigByRepo.current.get(repo);
-    if (prevSig !== undefined && prevSig !== key) {
-      invalidateNbaCache({ kind: "project", repo });
-    }
-    lastNbaSigByRepo.current.set(repo, key);
     void (async () => {
       try {
         const apiKey = getClaudeKey() ?? "";
@@ -888,6 +883,7 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
             overdueCommitments,
           },
           apiKey,
+          nbaKey,
         );
         if (cancelled || !mounted.current) return;
         const actions = result.actions.map(toNextBestAction);

--- a/src/utils/nextBestActionEngine.ts
+++ b/src/utils/nextBestActionEngine.ts
@@ -23,8 +23,14 @@
  *   - per-project → `makeit_nba:{repo}`
  *   - portfolio   → `makeit_portfolio_nba`
  * A cache entry is fresh only within the ISO week it was written; a new
- * week always forces a real recompute. `invalidateNbaCache(scope)`
- * powers the "Regenerate" button (Epic-010 UI wiring landed in #418/#349).
+ * week always forces a real recompute. #476: a per-project entry also
+ * carries the signature of the inputs that produced it, so
+ * `computeProjectNBA(repo, inputs, apiKey, sig)` recomputes when the
+ * signals changed *within* the same ISO week — including across a full
+ * page reload (the engine gates on the stored `env.sig`, so no hook-side
+ * ref workaround is needed). A no-sig caller (portfolio) keeps the pure
+ * ISO-week behavior. `invalidateNbaCache(scope)` powers the "Regenerate"
+ * button (Epic-010 UI wiring landed in #418/#349).
  *
  * #389: the portfolio aggregate is derived from the per-project results,
  * so a mid-week per-project invalidation could leave the week-scoped
@@ -178,6 +184,16 @@ function isoWeekKey(d: Date = new Date()): string {
 interface CacheEnvelope {
   week: string;
   result: NbaResult;
+  /**
+   * Signature of the inputs that produced `result` (#476). Optional: a
+   * caller may not supply one (portfolio aggregate, budget-degrade reads)
+   * and envelopes written before #476 lack it entirely. `readCache` only
+   * gates on it when the caller passes a defined `sig` AND `requireFresh`
+   * — so a no-sig caller keeps the pure ISO-week behavior, and an old
+   * sig-less envelope is treated as stale exactly once (one recompute,
+   * then a rewrite carries the sig and the cache stabilises).
+   */
+  sig?: string;
 }
 
 function scopeKey(scope: NbaScope): string {
@@ -191,8 +207,22 @@ function scopeKey(scope: NbaScope): string {
  * returns `null` when the entry is from an earlier ISO week so the
  * caller recomputes. `requireFresh=false` (budget hard-stop fallback)
  * returns even a stale entry so the UI has *something* to show.
+ *
+ * `sig` (#476) is the signature of the inputs the caller is about to
+ * compute over. It is ONLY consulted when `requireFresh === true` AND a
+ * defined `sig` is supplied: then a stored `env.sig` differing from it
+ * (including the `undefined → defined` case for a pre-#476 envelope)
+ * means the same-ISO-week entry was produced by *different* inputs, so
+ * it is treated as stale and `null` is returned for a recompute. When
+ * `sig` is undefined the check is skipped entirely — every existing
+ * no-sig caller (portfolio aggregate, budget-degrade `requireFresh=false`
+ * reads) keeps its exact pre-#476 ISO-week-only behavior.
  */
-function readCache(scope: NbaScope, requireFresh: boolean): NbaResult | null {
+function readCache(
+  scope: NbaScope,
+  requireFresh: boolean,
+  sig?: string,
+): NbaResult | null {
   if (typeof localStorage === "undefined") return null;
   let raw: string | null;
   try {
@@ -212,15 +242,28 @@ function readCache(scope: NbaScope, requireFresh: boolean): NbaResult | null {
       return null;
     }
     if (requireFresh && env.week !== isoWeekKey()) return null;
+    // Signature gate (#476): only when the caller supplied a defined
+    // `sig` and wants a fresh entry. `env.sig !== sig` covers both a
+    // genuine input change and a pre-#476 envelope (`env.sig` undefined
+    // vs a defined incoming `sig`) → treated as stale → one recompute,
+    // then `writeCache` rewrites with `sig` and the cache stabilises.
+    if (requireFresh && sig !== undefined && env.sig !== sig) return null;
     return env.result;
   } catch {
     return null;
   }
 }
 
-function writeCache(scope: NbaScope, result: NbaResult): void {
+function writeCache(
+  scope: NbaScope,
+  result: NbaResult,
+  sig?: string,
+): void {
   if (typeof localStorage === "undefined") return;
-  const env: CacheEnvelope = { week: isoWeekKey(), result };
+  // Store `sig` only when supplied — a no-sig caller (portfolio) writes a
+  // sig-less envelope exactly as before, and `JSON.stringify` drops the
+  // undefined key so the on-disk shape is unchanged for those callers.
+  const env: CacheEnvelope = { week: isoWeekKey(), result, sig };
   try {
     localStorage.setItem(scopeKey(scope), JSON.stringify(env));
   } catch {
@@ -408,29 +451,44 @@ function parseActions(text: string, repo: string): NbaAction[] {
  * Top-3 next actions for one project.
  *
  * Order of operations:
- *   1. Fresh week-cache hit → return it, no Claude call.
- *   2. No actionable signal → return empty result (and cache it so we
- *      don't re-prompt an empty project every render).
+ *   1. Fresh week-cache hit (same ISO week AND, when `sig` is supplied,
+ *      same input signature) → return it, no Claude call.
+ *   2. No actionable signal → return empty result (and cache it, keyed by
+ *      `sig`, so we don't re-prompt an empty project every render).
  *   3. Budget hard-stop → return stale cache + warning, never throw.
  *   4. Otherwise call Claude (Sonnet, or Haiku on budget fallback),
  *      parse, cache, return.
  *
  * `apiKey` is injected by the caller (pure-injectable — the engine never
  * reads it from config/localStorage itself).
+ *
+ * `sig` (#476) is an optional signature of `inputs`. When supplied, a
+ * same-ISO-week cache entry produced by a *different* signature (or by a
+ * pre-#476 sig-less write) is treated as stale → one recompute, then the
+ * rewrite carries `sig` and the cache stabilises. Omitting `sig`
+ * preserves the exact pre-#476 behavior (ISO-week-only freshness) for
+ * every existing caller (`portfolioNbaCollector`). The stale-fallback
+ * budget-degrade `readCache(scope, false)` reads deliberately pass NO
+ * sig — they intentionally serve any last-good cache.
  */
 export async function computeProjectNBA(
   repo: string,
   inputs: NbaInputs,
   apiKey: string,
+  sig?: string,
 ): Promise<NbaResult> {
   const scope: NbaScope = { kind: "project", repo };
 
-  const fresh = readCache(scope, true);
+  const fresh = readCache(scope, true, sig);
   if (fresh !== null) return fresh;
 
   if (!hasAnySignal(inputs)) {
     const empty: NbaResult = { actions: [], budgetFallback: false };
-    writeCache(scope, empty);
+    // Key the empty result by `sig` too: an empty cached under an old
+    // signature must not serve under a new one (otherwise a project that
+    // gained a risk/commitment after a no-signal run would keep showing
+    // empty for the rest of the ISO week).
+    writeCache(scope, empty, sig);
     return empty;
   }
 
@@ -510,7 +568,7 @@ export async function computeProjectNBA(
       actions: parseActions(text, repo),
       budgetFallback,
     };
-    writeCache(scope, result);
+    writeCache(scope, result, sig);
     return result;
   } catch (e) {
     // Network / parse / auth failure must not break the dashboard.


### PR DESCRIPTION
Closes #476

## Что изменилось

Per-project NBA week-кэш теперь signature-aware: свежесть гейтится не только по ISO-неделе, но и по сигнатуре входов, которые произвели результат. Это убирает cross-page-reload staleness и делает hook-side workaround из #460 ненужным.

### `src/utils/nextBestActionEngine.ts`
- `interface CacheEnvelope` — добавлено опциональное поле `sig?: string`.
- `readCache(scope, requireFresh, sig?)` — новый опциональный 3-й параметр. Гейт срабатывает **только** при `requireFresh === true && sig !== undefined && env.sig !== sig` → возвращает `null` (recompute). При `sig === undefined` проверка пропускается полностью.
- `writeCache(scope, result, sig?)` — новый опциональный 3-й параметр; `sig` пишется в envelope (при `undefined` `JSON.stringify` отбрасывает ключ → on-disk shape для no-sig вызовов байт-в-байт прежний).
- `computeProjectNBA(repo, inputs, apiKey, sig?)` — опциональный 4-й параметр; прокинут в early fresh-read `readCache(scope, true, sig)`, в success-path `writeCache(scope, result, sig)` И в no-signal empty-write `writeCache(scope, empty, sig)` (пустой результат тоже keyed by sig — иначе empty под старой sig обслуживался бы под новой).
- Budget-degrade `readCache(scope, false)` пути **намеренно** sig не получают — они отдают любой last-good кэш.
- `computePortfolioNBA` и `portfolioNbaCollector` не трогались — sig нигде не передаётся → поведение ровно как раньше (ISO-week-only).
- Обновлены doc-комментарии (file-level cache раздел, `computeProjectNBA` order-of-operations).

### `src/hooks/useProjectHub.ts`
- `nbaKey` (существующий useMemo-сигнатура из #460) теперь передаётся 4-м аргументом в `computeProjectNBA`.
- Удалён hook-side workaround из #460: `lastNbaSigByRepo = useRef<Map>` и блок `invalidateNbaCache({kind:"project",repo})`-on-signature-change. Движок теперь гейтит по sig сам — включая полный page reload (раньше пустой ref после перезагрузки отдавал stale same-week кэш).
- Убран теперь неиспользуемый импорт `invalidateNbaCache` (остаётся экспортированным в движке; `usePortfolioNba.ts` всё ещё его использует для Regenerate).
- Стейл doc-комментарий переписан: объясняет engine-side sig вместо ref-workaround. Effect deps/guards (`cancelled`/`mounted`, setState только после await) не изменены.

## Backward-compat
- No-sig вызовы (`portfolioNbaCollector`, budget-degrade reads, `computePortfolioNBA`) → sig undefined → sig-проверка пропускается → поведение идентично pre-#476.
- Миграция старых envelope: pre-#476 запись имеет `env.sig === undefined`; при defined входящем `sig` → `undefined !== sig` → readCache `null` → один recompute → success-write перезаписывает с `sig` → дальше cache hit. Ровно «один recompute, затем стабильно».

## Verification
- `npx tsc --noEmit` — чисто
- `npm run lint` — чисто (strict react-hooks/*)
- `npm run build` — успешно (chunk-size warning pre-existing, не связан)

Самопроверка: 13 пунктов, senior review, P1: 0