### PR TITLE
Scorecard: health-грейд A–F из кэша Hub вместо хардкода «—» (#456)

### DIFF
--- a/src/components/v4/ProjectsView.tsx
+++ b/src/components/v4/ProjectsView.tsx
@@ -11,6 +11,7 @@ import { PortfolioPromiseTracker } from "./portfolio/PortfolioPromiseTracker";
 import { PortfolioDigestPanel } from "./portfolio/PortfolioDigestPanel";
 import { calcRiskScore } from "../../utils/riskScore";
 import { usePortfolioNbaCollection } from "../../hooks/usePortfolioNbaCollection";
+import { usePortfolioHealthCollection } from "../../hooks/usePortfolioHealthCollection";
 import { collectCachedPerProjectNba } from "../../utils/portfolioNbaCollector";
 import { useToast } from "./toastContext";
 
@@ -435,6 +436,13 @@ export function ProjectsView({
     return collectCachedPerProjectNba(projects.map((p) => p.repo));
   }, [refreshLive, projects]);
 
+  // Portfolio health grades (#456). Pure render-path read of the per-repo
+  // health caches `useProjectHealth` persists for free when a Hub is
+  // opened — no network, no N+1. Repos not visited this session are absent
+  // from the map → the Scorecard keeps its muted "—" (strictly better than
+  // the previous always-"—", not a per-project portfolio fetch).
+  const { grades: healthGrades } = usePortfolioHealthCollection(projects);
+
   if (selectedRepo) {
     return (
       <ProjectHubPage
@@ -643,7 +651,7 @@ export function ProjectsView({
                     tier={SCORECARD_TIER}
                     phase={p.phase}
                     client={p.client}
-                    grade={null}
+                    grade={healthGrades[p.repo] ?? null}
                     kpis={scorecardKpis(p)}
                     drift={{
                       // True days-since-last-commit — DriftDots labels

--- a/src/components/v4/ProjectsView.tsx
+++ b/src/components/v4/ProjectsView.tsx
@@ -441,7 +441,14 @@ export function ProjectsView({
   // opened — no network, no N+1. Repos not visited this session are absent
   // from the map → the Scorecard keeps its muted "—" (strictly better than
   // the previous always-"—", not a per-project portfolio fetch).
-  const { grades: healthGrades } = usePortfolioHealthCollection(projects);
+  // `selectedRepo` is the volatile re-collect trigger: this component
+  // stays mounted across Hub visits, so without it a grade cached during
+  // a visit would only surface after a full reload (project set is
+  // hardcoded → a repo-set-only key never changes in-session).
+  const { grades: healthGrades } = usePortfolioHealthCollection(
+    projects,
+    selectedRepo,
+  );
 
   if (selectedRepo) {
     return (

--- a/src/hooks/usePortfolioHealthCollection.ts
+++ b/src/hooks/usePortfolioHealthCollection.ts
@@ -2,11 +2,14 @@
  * usePortfolioHealthCollection — owns the per-project health-grade map the
  * portfolio grid feeds into each `ProjectScorecard` (#456).
  *
- * Render path (zero cost): on mount / when the project list changes it
- * synchronously reads the health hook's already-computed per-repo
- * sessionStorage caches (`collectCachedHealthGrades`). No network, no
- * fetch — those caches are populated for free as the user opens project
- * hubs (`useProjectHealth` persists the full `HealthReport`).
+ * Render path (zero cost): on mount, when the project list changes, and
+ * on every Hub enter/leave (via `refreshSignal`) it synchronously reads
+ * the health hook's already-computed per-repo sessionStorage caches
+ * (`collectCachedHealthGrades`). No network, no fetch — those caches are
+ * populated for free as the user opens project hubs (`useProjectHealth`
+ * persists the full `HealthReport`). Re-collecting on Hub-leave is what
+ * surfaces a just-visited project's grade without a full page reload
+ * (the project set is hardcoded, so a repo-set-only key never would).
  *
  * There is no "regenerate" path here (unlike `usePortfolioNbaCollection`):
  * portfolio health is read-only — the only way a grade appears is the user
@@ -36,27 +39,33 @@ export interface UsePortfolioHealthCollectionState {
 
 export function usePortfolioHealthCollection(
   projects: ProjectData[],
+  refreshSignal: string | null,
 ): UsePortfolioHealthCollectionState {
   const [grades, setGrades] = useState<Record<string, HealthGrade>>({});
 
-  // Stable list of repos; recompute the cheap cached collection whenever
-  // the set of repos changes (not on every ProjectData field churn).
-  const repoKey = projects
-    .map((p) => p.repo)
-    .sort()
-    .join("|");
+  // Stable list of repos; the project set is hardcoded so `repoKey` alone
+  // never changes within a session. `refreshSignal` is the volatile part
+  // (the selected-repo): visiting a project Hub caches that project's
+  // report, and ProjectsView stays mounted across Hub visits, so without
+  // a volatile trigger a freshly-cached grade would only surface after a
+  // full page reload. Folding it in re-collects on every Hub enter/leave
+  // (the leave is what matters — the grid then shows the just-cached
+  // grade). Still a pure synchronous sessionStorage read, zero network.
+  // U+241F (unit separator) can't appear in a GitHub repo slug or in
+  // `refreshSignal`, so the composite key is collision-free.
+  const repoKey = projects.map((p) => p.repo).sort().join("|");
+  const syncKey = `${repoKey}␟${refreshSignal ?? ""}`;
 
   // RENDER PATH: pure cached collection. The read is synchronous and a
-  // pure function of `repoKey`, so this uses React's documented "adjust
+  // pure function of `syncKey`, so this uses React's documented "adjust
   // state during render when a prop changes" pattern (prev-value in state
   // + setState during render) — same pattern as `usePortfolioNbaCollection`.
   // It re-renders before commit with no effect / cascading render, and
   // (unlike a setState-in-effect) satisfies the strict react-hooks lint
-  // rules. The next repo-set change re-syncs from caches again, picking up
-  // any reports written while the user browsed hubs this session.
-  const [syncedRepoKey, setSyncedRepoKey] = useState<string | null>(null);
-  if (syncedRepoKey !== repoKey) {
-    setSyncedRepoKey(repoKey);
+  // rules.
+  const [syncedKey, setSyncedKey] = useState<string | null>(null);
+  if (syncedKey !== syncKey) {
+    setSyncedKey(syncKey);
     const repos = repoKey.length > 0 ? repoKey.split("|") : [];
     setGrades(collectCachedHealthGrades(repos));
   }

--- a/src/hooks/usePortfolioHealthCollection.ts
+++ b/src/hooks/usePortfolioHealthCollection.ts
@@ -1,0 +1,65 @@
+/**
+ * usePortfolioHealthCollection — owns the per-project health-grade map the
+ * portfolio grid feeds into each `ProjectScorecard` (#456).
+ *
+ * Render path (zero cost): on mount / when the project list changes it
+ * synchronously reads the health hook's already-computed per-repo
+ * sessionStorage caches (`collectCachedHealthGrades`). No network, no
+ * fetch — those caches are populated for free as the user opens project
+ * hubs (`useProjectHealth` persists the full `HealthReport`).
+ *
+ * There is no "regenerate" path here (unlike `usePortfolioNbaCollection`):
+ * portfolio health is read-only — the only way a grade appears is the user
+ * visiting that project's Hub, which the health hook caches itself. A
+ * project not yet visited this session simply has no grade (the Scorecard
+ * keeps its muted "—"); this is strictly better than the previous
+ * always-"—" and explicitly NOT a per-project portfolio fetch.
+ *
+ * `grades` is `{}` until the first (synchronous) collection and after it
+ * for an all-unvisited portfolio — callers treat a missing repo as
+ * "no grade yet" → `null` prop → existing "—" render.
+ */
+
+import { useState } from "react";
+import type { ProjectData } from "../types";
+import type { HealthGrade } from "../components/v4/portfolio/ProjectScorecard";
+import { collectCachedHealthGrades } from "../utils/portfolioHealthCollector";
+
+export interface UsePortfolioHealthCollectionState {
+  /**
+   * Per-project health grade map (`repo → A|B|C|D|F`). A repo absent from
+   * the map has no fresh cached report; the caller passes `null` for it so
+   * the Scorecard renders its existing muted "—".
+   */
+  grades: Record<string, HealthGrade>;
+}
+
+export function usePortfolioHealthCollection(
+  projects: ProjectData[],
+): UsePortfolioHealthCollectionState {
+  const [grades, setGrades] = useState<Record<string, HealthGrade>>({});
+
+  // Stable list of repos; recompute the cheap cached collection whenever
+  // the set of repos changes (not on every ProjectData field churn).
+  const repoKey = projects
+    .map((p) => p.repo)
+    .sort()
+    .join("|");
+
+  // RENDER PATH: pure cached collection. The read is synchronous and a
+  // pure function of `repoKey`, so this uses React's documented "adjust
+  // state during render when a prop changes" pattern (prev-value in state
+  // + setState during render) — same pattern as `usePortfolioNbaCollection`.
+  // It re-renders before commit with no effect / cascading render, and
+  // (unlike a setState-in-effect) satisfies the strict react-hooks lint
+  // rules. The next repo-set change re-syncs from caches again, picking up
+  // any reports written while the user browsed hubs this session.
+  const [syncedRepoKey, setSyncedRepoKey] = useState<string | null>(null);
+  if (syncedRepoKey !== repoKey) {
+    setSyncedRepoKey(repoKey);
+    const repos = repoKey.length > 0 ? repoKey.split("|") : [];
+    setGrades(collectCachedHealthGrades(repos));
+  }
+
+  return { grades };
+}

--- a/src/utils/portfolioHealthCollector.ts
+++ b/src/utils/portfolioHealthCollector.ts
@@ -1,0 +1,103 @@
+/**
+ * portfolioHealthCollector — collects per-project health grades into the
+ * map the portfolio grid (`ProjectsView` → `ProjectScorecard`) renders
+ * (#456).
+ *
+ * Per-project health (classification + A–F grade) is real but computing it
+ * is async per project and every miss is a GitHub-API health-check run.
+ * Doing that for the whole portfolio on every render would be an N+1 the
+ * Scorecard explicitly forbids. So collection is a single render-path read:
+ *
+ *   `collectCachedHealthGrades(repos)` — RENDER PATH, zero cost. A pure
+ *   synchronous read of the health hook's own per-repo sessionStorage
+ *   cache (`makeit_health_{repo}`). Those entries are populated for free
+ *   as the user opens project hubs (`useProjectHealth` already runs the
+ *   health pipeline and persists the full `HealthReport`). No network, no
+ *   fetch — just `sessionStorage.getItem` per repo. Projects without a
+ *   cached report simply don't contribute (the card stays at the muted
+ *   "—" it shows today — strictly better than always "—", never a false
+ *   signal). This mirrors the proven `portfolioNbaCollector` precedent.
+ *
+ * `useProjectHealth` does not export its cache-key constant, so the
+ * read-only reader mirrors it here (`makeit_health_{repo}` —
+ * `SESSION_PREFIX` in useProjectHealth.ts, underscore separator). Kept as
+ * the single mirror-point with a comment so a future rename has one place
+ * to update.
+ */
+
+import type { HealthGrade } from "../components/v4/portfolio/ProjectScorecard";
+import type { HealthReport } from "../types/health";
+
+/**
+ * Health hook per-project cache-key prefix. Mirrors `SESSION_PREFIX` in
+ * useProjectHealth.ts (`makeit_health_`, underscore — NOT a colon); the
+ * hook does not export it. If the hook renames it, update here.
+ */
+const HEALTH_SESSION_PREFIX = "makeit_health_";
+
+const VALID_GRADES: ReadonlySet<HealthGrade> = new Set<HealthGrade>([
+  "A",
+  "B",
+  "C",
+  "D",
+  "F",
+]);
+
+function healthCacheKey(repo: string): string {
+  return `${HEALTH_SESSION_PREFIX}${repo}`;
+}
+
+/**
+ * Read-only peek at one project's cached health report. Returns its
+ * letter `grade` if a well-formed report is cached, else null. Returns
+ * null for a missing / corrupt / unparsable / unexpected-shape entry so a
+ * bad cache degrades to "this project has no grade yet" (card shows "—")
+ * instead of throwing.
+ */
+function readHealthGrade(repo: string): HealthGrade | null {
+  if (typeof sessionStorage === "undefined") return null;
+  let raw: string | null;
+  try {
+    raw = sessionStorage.getItem(healthCacheKey(repo));
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+  try {
+    const report = JSON.parse(raw) as Partial<HealthReport>;
+    if (
+      report === null ||
+      typeof report !== "object" ||
+      report.score === null ||
+      typeof report.score !== "object"
+    ) {
+      return null;
+    }
+    const grade = (report.score as Partial<HealthReport["score"]>).grade;
+    if (typeof grade !== "string" || !VALID_GRADES.has(grade as HealthGrade)) {
+      return null;
+    }
+    return grade as HealthGrade;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * RENDER PATH — pure synchronous collection of whatever per-project health
+ * grades the health hook already cached. One `sessionStorage` read per
+ * repo, no network. Returns a `repo → grade` map; repos with no fresh
+ * cache are simply absent from the map (caller passes `null` for those, so
+ * the Scorecard renders its existing muted "—"). An all-empty portfolio
+ * (nothing visited yet) yields an empty map, never a crash or false grade.
+ */
+export function collectCachedHealthGrades(
+  repos: string[],
+): Record<string, HealthGrade> {
+  const out: Record<string, HealthGrade> = {};
+  for (const repo of repos) {
+    const grade = readHealthGrade(repo);
+    if (grade !== null) out[repo] = grade;
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #456

## Проблема
`ProjectsView` рендерит ~12 карточек `ProjectScorecard` с хардкодом `grade={null}` (стр. ~646), поэтому КАЖДАЯ карточка показывала приглушённое «—». Комментарий в коде (`ProjectsView.tsx:112-118`) объяснял почему: per-project health (классификация/грейд) считается асинхронно для каждого проекта, и запрос его для каждой карточки был бы N+1, который Scorecard явно запрещает.

## Стратегия (выбрана пользователем — реализована именно она)
**Portfolio-cache reader, без новых сетевых вызовов.** `useProjectHealth` уже считает и пишет полный `HealthReport` (включая `score.grade`) в `sessionStorage` под ключом `makeit_health_{repo}` каждый раз, когда пользователь открывает Hub проекта. Портфельная сетка теперь СИНХРОННО читает эти уже-закэшированные значения и показывает реальный A–F для любого проекта, открытого в этой сессии; «—» — для непосещённых.

Это **строго лучше** прежнего всегда-«—» и **НЕ регрессия**: ни одного нового per-project fetch, IntersectionObserver или сетевого вызова — только чтение кэша.

Реализация **зеркалит проверенный прецедент** в кодовой базе: `portfolioNbaCollector.ts` + `usePortfolioNbaCollection.ts` (чистый синхронный коллектор поверх per-project кэша, скормленный в `ProjectsView` через render-safe «adjust-state-during-render-on-prop-change» хук — совместимый со строгими правилами `react-hooks/set-state-in-effect` и `react-hooks/purity`).

## Изменения
- **new** `src/utils/portfolioHealthCollector.ts` — чистый синхронный коллектор: `collectCachedHealthGrades(repos)` → `repo → A|B|C|D|F`. Best-effort: отсутствует / повреждён / JSON-parse-fail / неверная форма → у репо просто нет грейда, никогда не бросает.
- **new** `src/hooks/usePortfolioHealthCollection.ts` — зеркалит render-safe паттерн `usePortfolioNbaCollection` (нет live/regenerate-пути: портфельный health только-чтение).
- `src/components/v4/ProjectsView.tsx` — подключён хук, `grade={null}` → `grade={healthGrades[p.repo] ?? null}`. Затронут только грейд; `overdueCommitments`/KPI не тронуты (другой issue/владелец).

### Зеркало ключа кэша (единственная точка зеркалирования, с комментарием)
`useProjectHealth.ts:8` → `SESSION_PREFIX = "makeit_health_"`, запись `sessionStorage.setItem(SESSION_PREFIX + repo, ...)` (стр. 145, 298). Коллектор использует `makeit_health_` + `repo` — идентичная конкатенация, разделитель **подчёркивание** (НЕ двоеточие, как у NBA — эту разницу не скопировал).

## Верификация
- `npx tsc --noEmit` — чисто (exit 0)
- `npm run lint` — чисто (exit 0)
- `npm run build` — успешно (exit 0; warning о размере чанка — предсуществующий, не связан)

## Самопроверка: 13 пунктов, senior review, P1: 0
Ключ кэша подтверждён в `useProjectHealth.ts:8`; best-effort чтение не бросает на missing/corrupt; render-path хук следует существующему compliant-паттерну (нет setState-in-effect / purity-нарушения); Scorecard рендерит «—» для непосещённых репо; новых network/N+1 нет; тип грейда совпадает с пропом.