### PR TITLE
Hub: рабочая кнопка «Регенерировать» NBA (#459)

### DIFF
--- a/src/components/v4/hub/ProjectHubHeader.tsx
+++ b/src/components/v4/hub/ProjectHubHeader.tsx
@@ -21,8 +21,11 @@ function formatLastActivity(iso: string | null): string {
 /**
  * Header for ProjectHubPage. Composes data from useProjectHub: project
  * identity on the left, health KPI on the right, NBA strip in the middle.
- * The "Регенерировать" button is wired to a no-op stub today — Epic-012
- * (Task-05 NBA engine) replaces it with a real action.
+ * The "Регенерировать" button forces a fresh NBA recompute (#459):
+ * `data.regenerateNBA` invalidates the engine week-cache (incl. the #389
+ * portfolio aggregate) and bumps the engine signature so Claude actually
+ * recomputes; it stays disabled while the Overview/NBA section is
+ * recomputing (`data.loadingTab.overview`).
  *
  * Visuals reuse existing v4 tokens via `v4-hub-*` classes defined in
  * v4.css; tier pills reuse the `ph-tag` family for parity with the Health
@@ -38,6 +41,11 @@ export function ProjectHubHeader({ data }: Props) {
   const hasGrade = data.health !== null;
   const scorePct = data.health?.score.raw ?? null;
   const nbaText = data.nba[0]?.text ?? "—";
+  // `loadingTab.overview` mirrors the NBA section's loading slice — true
+  // while a recompute (incl. one this button just triggered) is in
+  // flight, so the button shows a pending affordance and can't be
+  // double-fired into overlapping recomputes.
+  const regenerating = data.loadingTab.overview;
 
   return (
     <header className="v4-hub-header">
@@ -74,11 +82,21 @@ export function ProjectHubHeader({ data }: Props) {
         <button
           type="button"
           className="v4-btn"
-          disabled
-          title="Будет в Epic-012 (NBA engine)"
-          aria-label="Регенерировать NBA — будет доступно в Epic-012"
+          onClick={() => data.regenerateNBA()}
+          disabled={regenerating}
+          aria-busy={regenerating}
+          title={
+            regenerating
+              ? "Пересчёт Next Best Action…"
+              : "Сбросить кэш и пересчитать Next Best Action"
+          }
+          aria-label={
+            regenerating
+              ? "Идёт пересчёт Next Best Action"
+              : "Регенерировать Next Best Action — сбросить кэш и пересчитать"
+          }
         >
-          Регенерировать
+          {regenerating ? "Пересчёт…" : "Регенерировать"}
         </button>
       </div>
     </header>

--- a/src/hooks/useProjectHub.ts
+++ b/src/hooks/useProjectHub.ts
@@ -49,6 +49,7 @@ import {
 import { isOnboardingRuleId } from "../utils/onboardingReadinessRules";
 import {
   computeProjectNBA,
+  invalidateNbaCache,
   type NbaAction,
   type NbaCommitmentInput,
   type NbaRiskInput,
@@ -839,6 +840,16 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     );
     return list.length > 0 ? list : EMPTY_OVERDUE_COMMITMENTS;
   }, [commitmentsYamlFresh, commitmentsYamlResolved, briefMd]);
+  // Manual-regenerate nonce (#459). Bumped by `regenerateNBA` and folded
+  // into `nbaKey` below. Because `nbaKey` is simultaneously the engine
+  // `sig` (#476), the NBA effect's re-run key, and the `deriveSection`
+  // freshness key, a single nonce bump (a) changes the engine signature
+  // → `computeProjectNBA` cache-misses → a real fresh Claude recompute,
+  // (b) re-runs the NBA effect, and (c) makes `nbaSection` read as
+  // `loading` until the new key resolves (the header shows progress, no
+  // stale flash). Starts at 0; a normal input change still drives a
+  // recompute via the existing signature segments, untouched by this.
+  const [regenNonce, setRegenNonce] = useState(0);
   const nbaKey = useMemo(
     () =>
       [
@@ -852,8 +863,9 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
         overdueCommitments
           .map((c) => `${c.title}:${c.dueDate}:${c.daysOverdue ?? ""}`)
           .join("¦"),
+        `regen:${regenNonce}`,
       ].join("|"),
-    [repo, failingFindings, nbaRisks, overdueCommitments],
+    [repo, failingFindings, nbaRisks, overdueCommitments, regenNonce],
   );
   const [nbaResolved, setNbaResolved] =
     useState<Resolved<NextBestAction[]> | null>(null);
@@ -866,9 +878,9 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
   // its invalidate-on-change workaround (removed here): the engine now
   // owns same-week staleness end to end. Switching to a *different* repo
   // still reuses that repo's own valid week+sig cache (no spurious
-  // Claude call / #389 portfolio cascade). `invalidateNbaCache` is no
-  // longer imported here (the engine sig replaced its only use in this
-  // hook); it remains in the engine module for the Regenerate flow.
+  // Claude call / #389 portfolio cascade). `invalidateNbaCache` is used
+  // only by `regenerateNBA` below (#459) — the manual force-recompute —
+  // never on a normal input change (the engine sig handles those).
   useEffect(() => {
     const key = nbaKey;
     let cancelled = false;
@@ -936,10 +948,24 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     // Hub-level button is a no-op placeholder by design (the real
     // affordance lives in the widget, not here).
   }, []);
+  // Force a fresh NBA recompute for this repo (#459). Two steps, each
+  // load-bearing and distinct:
+  //   1. `invalidateNbaCache({kind:"project",repo})` drops this repo's
+  //      week-cache entry AND (per #389) the portfolio aggregate, so the
+  //      sidebar/portfolio NBA refreshes too — a bare sig bump alone
+  //      would never touch the portfolio key.
+  //   2. The functional `setRegenNonce` bump changes `nbaKey`; since
+  //      `nbaKey` is the engine `sig`, the effect dep, and the section
+  //      freshness key, this drives the real Claude recompute and the
+  //      loading affordance (see the `regenNonce` doc above).
+  // Functional updater → no `regenNonce` dep → referentially stable
+  // across recomputes (only `repo` can change it). Idempotent: a second
+  // click mid-run just bumps again and the effect re-runs cleanly under
+  // the existing cancelled/mounted guards.
   const regenerateNBA = useCallback(async () => {
-    // NBA regeneration is owned by the portfolio / section controls; the
-    // Hub-level button is a no-op placeholder by design.
-  }, []);
+    invalidateNbaCache({ kind: "project", repo });
+    setRegenNonce((n) => n + 1);
+  }, [repo]);
 
   // Fall back to the stable empty array when the extractor produced no
   // decisions — keeps reference equality for downstream memo deps.


### PR DESCRIPTION
Closes #459

## Проблема
Кнопка «Регенерировать» в шапке Project Hub была `disabled` с `title="Будет в Epic-012 (NBA engine)"`, а `regenerateNBA` в `useProjectHub` — пустой no-op `useCallback`. NBA уже считается через `computeProjectNBA` (week-cache + сигнатура входа), но форс-пересчёта не было.

## Механизм
Так как после #476 `nbaKey` одновременно является (а) сигнатурой входа движка (`sig`), (б) ключом ре-рана NBA-эффекта и (в) ключом свежести `deriveSection`, форс-регенерация сделана через nonce, вплетённый в `nbaKey`:

1. **`regenNonce`** — новый `useState(0)` в `useProjectHub`. `regenerateNBA` = стабильный `useCallback([repo])`, который:
   - вызывает `invalidateNbaCache({ kind: "project", repo })` → дропает запись repo-кэша **и** (по #389) портфельный агрегат, чтобы боковой/портфельный NBA тоже обновился (один лишь bump сигнатуры портфельный ключ не трогает — поэтому шаг обязателен и самостоятелен);
   - бампит `setRegenNonce(n => n + 1)` (функциональный updater → нет зависимости от `regenNonce` → стабильная ссылка, нет stale-замыкания).
2. **`regen:${regenNonce}`** добавлен сегментом в memo `nbaKey` и в его deps. Бамп nonce → новый `nbaKey` → новый `sig` → `computeProjectNBA` промахивается по кэшу (`env.sig !== sig`) → реальный свежий вызов Claude; эффект ре-ранится (nbaKey в deps); `deriveSection(nbaResolved, nbaKey)` видит несовпадение ключа → секция `loading` (UI показывает прогресс, без вспышки устаревших данных).
3. **`ProjectHubHeader.tsx`**: убраны `disabled`/Epic-012 `title`/`aria-label`; `onClick={() => data.regenerateNBA()}`; кнопка `disabled` + `aria-busy` + текст «Пересчёт…» пока `data.loadingTab.overview` (= `nbaSection.loading`); корректные русские `title`/`aria-label`. Классы/разметка v4 сохранены.

Движок `nextBestActionEngine.ts` НЕ менялся — `invalidateNbaCache` + sig-gated кэш уже существовали.

Нормальная (не-регенерация) свежесть при изменении findings/risks/overdue работает ровно как после #476: исходные 4 сегмента сигнатуры не тронуты, `regen:0` — константный суффикс до первого клика.

## Проверка
- `npx tsc --noEmit` — чисто
- `npm run lint` — чисто (строгие react-hooks правила: setState только в onClick-хендлере, memo-тело чистое)
- `npm run build` — успешно (только пред-существующее предупреждение о размере чанка)

Самопроверка: 13 пунктов, senior review, P1: 0