### PR TITLE
chore: onboard makeit-dashboard to MakeIT Hub conventions

### DIFF
--- a/docs/BRIEF.md
+++ b/docs/BRIEF.md
@@ -1,0 +1,24 @@
+# BRIEF: makeit-dashboard
+
+## Проект
+- Репозиторий: Sergio1990-1/makeit-dashboard
+- Клиент: внутренний (makeit-knowledge/PORTFOLIO.md — тип «Свой», клиент «—», Tier 3)
+
+## Цель
+Единый live-дашборд по всем проектам MakeIT: статус, приоритеты, заблокированные
+задачи, аудит, pipeline, мониторинг — в одном интерфейсе (см. `docs/OVERVIEW.md`).
+
+## Контекст
+Данные по проектам разбросаны по GitHub — нет единой картины. Дашборд работает
+как control tower портфеля MakeIT (источник: `docs/OVERVIEW.md`).
+
+## Пользователь
+- Роль: команда MakeIT (оператор портфеля)
+- Сценарий: вместо обхода каждого репозитория вручную — один SPA со сводными
+  метриками, drift-сигналами, аудитом и pipeline
+
+## Источник
+Собственная идея (внутренний инструмент)
+
+## Commitments
+- TODO(human: makeit-dashboard is an internal Tier-3 tool with no client — list real internal delivery commitments with dates, or confirm there are none)

--- a/docs/commitments.yaml
+++ b/docs/commitments.yaml
@@ -1,0 +1,12 @@
+# MakeIT Hub — commitments for makeit-dashboard.
+# makeit-dashboard is an INTERNAL Tier-3 tool (makeit-knowledge/PORTFOLIO.md:
+# type "Свой", client "—"). No external counterparty / contract / SOW exists
+# in this repo, so no client deliverable can be grounded. The row below is a
+# visible TODO placeholder, NOT a fabricated promise. Replace it with real
+# internal delivery commitments (text + YYYY-MM-DD due) or remove it if none.
+# status is only `open` | `done` — `overdue` is derived at render time.
+commitments:
+  - text: "TODO(human: makeit-dashboard is an internal Tier-3 tool with no client — list real internal delivery commitments with dates, or confirm there are none)"
+    due: ""
+    client: ""
+    status: open

--- a/docs/project_norm.yaml
+++ b/docs/project_norm.yaml
@@ -1,0 +1,16 @@
+# Drift norm override for makeit-dashboard. Seeded from the tier-3 baseline.
+# Tier grounded from makeit-knowledge/PORTFOLIO.md (makeit-dashboard = "Свой",
+# Tier 3, internal live dashboard). All four keys are required and must be
+# positive whole-day integers — a missing/zero/non-number key invalidates the
+# WHOLE file and the dashboard silently falls back to the tier default.
+#
+# Not tuned away from baseline on purpose: recent git history is a finite
+# Epic-010/011/012 build-out burst, not the steady-state cadence — keeping the
+# lenient tier-3 baseline avoids flagging a natural post-sprint slowdown on
+# this internal tool as drift. client_touch_interval_days is non-meaningful
+# here (internal tool, no client) but kept at the tier-3 baseline because the
+# schema requires all four keys.
+commit_cadence_days: 21
+deploy_freq_days: 45
+audit_freq_days: 120
+client_touch_interval_days: 60

--- a/docs/renewals.yaml
+++ b/docs/renewals.yaml
@@ -1,0 +1,11 @@
+# MakeIT Hub — manual renewals for makeit-dashboard.
+# No SSL cert / custom domain / paid license / client contract is grounded in
+# this repo: GitHub Pages serves on *.github.io (nothing we renew); the VPS
+# copy is referenced only by IP (89.167.17.79) — any custom domain and its
+# SSL expiry live in server config (/opt/apps/nginx-proxy), not in this repo.
+# npm-dependency deprecations are auto-scanned by the dashboard from
+# package.json — do NOT hand-add `dep` rows here.
+# An empty list is valid and stops the Renewals panel erroring.
+# TODO(human: add ssl/domain/contract/license rows with real YYYY-MM-DD
+# expiries if a custom domain or paid license exists for the VPS instance)
+renewals: []

--- a/docs/risks.yaml
+++ b/docs/risks.yaml
@@ -1,0 +1,34 @@
+# MakeIT Hub — risk register for makeit-dashboard. Hand-authored, source: manual.
+# Only repo-grounded risks. Enum tokens are exact:
+#   severity: low | med | high | critical   (note: "med", not "medium")
+#   probability: low | med | high
+#   status: open | mitigated | accepted | closed
+#   due: "YYYY-MM-DD" or null  (non-ISO becomes null at read time)
+risks:
+  - id: risk-1
+    title: "GitHub PAT persisted in browser localStorage (repo + read:project scope across the whole Sergio1990-1 org)"
+    severity: med
+    probability: low
+    mitigation: "Use a fine-grained / short-lived token; document a clear+rotate step; token already kept out of code (CLAUDE.md), only in localStorage"
+    owner: "TODO(human: risk owner)"
+    due: null
+    status: open
+    source: manual
+  - id: risk-2
+    title: "Single-operator control tower — no documented backup owner for portfolio monitoring if the sole operator is unavailable"
+    severity: med
+    probability: low
+    mitigation: "TODO(human: document a backup monitoring contact / hand-off runbook)"
+    owner: "TODO(human: risk owner)"
+    due: null
+    status: open
+    source: manual
+  - id: risk-3
+    title: "Self-hosted VPS instance (89.167.17.79) is single-host with no failover"
+    severity: low
+    probability: med
+    mitigation: "Mitigated by design: GitHub Pages is the primary deploy (CLAUDE.md), the VPS copy is secondary — a VPS outage does not take the dashboard down"
+    owner: "TODO(human: risk owner)"
+    due: null
+    status: mitigated
+    source: manual


### PR DESCRIPTION
## Summary

Onboards this repo to the MakeIT Hub data conventions: adds the four Hub files + a BRIEF `## Commitments` section that the dashboard reads per project. Before this, the Hub Commitments / Risks / Renewals / Drift panels were empty for makeit-dashboard (files physically absent).

All data is repo-grounded; nothing fabricated. Where a real value could not be grounded, a visible `TODO(human: ...)` placeholder is left instead of a guess.

**Files (all new — no pre-existing Hub file to merge):**
- `docs/commitments.yaml` — 1 placeholder row (no client → no grounded commitment)
- `docs/BRIEF.md` — minimal, grounded from `docs/OVERVIEW.md`/README; `## Commitments` mirrors the yaml (verified: merges to exactly 1 row, no dup)
- `docs/risks.yaml` — 3 grounded risks (manual)
- `docs/renewals.yaml` — valid empty list (nothing grounded) + TODO comment
- `docs/project_norm.yaml` — tier-3 baseline (21/45/120/60), untuned

**PROJECT_TIER:** 3 — *inferred*, not supplied. Grounded from `makeit-knowledge/PORTFOLIO.md` (makeit-dashboard = type "Свой", client "—", Tier 3, internal live dashboard).

## TODO(human) — real data a human must supply

1. **`docs/commitments.yaml`** — the single row is a placeholder. makeit-dashboard is an internal Tier-3 tool with no client/contract/SOW in-repo, so no client commitment is grounded. Either list real *internal* delivery commitments (`text` + `YYYY-MM-DD` `due`) or delete the row if there genuinely are none. The same bullet in `docs/BRIEF.md` `## Commitments` must be kept in sync (same text).
2. **`docs/risks.yaml` risk-1 / risk-2 / risk-3** — `owner: "TODO(human: risk owner)"` on all three: set the real owner handle.
3. **`docs/risks.yaml` risk-2** — `mitigation: "TODO(human: document a backup monitoring contact / hand-off runbook)"`: supply the real mitigation/runbook reference.
4. **`docs/renewals.yaml`** — empty list with a TODO comment: if the VPS-hosted instance has a custom domain and/or paid license, add real `ssl`/`domain`/`contract`/`license` rows with `YYYY-MM-DD` expiries (domain + cert info live in server config, not this repo). `dep` rows are auto-scanned — do not add them.

## Deliberately NOT written (ambiguous / ungrounded)

- No client name anywhere — repo + PORTFOLIO confirm there is no counterparty (internal tool).
- No commitment dates — no contract/SOW/decision-log with calendar deliverables exists in-repo (epics are a roadmap, not dated promises).
- `project_norm.yaml` left at the tier-3 baseline despite a recent high-commit burst: that burst is a finite Epic-010/011/012 build-out, not steady-state cadence; tightening it would falsely flag the expected post-sprint slowdown of a stable internal tool. `client_touch_interval_days` is non-meaningful (no client) but required by schema, so kept at baseline.
- No extra "single VPS / no backups" style risks beyond risk-3: the dashboard has no backend/DB (static SPA) and the VPS copy is secondary to GitHub Pages, so risk-3 is recorded as `mitigated`.

## Validation done

- All three yaml files parsed with the same `js-yaml` the dashboard uses.
- Enum tokens checked against the real parsers (`risksRegister.ts`, `commitmentsExtractor.ts`, `renewalsScanner.ts`, `driftNorm.ts`): severity/probability/status/source all valid; `med` not `medium`; commitment status only `open`/`done`.
- `project_norm.yaml`: all four keys present, positive integers, no extra keys (passes `coerceNorm`).
- BRIEF `## Commitments` heading + bullet reproduced through `commitmentsExtractor` regexes → dedups against the yaml to exactly 1 row (no duplicate).
- Only `docs/` touched — no app code / CI / unrelated files.

Do **not** merge automatically — fill the TODO(human) items first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)