### PR TITLE
Scorecard: реальный «⏰ просроч.» из кэша Hub вместо хардкода 0 (#462)

### DIFF
--- a/src/components/v4/ProjectsView.tsx
+++ b/src/components/v4/ProjectsView.tsx
@@ -12,6 +12,7 @@ import { PortfolioDigestPanel } from "./portfolio/PortfolioDigestPanel";
 import { calcRiskScore } from "../../utils/riskScore";
 import { usePortfolioNbaCollection } from "../../hooks/usePortfolioNbaCollection";
 import { usePortfolioHealthCollection } from "../../hooks/usePortfolioHealthCollection";
+import { usePortfolioCommitmentsCollection } from "../../hooks/usePortfolioCommitmentsCollection";
 import { collectCachedPerProjectNba } from "../../utils/portfolioNbaCollector";
 import { useToast } from "./toastContext";
 
@@ -120,9 +121,14 @@ const SCORECARD_TIER = 2 as const;
 
 // KPIs the Scorecard shows. `open` mirrors the existing card; in-progress /
 // blocked are derived from the already-loaded `issues` list (no extra
-// fetch — pure reduce). Overdue client commitments are not in this view's
-// data model (the Promise Tracker widget above owns that cross-project
-// surface), so the per-card value is 0 here.
+// fetch — pure reduce). `overdueCommitments` stays 0 here as the baseline
+// fallback: the per-project overdue count is not in this view's data model
+// (deriving it needs each repo's BRIEF + commitments.yaml). The call site
+// overrides it with the real count for any project whose Hub was visited
+// this session — a pure render-path read of the cache `useProjectHub`
+// persists for free (`usePortfolioCommitmentsCollection`, same #456
+// pattern as `grade`), 0 only for not-yet-visited projects (strictly
+// better than the previous always-0-for-all, NOT a per-project fetch).
 function scorecardKpis(p: ProjectData): ScorecardKpis {
   let inProgress = 0;
   let blocked = 0;
@@ -450,6 +456,20 @@ export function ProjectsView({
     selectedRepo,
   );
 
+  // Portfolio overdue-commitment counts (#462). Same proven render-path
+  // cache-reader as the health grades above: a pure synchronous read of
+  // the per-repo count `useProjectHub` persists for free when a Hub is
+  // opened — no network, no N+1. Repos not visited this session are
+  // absent → the Scorecard's "⏰ просроч." KPI keeps its 0 (strictly
+  // better than the previous always-0-for-all, not a per-project fetch).
+  // `selectedRepo` is the same volatile re-collect trigger as the grades
+  // hook so a count cached during a Hub visit surfaces in-session on
+  // Hub-leave without a full reload.
+  const { overdueByRepo } = usePortfolioCommitmentsCollection(
+    projects,
+    selectedRepo,
+  );
+
   if (selectedRepo) {
     return (
       <ProjectHubPage
@@ -659,7 +679,10 @@ export function ProjectsView({
                     phase={p.phase}
                     client={p.client}
                     grade={healthGrades[p.repo] ?? null}
-                    kpis={scorecardKpis(p)}
+                    kpis={{
+                      ...scorecardKpis(p),
+                      overdueCommitments: overdueByRepo[p.repo] ?? 0,
+                    }}
                     drift={{
                       // True days-since-last-commit — DriftDots labels
                       // this literally "commit: Nд назад" and grades it

--- a/src/hooks/usePortfolioCommitmentsCollection.ts
+++ b/src/hooks/usePortfolioCommitmentsCollection.ts
@@ -1,0 +1,77 @@
+/**
+ * usePortfolioCommitmentsCollection — owns the per-project
+ * overdue-commitment-count map the portfolio grid feeds into each
+ * `ProjectScorecard`'s "⏰ просроч." KPI (#462).
+ *
+ * Render path (zero cost): on mount, when the project list changes, and
+ * on every Hub enter/leave (via `refreshSignal`) it synchronously reads
+ * the counts `useProjectHub` already persisted per repo to sessionStorage
+ * (`collectOverdueCommitmentCounts`). No network, no fetch — those entries
+ * are written for free as the user opens project hubs (`useProjectHub`
+ * resolves the overdue commitments list and stores its `.length`).
+ * Re-collecting on Hub-leave is what surfaces a just-visited project's
+ * count without a full page reload (the project set is hardcoded, so a
+ * repo-set-only key never would).
+ *
+ * There is no "regenerate" path here (unlike `usePortfolioNbaCollection`):
+ * portfolio overdue counts are read-only — the only way a count appears
+ * is the user visiting that project's Hub, which the Hub caches itself. A
+ * project not yet visited this session simply has no count (the Scorecard
+ * keeps its 0); this is strictly better than the previous always-0-for-all
+ * and explicitly NOT a per-project portfolio fetch.
+ *
+ * `overdueByRepo` is `{}` until the first (synchronous) collection and
+ * after it for an all-unvisited portfolio — callers treat a missing repo
+ * as "no count yet" → `0` → existing Scorecard render.
+ */
+
+import { useState } from "react";
+import type { ProjectData } from "../types";
+import { collectOverdueCommitmentCounts } from "../utils/portfolioCommitmentsCollector";
+
+export interface UsePortfolioCommitmentsCollectionState {
+  /**
+   * Per-project overdue-commitment count map (`repo → count`). A repo
+   * absent from the map has no cached count; the caller passes `0` for it
+   * so the Scorecard renders its existing 0.
+   */
+  overdueByRepo: Record<string, number>;
+}
+
+export function usePortfolioCommitmentsCollection(
+  projects: ProjectData[],
+  refreshSignal: string | null,
+): UsePortfolioCommitmentsCollectionState {
+  const [overdueByRepo, setOverdueByRepo] = useState<Record<string, number>>(
+    {},
+  );
+
+  // Stable list of repos; the project set is hardcoded so `repoKey` alone
+  // never changes within a session. `refreshSignal` is the volatile part
+  // (the selected-repo): visiting a project Hub caches that project's
+  // count, and ProjectsView stays mounted across Hub visits, so without
+  // a volatile trigger a freshly-cached count would only surface after a
+  // full page reload. Folding it in re-collects on every Hub enter/leave
+  // (the leave is what matters — the grid then shows the just-cached
+  // count). Still a pure synchronous sessionStorage read, zero network.
+  // U+241F (unit separator) can't appear in a GitHub repo slug or in
+  // `refreshSignal`, so the composite key is collision-free.
+  const repoKey = projects.map((p) => p.repo).sort().join("|");
+  const syncKey = `${repoKey}␟${refreshSignal ?? ""}`;
+
+  // RENDER PATH: pure cached collection. The read is synchronous and a
+  // pure function of `syncKey`, so this uses React's documented "adjust
+  // state during render when a prop changes" pattern (prev-value in state
+  // + setState during render) — same pattern as `usePortfolioHealthCollection`.
+  // It re-renders before commit with no effect / cascading render, and
+  // (unlike a setState-in-effect) satisfies the strict react-hooks lint
+  // rules.
+  const [syncedKey, setSyncedKey] = useState<string | null>(null);
+  if (syncedKey !== syncKey) {
+    setSyncedKey(syncKey);
+    const repos = repoKey.length > 0 ? repoKey.split("|") : [];
+    setOverdueByRepo(collectOverdueCommitmentCounts(repos));
+  }
+
+  return { overdueByRepo };
+}

--- a/src/hooks/useProjectHub.ts
+++ b/src/hooks/useProjectHub.ts
@@ -840,6 +840,39 @@ export function useProjectHub(repo: string, project?: ProjectData): ProjectHubDa
     );
     return list.length > 0 ? list : EMPTY_OVERDUE_COMMITMENTS;
   }, [commitmentsYamlFresh, commitmentsYamlResolved, briefMd]);
+
+  // Persist this repo's overdue-commitment COUNT to sessionStorage so the
+  // portfolio grid's "⏰ просроч." Scorecard KPI can read a real number for
+  // any project whose Hub was opened this session — the same proven
+  // render-path cache-reader pattern #456 uses for the health grade
+  // (`useProjectHealth` persists the full report; the grid reads it). This
+  // is a point-in-time snapshot: `overdue` is `due < now` at the moment
+  // the Hub computed it, so the portfolio shows the last value cached while
+  // the Hub was open (same accepted staleness tradeoff #456 documents for
+  // the grade — not a per-project portfolio fetch). Gated on the SAME
+  // `commitmentsYamlFresh` as the memo so a stale-repo count (navigation
+  // mid-fetch) can never leak into the cache. A `sessionStorage.setItem`
+  // is a side-effect, so it lives in an effect (satisfies
+  // `react-hooks/purity`); it is not a setState, so it does not violate
+  // `react-hooks/set-state-in-effect`. Best-effort: quota / disabled
+  // storage → silently skip (the KPI just stays at its 0 fallback).
+  // Cache key: `makeit_commitments_overdue_` + repo — MUST stay byte-for-
+  // byte identical to `COMMITMENTS_OVERDUE_PREFIX` in
+  // portfolioCommitmentsCollector.ts (the read side); a single mirror-point
+  // (the hook can't export it without a cycle), underscore separator to
+  // match `useProjectHealth`'s `SESSION_PREFIX` convention — NOT a colon.
+  useEffect(() => {
+    if (!commitmentsYamlFresh) return;
+    try {
+      sessionStorage.setItem(
+        `makeit_commitments_overdue_${repo}`,
+        String(overdueCommitments.length),
+      );
+    } catch {
+      // Quota exceeded / storage disabled — non-fatal; the portfolio KPI
+      // falls back to 0 for this repo, never crashes.
+    }
+  }, [repo, commitmentsYamlFresh, overdueCommitments]);
   // Manual-regenerate nonce (#459). Bumped by `regenerateNBA` and folded
   // into `nbaKey` below. Because `nbaKey` is simultaneously the engine
   // `sig` (#476), the NBA effect's re-run key, and the `deriveSection`

--- a/src/utils/portfolioCommitmentsCollector.ts
+++ b/src/utils/portfolioCommitmentsCollector.ts
@@ -1,0 +1,84 @@
+/**
+ * portfolioCommitmentsCollector — collects per-project overdue-commitment
+ * counts into the map the portfolio grid (`ProjectsView` →
+ * `ProjectScorecard`) feeds the "⏰ просроч." KPI (#462).
+ *
+ * Per-project overdue commitments are real but they are not in the
+ * portfolio view's data model: deriving them needs each repo's
+ * BRIEF `## Commitments` + `docs/commitments.yaml` (an async per-repo
+ * fetch). Doing that for the whole portfolio on every render would be an
+ * N+1 the Scorecard explicitly forbids. So collection is a single
+ * render-path read:
+ *
+ *   `collectOverdueCommitmentCounts(repos)` — RENDER PATH, zero cost. A
+ *   pure synchronous read of the count `useProjectHub` already persists
+ *   per repo to sessionStorage (`makeit_commitments_overdue_{repo}`).
+ *   Those entries are written for free as the user opens project hubs
+ *   (`useProjectHub` resolves the overdue list and stores its `.length`).
+ *   No network, no fetch — just `sessionStorage.getItem` per repo.
+ *   Projects without a cached count simply don't contribute (the card
+ *   stays at the 0 the caller passes for them — strictly better than the
+ *   previous always-0-for-all, never a false signal). This mirrors the
+ *   proven `portfolioHealthCollector` precedent (#456).
+ *
+ * `useProjectHub` does not export its cache-key constant (exporting it
+ * would create an import cycle), so the read-only reader mirrors it here
+ * (`makeit_commitments_overdue_{repo}` — the write key in
+ * useProjectHub.ts, underscore separator to match useProjectHealth's
+ * `SESSION_PREFIX` convention, NOT a colon). Kept as the single
+ * mirror-point with a comment so a future rename has one place to update.
+ */
+
+/**
+ * Hub per-project overdue-commitment-count cache-key prefix. Mirrors the
+ * `sessionStorage.setItem` write key in useProjectHub.ts
+ * (`makeit_commitments_overdue_`, underscore — NOT a colon); the hook
+ * does not export it (an export would create an import cycle). If the
+ * hook renames it, update here — these two strings MUST stay identical
+ * or the portfolio silently ships always-0.
+ */
+const COMMITMENTS_OVERDUE_PREFIX = "makeit_commitments_overdue_";
+
+function commitmentsCacheKey(repo: string): string {
+  return `${COMMITMENTS_OVERDUE_PREFIX}${repo}`;
+}
+
+/**
+ * Read-only peek at one project's cached overdue-commitment count.
+ * Returns the integer count if a well-formed value is cached, else null.
+ * Returns null for a missing / corrupt / non-integer / negative / NaN
+ * entry so a bad cache degrades to "this project has no count yet" (card
+ * shows 0) instead of throwing.
+ */
+function readOverdueCount(repo: string): number | null {
+  if (typeof sessionStorage === "undefined") return null;
+  let raw: string | null;
+  try {
+    raw = sessionStorage.getItem(commitmentsCacheKey(repo));
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 0) return null;
+  return n;
+}
+
+/**
+ * RENDER PATH — pure synchronous collection of whatever per-project
+ * overdue-commitment counts the Hub already cached. One `sessionStorage`
+ * read per repo, no network. Returns a `repo → count` map; repos with no
+ * cached count are simply absent from the map (caller passes `0` for
+ * those, so the Scorecard renders its existing 0). An all-empty portfolio
+ * (no Hub visited yet) yields an empty map, never a crash or false count.
+ */
+export function collectOverdueCommitmentCounts(
+  repos: string[],
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const repo of repos) {
+    const count = readOverdueCount(repo);
+    if (count !== null) out[repo] = count;
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #462

## Проблема
`ProjectsView.scorecardKpis(p)` возвращал `overdueCommitments: 0` захардкоженным, поэтому KPI «⏰ просроч.» на КАЖДОЙ портфельной карточке всегда был 0. Причина (устаревший комментарий ~119-124): per-project просроченные обещания не входят в data-model портфельного списка, а считать их per-card — это запрещённый Scorecard'ом N+1.

## Решение — зеркало проверенного паттерна #456 (health grade)
Чисто render-path чтение per-repo кэша, который Project Hub и так заполняет бесплатно. Никакой новой сети, никакого N+1.

- **Write side — `useProjectHub.ts`:** dedicated `useEffect` персистит COUNT просроченных обещаний в `sessionStorage` под ключом `makeit_commitments_overdue_{repo}` (underscore-конвенция как у `useProjectHealth`'s `SESSION_PREFIX`, НЕ двоеточие). Gated на том же `commitmentsYamlFresh`, что и memo `overdueCommitments` — stale-repo значение не утечёт. `setItem` — side-effect → живёт в эффекте (`react-hooks/purity` ok); не setState → `set-state-in-effect` ok. Best-effort try/catch (quota/disabled storage → молча skip). Deps: `[repo, commitmentsYamlFresh, overdueCommitments]`.
- **Collector — новый `portfolioCommitmentsCollector.ts`:** зеркало `portfolioHealthCollector.ts`. `collectOverdueCommitmentCounts(repos) → Record<string, number>`, синхронный, один `getItem` на repo, `Number.parseInt`, принимает только конечное целое ≥ 0 (missing/corrupt/negative/NaN → repo просто отсутствует в map, никогда не бросает).
- **Collection hook — новый `usePortfolioCommitmentsCollection.ts`:** зеркало `usePortfolioHealthCollection.ts` 1:1 по структуре, включая второй параметр `refreshSignal`, свёрнутый в `syncKey` (`repoKey + "␟" + (refreshSignal ?? "")`) — счётчик, закэшированный во время визита Hub, всплывает в сессии на Hub-leave без полной перезагрузки. Паттерн «adjust state during render» (prev-value-in-state + setState-during-render, без эффекта).
- **Wire — `ProjectsView.tsx`:** хук вызван рядом с `usePortfolioHealthCollection(projects, selectedRepo)` (те же аргументы, до early-return — Rules of Hooks). На call-site `<ProjectScorecard>` count переопределён точно как `grade`: `kpis={{ ...scorecardKpis(p), overdueCommitments: overdueByRepo[p.repo] ?? 0 }}`. `scorecardKpis` остаётся pure (0 — baseline fallback). Устаревший комментарий обновлён. `ProjectScorecard.tsx` НЕ менялся — просто получает реальное число.

## Tradeoff (тот же, что принял #456 для grade)
Snapshot-семантика: `overdue` = `due < now` на момент, когда Hub посчитал список; портфель показывает последнее значение, закэшированное пока Hub был открыт. Проект, чей Hub не открывали в этой сессии → 0 (как раньше). Это **строго лучше** прежнего always-0-for-all и **НЕ** per-project portfolio fetch. Данные полностью заполняются по мере онбординга (#458) и обхода Hub'ов.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` (strict react-hooks) — clean
- `npm run build` — succeeds
- Cache-key `makeit_commitments_overdue_` проверен byte-for-byte идентичным на write (useProjectHub) и read (collector) — известный recurring failure mode этого кодбейза.

Самопроверка: 13 пунктов, senior review, P1: 0.