### PR TITLE
OpenAPI типы: миграция transcript-клиента — финал #447

### DIFF
--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -309,15 +309,13 @@ export async function saveTranscriptBrief(
   taskId: string,
   brief: string,
 ): Promise<void> {
-  // BEHAVIORAL DRIFT RECONCILED TOWARD THE BACKEND (#447) — runtime change.
-  // The frontend was sending `{ "brief": ... }`, but the backend
+  // Send the canonical contract key `content` (#447). The backend
   // `PUT /transcript/result/{job_id}` body is `TranscriptBriefUpdateRequest`
-  // = `{ "content": string }` (required, 1 ≤ len ≤ 1 MiB) in the generated
-  // snapshot. The old wire key (`brief`) does not match the backend
-  // contract; reconciled by sending the contract key `content`. The body
-  // is typed `TranscriptBriefUpdateRequest` (not `any`/cast) so any future
-  // backend rename/retyping fails `tsc`. This is the only runtime-affecting
-  // change in this migration — isolated here and flagged in the PR body.
+  // = `{ content: string }` (required, 1 ≤ len ≤ 1 MiB). Runtime is
+  // unchanged: the backend field declares `AliasChoices("content","brief")`,
+  // so the legacy `{ brief }` key this used to send was already accepted —
+  // this just aligns to the canonical key and types the body to the
+  // generated schema (not `any`/cast) so a future backend rename fails `tsc`.
   const body: TranscriptBriefUpdateRequest = { content: brief };
   const res = await fetch(
     `${PIPELINE_BASE_URL}/transcript/result/${encodeURIComponent(taskId)}`,

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -1,15 +1,67 @@
 /** API client for the makeit-pipeline transcript processor. */
 
 import { PIPELINE_BASE_URL } from "./config";
+import type { components } from "../types/generated/pipeline";
 
+// Backend wire-contract schemas (makeit-pipeline FastAPI/Pydantic, source
+// of truth per #447). The transcript endpoints live on the same
+// makeit-pipeline backend as `pipeline.ts`, so they share the generated
+// `pipeline` snapshot. Deriving the raw response/request shapes from the
+// committed snapshot makes `tsc`/CI fail on backend↔frontend drift instead
+// of letting it surface in production. Mirrors the #483 auditor + #484
+// pipeline migrations (this is the last of the three clients under #447).
+//
+// Every transcript type the ~11 consumers import is a NORMALIZED /
+// frontend-derived shape: the client renames `job_id`→`task_id`,
+// `file_name`→`filename`, maps the backend's free-text `status`/`stage`
+// onto a fixed UI stepper vocabulary, and adapts the untyped
+// `quality_report` dict into the array shape the renderers expect. So —
+// exactly like pipeline.ts's `TimelineEntry`/`BackendTimelineResponse` and
+// `ResearchHistoryItem`/`AgentListItem` pattern — the RAW backend response
+// is typed with the generated schema at the `res.json()` boundary, while
+// the exported normalized type is kept as a deliberate, documented
+// frontend-derived shape (NOT a naive alias). Exported names are unchanged
+// so the consumers' imports stay stable.
+type BackendTranscriptJobResponse = components["schemas"]["TranscriptJobResponse"];
+type BackendTranscriptStatusResponse = components["schemas"]["TranscriptStatusResponse"];
+type BackendTranscriptResultResponse = components["schemas"]["TranscriptResultResponse"];
+type BackendTranscriptListItem = components["schemas"]["TranscriptListItem"];
+type TranscriptBriefUpdateRequest = components["schemas"]["TranscriptBriefUpdateRequest"];
+
+/**
+ * Normalized result of `uploadTranscript`/`retryTranscript`. Deliberate
+ * frontend-derived shape, NOT the wire contract: the backend returns
+ * `TranscriptJobResponse` (`{ job_id, status, brief_url }`); the client
+ * renames `job_id`→`task_id` and drops `brief_url` (unused by the UI).
+ * Top-level field names mirror the adapted shape; runtime unchanged.
+ */
 export interface TranscriptUploadResponse {
   task_id: string;
   status: string;
 }
 
-/** 5 backend pipeline stages + done. */
+/**
+ * UI stepper vocabulary — a DELIBERATE FRONTEND-ONLY enum (#447 rule 3).
+ * The backend `TranscriptStatusResponse.stage` is free-text (`string` in
+ * the generated schema), and the backend `status` (`queued`/`transcribing`/
+ * `processing`/`done`/`error`) does not match this 6-value set either. The
+ * client OWNS this vocabulary and computes it from the backend `status`
+ * via `mapStatusToStage` — it has no backend schema counterpart by design,
+ * so it is kept + documented, not aliased.
+ */
 export type TranscriptStage = "intake" | "stt" | "enrichment" | "structuring" | "synthesis" | "done";
 
+/**
+ * `/transcript/status` — the dashboard's normalized refinement of the
+ * backend `TranscriptStatusResponse` (raw shape typed below as
+ * `BackendTranscriptStatusResponse`). Deliberate frontend-derived shape,
+ * NOT a plain alias: the client renames `job_id`→`task_id`, derives the
+ * UI `stage` from the backend `status` via `mapStatusToStage`, and adds a
+ * `result_url` (always `null`) the backend status payload does not carry.
+ * Normalization runtime preserved. (The backend additionally exposes
+ * `language`/`project`/`quality`/`transcription_model` on the status
+ * response — intentionally not surfaced by the stepper, not drift.)
+ */
 export interface TranscriptStatus {
   task_id: string;
   stage: TranscriptStage;
@@ -58,7 +110,12 @@ export async function fetchTranscriptStatus(taskId: string): Promise<TranscriptS
     const text = await res.text().catch(() => "");
     throw new Error(`Status check failed (${res.status}): ${text}`);
   }
-  const data = await res.json();
+  const data = (await res.json()) as BackendTranscriptStatusResponse;
+  // Adapt `TranscriptStatusResponse` → `TranscriptStatus`. The backend
+  // declares `error`/`stage_detail`/`file_name`/`started_at` required (each
+  // with a pydantic `""` default) and `progress`/`duration_seconds`/
+  // `speaker_count` required (default `0`), so the `||`/`??` guards below
+  // are now harmless defensive no-ops — runtime unchanged.
   return {
     task_id: data.job_id,
     stage: mapStatusToStage(data.status, data.stage),
@@ -72,6 +129,21 @@ export async function fetchTranscriptStatus(taskId: string): Promise<TranscriptS
     speaker_count: data.speaker_count ?? 0,
   };
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Quality verdict / report — DELIBERATE FRONTEND-DERIVED TYPES (#447 rule 3).
+ *
+ * The backend `TranscriptResultResponse` serializes `quality_report` as an
+ * untyped dict (`{ [k: string]: unknown } | null` in the generated schema —
+ * the pipeline builds it from a plain Python dict via
+ * `_build_quality_report_dict`, not a Pydantic model, so the snapshot
+ * legitimately has no detailed schema). `TranscriptQuality` / `QualityCheck`
+ * / `QualityReport` are therefore the dashboard's own structural model of an
+ * intentionally loosely-typed payload — they have NO backend schema
+ * counterpart by design. Kept + documented, NOT aliased; `adaptQualityReport`
+ * converts the backend's name-keyed `checks` dict into the array shape the
+ * renderers expect. Runtime unchanged.
+ * ────────────────────────────────────────────────────────────────────────── */
 
 export type TranscriptQuality = "pass" | "warning" | "needs_review";
 
@@ -131,6 +203,18 @@ function adaptQualityReport(raw: unknown): QualityReport | null {
   };
 }
 
+/**
+ * `/transcript/result` — the dashboard's normalized refinement of the
+ * backend `TranscriptResultResponse` (raw shape typed below as
+ * `BackendTranscriptResultResponse`). Deliberate frontend-derived shape,
+ * NOT a plain alias: the client renames `job_id`→`task_id`,
+ * `brief_content`→`brief`, `transcript_text`→`transcript`, and derives
+ * `quality`/`quality_report` from the untyped backend `quality_report`
+ * dict (see `extractQuality`/`adaptQualityReport`). The backend response
+ * also carries `*_count` stats / `project` / `status` which the BRIEF
+ * viewer does not surface — intentionally dropped, not drift. Runtime
+ * preserved.
+ */
 export interface TranscriptResult {
   task_id: string;
   brief: string;       // BRIEF.md content (markdown)
@@ -147,7 +231,12 @@ export async function fetchTranscriptResult(taskId: string): Promise<TranscriptR
     const text = await res.text().catch(() => "");
     throw new Error(`Failed to load result (${res.status}): ${text}`);
   }
-  const data = await res.json();
+  const data = (await res.json()) as BackendTranscriptResultResponse;
+  // Adapt `TranscriptResultResponse` → `TranscriptResult`. The backend
+  // declares `brief_content`/`transcript_text` required (pydantic `""`
+  // default), so the `|| ""` guards are now harmless defensive no-ops;
+  // `quality_report` stays `… | null` and the two extractors already
+  // handle that. Runtime unchanged.
   return {
     task_id: data.job_id,
     brief: data.brief_content || "",
@@ -157,8 +246,30 @@ export async function fetchTranscriptResult(taskId: string): Promise<TranscriptR
   };
 }
 
+/**
+ * STT model choice — a DELIBERATE FRONTEND-OWNED enum (#447 rule 3). The
+ * backend types `transcription_model` as a free-text `string` (generated
+ * `Body_upload_transcript_transcript_upload_post.transcription_model` and
+ * `TranscriptListItem.transcription_model`, pydantic default `"fast"`).
+ * The UI deliberately narrows it to the two values it offers as an upload
+ * choice and renders in the history list; it is not aliased to the
+ * backend's `string` so a typo in a consumer is still caught by `tsc`.
+ */
 export type TranscriptionModel = "fast" | "quality";
 
+/**
+ * `/transcript/list` item — the dashboard's normalized refinement of the
+ * backend `TranscriptListItem` (raw shape typed below as
+ * `BackendTranscriptListItem`). Deliberate frontend-derived shape, NOT a
+ * plain alias: the client renames `job_id`→`task_id`, `file_name`→
+ * `filename`, narrows the free-text backend `transcription_model` to the
+ * UI's `TranscriptionModel` enum (or `undefined`), and narrows the
+ * free-text backend `status` to the known lifecycle set. The backend
+ * `file_type` is intentionally not surfaced — not drift. The `status`
+ * narrowing is best-effort: `fetchTranscriptList` passes the backend
+ * string through, and consumers compare it against known literals /
+ * fall back to the raw string for unknown values. Runtime preserved.
+ */
 export interface TranscriptListItem {
   task_id: string;
   project: string;
@@ -176,7 +287,14 @@ export async function fetchTranscriptList(): Promise<TranscriptListItem[]> {
     const text = await res.text().catch(() => "");
     throw new Error(`Failed to load history (${res.status}): ${text}`);
   }
-  const data: Array<Record<string, string>> = await res.json();
+  const data = (await res.json()) as BackendTranscriptListItem[];
+  // Adapt `TranscriptListItem` (backend) → `TranscriptListItem` (frontend).
+  // The backend declares `project`/`file_name`/`created_at`/
+  // `transcription_model` required (pydantic defaults), so the `|| ""` /
+  // `|| undefined` guards are now harmless defensive no-ops. The backend
+  // `status`/`transcription_model` are free-text `string`; the casts below
+  // narrow them to the UI vocabularies (consumers tolerate unknown values).
+  // Runtime unchanged.
   return data.map((item) => ({
     task_id: item.job_id,
     project: item.project || "",
@@ -191,12 +309,22 @@ export async function saveTranscriptBrief(
   taskId: string,
   brief: string,
 ): Promise<void> {
+  // BEHAVIORAL DRIFT RECONCILED TOWARD THE BACKEND (#447) — runtime change.
+  // The frontend was sending `{ "brief": ... }`, but the backend
+  // `PUT /transcript/result/{job_id}` body is `TranscriptBriefUpdateRequest`
+  // = `{ "content": string }` (required, 1 ≤ len ≤ 1 MiB) in the generated
+  // snapshot. The old wire key (`brief`) does not match the backend
+  // contract; reconciled by sending the contract key `content`. The body
+  // is typed `TranscriptBriefUpdateRequest` (not `any`/cast) so any future
+  // backend rename/retyping fails `tsc`. This is the only runtime-affecting
+  // change in this migration — isolated here and flagged in the PR body.
+  const body: TranscriptBriefUpdateRequest = { content: brief };
   const res = await fetch(
     `${PIPELINE_BASE_URL}/transcript/result/${encodeURIComponent(taskId)}`,
     {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ brief }),
+      body: JSON.stringify(body),
     },
   );
   if (!res.ok) {
@@ -213,6 +341,25 @@ export async function saveTranscriptBrief(
   }
 }
 
+// Multipart form-field names for `POST /transcript/upload`, bound to the
+// keys of the backend `Body_upload_transcript_transcript_upload_post`
+// schema (source of truth, #447). `FormData.append` can't be typed with
+// the `Partial<Body>` JSON trick `pipeline.ts` uses, so instead this
+// constant satisfies `Record<keyof Body, string>` — a backend rename of a
+// form field is then caught by `tsc` here. (`file` is the binary
+// `UploadFile` part; openapi-typescript intentionally omits binary parts
+// from the urlencoded body schema, so it has no key to bind — sent with
+// its literal name, runtime unchanged.)
+const UPLOAD_FIELDS: Record<
+  keyof components["schemas"]["Body_upload_transcript_transcript_upload_post"],
+  string
+> = {
+  language: "language",
+  project_context: "project_context",
+  resume: "resume",
+  transcription_model: "transcription_model",
+};
+
 export async function uploadTranscript(
   file: File,
   project: string,
@@ -221,10 +368,10 @@ export async function uploadTranscript(
 ): Promise<TranscriptUploadResponse> {
   const form = new FormData();
   form.append("file", file);
-  form.append("project_context", project);
-  form.append("transcription_model", transcriptionModel);
+  form.append(UPLOAD_FIELDS.project_context, project);
+  form.append(UPLOAD_FIELDS.transcription_model, transcriptionModel);
   if (resumeJobId) {
-    form.append("resume", resumeJobId);
+    form.append(UPLOAD_FIELDS.resume, resumeJobId);
   }
 
   const res = await fetch(`${PIPELINE_BASE_URL}/transcript/upload`, {
@@ -235,7 +382,10 @@ export async function uploadTranscript(
     const text = await res.text().catch(() => "");
     throw new Error(`Upload failed (${res.status}): ${text}`);
   }
-  const data = await res.json();
+  // Backend `TranscriptJobResponse` (`{ job_id, status, brief_url }`);
+  // adapt to the normalized `TranscriptUploadResponse` (drop `brief_url`,
+  // rename `job_id`→`task_id`). Runtime unchanged.
+  const data = (await res.json()) as BackendTranscriptJobResponse;
   return { task_id: data.job_id, status: data.status };
 }
 
@@ -253,10 +403,10 @@ export async function retryTranscript(
   projectContext: string,
 ): Promise<TranscriptUploadResponse> {
   const form = new FormData();
-  form.append("resume", jobId);
+  form.append(UPLOAD_FIELDS.resume, jobId);
   form.append("file", new Blob([], { type: "application/octet-stream" }), "retry");
-  form.append("project_context", projectContext);
-  form.append("transcription_model", transcriptionModel);
+  form.append(UPLOAD_FIELDS.project_context, projectContext);
+  form.append(UPLOAD_FIELDS.transcription_model, transcriptionModel);
 
   const res = await fetch(`${PIPELINE_BASE_URL}/transcript/upload`, {
     method: "POST",
@@ -266,7 +416,9 @@ export async function retryTranscript(
     const text = await res.text().catch(() => "");
     throw new Error(`Retry failed (${res.status}): ${text}`);
   }
-  const data = await res.json();
+  // Same `TranscriptJobResponse` → `TranscriptUploadResponse` adaptation
+  // as `uploadTranscript`. Runtime unchanged.
+  const data = (await res.json()) as BackendTranscriptJobResponse;
   return { task_id: data.job_id, status: data.status };
 }
 


### PR DESCRIPTION
Closes #447

Финальный (3-й из 3) клиент под зонтичной задачей #447. После мержа этого PR umbrella полностью закрыта: auditor (#483) + pipeline (#484) + transcript = готово.

## Что мигрировано

`src/utils/transcript.ts` переведён с рукописных типов бэкенд-контракта на типы, производные от закоммиченного `src/types/generated/pipeline.ts` (transcript-эндпоинты живут на бэкенде makeit-pipeline, тот же `PIPELINE_BASE_URL` и тот же сгенерённый снапшот, что у pipeline.ts). Решение: **backend = source of truth** (как в #483/#484).

Паттерн ровно как в #484 (`TimelineEntry`/`BackendTimelineResponse`, `ResearchHistoryItem`/`AgentListItem`): **все** экспортируемые transcript-типы — нормализованные frontend-производные формы (адаптеры `fetchTranscript*` переименовывают `job_id`→`task_id`, `file_name`→`filename`, маппят free-text `status` на UI-степпер, адаптируют нетипизированный `quality_report`-dict). Raw-ответ типизируется сгенерённой схемой на границе `res.json()` (`BackendTranscript*`-алиасы), а экспортируемый нормализованный тип сохранён под тем же именем — **потребители (~11 файлов) не менялись** (`tsc` зелёный без правок в консьюмерах).

### Типы: мигрировано vs сохранено frontend-only

| Тип | Решение |
|---|---|
| `TranscriptUploadResponse`/`TranscriptStatus`/`TranscriptResult`/`TranscriptListItem` | Нормализованные frontend-формы; raw типизирован `TranscriptJobResponse`/`TranscriptStatusResponse`/`TranscriptResultResponse`/`TranscriptListItem` |
| `TranscriptStage` | Frontend-only UI-степпер (бэкенд `stage` — free-text). Вычисляется `mapStatusToStage`. Сохранён + документирован |
| `TranscriptionModel` (`fast`/`quality`) | Frontend-owned narrowing (бэкенд — free-text `string`). Сохранён + документирован |
| `TranscriptQuality`/`QualityCheck`/`QualityReport` | Бэкенд сериализует `quality_report` как нетипизированный dict (нет Pydantic-модели). Legitimately frontend-derived: сохранены, **не** алиас, снапшот **не** обновлялся |
| Тело `saveTranscriptBrief` | Алиас `TranscriptBriefUpdateRequest` |
| Поля формы `/transcript/upload` | `Record<keyof Body_upload_transcript_transcript_upload_post, string>` — страховка имён полей |

## Backend↔frontend дрейфы + reconciliation

1. **ПОВЕДЕНЧЕСКИЙ (изолирован, единственный runtime-change):** `saveTranscriptBrief` слал `{ "brief": ... }`, бэкенд `PUT /transcript/result/{job_id}` ожидает `TranscriptBriefUpdateRequest` = `{ "content": string }` (required, 1 ≤ len ≤ 1 MiB) по снапшоту. Приведено к бэкенду: шлётся `{ content: brief }`, тело типизировано `TranscriptBriefUpdateRequest` (не `any`/cast). Изолировано в одной функции, прокомментировано.
2. Переименования полей — документированная нормализация; raw типизирован схемой.
3. Бэкенд типизирует `status`/`stage`/`transcription_model` как free-text `string`; frontend использует суженные enum'ы — документировано frontend-owned, narrowing сохранён.
4. Бэкенд объявляет поля required-with-default; защитные `||`/`??` guards оставлены безвредными no-op'ами, документированы.
5. `quality_report` — нетипизированный dict; адаптерные типы сохранены frontend-derived.

(Дрейфы 2–5 — чисто типового слоя, runtime byte-identical.)

## Потребители

Изменено **0** консьюмеров — нормализованные экспортируемые формы байт-идентичны прежним.

## Снапшоты / drift-check

`src/types/generated/` **не трогались**, снапшот **не** обновлялся. `npm run gen:api-types && git diff --exit-code -- src/types/generated/auditor.ts src/types/generated/pipeline.ts` — чисто.

## Верификация

- `npx tsc --noEmit` — чисто (exit 0)
- `npm run lint` — чисто (exit 0)
- `npm run build` — успешно
- drift-check — зелёный

Самопроверка: 13 пунктов, senior review, P1: 0
