### PR TITLE
feat: mobile/PWA adaptivity — touch targets, dvh, mobile search, topbar declutter

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -172,6 +172,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
   min-height: 100vh;
+  min-height: 100dvh;
   position: relative;
   overflow-x: hidden;
   letter-spacing: -0.015em; /* Apple-style tight tracking */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -564,6 +564,7 @@ function AppInner({ onFirstFetchDone }: AppInnerProps = {}) {
           onLogout={handleLogout}
           onSettings={() => setSettingsOpen(true)}
           onBurger={() => setSideOpen(true)}
+          onOpenSearch={() => setPaletteOpen(true)}
         />
 
         {error && <div className="v4-error">{error}</div>}

--- a/src/components/v4/Topbar.tsx
+++ b/src/components/v4/Topbar.tsx
@@ -21,6 +21,10 @@ interface Props {
   onSettings?: () => void;
   /** Mobile sidebar toggle */
   onBurger?: () => void;
+  /** Opens the global Command Palette. On phones the full search field is
+   *  hidden, so a dedicated icon button (visible ≤700px) calls this — it is
+   *  the only touch entry point to search, since ⌘K is keyboard-only. */
+  onOpenSearch?: () => void;
   /** Optional search submit. The ⌘K shortcut now opens the global Command
    *  Palette instead of focusing this input — it remains a passive search
    *  field for click-and-type usage. */
@@ -37,6 +41,7 @@ export function Topbar({
   onLogout,
   onSettings,
   onBurger,
+  onOpenSearch,
   onSearch,
 }: Props) {
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -86,6 +91,18 @@ export function Topbar({
         <RateLimitPill />
       </div>
       <div className="v4-top-right">
+        <button
+          type="button"
+          className="v4-ibtn v4-search-trigger"
+          onClick={onOpenSearch}
+          aria-label="Поиск"
+          title="Поиск (Command Palette)"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" />
+            <path d="M21 21l-4.35-4.35" />
+          </svg>
+        </button>
         <form
           className="v4-search"
           onSubmit={(e) => {

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -99,6 +99,7 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   display: grid;
   grid-template-columns: 240px 1fr;
   min-height: 100vh;
+  min-height: 100dvh;
   background: var(--v4-bg);
   color: var(--v4-ink-800);
   font-family: var(--v4-sans);
@@ -112,6 +113,7 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   position: sticky;
   top: 0;
   height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
 }
@@ -366,6 +368,14 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
   position: relative;
   width: 280px;
 }
+/* A3: mobile-only search trigger. The button carries both `.v4-ibtn`
+   (which sets display:flex) and `.v4-search-trigger`. The compound
+   `.v4-ibtn.v4-search-trigger` selector (specificity 0,2,0) is required
+   so this hide reliably beats `.v4-ibtn { display:flex }` (0,1,0) on
+   desktop regardless of source order. The ≤700px override uses the same
+   compound selector and is declared LATER in source, so it wins on phones
+   (equal specificity → source order). Keep this rule above that block. */
+.v4-ibtn.v4-search-trigger { display: none; }
 .v4-search input {
   width: 100%;
   height: 32px;
@@ -6790,6 +6800,37 @@ ul.v4-rsh-list {
     gap: 8px;
   }
   .v4-search { display: none; }
+  /* A3: search field is hidden on phones — expose a tap target that opens
+     the global Command Palette (the only mobile entry point, since ⌘K is
+     keyboard-only). Compound selector matches the base hide rule's
+     specificity (0,2,0); wins here by later source order. */
+  .v4-ibtn.v4-search-trigger { display: inline-flex; }
+  /* M2: iOS Safari zooms the viewport when a focused input has a computed
+     font-size < 16px. Force 16px on phones to kill the zoom-on-focus jump.
+     !important is required to beat per-component input font-sizes; scoped
+     to ≤700px so desktop is untouched. */
+  input,
+  textarea,
+  select { font-size: 16px !important; }
+}
+
+/* ── A1: touch ergonomics. Enlarge tap targets to the 44px Apple HIG /
+   WCAG 2.5.5 minimum on touch/pen devices only. Desktop (fine pointer)
+   is intentionally frozen — no visual change with a mouse. ── */
+@media (pointer: coarse) {
+  .v4-ibtn {
+    width: 44px;
+    height: 44px;
+  }
+  .v4-nav-item {
+    min-height: 44px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+  .v4-crumb-link {
+    padding: 10px 8px;
+    margin: -8px 0;
+  }
 }
 
 /* ──────────────────────────────────────────────────────────────────
@@ -7843,11 +7884,26 @@ ul.v4-rsh-list {
   /* TOPBAR — drop search + breadcrumb prefix + live pill text */
   .v4-top { padding: 0 12px; gap: 8px; }
   .v4-crumbs { font-size: 12px; gap: 4px; flex-wrap: nowrap; overflow: hidden; }
-  .v4-crumbs > .v4-sep:first-of-type,
-  .v4-crumbs > a:first-of-type { display: none; }
+  /* Drop the "Все проекты" root crumb + its leading separator on phones.
+     It wraps to two lines and wastes the cramped topbar; show only the
+     current page (and any deeper crumb). DOM order inside .v4-crumbs:
+     button.v4-burger, span(crumb0 "Все проекты"), span(crumb1 = leading
+     .v4-sep + <b>), … — so the first SPAN is crumb0, the second its peer.
+     The old `.v4-crumbs > a:first-of-type` rule was dead (crumbs are
+     <span>, never <a>). */
+  /* !important: the crumb wrapper carries an inline `display:inline-flex`
+     (set in Topbar.tsx), which a plain rule can't override. Scoped to
+     ≤720px so desktop is unaffected. */
+  .v4-crumbs > span:first-of-type { display: none !important; }
+  .v4-crumbs > span:nth-of-type(2) > .v4-sep { display: none; }
   .v4-crumbs b { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .v4-live { padding: 3px 6px; font-size: 0; gap: 0; margin-left: 6px; }
   .v4-live-dot { margin: 0; }
+  /* RateLimitPill is a desktop-only API-budget affordance. On phones it is
+     ~90px wide and collides with the right-hand icon cluster (made worse by
+     the A3 search button), so drop it — matches the existing intent of this
+     block ("strip the topbar down on mobile"). */
+  .v4-ratelimit { display: none; }
   .v4-top-right { gap: 4px; }
   .v4-top-right .icon-btn { padding: 6px; }
 
@@ -8382,6 +8438,7 @@ ul.v4-rsh-list {
   width: 100%;
   max-width: 720px;
   max-height: calc(100vh - 80px);
+  max-height: calc(100dvh - 80px);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -8762,6 +8819,7 @@ ul.v4-rsh-list {
   .v4-mspopup-bd { padding: 16px; align-items: flex-end; }
   .v4-mspopup {
     max-height: calc(100vh - 32px);
+    max-height: calc(100dvh - 32px);
     border-radius: 14px 14px 0 0;
   }
   .v4-mspopup-issue {


### PR DESCRIPTION
## Summary

Top-4 mobile/PWA audit fixes (desktop intentionally frozen) + an in-review header overflow fix.

- **A1** — 44px tap targets via `@media (pointer: coarse)` (`.v4-ibtn`, `.v4-nav-item`, crumbs). Desktop with a fine pointer is byte-identical.
- **A2** — `100vh → 100dvh` fallback pairs (shell, sidebar, 2 modals, legacy body) — fixes iOS Safari URL-bar clipping. `dvh==vh` off-iOS so no desktop change.
- **A3** — mobile-only search-icon button → Command Palette. The full `.v4-search` form is `display:none` on phones and ⌘K is keyboard-only, so this was the missing touch entry point. Compound `.v4-ibtn.v4-search-trigger` selector resolves a CSS source-order/specificity bug found in review (would have made the button visible on desktop / unreliable on mobile).
- **M2** — `input/textarea/select { font-size:16px }` ≤700px to stop iOS zoom-on-focus.
- **Topbar declutter ≤720px** — hide `RateLimitPill` (it collided with the right-hand icon cluster, worsened by the A3 button) and the "Все проекты" root crumb (wrapped to two lines). Replaces a dead `.v4-crumbs > a:first-of-type` rule.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint .` clean
- [x] `vite build` OK (PWA SW regenerated)
- [x] Live v4 shell @375px: A3 button visible, opens Command Palette (87 actions, input focused); header single-line, no overlap; M2 input computed `16px`
- [x] @1280px: `.v4-search-trigger` `display:none`, plain `.v4-ibtn` unchanged (32px) — desktop frozen
- [ ] Real touch device: confirm 44px targets under `pointer: coarse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)