### PR TITLE
feat: PWA/mobile batch — offline cache, scroll-safe matrix, safe-area, dead CSS

### DIFF
--- a/src/components/v4/ProgressMatrix.tsx
+++ b/src/components/v4/ProgressMatrix.tsx
@@ -327,6 +327,7 @@ export function ProgressMatrix({ projects }: Props) {
         </div>
       </div>
 
+      <div className="v4-pm-scroll">
       <div
         style={{
           display: "grid",
@@ -639,6 +640,7 @@ export function ProgressMatrix({ projects }: Props) {
             </div>
           );
         })}
+      </div>
       </div>
     </div>
   );

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -2472,6 +2472,14 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 }
 .v4-pcard-heat-grid .v4-cc { height: 14px; }
 
+/* #491: ProgressMatrix is a fixed-width grid (≈680px min: 170+100+70+70+70
+   + 4 flexible cols). Wrap it in a horizontal scroll container so narrow
+   phones scroll instead of clipping. The min-width only engages when the
+   viewport is narrower than the grid — the panel is always wider on
+   desktop, so this is a no-op there (desktop intentionally frozen). */
+.v4-pm-scroll { overflow-x: auto; }
+.v4-pm-scroll > div { min-width: 680px; }
+
 /* Quick-actions kebab menu */
 .v4-pcard-menu { position: relative; }
 .v4-pcard-menu-btn {
@@ -6787,7 +6795,7 @@ ul.v4-rsh-list {
 }
 .v4-burger { display: none; }
 @media (max-width: 700px) {
-  .v4-content { padding: 0 14px 28px; }
+  .v4-content { padding: 0 14px max(28px, env(safe-area-inset-bottom)); }
   .v4-top { padding: env(safe-area-inset-top) 14px 0; }
   .v4-kpi-row { grid-template-columns: 1fr; }
   .v4-ms-grid { grid-template-columns: 1fr; }
@@ -7908,7 +7916,7 @@ ul.v4-rsh-list {
   .v4-top-right .icon-btn { padding: 6px; }
 
   /* PAGE HEADER */
-  .v4-content { padding: 0 12px 24px; }
+  .v4-content { padding: 0 12px max(24px, env(safe-area-inset-bottom)); }
   .v4-ph { padding-top: 16px; gap: 8px; flex-wrap: wrap; }
   .v4-ph h1 { font-size: 22px; line-height: 1.15; letter-spacing: -0.01em; }
   .v4-ph .v4-sub { font-size: 12px; }
@@ -7973,13 +7981,17 @@ ul.v4-rsh-list {
   /* PIPELINE CONFIG */
   .v4-pl-cx-grid { grid-template-columns: 1fr !important; }
 
-  /* CHAT BUTTON — smaller floating */
-  .v4-chat-btn { right: 12px; bottom: 12px; }
+  /* #493: lift sub-10px badges/counters to a readable size on phones — the
+     sidebar is a full-width drawer here so there's room. Scoped to ≤720px,
+     desktop intentionally frozen. */
+  .v4-nav-badge,
+  .sidebar-badge { font-size: 10px; }
+  .v4-nav-count { font-size: 11px; }
 }
 
 /* ≤ 480px — extra-tight phones */
 @media (max-width: 480px) {
-  .v4-content { padding: 0 10px 20px; }
+  .v4-content { padding: 0 10px max(20px, env(safe-area-inset-bottom)); }
   .v4-ph h1 { font-size: 20px; }
   .v4-mshero-num { font-size: 28px; }
   .v4-mshero-ring { width: 80px; height: 80px; }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -88,6 +88,29 @@ export default defineConfig({
               },
             },
           },
+          {
+            // #486: Auditor / Pipeline / Transcripts / settings / monitors
+            // live on separate, runtime-configured origins (AUDITOR_URL /
+            // PIPELINE_URL / BetterStack worker), so match by path family
+            // rather than host. NetworkFirst keeps online behaviour
+            // unchanged; offline (or on a 6s network stall) it serves the
+            // last response within the TTL so those tabs degrade
+            // gracefully instead of blanking.
+            urlPattern:
+              /\/(pipeline|audit|findings|runs|verify|transcripts|settings|monitors|uptime)\b/i,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'cache-api',
+              networkTimeoutSeconds: 6,
+              expiration: {
+                maxEntries: 60,
+                maxAgeSeconds: 60 * 30,
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
         ],
       },
     }),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,13 +91,18 @@ export default defineConfig({
           {
             // #486: Auditor / Pipeline / Transcripts / settings / monitors
             // live on separate, runtime-configured origins (AUDITOR_URL /
-            // PIPELINE_URL / BetterStack worker), so match by path family
-            // rather than host. NetworkFirst keeps online behaviour
-            // unchanged; offline (or on a 6s network stall) it serves the
-            // last response within the TTL so those tabs degrade
-            // gracefully instead of blanking.
-            urlPattern:
-              /\/(pipeline|audit|findings|runs|verify|transcripts|settings|monitors|uptime)\b/i,
+            // PIPELINE_URL / BetterStack worker). Match cross-origin
+            // requests only (never the SPA's own assets/navigations) whose
+            // path is in the API family — host can't be hard-coded since
+            // the URLs come from runtime config.js. NetworkFirst keeps
+            // online behaviour unchanged; offline (or on a 6s network
+            // stall) it serves the last response within the TTL so those
+            // tabs degrade gracefully instead of blanking.
+            urlPattern: ({ url, sameOrigin }) =>
+              !sameOrigin &&
+              /\/(pipeline|audit|findings|runs|verify|transcripts|settings|monitors|uptime)\b/i.test(
+                url.pathname,
+              ),
             handler: 'NetworkFirst',
             options: {
               cacheName: 'cache-api',


### PR DESCRIPTION
## Summary

Безопасный батч из milestone #15 (десктоп намеренно заморожен, **без мержа** — на ревью).

- **#486** — `NetworkFirst` runtimeCaching для Auditor/Pipeline/Transcripts/settings/monitors (отдельные runtime-origin, матч по path-family, не по host). `networkTimeoutSeconds:6` → офлайн/висящая сеть отдаёт last-good вместо пустых вкладок. Онлайн-поведение не меняется.
- **#489** — удалено мёртвое правило `.v4-chat-btn` (кнопка рендерится с `.chat-fab`; селектор ни на что не матчился).
- **#491** — `ProgressMatrix` (фиксированная сетка ≈680px) обёрнут в `.v4-pm-scroll` (`overflow-x:auto` + `min-width:680px`): на телефоне горизонтальный скролл вместо клипа; на десктопе no-op (панель всегда шире).
- **#492** — `env(safe-area-inset-bottom)` в 3 мобильных `.v4-content` (контент не уезжает под home-indicator iPhone). Chat-fab уже был с safe-area.
- **#493** — sub-10px бейджи/счётчики сайдбара подняты до читаемого размера ≤720px.

#488 (orientation lock) закрыт ранее как wontfix с обоснованием.

## Test plan

- [x] `tsc --noEmit` чисто (изолированный worktree от origin/main)
- [x] `eslint .` чисто
- [x] `vite build` OK, Workbox SW перегенерён (новый хэш ⇒ #486 в sw.js)
- [ ] Live @375px: ProgressMatrix скроллится без клипа; safe-area на устройстве с home-indicator — проверить вручную (headless-превью не воспроизводит notch)
- [ ] Desktop ≥1100px: без визуальных изменений

> Примечание: батч собран в изолированном git-worktree, т.к. в основном checkout параллельный процесс правит ~14 файлов (RateLimitPill/hub) — они в этот PR НЕ входят.

🤖 Generated with [Claude Code](https://claude.com/claude-code)