### PR TITLE
feat: русификация Project Hub + время до сброса лимита GitHub API

### DIFF
--- a/src/components/v4/ProjectsView.tsx
+++ b/src/components/v4/ProjectsView.tsx
@@ -47,23 +47,23 @@ const STORAGE_KEY = "makeit.projectsView.v1";
 
 const PHASE_LABELS: Record<PhaseFilter, string> = {
   all: "Все",
-  "pre-dev": "Pre-dev",
-  development: "Dev",
-  support: "Support",
-  stale: "Stale",
+  "pre-dev": "До разработки",
+  development: "Разработка",
+  support: "Поддержка",
+  stale: "Застой",
 };
 
 const SORT_LABELS: Record<SortKey, string> = {
   activity: "Активность",
   open: "Открытые",
-  risk: "Risk score",
+  risk: "Риск-скор",
   progress: "Прогресс",
   name: "Имя",
 };
 
 const PHASE_GROUP_TITLE: Record<Phase, string> = {
   development: "В разработке",
-  "pre-dev": "Pre-dev",
+  "pre-dev": "До разработки",
   support: "Поддержка",
 };
 
@@ -553,7 +553,7 @@ export function ProjectsView({
             <div className="v4-projects-agg-n num" style={{ color: agg.stale > 0 ? "var(--v4-warn-700)" : undefined }}>
               {agg.stale}
             </div>
-            <div className="v4-projects-agg-l">stale</div>
+            <div className="v4-projects-agg-l">застой</div>
           </div>
           <div className="v4-projects-agg-cell">
             <div className="v4-projects-agg-n num">{agg.progress}%</div>

--- a/src/components/v4/RateLimitPill.tsx
+++ b/src/components/v4/RateLimitPill.tsx
@@ -44,8 +44,8 @@ export function RateLimitPill() {
   if (!data) return null;
 
   const { rest, graphql } = data;
-  // Nearest of the two independent reset windows — that's the soonest the
-  // more-depleted pool can recover, so it's the number worth surfacing.
+  // Earliest of the two independent reset windows — the next time any
+  // quota refreshes, which is the number worth surfacing.
   const nearestReset = Math.min(rest.reset, graphql.reset);
   const title =
     `GitHub API лимит (опрос не тратит лимит)\n` +

--- a/src/components/v4/RateLimitPill.tsx
+++ b/src/components/v4/RateLimitPill.tsx
@@ -22,6 +22,17 @@ function resetAt(epochSec: number): string {
   });
 }
 
+/** Time left until `epochSec`, minute-granular: "42м", "1ч 5м", "<1м". */
+function untilReset(epochSec: number): string {
+  const ms = epochSec * 1000 - Date.now();
+  if (ms <= 0) return "<1м";
+  const totalMin = Math.ceil(ms / 60000);
+  if (totalMin < 60) return `${totalMin}м`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return m === 0 ? `${h}ч` : `${h}ч ${m}м`;
+}
+
 /**
  * Header widget showing remaining GitHub REST + GraphQL quota. Self-
  * contained: owns its own polling hook so the Topbar stays presentational
@@ -33,6 +44,9 @@ export function RateLimitPill() {
   if (!data) return null;
 
   const { rest, graphql } = data;
+  // Nearest of the two independent reset windows — that's the soonest the
+  // more-depleted pool can recover, so it's the number worth surfacing.
+  const nearestReset = Math.min(rest.reset, graphql.reset);
   const title =
     `GitHub API лимит (опрос не тратит лимит)\n` +
     `REST: ${rest.remaining}/${rest.limit}, сброс ${resetAt(rest.reset)}\n` +
@@ -47,6 +61,8 @@ export function RateLimitPill() {
       <span className={`v4-ratelimit-seg v4-ratelimit-seg--${tier(graphql)}`}>
         GQL {compact(graphql.remaining)}
       </span>
+      <span className="v4-ratelimit-sep">·</span>
+      <span className="v4-ratelimit-reset">↻ {untilReset(nearestReset)}</span>
     </span>
   );
 }

--- a/src/components/v4/hub/CustomerHealthGauge.tsx
+++ b/src/components/v4/hub/CustomerHealthGauge.tsx
@@ -229,7 +229,7 @@ export function CustomerHealthGauge({
             color: "var(--v4-ink-500)",
           }}
         >
-          Customer Health
+          Здоровье клиента
         </div>
         <button
           type="button"
@@ -315,7 +315,7 @@ export function CustomerHealthGauge({
                   width="100%"
                   height={GAUGE_H}
                   role="img"
-                  aria-label={`Customer Health: ${Math.round(score)} из 100, зона ${zone.label}`}
+                  aria-label={`Здоровье клиента: ${Math.round(score)} из 100, зона ${zone.label}`}
                 >
                   {/* Track */}
                   <path
@@ -392,10 +392,10 @@ export function CustomerHealthGauge({
               >
                 {(
                   [
-                    ["Sentiment", c.sentiment],
-                    ["Cadence", c.cadence],
-                    ["Delivery", c.delivery],
-                    ["Paid", c.paid],
+                    ["Настроение", c.sentiment],
+                    ["Ритм", c.cadence],
+                    ["Поставка", c.delivery],
+                    ["Оплата", c.paid],
                   ] as const
                 ).map(([label, value]) => (
                   <div

--- a/src/components/v4/hub/DecisionLog.tsx
+++ b/src/components/v4/hub/DecisionLog.tsx
@@ -55,11 +55,11 @@ function formatDate(iso: string | undefined): string {
 function sourceLabel(tag: string): string {
   switch (tag) {
     case "brief":
-      return "Brief";
+      return "Бриф";
     case "commit":
-      return "Commit";
+      return "Коммит";
     case "adr":
-      return "ADR";
+      return "Арх. решение";
     default:
       return tag;
   }

--- a/src/components/v4/hub/DigestViewer.tsx
+++ b/src/components/v4/hub/DigestViewer.tsx
@@ -187,14 +187,14 @@ export function DigestViewer({ repo, input }: Props) {
             id="v4-hub-digest-title"
             style={{ fontSize: 14, fontWeight: 600, margin: 0 }}
           >
-            Weekly Digest
+            Недельный дайджест
           </h3>
           {entry?.budgetFallback ? (
             <span
               style={badgeStyle}
               title="Дайджест сгенерирован на Haiku из-за превышения бюджета Claude"
             >
-              budget fallback
+              бюджет исчерпан
             </span>
           ) : null}
         </div>
@@ -232,7 +232,7 @@ export function DigestViewer({ repo, input }: Props) {
               disabled={busy}
               onClick={() => setConfirming(true)}
             >
-              {busy ? "Генерация…" : "Regenerate"}
+              {busy ? "Генерация…" : "Перегенерировать"}
             </button>
           ) : null}
         </div>

--- a/src/components/v4/hub/DoraCards.tsx
+++ b/src/components/v4/hub/DoraCards.tsx
@@ -22,16 +22,16 @@ interface Props {
 function tierStyle(tier: DoraTier): { background: string; accent: string; label: string } {
   switch (tier) {
     case "elite":
-      return { background: "rgba(34, 197, 94, 0.12)", accent: "#16a34a", label: "Elite" };
+      return { background: "rgba(34, 197, 94, 0.12)", accent: "#16a34a", label: "Элитный" };
     case "high":
-      return { background: "rgba(132, 204, 22, 0.12)", accent: "#65a30d", label: "High" };
+      return { background: "rgba(132, 204, 22, 0.12)", accent: "#65a30d", label: "Высокий" };
     case "medium":
-      return { background: "rgba(234, 179, 8, 0.14)", accent: "#ca8a04", label: "Medium" };
+      return { background: "rgba(234, 179, 8, 0.14)", accent: "#ca8a04", label: "Средний" };
     case "low":
-      return { background: "rgba(239, 68, 68, 0.12)", accent: "#dc2626", label: "Low" };
+      return { background: "rgba(239, 68, 68, 0.12)", accent: "#dc2626", label: "Низкий" };
     case "na":
     default:
-      return { background: "var(--v4-border, rgba(0,0,0,0.05))", accent: "var(--v4-ink-500)", label: "n/a" };
+      return { background: "var(--v4-border, rgba(0,0,0,0.05))", accent: "var(--v4-ink-500)", label: "н/д" };
   }
 }
 
@@ -135,10 +135,10 @@ export function DoraCards({ metrics }: Props) {
           gap: 12,
         }}
       >
-        <Card title="Deploy Frequency" value="—" tier="na" tooltip="Нет данных" />
-        <Card title="Lead Time" value="—" tier="na" tooltip="Нет данных" />
-        <Card title="MTTR" value="—" tier="na" tooltip="Нет данных" />
-        <Card title="Change Failure Rate" value="—" tier="na" tooltip="Нет данных" />
+        <Card title="Частота деплоя" value="—" tier="na" tooltip="Нет данных" />
+        <Card title="Время поставки" value="—" tier="na" tooltip="Нет данных" />
+        <Card title="Время восстановления" value="—" tier="na" tooltip="Нет данных" />
+        <Card title="Доля сбойных изменений" value="—" tier="na" tooltip="Нет данных" />
       </div>
     );
   }
@@ -153,25 +153,25 @@ export function DoraCards({ metrics }: Props) {
       }}
     >
       <Card
-        title="Deploy Frequency"
-        value={formatNumber(metrics.deployFreq, "/day")}
+        title="Частота деплоя"
+        value={formatNumber(metrics.deployFreq, "/день")}
         tier={metrics.tiers.deployFreq}
         tooltip="Commits на main с префиксом feat:/fix:/release: за окно ÷ количество дней окна. Elite ≥ 1/день."
       />
       <Card
-        title="Lead Time"
+        title="Время поставки"
         value={formatHours(metrics.leadTimeHours)}
         tier={metrics.tiers.leadTime}
         tooltip="Медиана (merged_at − created_at) для merged PR в окне. Elite ≤ 1 дня."
       />
       <Card
-        title="MTTR"
+        title="Время восстановления"
         value={formatHours(metrics.mttrHours)}
         tier={metrics.tiers.mttr}
         tooltip="Медиана длительности downtime по BetterStack monitor проекта. n/a если monitor не сопоставлен."
       />
       <Card
-        title="Change Failure Rate"
+        title="Доля сбойных изменений"
         value={formatPercent(metrics.cfr)}
         tier={metrics.tiers.cfr}
         tooltip="Доля деплоев, за которыми в течение 7 дней последовал fix-коммит ИЛИ critical audit finding. Elite ≤ 5%."

--- a/src/components/v4/hub/ProjectHubHeader.tsx
+++ b/src/components/v4/hub/ProjectHubHeader.tsx
@@ -63,13 +63,13 @@ export function ProjectHubHeader({ data }: Props) {
             </span>
           )}
           {client && <span className="v4-hub-client">{client}</span>}
-          <span className="v4-hub-meta">last activity: {formatLastActivity(lastActivity)}</span>
+          <span className="v4-hub-meta">последняя активность: {formatLastActivity(lastActivity)}</span>
         </div>
       </div>
       <div className="v4-hub-header-health" aria-label="Health summary">
         <div
           className={hasGrade ? `v4-hub-grade v4-hub-grade--${grade.toLowerCase()}` : "v4-hub-grade"}
-          aria-label={hasGrade ? `Grade ${grade}` : "Grade not yet available"}
+          aria-label={hasGrade ? `Оценка ${grade}` : "Оценка пока недоступна"}
         >
           {grade}
         </div>
@@ -77,7 +77,7 @@ export function ProjectHubHeader({ data }: Props) {
         <div className="v4-sparkline-placeholder" aria-hidden="true" />
       </div>
       <div className="v4-hub-nba-row">
-        <span className="v4-hub-nba-label">Next Best Action:</span>
+        <span className="v4-hub-nba-label">Что делать дальше:</span>
         <span className="v4-hub-nba-text">{nbaText}</span>
         <button
           type="button"

--- a/src/components/v4/hub/ProjectHubTabs.tsx
+++ b/src/components/v4/hub/ProjectHubTabs.tsx
@@ -14,11 +14,11 @@ interface TabSpec {
 }
 
 const TABS: readonly TabSpec[] = [
-  { id: "overview", label: "Overview" },
-  { id: "health", label: "Health" },
-  { id: "activity", label: "Activity" },
-  { id: "decisions", label: "Decisions & Risks" },
-  { id: "delivery", label: "Delivery" },
+  { id: "overview", label: "Обзор" },
+  { id: "health", label: "Здоровье" },
+  { id: "activity", label: "Активность" },
+  { id: "decisions", label: "Решения и риски" },
+  { id: "delivery", label: "Поставка" },
   { id: "processes", label: "Бизнес-процессы" },
 ] as const;
 

--- a/src/components/v4/hub/RenewalsTable.tsx
+++ b/src/components/v4/hub/RenewalsTable.tsx
@@ -723,7 +723,7 @@ export function RenewalsTable({ repo, onCount }: Props) {
                     key={rowKey}
                     title={
                       isAuto
-                        ? "Auto-detected, fix in package.json"
+                        ? "Определено автоматически, правьте в package.json"
                         : undefined
                     }
                   >
@@ -749,16 +749,16 @@ export function RenewalsTable({ repo, onCount }: Props) {
                     <td style={cellStyle}>{r.notes || "—"}</td>
                     <td style={cellStyle}>
                       <span style={pillStyle}>
-                        {isAuto ? "Auto-scan" : "Manual"}
+                        {isAuto ? "Автоскан" : "Вручную"}
                       </span>
                     </td>
                     <td style={cellStyle}>
                       {isAuto ? (
                         <span
                           style={{ fontSize: 12, color: "var(--v4-ink-500)" }}
-                          title="Auto-detected, fix in package.json"
+                          title="Определено автоматически, правьте в package.json"
                         >
-                          read-only
+                          только чтение
                         </span>
                       ) : (
                         <div style={{ display: "flex", gap: 6 }}>

--- a/src/components/v4/hub/RiskRegisterTable.tsx
+++ b/src/components/v4/hub/RiskRegisterTable.tsx
@@ -46,16 +46,16 @@ import {
  */
 
 const SEVERITY_LABEL: Record<RiskSeverity, string> = {
-  low: "Low",
-  med: "Medium",
-  high: "High",
-  critical: "Critical",
+  low: "Низкая",
+  med: "Средняя",
+  high: "Высокая",
+  critical: "Критическая",
 };
 
 const PROBABILITY_LABEL: Record<RiskProbability, string> = {
-  low: "Low",
-  med: "Medium",
-  high: "High",
+  low: "Низкая",
+  med: "Средняя",
+  high: "Высокая",
 };
 
 const STATUS_LABEL: Record<RiskStatus, string> = {
@@ -66,9 +66,9 @@ const STATUS_LABEL: Record<RiskStatus, string> = {
 };
 
 const SOURCE_LABEL: Record<RiskSource, string> = {
-  manual: "Manual",
-  "transcript-extracted": "Transcript",
-  "audit-promoted": "Audit",
+  manual: "Вручную",
+  "transcript-extracted": "Транскрипт",
+  "audit-promoted": "Аудит",
 };
 
 /**
@@ -596,7 +596,7 @@ export function RiskRegisterTable({ repo, onCount }: Props) {
           >
             {extractPhase === "extracting"
               ? "Извлечение…"
-              : "Extract from transcripts"}
+              : "Извлечь из транскриптов"}
           </button>
           <button
             type="button"
@@ -677,7 +677,7 @@ export function RiskRegisterTable({ repo, onCount }: Props) {
           >
             <thead>
               <tr style={{ textAlign: "left", color: "var(--v4-ink-500)" }}>
-                <th style={{ ...cellStyle, fontWeight: 600 }}>Severity</th>
+                <th style={{ ...cellStyle, fontWeight: 600 }}>Серьёзность</th>
                 <th style={{ ...cellStyle, fontWeight: 600 }}>Риск</th>
                 <th style={{ ...cellStyle, fontWeight: 600 }}>Вероятность</th>
                 <th style={{ ...cellStyle, fontWeight: 600 }}>Митигация</th>
@@ -1080,9 +1080,9 @@ function ProposalEditForm({ value, onChange }: ProposalEditFormProps) {
       </label>
       <div style={{ display: "flex", gap: 12 }}>
         <label style={{ ...field, flex: 1 }}>
-          Severity
+          Серьёзность
           <select
-            aria-label="Severity"
+            aria-label="Серьёзность"
             style={inputStyle}
             value={value.severity}
             onChange={(e) =>

--- a/src/components/v4/hub/tabs/ActivityTab.tsx
+++ b/src/components/v4/hub/tabs/ActivityTab.tsx
@@ -208,7 +208,7 @@ export function ActivityTab({ repo, onVisited }: Props) {
             className="v4-hub-activity-title"
             id="v4-hub-activity-inbox-title"
           >
-            Inbox
+            Входящие
             {unread.length > 0 ? (
               <span className="v4-hub-activity-count">{unread.length}</span>
             ) : null}
@@ -332,7 +332,7 @@ export function ActivityTab({ repo, onVisited }: Props) {
                     {pr.title}
                   </span>
                   {pr.isDraft ? (
-                    <span className="v4-hub-activity-pr-badge">draft</span>
+                    <span className="v4-hub-activity-pr-badge">черновик</span>
                   ) : null}
                   {pr.author ? (
                     <span className="v4-hub-activity-pr-author">

--- a/src/components/v4/hub/tabs/DecisionsRisksTab.tsx
+++ b/src/components/v4/hub/tabs/DecisionsRisksTab.tsx
@@ -80,10 +80,10 @@ interface SectionDef {
 
 /** Fixed order — Decision Log → Risk Register → Commitments → Renewals. */
 const SECTIONS: readonly SectionDef[] = [
-  { id: "decisions", title: "Decision Log", icon: "book" },
-  { id: "risks", title: "Risk Register", icon: "alert" },
-  { id: "commitments", title: "Commitments", icon: "clock" },
-  { id: "renewals", title: "Renewals", icon: "shield" },
+  { id: "decisions", title: "Журнал решений", icon: "book" },
+  { id: "risks", title: "Реестр рисков", icon: "alert" },
+  { id: "commitments", title: "Обещания", icon: "clock" },
+  { id: "renewals", title: "Продления", icon: "shield" },
 ] as const;
 
 function isSectionId(value: string): value is SectionId {
@@ -268,7 +268,7 @@ export function DecisionsRisksTab({ decisions, repo, scrollTo }: Props) {
               className="v4-hub-decisions-title"
               id="v4-hub-decisions-decisions-title"
             >
-              Decision Log
+              Журнал решений
               <span className="v4-hub-decisions-count">
                 {decisions.length}
               </span>
@@ -292,7 +292,7 @@ export function DecisionsRisksTab({ decisions, repo, scrollTo }: Props) {
               className="v4-hub-decisions-title"
               id="v4-hub-decisions-risks-title"
             >
-              Risk Register
+              Реестр рисков
               {riskCount !== null ? (
                 <span className="v4-hub-decisions-count">{riskCount}</span>
               ) : null}
@@ -317,7 +317,7 @@ export function DecisionsRisksTab({ decisions, repo, scrollTo }: Props) {
               className="v4-hub-decisions-title"
               id="v4-hub-decisions-commitments-title"
             >
-              Commitments
+              Обещания
               {commitCount !== null ? (
                 <span className="v4-hub-decisions-count">{commitCount}</span>
               ) : null}
@@ -342,7 +342,7 @@ export function DecisionsRisksTab({ decisions, repo, scrollTo }: Props) {
               className="v4-hub-decisions-title"
               id="v4-hub-decisions-renewals-title"
             >
-              Renewals
+              Продления
               {renewalCount !== null ? (
                 <span className="v4-hub-decisions-count">{renewalCount}</span>
               ) : null}

--- a/src/components/v4/hub/tabs/DeliveryTab.tsx
+++ b/src/components/v4/hub/tabs/DeliveryTab.tsx
@@ -96,11 +96,11 @@ export function DeliveryTab({ repo, data }: Props) {
         aria-labelledby="delivery-dora-title"
       >
         <h2 id="delivery-dora-title" className="delivery-section-title">
-          DORA
+          DevOps-метрики
         </h2>
         {dora === null ? (
           <p className="delivery-empty">
-            DORA-метрики ещё считаются (или недостаточно активности на main).
+            DevOps-метрики ещё считаются (или недостаточно активности на main).
           </p>
         ) : (
           <DoraCards metrics={dora} />
@@ -117,7 +117,7 @@ export function DeliveryTab({ repo, data }: Props) {
             id="delivery-health-title"
             className="delivery-section-title"
           >
-            Customer Health
+            Здоровье клиента
           </h2>
           {customerHealth === null ? (
             <p className="delivery-empty">
@@ -136,7 +136,7 @@ export function DeliveryTab({ repo, data }: Props) {
             id="delivery-onboarding-title"
             className="delivery-section-title"
           >
-            Onboarding Readiness
+            Готовность к онбордингу
           </h2>
           {!hasOnboarding ? (
             <p className="delivery-empty">
@@ -155,10 +155,10 @@ export function DeliveryTab({ repo, data }: Props) {
         aria-labelledby="delivery-digest-title"
       >
         <h2 id="delivery-digest-title" className="delivery-section-title">
-          Weekly Digest
+          Недельный дайджест
         </h2>
         {/* Always mount: DigestViewer owns its own per-week empty state
-            («…ещё не сгенерирован. Нажмите «Regenerate».») which is now
+            («…ещё не сгенерирован. Нажмите «Перегенерировать».») which is now
             actionable since `input` is supplied — so the FIRST digest can
             be created, not just regenerated. */}
         <DigestViewer repo={repo} input={digestInput} />

--- a/src/components/v4/hub/tabs/OverviewTab.tsx
+++ b/src/components/v4/hub/tabs/OverviewTab.tsx
@@ -95,7 +95,7 @@ function NbaBlock({ nba, onOpenTab }: NbaBlockProps) {
           <Icon name="lightbulb" />
         </span>
         <h3 className="v4-hub-mini-title" id="v4-hub-mini-nba-title">
-          Next Best Action
+          Что делать дальше
         </h3>
       </header>
 
@@ -416,13 +416,13 @@ function filterUrgentCommitments(commitments: Commitment[]): Commitment[] {
 function severityLabel(severity: Risk["severity"]): string {
   switch (severity) {
     case "critical":
-      return "Critical";
+      return "Критичный";
     case "high":
-      return "High";
+      return "Высокий";
     case "med":
-      return "Medium";
+      return "Средний";
     case "low":
-      return "Low";
+      return "Низкий";
     default:
       return severity;
   }

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -358,6 +358,7 @@ body.v4 .v4-mono { font-family: var(--v4-mono); }
 .v4-ratelimit-seg--ok { color: var(--v4-success-700); }
 .v4-ratelimit-seg--warn { color: var(--v4-warn-700); }
 .v4-ratelimit-seg--crit { color: var(--v4-danger-700); }
+.v4-ratelimit-reset { color: var(--v4-ink-500); }
 .v4-top-right {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- **Русификация** страницы проектов и 6 вкладок Project Hub: переведены все пользовательские строки (вкладки, шапка, Overview, Decisions & Risks, Risk Register, Renewals, Delivery, Customer Health, DORA-карточки, Activity, DecisionLog, DigestViewer, фильтры/агрегаты ProjectsView). Менялись только label-значения и JSX-текст — enum-ключи и логика не затронуты.
- **Плашка лимитов GitHub API**: рядом с REST/GQL добавлена метка `↻ Nм` — обратный отсчёт до ближайшего из двух окон сброса.
- **iOS safe-area-inset** для `.v4-content` (контент не уезжает под home-indicator) + удалён избыточный мобильный `.v4-chat-btn` override.

Спорные термины согласованы с владельцем: Delivery→Поставка, Cadence→Ритм, MTTR→Время восстановления, DORA→DevOps-метрики, ADR→Арх. решение.

## Test plan
- [x] `npx tsc --noEmit` — чисто
- [x] `npm run lint` — exit 0
- [x] `npm run build` — успешно
- [ ] Визуальная проверка Hub на проде (требует GitHub PAT — вне локального окружения)

🤖 Generated with [Claude Code](https://claude.com/claude-code)