### PR TITLE
[CSS] Канонические брейкпоинт-токены: зоопарк из 14 порогов → 3

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,6 +3,12 @@
    Mobile-first · Dark-first
    ══════════════════════════════════════════ */
 
+/* Responsive breakpoint contract (issue #490) defined in
+   src/styles/v4.css. Canonical tokens: 480 / 768 / 1100.
+   Desktop ≥1100 is frozen. Legacy 1024 → 1100 closes the
+   1024–1100 dead zone (sidebar already a drawer at v4 1100,
+   legacy content stayed desktop until 1024). */
+
 /* ── Design Tokens (Dark Theme — Primary) ── */
 :root {
   /* Gray scale */
@@ -251,7 +257,7 @@ body::after {
   grid-column: 5 / span 8;
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 1100px) {
   .bento-grid {
     display: flex;
     flex-direction: column;
@@ -483,7 +489,7 @@ body::after {
   margin-top: auto;
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 1100px) {
   .pc-row {
     grid-template-columns: 1fr;
     grid-template-rows: unset;

--- a/src/components/PipelineActiveTasksBlock/styles.css
+++ b/src/components/PipelineActiveTasksBlock/styles.css
@@ -1,6 +1,8 @@
 /* ──────────────────────────────────────────────────────────────────
    Pipeline · Active Tasks redesign — Variant C (dense mono CI-style)
    Tokens: --v4-* from src/styles/v4.css
+   Responsive breakpoint contract (issue #490) defined in
+   src/styles/v4.css. Canonical tokens: 480 / 768 / 1100.
    ────────────────────────────────────────────────────────────────── */
 
 @keyframes pl2-pulse {
@@ -584,11 +586,11 @@
 }
 
 /* ── Responsive ─────────────────────────────────────────────── */
-@media (max-width: 767px) {
+@media (max-width: 768px) {
   .pl2-c-phase-name { display: none; }
   .pl2-title { font-size: 12px; }
 }
-@media (max-width: 479px) {
+@media (max-width: 480px) {
   .pl2-card { padding-right: 36px; }
   .pl2-c-stat--model,
   .pl2-c-stat--attempt { display: none; }

--- a/src/styles/v4-health.css
+++ b/src/styles/v4-health.css
@@ -2,6 +2,11 @@
    PROJECT HEALTH — vibrant redesign on v4
    ══════════════════════════════════════════ */
 
+/* Responsive breakpoint contract (issue #490) defined in
+   src/styles/v4.css. Canonical tokens: 480 / 768 / 1100.
+   The 1180px query below is a documented exception: it is
+   >1100, so snapping it would alter desktop ≥1100. */
+
 /* Page container */
 .ph-page {
   padding: 18px 28px 60px;
@@ -1015,12 +1020,14 @@
 .ph-state-banner span { color: rgba(255,255,255,0.55); font-weight: 400; text-transform: none; letter-spacing: 0; font-family: var(--v4-sans); }
 
 /* responsive */
+/* Breakpoint contract exception (issue #490): 1180 is >1100;
+   snapping it to a token would alter desktop ≥1100 rendering. */
 @media (max-width: 1180px) {
   .ph-page { grid-template-columns: 1fr; }
   .ph-side { position: static; }
   .ph-kpi-row { grid-template-columns: 1fr; }
 }
-@media (max-width: 760px) {
+@media (max-width: 768px) {
   .ph-fi-top { grid-template-columns: 1fr; }
   .ph-fi-actions { flex-direction: row; align-items: center; }
   .ph-fi-rem { margin-left: 0; }
@@ -1251,7 +1258,7 @@
   display: flex; gap: 8px;
 }
 
-@media (max-width: 760px) {
+@media (max-width: 768px) {
   .ph-bulk-row-main { grid-template-columns: auto 1fr auto; }
   .ph-bulk-row-main .ph-sev { grid-column: 1 / -1; }
   .ph-bulk-row-status { grid-column: 1 / -1; }

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -5,6 +5,31 @@
    moliyakg/project/MakeIT Dashboard.html
    ══════════════════════════════════════════ */
 
+/* ══════════════════════════════════════════
+   RESPONSIVE BREAKPOINT CONTRACT  (issue #490)
+   Canonical tokens — use ONLY these widths for
+   new or migrated media queries:
+     bp-sm   480px   compact phone
+     bp-md   768px   phone ↔ tablet
+     bp-lg  1100px   tablet ↔ desktop  (freeze line)
+   Rules:
+   - CSS custom properties cannot be used inside
+     @media, so this is a documented value contract,
+     not runtime variables.
+   - max-width snaps UP to the nearest token at or
+     above it (mobile layer only widens, never
+     narrows — no viewport loses its mobile fix).
+   - min-width desktop enhancements snap to bp-lg
+     (≥1100 must stay pixel-identical).
+   - Desktop ≥1100px is FROZEN: never add or lower a
+     max-width >1100, nor a min-width that shifts the
+     ≥1100 rendering.
+   Known exceptions (intentionally outside the token
+   set — collapsing them would alter desktop ≥1100):
+     • v4.css        @media (min-width: 1280px) delivery split
+     • v4-health.css @media (max-width: 1180px) Hub page
+   ══════════════════════════════════════════ */
+
 :root {
   /* Surfaces / ink */
   --v4-bg: #F6F7F9;
@@ -6721,7 +6746,7 @@ ul.v4-rsh-list {
   color: var(--v4-accent-500);
 }
 
-@media (max-width: 700px) {
+@media (max-width: 768px) {
   .v4-spc-card-head {
     grid-template-columns: 1fr;
     gap: 10px;
@@ -6795,7 +6820,7 @@ ul.v4-rsh-list {
   .v4-tpc-submit { margin-left: 0; }
 }
 .v4-burger { display: none; }
-@media (max-width: 700px) {
+@media (max-width: 768px) {
   .v4-content { padding: 0 14px max(28px, env(safe-area-inset-bottom)); }
   .v4-top { padding: env(safe-area-inset-top) 14px 0; }
   .v4-kpi-row { grid-template-columns: 1fr; }
@@ -7736,7 +7761,7 @@ ul.v4-rsh-list {
 @media (max-width: 1100px) {
   .v4-msgrid, .v4-msgrid--compact { grid-template-columns: repeat(2, 1fr); }
 }
-@media (max-width: 720px) {
+@media (max-width: 768px) {
   .v4-msgrid, .v4-msgrid--compact { grid-template-columns: 1fr; }
   .v4-mshero { grid-template-columns: 1fr; }
   .v4-msgantt-body { grid-template-columns: 220px 1fr; }
@@ -7889,7 +7914,7 @@ ul.v4-rsh-list {
    viewports (375–720px). Goal: nothing horizontally clipped except the
    Gantt chart (which scrolls intentionally).
    ──────────────────────────────────────── */
-@media (max-width: 720px) {
+@media (max-width: 768px) {
   /* TOPBAR — drop search + breadcrumb prefix + live pill text */
   .v4-top { padding: 0 12px; gap: 8px; }
   .v4-crumbs { font-size: 12px; gap: 4px; flex-wrap: nowrap; overflow: hidden; }
@@ -8828,7 +8853,7 @@ ul.v4-rsh-list {
   font-weight: 600;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 768px) {
   .v4-mspopup-bd { padding: 16px; align-items: flex-end; }
   .v4-mspopup {
     max-height: calc(100vh - 32px);
@@ -8872,7 +8897,7 @@ ul.v4-rsh-list {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
-@media (min-width: 1024px) {
+@media (min-width: 1100px) {
   .v4-portfolio-widgets {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -9076,7 +9101,7 @@ ul.v4-rsh-list {
 }
 .v4-hub-tab-stub a:hover { text-decoration: underline; }
 
-@media (max-width: 640px) {
+@media (max-width: 768px) {
   .v4-hub-header {
     grid-template-columns: 1fr;
     grid-template-areas: "id" "health" "nba";
@@ -9102,7 +9127,7 @@ ul.v4-rsh-list {
   grid-template-columns: 1fr;
   gap: 16px;
 }
-@media (min-width: 1024px) {
+@media (min-width: 1100px) {
   .v4-hub-overview {
     grid-template-columns: 1fr 1fr;
   }
@@ -9414,7 +9439,7 @@ ul.v4-rsh-list {
   white-space: nowrap;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 768px) {
   .v4-hub-mini { min-height: 0; }
   .v4-hub-pulse-item,
   .v4-hub-risk-item,
@@ -9462,6 +9487,8 @@ ul.v4-rsh-list {
   gap: 24px;
 }
 
+/* Breakpoint contract exception (issue #490): 1280 is >1100;
+   snapping it to a token would alter desktop ≥1100 rendering. */
 @media (min-width: 1280px) {
   .delivery-tab .delivery-row--split {
     grid-template-columns: 1fr 1fr;
@@ -9704,7 +9731,7 @@ ul.v4-rsh-list {
   gap: 16px;
   align-items: start;
 }
-@media (min-width: 960px) {
+@media (min-width: 1100px) {
   .v4-hub-decisions {
     grid-template-columns: 200px minmax(0, 1fr);
     gap: 24px;
@@ -9728,7 +9755,7 @@ ul.v4-rsh-list {
   border-radius: 12px;
   background: var(--v4-paper);
 }
-@media (min-width: 960px) {
+@media (min-width: 1100px) {
   .v4-hub-decisions .v4-hub-decisions-nav {
     flex-direction: column;
     flex-wrap: nowrap;


### PR DESCRIPTION
Closes #490

## Что сделано
Находка **M1** аудита 2026-05-16. ~14 разных порогов медиазапросов
(479/480/600/640/700/720/760/767/768/960/1024/1100/1180/1280) сведены к
**3 каноническим токенам**: `480` / `768` / `1100`.

CSS-переменные нельзя использовать внутри `@media` в чистом CSS, поэтому
контракт оформлен как **comment-contract**: authoritative-блок в шапке
`src/styles/v4.css` + краткие ссылки в `App.css`, `v4-health.css`,
`PipelineActiveTasksBlock/styles.css`.

### Политика маппинга
- `max-width` снапится **вверх** к ближайшему токену (мобильный слой
  только расширяется — ни один вьюпорт не теряет свой фикс)
- `min-width` десктоп-энхансы (960/1024) → `1100`
- **App.css `1024 → 1100`** — закрыта мёртвая зона 1024–1100px: v4 уже
  показывал drawer на 1100, а легаси-контент сворачивался только на 1024.
  Это ядро находки M1.

### Десктоп ≥1100 заморожен
Ни один `max-width` не поднят выше 1100, ни один `min-width` не поднят
выше 1100 → рендеринг при ширине >1100 **доказуемо идентичен** (семантика
media-queries). `1180` (Project Hub) и `1280` (delivery split) оставлены
как **документированные исключения** — они >1100, схлопывание изменило бы
десктоп.

### Итог
14 порогов → 3 токена (480/768/1100) + 2 документированных исключения.

## Тесты
CSS-only рефактор: автотесты не добавлялись. Проверено:
- `npx tsc --noEmit` — чисто
- `npm run lint` — чисто (exit 0)
- `npm run build` — успех
- Браузер: dev-сервер на 1050px (бывшая мёртвая зона) — CSS парсится,
  ноль console-ошибок. Полный визуальный обход аутентифицированного
  дашборда невозможен (UI за паролем); корректность гарантирована
  семантикой media-queries, а не визуально.

## Самопроверка
- [x] 13 пунктов пройдены
- [x] Senior review проведён
- [x] P1 issues: 0