### PR TITLE
fix(server): поднять cap milestones — open 20→100, closed 10→50

### DIFF
--- a/server/src/github.ts
+++ b/server/src/github.ts
@@ -326,7 +326,7 @@ query($owner: String!, $repo: String!) {
     description
     openIssueCount: issues(states: OPEN) { totalCount }
     closedIssueCount: issues(states: CLOSED) { totalCount }
-    openMilestones: milestones(first: 20, states: OPEN, orderBy: {field: DUE_DATE, direction: ASC}) {
+    openMilestones: milestones(first: 100, states: OPEN, orderBy: {field: DUE_DATE, direction: ASC}) {
       nodes {
         title
         description
@@ -337,7 +337,7 @@ query($owner: String!, $repo: String!) {
         openIssues: issues(states: OPEN) { totalCount }
       }
     }
-    closedMilestones: milestones(first: 10, states: CLOSED, orderBy: {field: DUE_DATE, direction: DESC}) {
+    closedMilestones: milestones(first: 50, states: CLOSED, orderBy: {field: DUE_DATE, direction: DESC}) {
       nodes {
         title
         description


### PR DESCRIPTION
## Проблема

Backend cache в \`server/src/github.ts\` запрашивает у GitHub GraphQL только **20 ближайших open milestones** (\`orderBy DUE_DATE ASC\`) на каждый репо. Для проектов с большим бэклогом milestone-based эпиков (moliyakg: 29 open) это обрезает хвост — milestones с дальними дедлайнами не попадают в cache → **не отображаются в dashboard нигде** (ни в виджете \"≤30д\", ни в Milestones page, ни в search).

## Воспроизведение

1. В moliyakg создан milestone \"Holding multi-company (H2-H6)\" с deadline 2026-10-31.
2. У moliyakg уже 28 других open milestones с close-to-now дедлайнами.
3. Через REST \`gh api repos/Sergio1990-1/moliyakg/milestones?state=open\` — milestone виден.
4. Через backend cache (\`/api/cache/api/projects\`) — moliyakg показывает только 30 milestones (20 open + 10 closed), нашего нет.
5. Dashboard UI — \"Holding\" search не находит, Milestones page не показывает.

## Fix

\`\`\`diff
-    openMilestones: milestones(first: 20, states: OPEN, orderBy: {field: DUE_DATE, direction: ASC}) {
+    openMilestones: milestones(first: 100, states: OPEN, orderBy: {field: DUE_DATE, direction: ASC}) {

-    closedMilestones: milestones(first: 10, states: CLOSED, orderBy: {field: DUE_DATE, direction: DESC}) {
+    closedMilestones: milestones(first: 50, states: CLOSED, orderBy: {field: DUE_DATE, direction: DESC}) {
\`\`\`

- **openMilestones 20 → 100**: покрывает все realistic кейсы для проекта с большим бэклогом.
- **closedMilestones 10 → 50**: counter \"Завершённые · 77\" на Milestones page обрезался — теперь покажет большую часть истории.
- GraphQL запрос остаётся одной operation на repo, нагрузка на API не меняется.

## Test plan

- [ ] Deploy через \`infra/deploy.sh\` на VPS 89.167.17.79
- [ ] Подождать 15 мин (SYNC_INTERVAL) для следующего auto-sync
- [ ] Проверить \`curl http://89.167.17.79/api/cache/api/projects\` — moliyakg должно иметь ~106 milestones (29 open + ~77 closed)
- [ ] В dashboard поиск \"Holding\" → должен найти \"Holding multi-company (H2-H6)\"
- [ ] Milestones page → moliyakg группа → milestone виден

🤖 Generated with [Claude Code](https://claude.com/claude-code)