### PR TITLE
feat(quality): новая вкладка «Качество кода и изменения» (Codex)

### DIFF
--- a/docs/QUALITY-TELEMETRY-VISION.md
+++ b/docs/QUALITY-TELEMETRY-VISION.md
@@ -1,0 +1,217 @@
+# Quality Telemetry — Vision
+
+**Date:** 2026-05-25
+**Status:** Discussion brief (для согласования с Codex)
+**Author:** sergey + Claude
+**Scope:** видение системы наблюдения за качеством разработки в MakeIT — три потока сигналов, как их собирать и где визуализировать.
+
+---
+
+## 1. Контекст
+
+Затравкой стала задача: "сделать график чистоты кода Codex по каждому проекту". В процессе brainstorm'а вскрылось, что это лишь **один из трёх** взаимосвязанных сигналов качества разработки, которые сейчас разбросаны по разным местам:
+
+| Сигнал | Что измеряет | Где сейчас данные | Покрытие |
+|---|---|---|---|
+| **A. Codex review density** | % PR с критическими дефектами, замеченными `chatgpt-codex-connector[bot]` | GitHub PR review comments | 100% PR с ботом |
+| **B. CI failure rate** | % пушей в main / % PR где CI упал ≥1 раз | GitHub Actions API | 100% репо с CI |
+| **C. Agent dev errors** | retries/escapes/false-starts в работе AI-агента | `~/.claude/projects/*/transcripts/*.jsonl` (manual) + pipeline `metrics.jsonl` (auto) | Pipeline — да, ручные — **нет** |
+
+**Pipeline уже умеет (C) только для автоматических прогонов:**
+- `metrics_logger.py` пишет per-issue структурный лог в `metrics.jsonl` (25 полей)
+- `quality_signals.py` категоризирует review findings
+- `quality_metrics.py` считает first_pass_rate, retry_rate, cost_per_task, qa_pass_rate
+- `retro_agent.py` делает weekly retro через Claude API (LaunchAgent, воскресенья 20:00)
+- `auto_tuning.py` Tier 1-3 stage self-improvement с replay regression gate
+
+**Слепое пятно:** ручная работа с агентами (CLI-сессии `/makeit-dev`, аудиты, code-review, ad-hoc) **никак не проходит** через эту систему. Lessons не извлекаются, prompt-tuning не получает обратной связи, retro не учитывает половину работы.
+
+## 2. Целевая картина
+
+Дашборд = **визуализатор сигналов**, не их источник. Все три потока сигналов агрегируются на Pipeline Mac (cron'ами или в реальном времени), складываются в JSON-файлы, дашборд их читает и показывает.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Pipeline Mac (sergeymakarov) — Hub агрегации                │
+│  ┌────────────────┐  ┌────────────────┐  ┌─────────────────┐ │
+│  │ A. Codex sweep │  │ B. CI sweep    │  │ C. Agent collect│ │
+│  │ daily 03:00    │  │ daily 03:00    │  │ continuous      │ │
+│  │ → quality.json │  │ → quality.json │  │ → metrics.jsonl │ │
+│  └────────────────┘  └────────────────┘  └─────────────────┘ │
+│                              │                                │
+│                              ▼                                │
+│              ┌───────────────────────────┐                    │
+│              │ retro_agent.py + autotune │                    │
+│              │ (учитывает все 3 потока)  │                    │
+│              └───────────────────────────┘                    │
+└──────────────────────────────────────────────────────────────┘
+                              │ rsync
+                              ▼
+┌──────────────────────────────────────────────────────────────┐
+│ VPS — статика для дашборда                                   │
+│   /data/codex-quality.json    (A + B вместе)                 │
+│   /data/pipeline-kpi.json     (C, агрегаты)                  │
+└──────────────────────────────────────────────────────────────┘
+                              │ HTTPS
+                              ▼
+┌──────────────────────────────────────────────────────────────┐
+│ Dashboard (Browser SPA)                                       │
+│   Вкладка "Качество" — A + B (Codex P1/P2 + CI fail %)       │
+│   Вкладка "Pipeline KPI" — расширить существующую под C      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## 3. Поток A — Codex review density (готов spec)
+
+**Метрика:** `% грязных PR` = `(PR с ≥1 P0/P1/P2 находкой) / (все merged PR в бакете)`. Worst-wins: P0 (BLOCKER) > P1 > P2-only. P0 редкий, но критичный — отдельная pulse-плашка в KPI, в баре объединён с P1 в красный crit-сегмент.
+
+**Архитектура:**
+- Cron на Pipeline Mac в 03:00 Бали (= 19:00 UTC) через launchd.
+- Python-скрипт делает 12 × (2 REST-вызова): `/pulls?state=closed` + `/pulls/comments?since=Y`.
+- Парсит severity из regex `![P(\d) Badge]` (Codex использует только P1/P2).
+- Бакетизирует по `merged_at` (UTC): 30 дневных + 12 недельных бакетов.
+- Worst-wins: PR с обоими P1+P2 → в P1-сегмент (чтобы сумма частей = % грязных без двойного счёта).
+- Атомарная запись JSON + rsync на VPS.
+
+**UI:** новая 9-я вкладка "Качество". Сводный bar-chart + 12 карточек проектов с мини-чартами. Переключатель режима 30d/12w. Healthcheck-баннер если `generated_at` > 30 ч.
+
+**Логика чарта:** высота бара = `total_pr` в бакете (объём работы), стек снизу вверх: P1 (красный) → P2-only (жёлтый) → clean (голубой). Сразу видно объём + долю проблем.
+
+**Цвета:** `--v4-p1` (#EF4444 красный) для P1, `--v4-p2` (#F79009 жёлтый) для P2, `--v4-clean-soft` (#93C5FD голубой) для чистых.
+
+**Спец:** [`docs/superpowers/specs/2026-05-25-codex-quality-tab-design.md`](superpowers/specs/2026-05-25-codex-quality-tab-design.md)
+
+**Прототип:** [`quality-tab-prototype.html`](../quality-tab-prototype.html) (см. в браузере: `localhost:4173/makeit-dashboard/quality-tab-prototype.html`)
+
+## 4. Поток B — CI failure rate (предложение расширить spec A)
+
+**Зачем:** Codex ловит дефекты на ревью, CI ловит дефекты на runtime. Это **разные** failure-модели — нужно видеть обе.
+
+**Метрика:** `% красных PR` = `(PR где ≥1 CI run завершился failure/cancelled) / (все merged PR в бакете)`. Можно дополнительно: `% красных пушей в main` (для post-merge поломок).
+
+**Архитектура:**
+- Та же. Sweep-скрипт на Pipeline Mac в 03:00 Бали расширяется: добавляется запрос `GET /repos/{r}/actions/runs?branch=main&status=completed&created=>=Y` (filter по `conclusion: failure|cancelled`).
+- Те же бакеты, тот же JSON-формат (поле `with_ci_fail` рядом с `with_p1`/`with_p2_only`).
+- UI-паттерн открытый вопрос: либо четвёртый цвет в том же баре (но три+four цветов в одном баре уже трудно читать), либо **отдельный mini-чарт** в той же карточке проекта (CI fail rate отдельной полосой). Я склоняюсь ко второму — каждая метрика на своём чарте, общая ось времени.
+
+**Затраты:** +1 час к sweep-скрипту, +1 цвет/легенда на чарт. Никакой новой инфры.
+
+**Рекомендация:** добавить B в спец A до начала имплементации. Одна вкладка "Качество" = (Codex review density) + (CI failure rate). Логично, что лежит рядом — обе метрики про "что плохого случилось с кодом".
+
+**Open question:** включать ли `% красных пушей в main` отдельной метрикой (post-merge поломки) или только pre-merge CI на PR? Я склоняюсь к **только pre-merge** для v1 — для post-merge у нас уже есть `ci_monitor_runner.py` с auto-revert, отдельная история.
+
+## 5. Поток C — Manual agent telemetry (отдельный большой spec)
+
+**Это самая ценная часть, но самая объёмная.** Не делать в одном спеке с A+B.
+
+### 5.1 Что есть сейчас (pipeline batch-runs)
+
+Когда работает `phase_executor.py` в auto-режиме, всё логируется:
+- `metrics.jsonl` — 25 полей per issue (phase, duration, retries, cost, verdict, ...)
+- `timeline_logger.py` — per-issue timeline
+- `quality_signals.py` — категоризация review findings
+- `retro_agent.py` — weekly retro
+
+Это работает. Tier 1-3 auto-tuning двигает prompts на основе этих данных.
+
+### 5.2 Чего нет (manual sessions)
+
+Когда я (или ты) запускает Claude Code вручную (`claude` в терминале, `/makeit-dev` skill, `/makeit-codereview`, аудиты, ad-hoc вопросы):
+- Claude Code пишет transcript в `~/.claude/projects/<project-slug>/transcripts/<session-id>.jsonl` (это **факт** на основе Claude Code session-management).
+- Содержимое: каждый user/assistant message, tool calls, tool results, errors, hook outputs.
+- НИКТО эту телеметрию не агрегирует. Lessons теряются. Retro их не видит.
+
+### 5.3 Что нужно сделать
+
+**Backend (в pipeline-репо, не в dashboard):**
+- Новый модуль `manual_session_ingester.py`:
+  - Сканирует `~/.claude/projects/*/transcripts/*.jsonl` (ежечасно cron'ом)
+  - Парсит каждую сессию: tool calls, errors, retries-патерны (повторные Edit на тот же файл = коррекция), abandoned tasks (user interrupt), explicit corrections ("нет, не так", "stop", "это не работает")
+  - Категоризирует через keyword/LLM: успех / частичный успех / провал / прерывание
+  - Извлекает session_metadata: какой skill использовался (`/makeit-dev`, `/makeit-codereview`...), какой репо, длительность, стоимость токенов (из transcript headers)
+  - Пишет в общий `metrics.jsonl` (расширенная схема: `source: "manual" | "pipeline"`) или в отдельный `manual_metrics.jsonl` (проще — не ломает существующий формат)
+- Расширить `retro_agent.py` чтобы он видел оба источника.
+- Расширить `quality_metrics.py` чтобы first_pass_rate / retry_rate считались по обоим.
+- AutoTuner (Tier 1-3) автоматически получает больше сигнала.
+
+**Frontend (в dashboard):**
+- Расширить (или создать) вкладку "Pipeline KPI" — показывать суммарные метрики из manual + pipeline:
+  - First-pass rate (manual vs pipeline)
+  - Retry rate
+  - Cost per task (с делением)
+  - Top 5 skill-сессий с наибольшим retry rate (где prompt-tuning имеет максимум ценности)
+  - Top 5 "проваленных тем" по retro
+
+### 5.4 Сложности
+
+- **Privacy:** transcripts содержат всё что мы обсуждаем. Парсер должен жить **локально** на Pipeline Mac, не отправлять raw в облако. Только агрегаты в JSON.
+- **Категоризация:** "успех" vs "провал" нетривиально определить из transcript'а. Эвристики (длительность, # retries, наличие explicit "спасибо/готово" в конце) + LLM-классификация для нерешённых случаев.
+- **Объём:** transcripts могут быть огромными (мегабайты). Sweep должен быть инкрементальным (по mtime).
+- **Schema migration:** существующий `metrics.jsonl` уже мигрировал 10→25 полей (`metrics_migrator.py`). Добавление source-поля — ещё одна миграция.
+- **Связь с GitHub Issue:** для pipeline-runs всегда есть `issue_number`. Для ручных сессий — иногда (если skill упомянул #N), иногда нет. Нужно либо требовать `#N` в первом сообщении, либо мириться с "сессии без привязки к issue".
+
+### 5.5 Estimated work
+
+- Backend (ingester + retro extension): ~12-16 часов
+- Frontend (KPI вкладка): ~6-8 часов
+- Privacy + schema migration: ~4 часа
+- **Итого: 22-28 часов**. Отдельный эпик.
+
+## 6. Annotations (event markers на чарте)
+
+**Зачем:** без аннотаций ты увидишь "качество упало неделю назад", но не свяжешь это с причиной — "потому что я обновил `/makeit-dev` и AutoTuner поднял Tier-2 промпт". Аннотации — это **причинно-следственная корреляция** между интервенциями в систему разработки и её результатом.
+
+**Фаза 1 (в скоупе текущего spec'а A) — ручные аннотации:**
+- UI: кнопка "+ событие" в Quality-вкладке → модалка дата/категория/описание
+- 3 категории: `skill` (синий), `deploy` (зелёный), `manual` (фиолетовый)
+- Storage: `/data/annotations.json` рядом с `codex-quality.json` на VPS
+- Backend: `POST/DELETE /annotations` на Pipeline FastAPI
+- UI: вертикальные пунктирные линии на сводном графике + dot сверху + tooltip
+
+**Фаза 2 (отдельный issue в `makeit-pipeline`-репо) — auto-events из 3 источников:**
+
+| Источник | Что даёт | Реализация |
+|---|---|---|
+| **`prompt_versioning.py`** | Каждый bump промпта auto-tuner'ом = маркер с категорией `auto-tune`, цвет orange, описание включает diff hash | Sweep-cron читает `~/.makeit-pipeline/prompts/versions.jsonl`, мержит с manual в общий feed |
+| **Git log на `~/.claude/skills/*/SKILL.md`** | Каждый коммит в файл скилла = маркер `skill-edit`. Title берётся из commit message, desc — из diff stat | Sweep-cron делает `git -C ~/.claude/skills/<name> log --since=Y --format=...`, парсит |
+| **Git log на `lessons-learned.md`** | Каждый коммит → новая lesson, влияющая на retro_agent | Аналогично |
+
+**Слияние:** financial-events-style merge — annotations sorted by date, near-duplicates (same day, same category) auto-grouped в один маркер с расширенным tooltip "5 событий 13.04".
+
+**Связь с pipeline self-improvement loop:**
+- AutoTuner ставит маркер ДО изменения промпта
+- Через 7 дней `retro_agent` считает delta-метрик "до/после маркера"
+- Если delta negative > threshold → **auto-rollback** + новый маркер `rollback`
+- В UI ты видишь полный жизненный цикл: маркер изменения → маркер отката, с пояснением
+
+Это превращает Quality-вкладку из "пассивного дашборда" в **петлю обратной связи для самообучения системы**.
+
+## 7. Рекомендуемая последовательность
+
+1. **Сейчас:** доделать спец A (Codex Quality tab + аннотации Фаза 1 + CI fail %). Один спец, один cron, одна вкладка "Качество". **~14-16 часов.**
+2. **Дальше (отдельный спец в `makeit-pipeline`-репо):** Фаза 2 аннотаций — auto-events из prompt_versioning, git log skills, git log lessons. **~6-8 часов.**
+3. **После того как Фаза 2 готова:** интеграция в `retro_agent` — auto-rollback на основе delta после маркеров. **~12-16 часов, новый эпик.**
+4. **Параллельно (отдельный спец):** `manual_session_ingester` — телеметрия ручной работы с агентами (см. п.5 ниже).
+5. **Финал:** новая вкладка "Pipeline KPI" в dashboard — визуализирует pipeline-метрики из обоих источников (auto + manual).
+
+**Почему так:**
+- A+B дают видимый результат за день — это мотивация и сразу полезно.
+- C дольше и рискованнее — лучше делать когда A+B уже работают и есть рабочий паттерн "cron → JSON → dashboard".
+- C должно жить в pipeline-репо, чтобы не размывать ответственность (dashboard = view, pipeline = capture+analyse+tune).
+
+## 7. Open questions для Codex
+
+1. **(B) Метрика CI:** `% PR где CI упал ≥1 раз` vs `% PR с финальным CI failure`. Первое чувствительнее (видишь "грязный код, который пришлось чинить"), второе — итог. Что больше говорит о качестве?
+2. **(B) Включать ли `% красных пушей в main`** (post-merge поломки) как отдельную метрику в v1, или это уже задача `ci_monitor_runner.py`?
+3. **(C) Категоризация manual session:** делать keyword-based (быстро, дёшево, неточно) или сразу LLM-based (медленнее, дороже, точнее)? Может, гибрид — keyword pre-filter, LLM только для unclear cases?
+4. **(C) Источник truth для skill-name:** парсить из первого ассистент-сообщения (`Skill('...')` calls), или требовать чтобы пользователь явно указывал в первом prompt'е?
+5. **(C) Что делать с сессиями без `#N`:** считать "ad-hoc" отдельным бакетом, или игнорировать вообще? Я склоняюсь к **отдельный бакет** — там тоже могут быть retry-patterns.
+6. **(C) Privacy boundary:** если ingester живёт на Pipeline Mac, и Pipeline Mac уже SSH-тоннелится к VPS — есть теоретический риск утечки transcript'а через тоннель. Хотим ли мы добавить локальный allowlist (только агрегаты, raw text никогда не покидает Mac)?
+7. **(всё) Где визуализировать:** одна общая вкладка "Качество разработки" с тремя секциями (Codex / CI / Pipeline) vs три отдельные вкладки. Я за **одну** для дашборда — меньше когнитивная нагрузка. Но это требует чтобы все 3 потока имели сопоставимые временные оси.
+
+## 8. Что НЕ обсуждали и сознательно отрезали
+
+- **Тип категоризации Codex** (security/perf/bug) — Codex сам не даёт, парсить из текста дорого, ценность под вопросом.
+- **Сравнение между проектами с весом по сложности** — нет надёжного способа нормализовать "проект X хуже потому что код сложнее".
+- **Алёрты** в Telegram/Slack — есть `notifier.py` в pipeline, можно подключить позже; не для v1.
+- **Историческая глубина >12 недель** — текущий sweep смотрит на 90 дней. Для исторической депти нужна отдельная БД или индексация старых JSON. Не для v1.

--- a/docs/superpowers/plans/2026-05-25-codex-quality-tab.md
+++ b/docs/superpowers/plans/2026-05-25-codex-quality-tab.md
@@ -1,0 +1,3005 @@
+# Codex Quality Tab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Реализовать новую 9-ю вкладку «Качество кода и изменения» в makeit-dashboard, показывающую динамику качества кода (**P0/P1/P2** находки Codex с worst-wins) и события на временной оси (skill-changes, deploys, manual) по 12 MakeIT-репо. Данные — daily-cron sweep на Pipeline Mac → JSON → nginx статика → React-SPA. P0 (BLOCKER) выделен отдельной pulse-плашкой в KPI, в баре объединён с P1 в красный crit-сегмент.
+
+**Architecture:**
+- **Backend** (репо `makeit-pipeline`): Python-скрипт `codex_quality_sweep.py` запускается launchd ежедневно в 19:00 UTC (= 03:00 Бали), тянет PR'ы и review-комменты через GitHub REST API из 12 репо, агрегирует в JSON, публикует на VPS через rsync `.tmp` + ssh `mv` (atomic). FastAPI endpoints `/quality/refresh`, `/annotations`, `/annotations/{id}` на том же сервисе. Локинг через `flock`. Retry с уважением `X-RateLimit-Reset`.
+- **VPS**: nginx отдаёт `/data/codex-quality.json` и `/data/annotations.json` как статику.
+- **Frontend** (репо `makeit-dashboard`): React 19 + TS, новая вкладка `<QualityTab>` с подкомпонентами для сводного чарта, KPI, грида карточек проектов, маркеров аннотаций, healthcheck-баннера. Hover-language идентичный для главного и mini-чартов (dim siblings + halo + value-chip + tooltip).
+
+**Tech Stack:**
+- Backend: Python 3.11, httpx, FastAPI, python-dotenv, pytest, fcntl/launchd (macOS)
+- Frontend: React 19, TypeScript, Vite, Vitest, существующие utils (`config.ts`, `settings.ts`)
+- Infra: rsync over SSH, nginx, Docker (на VPS, уже развёрнут)
+
+**Спец:** [`docs/superpowers/specs/2026-05-25-codex-quality-tab-design.md`](../specs/2026-05-25-codex-quality-tab-design.md) — v2, после Codex code-review.
+**Прототип:** [`quality-tab-prototype.html`](../../../quality-tab-prototype.html) — визуальный референс с моками.
+**Vision:** [`docs/QUALITY-TELEMETRY-VISION.md`](../../QUALITY-TELEMETRY-VISION.md) — общая картина с CI fail % (Phase B) и agent telemetry (Phase C) — НЕ в скоупе этого плана.
+
+---
+
+## File Structure
+
+### Repo `makeit-pipeline` (Pipeline Mac)
+```
+config/
+  quality_repos.json                          # NEW: source of truth для списка репо
+src/makeit_pipeline/
+  api.py                                       # MODIFY: добавить /quality/refresh + /annotations*
+  quality/
+    __init__.py                               # NEW
+    types.py                                   # NEW: Pydantic-модели (Bucket, RepoStatus, Payload, AnnotationCreate)
+    severity.py                                # NEW: parse_severity, group_findings_per_pr
+    bucketize.py                               # NEW: bucketize, aggregate_summary, low-sample logic
+    fetch.py                                   # NEW: fetch_repo_merged_prs, fetch_repo_review_comments, request_with_retry
+    publish.py                                 # NEW: write_json_atomic_local, publish_remote_atomic
+    locking.py                                 # NEW: acquire_lock context manager
+    annotations.py                             # NEW: load/save/add/delete annotations
+    sweep.py                                   # NEW: главная orchestration (main entry-point)
+tests/quality/
+  test_severity.py                            # NEW
+  test_bucketize.py                           # NEW
+  test_fetch.py                               # NEW (httpx mocks)
+  test_publish.py                             # NEW
+  test_annotations.py                         # NEW
+  test_sweep_integration.py                   # NEW (фикстура с моком GH API)
+scripts/
+  codex_quality_sweep.py                      # NEW: CLI entry-point (вызывает sweep.main())
+deploy/launchd/
+  com.makeit.codex-quality-sweep.plist        # NEW
+```
+
+### VPS (`/opt/apps/`)
+```
+nginx-proxy/conf.d/makeit.conf                # MODIFY: добавить location /data/
+makeit-stack/web/data/                        # NEW dir: куда rsync кладёт JSON
+```
+
+### Repo `makeit-dashboard`
+```
+public/config.js                              # MODIFY: добавить QUALITY_URL (optional)
+src/
+  types/quality.ts                            # NEW: TypeScript типы (QualityPayload, Annotation, и т.д.)
+  utils/
+    quality.ts                                # NEW: fetchQualityData, forceRefresh, annotation CRUD
+    quality-position.ts                       # NEW: isoMonday, annotation-position-calc (pure functions)
+  hooks/
+    useQuality.ts                             # NEW
+  components/quality/
+    QualityTab.tsx                            # NEW: orchestrator
+    QualitySummaryPanel.tsx                   # NEW: верхний блок (chart + KPI)
+    QualityChart.tsx                          # NEW: bar-chart (compact prop для миничартов)
+    QualityKPIs.tsx                           # NEW: 4 KPI-карточки
+    QualityProjectCard.tsx                    # NEW: один проект с мини-чартом
+    QualityProjectGrid.tsx                    # NEW: grid + sort
+    QualityAnnotations.tsx                    # NEW: вертикальные маркеры
+    QualityStaleBanner.tsx                    # NEW: healthcheck
+    AnnotationModal.tsx                       # NEW: + событие
+  styles/
+    v4-quality.css                            # NEW: все стили вкладки (импортируется в App.tsx)
+  App.tsx                                     # MODIFY: добавить 9-ю вкладку и Suspense-loader
+tests/quality/
+  quality-position.test.ts                    # NEW: isoMonday + position-math
+  useQuality.test.tsx                         # NEW
+  QualityChart.test.tsx                       # NEW
+  AnnotationModal.test.tsx                    # NEW
+```
+
+---
+
+## Phase A — Backend foundation (pure logic, no GitHub yet)
+
+### Task 1: Setup `quality_repos.json` config
+
+**Repo:** `makeit-pipeline`
+
+**Files:**
+- Create: `config/quality_repos.json`
+
+- [ ] **Step 1: Создать конфиг с 14 репо**
+
+```json
+{
+  "owner": "Sergio1990-1",
+  "repos": [
+    "Sewing-ERP", "mankassa-app", "solotax-kg", "Business-News",
+    "Beer_bot", "Uchet_bot", "quiet-walls", "moliyakg",
+    "MyMoney", "makeit-auditor", "makeit-pipeline", "makeit-dashboard",
+    "makeit-knowledge", "MetaSellerSupplies"
+  ],
+  "_comment": "Source of truth для quality sweep. Sync вручную с ~/.claude/CLAUDE.md."
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add config/quality_repos.json
+git commit -m "feat(quality): add repo config for codex quality sweep"
+```
+
+---
+
+### Task 2: Severity parsing
+
+**Repo:** `makeit-pipeline`
+
+**Files:**
+- Create: `src/makeit_pipeline/quality/__init__.py` (empty)
+- Create: `src/makeit_pipeline/quality/severity.py`
+- Create: `tests/quality/__init__.py` (empty)
+- Create: `tests/quality/test_severity.py`
+
+- [ ] **Step 1: Failing test for parse_severity**
+
+`tests/quality/test_severity.py`:
+```python
+from makeit_pipeline.quality.severity import parse_severity, group_findings_per_pr
+
+def test_parse_p1():
+    body = "**<sub><sub>![P1 Badge](https://example.com/p1.svg)</sub></sub> Security issue**\n\nSQL injection"
+    assert parse_severity(body) == "P1"
+
+def test_parse_p2():
+    body = "![P2 Badge](url) some text"
+    assert parse_severity(body) == "P2"
+
+def test_parse_no_badge():
+    assert parse_severity("just a regular comment") is None
+
+def test_parse_p3_returns_p3_even_if_codex_doesnt_use():
+    # graceful — пусть парсер вернёт что есть, фильтрация выше
+    assert parse_severity("![P3 Badge](url)") == "P3"
+
+def test_parse_p0():
+    """Codex реально emit'ит P0 для блокеров (например moliyakg#2282 — DB constraint).
+    Badge URL: https://img.shields.io/badge/P0-red?style=flat"""
+    body = "**<sub><sub>![P0 Badge](https://img.shields.io/badge/P0-red?style=flat)</sub></sub> Populate snapshot...**"
+    assert parse_severity(body) == "P0"
+
+def test_group_findings_per_pr_combines_overlapping_severities():
+    comments = [
+        {"pull_request_url": "...repos/X/pulls/1", "body": "![P0 Badge]() ..."},
+        {"pull_request_url": "...repos/X/pulls/1", "body": "![P1 Badge]() ..."},
+        {"pull_request_url": "...repos/X/pulls/1", "body": "![P2 Badge]() ..."},
+        {"pull_request_url": "...repos/X/pulls/2", "body": "![P1 Badge]() ..."},
+        {"pull_request_url": "...repos/X/pulls/2", "body": "![P2 Badge]() ..."},
+        {"pull_request_url": "...repos/X/pulls/3", "body": "![P2 Badge]() ..."},
+    ]
+    result = group_findings_per_pr(comments)
+    assert result == {
+        "...repos/X/pulls/1": {"has_p0": True,  "has_p1": True,  "has_p2": True},
+        "...repos/X/pulls/2": {"has_p0": False, "has_p1": True,  "has_p2": True},
+        "...repos/X/pulls/3": {"has_p0": False, "has_p1": False, "has_p2": True},
+    }
+
+def test_group_findings_ignores_non_p012():
+    comments = [{"pull_request_url": "...pulls/1", "body": "nitpick"}]
+    assert group_findings_per_pr(comments) == {}
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+`pytest tests/quality/test_severity.py -v` → ImportError.
+
+- [ ] **Step 3: Implementation**
+
+`src/makeit_pipeline/quality/severity.py`:
+```python
+import re
+from collections import defaultdict
+
+SEV_RE = re.compile(r"!\[P(\d) Badge\]")
+SUPPORTED_SEVERITIES = ("P0", "P1", "P2")  # P3 Codex не использует, но фильтруем явно
+
+
+def parse_severity(body: str) -> str | None:
+    """Извлечь severity из markdown-комментария Codex. None если бейджа нет.
+    Поддерживает P0 (red, BLOCKER), P1 (orange, high), P2 (yellow, medium)."""
+    m = SEV_RE.search(body or "")
+    return f"P{m.group(1)}" if m else None
+
+
+def group_findings_per_pr(comments: list[dict]) -> dict[str, dict]:
+    """Сгруппировать line-level комменты по PR. 3 уровня severity flags.
+    Worst-wins reasoning происходит в bucketize (with_p0 absorbs P1+P2 of same PR)."""
+    result: dict[str, dict] = defaultdict(lambda: {"has_p0": False, "has_p1": False, "has_p2": False})
+    for c in comments:
+        sev = parse_severity(c.get("body", ""))
+        if sev not in SUPPORTED_SEVERITIES:
+            continue
+        pr_url = c.get("pull_request_url", "")
+        if not pr_url:
+            continue
+        key = sev.lower().replace("p", "has_p")  # "P0" → "has_p0"
+        result[pr_url][key] = True
+    return dict(result)
+```
+
+- [ ] **Step 4: Run, verify PASS**
+
+`pytest tests/quality/test_severity.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/makeit_pipeline/quality/__init__.py src/makeit_pipeline/quality/severity.py tests/quality/
+git commit -m "feat(quality): parse P1/P2 severity from Codex review comments"
+```
+
+---
+
+### Task 3: Bucketize + low-sample
+
+**Repo:** `makeit-pipeline`
+
+**Files:**
+- Create: `src/makeit_pipeline/quality/bucketize.py`
+- Create: `tests/quality/test_bucketize.py`
+
+- [ ] **Step 1: Failing tests**
+
+`tests/quality/test_bucketize.py`:
+```python
+from datetime import datetime, timezone
+from makeit_pipeline.quality.bucketize import (
+    bucketize_daily, bucketize_weekly_iso, aggregate_summary, LOW_SAMPLE_THRESHOLD,
+)
+
+
+def _utc(s):
+    return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+
+def test_bucketize_daily_30_buckets():
+    prs = [
+        {"merged_at": "2026-05-20T10:00:00Z", "url": "p_blocker"},   # P0
+        {"merged_at": "2026-05-20T15:00:00Z", "url": "p_p1_p2"},     # P1 (worst-wins absorbs P2)
+        {"merged_at": "2026-05-20T18:00:00Z", "url": "p_p2_only"},   # P2 only
+        {"merged_at": "2026-05-24T00:01:00Z", "url": "p_clean"},     # no findings
+    ]
+    findings = {
+        "p_blocker":   {"has_p0": True,  "has_p1": True, "has_p2": True},   # worst-wins → with_p0
+        "p_p1_p2":     {"has_p0": False, "has_p1": True, "has_p2": True},   # worst-wins → with_p1_only
+        "p_p2_only":   {"has_p0": False, "has_p1": False, "has_p2": True},
+    }
+    today = _utc("2026-05-25T12:00:00")
+    buckets, labels = bucketize_daily(prs, findings, today, n=30)
+    assert len(buckets) == 30
+    assert labels[-1] == "2026-05-25"
+    # 20.05 bar: 3 PR — 1 P0, 1 P1-only, 1 P2-only
+    b = buckets[-6]
+    assert b == {"total_pr": 3, "with_p0": 1, "with_p1_only": 1, "with_p2_only": 1}
+
+
+def test_bucketize_weekly_iso_aligns_to_monday():
+    # PR merged on Wed 13 May 2026 → должен попасть в неделю с пн 11 May
+    prs = [{"merged_at": "2026-05-13T08:00:00Z", "url": "p1"}]
+    today = _utc("2026-05-25T12:00:00")  # Mon
+    buckets, labels = bucketize_weekly_iso(prs, {}, today, n=12)
+    assert len(buckets) == 12
+    # Последняя метка — текущая неделя (пн 25 May)
+    assert labels[-1] == "2026-05-25"
+    # Неделя с 11 May = индекс labels.index("2026-05-11")
+    idx = labels.index("2026-05-11")
+    assert buckets[idx]["total_pr"] == 1
+
+
+def test_aggregate_summary_excludes_errored_repos():
+    per_repo_buckets = {
+        "ok-repo":  [{"total_pr": 5, "with_p0": 0, "with_p1_only": 1, "with_p2_only": 0}],
+        "bad-repo": [{"total_pr": 10, "with_p0": 0, "with_p1_only": 0, "with_p2_only": 0}],  # фейк нулей
+    }
+    repo_status = {"ok-repo": "ok", "bad-repo": "error"}
+    summary = aggregate_summary(per_repo_buckets, repo_status)
+    assert summary == [{"total_pr": 5, "with_p0": 0, "with_p1_only": 1, "with_p2_only": 0}]
+
+
+def test_low_sample_threshold_constant():
+    assert LOW_SAMPLE_THRESHOLD == 8
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+`pytest tests/quality/test_bucketize.py -v` → ImportError.
+
+- [ ] **Step 3: Implementation**
+
+`src/makeit_pipeline/quality/bucketize.py`:
+```python
+from datetime import datetime, timedelta, timezone
+from typing import Iterable
+
+LOW_SAMPLE_THRESHOLD = 8
+
+
+def _iso_monday_utc(dt: datetime) -> datetime:
+    """Понедельник ISO-недели в UTC, обрезанный до полуночи."""
+    d = dt.astimezone(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    # weekday(): пн=0, вт=1, ..., вс=6
+    return d - timedelta(days=d.weekday())
+
+
+def _parse_merged(pr: dict) -> datetime:
+    return datetime.fromisoformat(pr["merged_at"].replace("Z", "+00:00"))
+
+
+def _empty_bucket() -> dict:
+    return {"total_pr": 0, "with_p0": 0, "with_p1_only": 0, "with_p2_only": 0}
+
+
+def _update_bucket(b: dict, finding: dict | None):
+    """Worst-wins: P0 > P1 > P2-only. PR с P0+P1+P2 учитывается только в with_p0."""
+    b["total_pr"] += 1
+    if not finding:
+        return
+    if finding.get("has_p0"):
+        b["with_p0"] += 1
+    elif finding.get("has_p1"):
+        b["with_p1_only"] += 1
+    elif finding.get("has_p2"):
+        b["with_p2_only"] += 1
+
+
+def bucketize_daily(prs: list[dict], findings: dict, today: datetime, n: int = 30):
+    """n дневных бакетов оканчивая сегодняшним днём (UTC). Возвращает (buckets, labels)."""
+    today_utc = today.astimezone(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    starts = [today_utc - timedelta(days=n - 1 - i) for i in range(n)]
+    labels = [s.strftime("%Y-%m-%d") for s in starts]
+    buckets = [_empty_bucket() for _ in range(n)]
+    for pr in prs:
+        m = _parse_merged(pr)
+        m_day = m.astimezone(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        idx = (m_day - starts[0]).days
+        if 0 <= idx < n:
+            _update_bucket(buckets[idx], findings.get(pr["url"]))
+    return buckets, labels
+
+
+def bucketize_weekly_iso(prs: list[dict], findings: dict, today: datetime, n: int = 12):
+    """n ISO-недель оканчивая текущей (понедельник). Возвращает (buckets, labels)."""
+    today_mon = _iso_monday_utc(today)
+    starts = [today_mon - timedelta(weeks=n - 1 - i) for i in range(n)]
+    labels = [s.strftime("%Y-%m-%d") for s in starts]
+    buckets = [_empty_bucket() for _ in range(n)]
+    for pr in prs:
+        m = _parse_merged(pr)
+        pr_mon = _iso_monday_utc(m)
+        idx = (pr_mon - starts[0]).days // 7
+        if 0 <= idx < n:
+            _update_bucket(buckets[idx], findings.get(pr["url"]))
+    return buckets, labels
+
+
+def aggregate_summary(per_repo_buckets: dict[str, list[dict]],
+                      repo_status: dict[str, str]) -> list[dict]:
+    """Суммировать buckets из ОК-репо (исключая error). Иначе summary занизит dirty rate."""
+    ok_repos = [r for r, s in repo_status.items() if s == "ok" and r in per_repo_buckets]
+    if not ok_repos:
+        return []
+    n = len(per_repo_buckets[ok_repos[0]])
+    summary = [_empty_bucket() for _ in range(n)]
+    for repo in ok_repos:
+        for i, b in enumerate(per_repo_buckets[repo]):
+            summary[i]["total_pr"]     += b["total_pr"]
+            summary[i]["with_p0"]      += b["with_p0"]
+            summary[i]["with_p1_only"] += b["with_p1_only"]
+            summary[i]["with_p2_only"] += b["with_p2_only"]
+    return summary
+```
+
+- [ ] **Step 4: Run, verify PASS**
+
+`pytest tests/quality/test_bucketize.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/makeit_pipeline/quality/bucketize.py tests/quality/test_bucketize.py
+git commit -m "feat(quality): bucketize PRs by day/ISO-week + summary excludes errored repos"
+```
+
+---
+
+### Task 4: Atomic local + remote publish
+
+**Repo:** `makeit-pipeline`
+
+**Files:**
+- Create: `src/makeit_pipeline/quality/publish.py`
+- Create: `tests/quality/test_publish.py`
+
+- [ ] **Step 1: Failing tests**
+
+`tests/quality/test_publish.py`:
+```python
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from makeit_pipeline.quality.publish import write_json_atomic_local, publish_remote_atomic
+
+
+def test_write_json_atomic_local_creates_file(tmp_path):
+    target = tmp_path / "x.json"
+    write_json_atomic_local(target, {"a": 1})
+    assert json.loads(target.read_text()) == {"a": 1}
+
+
+def test_write_json_atomic_local_does_not_leave_tmp(tmp_path):
+    target = tmp_path / "x.json"
+    write_json_atomic_local(target, {"a": 1})
+    assert not (tmp_path / "x.json.tmp").exists()
+
+
+def test_write_json_atomic_local_overwrites_existing(tmp_path):
+    target = tmp_path / "x.json"
+    target.write_text('{"old": true}')
+    write_json_atomic_local(target, {"new": True})
+    assert json.loads(target.read_text()) == {"new": True}
+
+
+@patch("makeit_pipeline.quality.publish.subprocess.run")
+def test_publish_remote_atomic_uses_tmp_then_mv(mock_run, tmp_path):
+    mock_run.return_value = MagicMock(returncode=0)
+    local = tmp_path / "q.json"
+    local.write_text("{}")
+    publish_remote_atomic(local, remote_host="vps", remote_dir="/opt/data")
+    # Проверяем что было 2 вызова: rsync + ssh mv
+    assert mock_run.call_count == 2
+    rsync_args = mock_run.call_args_list[0][0][0]
+    assert rsync_args[0] == "rsync"
+    assert rsync_args[-1].endswith(".codex-quality.json.tmp")
+    ssh_args = mock_run.call_args_list[1][0][0]
+    assert ssh_args[0] == "ssh"
+    assert "mv" in ssh_args[2]
+    assert ".codex-quality.json.tmp" in ssh_args[2]
+    assert "codex-quality.json" in ssh_args[2]
+
+
+@patch("makeit_pipeline.quality.publish.subprocess.run")
+def test_publish_raises_on_rsync_failure(mock_run, tmp_path):
+    import subprocess
+    mock_run.side_effect = subprocess.CalledProcessError(1, "rsync")
+    local = tmp_path / "q.json"; local.write_text("{}")
+    import pytest
+    with pytest.raises(subprocess.CalledProcessError):
+        publish_remote_atomic(local, remote_host="vps", remote_dir="/opt/data")
+```
+
+- [ ] **Step 2: Run, FAIL**
+
+`pytest tests/quality/test_publish.py -v` → ImportError.
+
+- [ ] **Step 3: Implementation**
+
+`src/makeit_pipeline/quality/publish.py`:
+```python
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+REMOTE_TMP_NAME = ".codex-quality.json.tmp"
+REMOTE_FINAL_NAME = "codex-quality.json"
+
+
+def write_json_atomic_local(target: Path, data: Any) -> None:
+    """Запись JSON через .tmp + os.replace (POSIX atomic rename на одном FS)."""
+    target = Path(target)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+    os.replace(tmp, target)
+
+
+def publish_remote_atomic(local_path: Path, *, remote_host: str, remote_dir: str,
+                          tmp_name: str = REMOTE_TMP_NAME,
+                          final_name: str = REMOTE_FINAL_NAME) -> None:
+    """rsync файл в .tmp на remote → ssh mv в final.
+    Без этого nginx может вернуть половину файла во время rsync."""
+    remote_tmp = f"{remote_dir.rstrip('/')}/{tmp_name}"
+    remote_final = f"{remote_dir.rstrip('/')}/{final_name}"
+    subprocess.run(
+        ["rsync", "-e", "ssh", str(local_path), f"{remote_host}:{remote_tmp}"],
+        check=True,
+    )
+    subprocess.run(
+        ["ssh", remote_host, f"mv {remote_tmp} {remote_final}"],
+        check=True,
+    )
+```
+
+- [ ] **Step 4: Run, PASS**
+
+`pytest tests/quality/test_publish.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/makeit_pipeline/quality/publish.py tests/quality/test_publish.py
+git commit -m "feat(quality): atomic local JSON write + remote publish via rsync .tmp + ssh mv"
+```
+
+---
+
+### Task 5: Locking
+
+**Repo:** `makeit-pipeline`
+
+**Files:**
+- Create: `src/makeit_pipeline/quality/locking.py`
+- Append to: `tests/quality/test_publish.py` (logical grouping — locking is publish-related)
+
+- [ ] **Step 1: Failing tests**
+
+Append to `tests/quality/test_publish.py`:
+```python
+import pytest
+from makeit_pipeline.quality.locking import acquire_lock, SweepAlreadyRunning
+
+
+def test_acquire_lock_works_first_time(tmp_path):
+    lock = tmp_path / "test.lock"
+    with acquire_lock(lock):
+        assert lock.exists()
+
+
+def test_acquire_lock_blocks_second_attempt(tmp_path):
+    lock = tmp_path / "test.lock"
+    with acquire_lock(lock):
+        with pytest.raises(SweepAlreadyRunning):
+            with acquire_lock(lock):
+                pass
+
+
+def test_acquire_lock_releases_on_exit(tmp_path):
+    lock = tmp_path / "test.lock"
+    with acquire_lock(lock):
+        pass
+    # После выхода — должен быть свободен
+    with acquire_lock(lock):
+        pass  # не упадёт
+```
+
+- [ ] **Step 2: Run, FAIL**
+
+`pytest tests/quality/test_publish.py::test_acquire_lock_works_first_time -v` → ImportError.
+
+- [ ] **Step 3: Implementation**
+
+`src/makeit_pipeline/quality/locking.py`:
+```python
+import fcntl
+from contextlib import contextmanager
+from pathlib import Path
+
+
+class SweepAlreadyRunning(Exception):
+    """Поднимается если кто-то уже держит exclusive lock."""
+
+
+@contextmanager
+def acquire_lock(lock_path: Path):
+    """Exclusive flock на файл. Освобождается на выходе из context'а.
+    Используется и cron'ом, и /quality/refresh endpoint'ом."""
+    lock_path = Path(lock_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    f = open(lock_path, "w")
+    try:
+        fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as e:
+        f.close()
+        raise SweepAlreadyRunning(f"Lock {lock_path} уже взят другим процессом") from e
+    try:
+        yield
+    finally:
+        fcntl.flock(f, fcntl.LOCK_UN)
+        f.close()
+```
+
+- [ ] **Step 4: Run, PASS**
+
+`pytest tests/quality/test_publish.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/makeit_pipeline/quality/locking.py tests/quality/test_publish.py
+git commit -m "feat(quality): flock-based locking for sweep + force-refresh"
+```
+
+---
+
+## Phase B — GitHub fetch
+
+### Task 6: Request with rate-limit-aware retry
+
+**Repo:** `makeit-pipeline`
+
+**Files:**
+- Create: `src/makeit_pipeline/quality/fetch.py`
+- Create: `tests/quality/test_fetch.py`
+
+- [ ] **Step 1: Failing tests**
+
+`tests/quality/test_fetch.py`:
+```python
+import time
+from unittest.mock import patch, MagicMock
+import pytest
+from makeit_pipeline.quality.fetch import request_with_retry
+
+
+def _resp(status, headers=None, json_data=None):
+    r = MagicMock()
+    r.status_code = status
+    r.headers = headers or {}
+    r.json.return_value = json_data or []
+    return r
+
+
+@patch("makeit_pipeline.quality.fetch.httpx.request")
+def test_success_first_try(mock_req):
+    mock_req.return_value = _resp(200, json_data=[{"id": 1}])
+    r = request_with_retry("GET", "https://example/x")
+    assert r.status_code == 200
+    assert mock_req.call_count == 1
+
+
+@patch("makeit_pipeline.quality.fetch.time.sleep")
+@patch("makeit_pipeline.quality.fetch.httpx.request")
+def test_retries_on_429_with_retry_after(mock_req, mock_sleep):
+    mock_req.side_effect = [
+        _resp(429, headers={"Retry-After": "2"}),
+        _resp(200, json_data=[]),
+    ]
+    request_with_retry("GET", "https://example/x")
+    assert mock_req.call_count == 2
+    # Должны были подождать минимум 2с + jitter < 4с
+    args = mock_sleep.call_args[0][0]
+    assert 2 <= args <= 4
+
+
+@patch("makeit_pipeline.quality.fetch.time.sleep")
+@patch("makeit_pipeline.quality.fetch.time.time")
+@patch("makeit_pipeline.quality.fetch.httpx.request")
+def test_retries_on_403_with_rate_limit_reset(mock_req, mock_now, mock_sleep):
+    mock_now.return_value = 1_000_000
+    mock_req.side_effect = [
+        _resp(403, headers={"X-RateLimit-Reset": "1000003"}),  # reset через 3с
+        _resp(200),
+    ]
+    request_with_retry("GET", "https://example/x")
+    args = mock_sleep.call_args[0][0]
+    assert 3 <= args <= 5
+
+
+@patch("makeit_pipeline.quality.fetch.time.sleep")
+@patch("makeit_pipeline.quality.fetch.httpx.request")
+def test_retries_on_5xx_with_expo_backoff(mock_req, mock_sleep):
+    mock_req.side_effect = [_resp(503), _resp(503), _resp(200)]
+    request_with_retry("GET", "https://example/x")
+    # 2 sleep'а: ~1с, ~2с (+jitter)
+    assert mock_sleep.call_count == 2
+    assert 1 <= mock_sleep.call_args_list[0][0][0] <= 2
+    assert 2 <= mock_sleep.call_args_list[1][0][0] <= 3
+
+
+@patch("makeit_pipeline.quality.fetch.time.sleep")
+@patch("makeit_pipeline.quality.fetch.httpx.request")
+def test_raises_on_4xx_other(mock_req, mock_sleep):
+    mock_req.return_value = _resp(404)
+    mock_req.return_value.raise_for_status.side_effect = Exception("404")
+    with pytest.raises(Exception, match="404"):
+        request_with_retry("GET", "https://example/x")
+```
+
+- [ ] **Step 2: Run, FAIL**
+
+`pytest tests/quality/test_fetch.py -v`
+
+- [ ] **Step 3: Implementation**
+
+`src/makeit_pipeline/quality/fetch.py`:
+```python
+import logging
+import random
+import time
+import httpx
+
+log = logging.getLogger(__name__)
+
+MAX_RETRIES = 3
+MAX_WAIT_SECONDS = 300
+
+
+def request_with_retry(method: str, url: str, **kwargs) -> httpx.Response:
+    """HTTP-запрос с уважением GitHub rate-limit headers + jitter.
+
+    - 429 + Retry-After / X-RateLimit-Reset → ждём указанное время
+    - 5xx → exponential backoff (1, 2, 4) с jitter
+    - Иначе raise_for_status
+    """
+    last_resp = None
+    for attempt in range(MAX_RETRIES):
+        resp = httpx.request(method, url, **kwargs)
+        last_resp = resp
+        if resp.status_code < 400:
+            return resp
+        if resp.status_code in (429, 403):
+            wait = _compute_rate_limit_wait(resp.headers)
+            log.warning("Rate-limit on %s: sleeping %.1fs", url, wait)
+            time.sleep(wait)
+            continue
+        if 500 <= resp.status_code < 600:
+            wait = (2 ** attempt) + random.uniform(0, 1)
+            log.warning("5xx on %s (attempt %d): sleeping %.1fs", url, attempt + 1, wait)
+            time.sleep(wait)
+            continue
+        resp.raise_for_status()
+    last_resp.raise_for_status()
+    return last_resp
+
+
+def _compute_rate_limit_wait(headers) -> float:
+    """Retry-After в приоритете; иначе X-RateLimit-Reset; иначе дефолт 30с. + jitter."""
+    retry_after = headers.get("Retry-After")
+    if retry_after:
+        wait = float(retry_after)
+    else:
+        reset = headers.get("X-RateLimit-Reset")
+        if reset:
+            wait = max(1.0, float(reset) - time.time())
+        else:
+            wait = 30.0
+    wait = min(wait, MAX_WAIT_SECONDS) + random.uniform(0, 2)
+    return wait
+```
+
+- [ ] **Step 4: Run, PASS**
+
+`pytest tests/quality/test_fetch.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/makeit_pipeline/quality/fetch.py tests/quality/test_fetch.py
+git commit -m "feat(quality): rate-limit-aware request_with_retry (Retry-After + X-RateLimit-Reset + jitter)"
+```
+
+---
+
+### Task 7: Fetch merged PRs (early-exit)
+
+**Repo:** `makeit-pipeline`
+
+**Files:**
+- Modify: `src/makeit_pipeline/quality/fetch.py`
+- Modify: `tests/quality/test_fetch.py`
+
+- [ ] **Step 1: Failing test**
+
+Append to `tests/quality/test_fetch.py`:
+```python
+from datetime import datetime, timezone, timedelta
+from makeit_pipeline.quality.fetch import fetch_repo_merged_prs
+
+
+def _pr(merged_at, updated_at, url):
+    return {"merged_at": merged_at, "updated_at": updated_at, "url": url}
+
+
+@patch("makeit_pipeline.quality.fetch.request_with_retry")
+def test_fetch_paginates_until_updated_at_below_since(mock_req):
+    since = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    page1 = [
+        _pr("2026-05-20T00:00:00Z", "2026-05-22T00:00:00Z", "pr/100"),
+        _pr(None, "2026-05-21T00:00:00Z", "pr/99"),  # закрыт без мержа — игнор
+        _pr("2026-05-05T00:00:00Z", "2026-05-10T00:00:00Z", "pr/98"),
+    ]
+    page2 = [_pr("2026-04-20T00:00:00Z", "2026-04-25T00:00:00Z", "pr/97")]  # updated < since → early exit
+    mock_req.side_effect = [
+        MagicMock(status_code=200, json=lambda: page1),
+        MagicMock(status_code=200, json=lambda: page2),
+    ]
+    result = fetch_repo_merged_prs("X", since, token="t")
+    assert len(result) == 2
+    assert {p["url"] for p in result} == {"pr/100", "pr/98"}
+    assert mock_req.call_count == 2  # дошёл до второй страницы и понял что можно выйти
+
+
+@patch("makeit_pipeline.quality.fetch.request_with_retry")
+def test_fetch_handles_empty_response(mock_req):
+    mock_req.return_value = MagicMock(status_code=200, json=lambda: [])
+    result = fetch_repo_merged_prs("X", datetime(2026, 5, 1, tzinfo=timezone.utc), token="t")
+    assert result == []
+
+
+@patch("makeit_pipeline.quality.fetch.request_with_retry")
+def test_fetch_review_comments_paginates(mock_req):
+    page1 = [{"body": "![P1 Badge]()", "pull_request_url": "pr/1", "user": {"login": "chatgpt-codex-connector[bot]"}}]
+    page2 = []
+    mock_req.side_effect = [
+        MagicMock(status_code=200, json=lambda: page1),
+        MagicMock(status_code=200, json=lambda: page2),
+    ]
+    from makeit_pipeline.quality.fetch import fetch_repo_review_comments
+    result = fetch_repo_review_comments("X", datetime(2026, 5, 1, tzinfo=timezone.utc), token="t")
+    # Только от бота
+    assert len(result) == 1
+```
+
+- [ ] **Step 2: Run, FAIL**
+
+`pytest tests/quality/test_fetch.py -v`
+
+- [ ] **Step 3: Implementation**
+
+Append to `src/makeit_pipeline/quality/fetch.py`:
+```python
+from datetime import datetime
+
+API_BASE = "https://api.github.com"
+MAX_PAGES = 50  # safety; на типичном репо << 5 страниц
+CODEX_BOT_LOGIN = "chatgpt-codex-connector[bot]"
+
+
+def _parse_dt(s: str) -> datetime:
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def fetch_repo_merged_prs(repo: str, since: datetime, *, token: str,
+                          owner: str = "Sergio1990-1") -> list[dict]:
+    """Pull merged PRs since cutoff.
+
+    Использует sort=updated+direction=desc + early-exit когда updated_at < since.
+    GitHub /pulls НЕ принимает ?since — мы фильтруем клиентски по merged_at."""
+    headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+    merged: list[dict] = []
+    for page in range(1, MAX_PAGES + 1):
+        resp = request_with_retry(
+            "GET", f"{API_BASE}/repos/{owner}/{repo}/pulls",
+            headers=headers,
+            params={"state": "closed", "sort": "updated", "direction": "desc",
+                    "per_page": 100, "page": page},
+        )
+        items = resp.json()
+        if not items:
+            break
+        for pr in items:
+            if _parse_dt(pr["updated_at"]) < since:
+                return merged  # early-exit, остальные тоже старые
+            if pr.get("merged_at") and _parse_dt(pr["merged_at"]) >= since:
+                merged.append(pr)
+    log.warning("Hit MAX_PAGES on %s — могут быть пропущены старые PR", repo)
+    return merged
+
+
+def fetch_repo_review_comments(repo: str, since: datetime, *, token: str,
+                               owner: str = "Sergio1990-1") -> list[dict]:
+    """Все review-комменты в репо since updated_at (включает редактирования старых).
+    Фильтрует на стороне клиента — только от Codex-бота."""
+    headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+    result: list[dict] = []
+    for page in range(1, MAX_PAGES + 1):
+        resp = request_with_retry(
+            "GET", f"{API_BASE}/repos/{owner}/{repo}/pulls/comments",
+            headers=headers,
+            params={"since": since.isoformat().replace("+00:00", "Z"),
+                    "per_page": 100, "page": page},
+        )
+        items = resp.json()
+        if not items:
+            break
+        for c in items:
+            if (c.get("user") or {}).get("login") == CODEX_BOT_LOGIN:
+                result.append(c)
+    return result
+```
+
+- [ ] **Step 4: Run, PASS**
+
+`pytest tests/quality/test_fetch.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/makeit_pipeline/quality/fetch.py tests/quality/test_fetch.py
+git commit -m "feat(quality): fetch merged PRs via sort=updated+early-exit (no nonexistent ?since); fetch Codex review comments"
+```
+
+---
+
+### Task 8: Sweep orchestration
+
+**Repo:** `makeit-pipeline`
+
+**Files:**
+- Create: `src/makeit_pipeline/quality/sweep.py`
+- Create: `tests/quality/test_sweep_integration.py`
+
+- [ ] **Step 1: Failing integration test**
+
+`tests/quality/test_sweep_integration.py`:
+```python
+from datetime import datetime, timezone
+from unittest.mock import patch
+from pathlib import Path
+import json
+from makeit_pipeline.quality.sweep import run_sweep
+
+
+@patch("makeit_pipeline.quality.sweep.fetch_repo_review_comments")
+@patch("makeit_pipeline.quality.sweep.fetch_repo_merged_prs")
+def test_sweep_produces_well_formed_json(mock_fetch_prs, mock_fetch_comments, tmp_path):
+    today = datetime(2026, 5, 25, 12, tzinfo=timezone.utc)
+    mock_fetch_prs.return_value = [
+        {"url": "pr/1", "merged_at": "2026-05-20T08:00:00Z", "updated_at": "2026-05-20T08:00:00Z"},
+    ]
+    mock_fetch_comments.return_value = [
+        {"pull_request_url": "pr/1", "body": "![P1 Badge]()", "user": {"login": "chatgpt-codex-connector[bot]"}},
+    ]
+    out = tmp_path / "q.json"
+    run_sweep(repos=["repo-A"], owner="X", token="t", out_path=out,
+              now=today, publish=False)
+    data = json.loads(out.read_text())
+    assert data["schema_version"] == 1
+    assert data["bucket_tz"] == "UTC"
+    assert "window_start" in data and "window_end" in data
+    assert data["repo_status"]["repo-A"]["status"] == "ok"
+    assert "30d" in data["buckets"] and "12w" in data["buckets"]
+    assert len(data["buckets"]["30d"]["labels"]) == 30
+    assert len(data["buckets"]["12w"]["labels"]) == 12
+    # pr/1 merged 2026-05-20 → P1 в дневном бакете 2026-05-20
+    daily_repo = data["buckets"]["30d"]["per_repo"]["repo-A"]["buckets"]
+    idx_20may = data["buckets"]["30d"]["labels"].index("2026-05-20")
+    assert daily_repo[idx_20may] == {"total_pr": 1, "with_p1": 1, "with_p2_only": 0}
+
+
+@patch("makeit_pipeline.quality.sweep.fetch_repo_review_comments")
+@patch("makeit_pipeline.quality.sweep.fetch_repo_merged_prs")
+def test_sweep_marks_failed_repo_in_status(mock_prs, mock_comments, tmp_path):
+    mock_prs.side_effect = [Exception("API exploded"), []]
+    mock_comments.return_value = []
+    out = tmp_path / "q.json"
+    run_sweep(repos=["bad", "good"], owner="X", token="t", out_path=out,
+              now=datetime(2026, 5, 25, tzinfo=timezone.utc), publish=False)
+    data = json.loads(out.read_text())
+    assert data["repo_status"]["bad"]["status"] == "error"
+    assert data["repo_status"]["good"]["status"] == "ok"
+    # bad НЕ участвует в summary
+    summary_total = sum(b["total_pr"] for b in data["buckets"]["30d"]["summary"])
+    assert summary_total == 0  # good вернул [] PR, bad excluded
+```
+
+- [ ] **Step 2: Run, FAIL**
+
+`pytest tests/quality/test_sweep_integration.py -v`
+
+- [ ] **Step 3: Implementation**
+
+`src/makeit_pipeline/quality/sweep.py`:
+```python
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from .fetch import fetch_repo_merged_prs, fetch_repo_review_comments
+from .severity import group_findings_per_pr
+from .bucketize import bucketize_daily, bucketize_weekly_iso, aggregate_summary, _iso_monday_utc
+from .publish import write_json_atomic_local, publish_remote_atomic
+
+log = logging.getLogger(__name__)
+SCHEMA_VERSION = 1
+WINDOW_DAYS = 90  # сколько тащим из API (покрывает 30d + 12w + запас)
+
+
+def run_sweep(*, repos: list[str], owner: str, token: str, out_path: Path,
+              now: datetime, publish: bool = True,
+              remote_host: str = "vps",
+              remote_dir: str = "/opt/apps/makeit-stack/web/data") -> dict:
+    """Главная sweep-функция. Делает fetch + bucketize + write JSON (+ publish)."""
+    since = now - timedelta(days=WINDOW_DAYS)
+    repo_status: dict[str, dict] = {}
+    per_repo_30d: dict[str, list[dict]] = {}
+    per_repo_12w: dict[str, list[dict]] = {}
+    per_repo_meta: dict[str, dict] = {}
+
+    for repo in repos:
+        try:
+            prs = fetch_repo_merged_prs(repo, since, token=token, owner=owner)
+            comments = fetch_repo_review_comments(repo, since, token=token, owner=owner)
+        except Exception as e:
+            log.exception("Failed to fetch %s", repo)
+            repo_status[repo] = {"status": "error", "code": "FETCH_FAILED",
+                                 "message": _short(str(e))}
+            continue
+
+        findings = group_findings_per_pr(comments)
+        d_buckets, d_labels = bucketize_daily(prs, findings, now, n=30)
+        w_buckets, w_labels = bucketize_weekly_iso(prs, findings, now, n=12)
+        per_repo_30d[repo] = d_buckets
+        per_repo_12w[repo] = w_buckets
+
+        # Codex coverage = доля PR с хотя бы одним коммент от бота
+        covered = sum(1 for pr in prs if pr["url"] in {c["pull_request_url"] for c in comments})
+        coverage_pct = round(covered / max(1, len(prs)) * 100)
+        per_repo_meta[repo] = {
+            "codex_coverage_pct": coverage_pct,
+            "codex_first_seen": comments[-1]["created_at"] if comments else None,
+        }
+        repo_status[repo] = {"status": "ok"}
+
+    # Только статуса нет — labels берём из ЛЮБОГО успешного репо ИЛИ генерируем из now
+    if any(s["status"] == "ok" for s in repo_status.values()):
+        any_ok = next(r for r, s in repo_status.items() if s["status"] == "ok")
+        d_labels = bucketize_daily([], {}, now, n=30)[1]
+        w_labels = bucketize_weekly_iso([], {}, now, n=12)[1]
+    else:
+        d_labels = bucketize_daily([], {}, now, n=30)[1]
+        w_labels = bucketize_weekly_iso([], {}, now, n=12)[1]
+
+    summary_30d = aggregate_summary(per_repo_30d, {r: s["status"] for r, s in repo_status.items()})
+    summary_12w = aggregate_summary(per_repo_12w, {r: s["status"] for r, s in repo_status.items()})
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": now.isoformat().replace("+00:00", "Z"),
+        "window_start": _iso_monday_utc(since).isoformat().replace("+00:00", "Z"),
+        "window_end": now.isoformat().replace("+00:00", "Z"),
+        "bucket_tz": "UTC",
+        "repo_status": repo_status,
+        "buckets": {
+            "30d": {
+                "labels": d_labels,
+                "summary": summary_30d,
+                "per_repo": {r: {"buckets": per_repo_30d[r], **per_repo_meta[r]}
+                             for r in per_repo_30d},
+            },
+            "12w": {
+                "labels": w_labels,
+                "summary": summary_12w,
+                "per_repo": {r: {"buckets": per_repo_12w[r], **per_repo_meta[r]}
+                             for r in per_repo_12w},
+            },
+        },
+    }
+    write_json_atomic_local(out_path, payload)
+    if publish:
+        publish_remote_atomic(out_path, remote_host=remote_host, remote_dir=remote_dir)
+    return payload
+
+
+def _short(s: str, n: int = 200) -> str:
+    """Обрезаем длинные exception-сообщения (могут содержать stack-trace, пути и т.д.)."""
+    s = s.replace("\n", " ").strip()
+    return s[:n] + ("…" if len(s) > n else "")
+```
+
+- [ ] **Step 4: Run, PASS**
+
+`pytest tests/quality/test_sweep_integration.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/makeit_pipeline/quality/sweep.py tests/quality/test_sweep_integration.py
+git commit -m "feat(quality): sweep orchestration with repo_status + coverage + schema metadata"
+```
+
+---
+
+## Phase C — CLI + launchd
+
+### Task 9: CLI entry-point + sanity
+
+**Repo:** `makeit-pipeline`
+
+**Files:**
+- Create: `scripts/codex_quality_sweep.py`
+
+- [ ] **Step 1: Create CLI**
+
+`scripts/codex_quality_sweep.py`:
+```python
+#!/usr/bin/env python3
+"""CLI entry для codex quality sweep. Используется launchd cron'ом и /quality/refresh."""
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from dotenv import load_dotenv
+import os
+from makeit_pipeline.quality.locking import acquire_lock, SweepAlreadyRunning
+from makeit_pipeline.quality.sweep import run_sweep
+
+EXIT_OK = 0
+EXIT_LOCK_BUSY = 2
+EXIT_NO_TOKEN = 3
+EXIT_INTERNAL = 1
+
+LOCK_PATH = Path("/tmp/codex-quality-sweep.lock")
+DEFAULT_OUT = Path.home() / "data" / "codex-quality.json"
+CONFIG_PATH = Path(__file__).parent.parent / "config" / "quality_repos.json"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("sweep")
+
+
+def main():
+    load_dotenv()
+    p = argparse.ArgumentParser()
+    p.add_argument("--out", default=str(DEFAULT_OUT))
+    p.add_argument("--no-publish", action="store_true", help="dry-run без rsync на VPS")
+    p.add_argument("--force", action="store_true", help="принудительный запуск (всё равно lock работает)")
+    args = p.parse_args()
+
+    token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+    if not token:
+        log.error("GH_TOKEN or GITHUB_TOKEN env var required")
+        print(json.dumps({"code": "NO_TOKEN"}))
+        return EXIT_NO_TOKEN
+
+    cfg = json.loads(CONFIG_PATH.read_text())
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with acquire_lock(LOCK_PATH):
+            run_sweep(
+                repos=cfg["repos"], owner=cfg["owner"], token=token,
+                out_path=out, now=datetime.now(timezone.utc),
+                publish=not args.no_publish,
+            )
+            return EXIT_OK
+    except SweepAlreadyRunning:
+        log.warning("Sweep already running, exiting")
+        print(json.dumps({"code": "ALREADY_RUNNING"}))
+        return EXIT_LOCK_BUSY
+    except Exception as e:
+        log.exception("Sweep failed")
+        print(json.dumps({"code": "INTERNAL"}))  # sanitized — не stderr
+        return EXIT_INTERNAL
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Manual smoke test**
+
+```bash
+GH_TOKEN=<your-pat> python scripts/codex_quality_sweep.py --no-publish --out /tmp/test-q.json
+cat /tmp/test-q.json | jq '.schema_version, .repo_status | keys'
+```
+Expected: schema_version=1, ключи всех 14 репо.
+
+- [ ] **Step 3: Commit**
+
+```bash
+chmod +x scripts/codex_quality_sweep.py
+git add scripts/codex_quality_sweep.py
+git commit -m "feat(quality): CLI entry-point for codex quality sweep with sanitized errors"
+```
+
+---
+
+### Task 10: launchd plist
+
+**Repo:** `makeit-pipeline`
+
+**Files:**
+- Create: `deploy/launchd/com.makeit.codex-quality-sweep.plist`
+
+- [ ] **Step 1: Создать plist**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.makeit.codex-quality-sweep</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/sergeymakarov/makeit-pipeline/.venv/bin/python</string>
+    <string>/Users/sergeymakarov/makeit-pipeline/scripts/codex_quality_sweep.py</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/sergeymakarov/makeit-pipeline</string>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key><integer>19</integer>      <!-- 19:00 UTC = 03:00 Bali (UTC+8) -->
+    <key>Minute</key><integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/Users/sergeymakarov/logs/codex-quality-sweep.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/sergeymakarov/logs/codex-quality-sweep.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <!-- GH_TOKEN читается из .env через python-dotenv, не из plist (не plain-text на диск) -->
+  </dict>
+</dict>
+</plist>
+```
+
+- [ ] **Step 2: Установить на Pipeline Mac (ssh sergeymakarov)**
+
+```bash
+scp deploy/launchd/com.makeit.codex-quality-sweep.plist \
+    sergeymakarov:~/Library/LaunchAgents/
+ssh sergeymakarov "launchctl load ~/Library/LaunchAgents/com.makeit.codex-quality-sweep.plist"
+ssh sergeymakarov "launchctl start com.makeit.codex-quality-sweep"
+sleep 30
+ssh sergeymakarov "tail -50 ~/logs/codex-quality-sweep.log"
+```
+Expected: INFO `sweep` logs, exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/launchd/com.makeit.codex-quality-sweep.plist
+git commit -m "feat(quality): launchd plist for daily 03:00 Bali sweep"
+```
+
+---
+
+## Phase D — Annotations backend
+
+### Task 11: Annotations store
+
+**Repo:** `makeit-pipeline`
+
+**Files:**
+- Create: `src/makeit_pipeline/quality/annotations.py`
+- Create: `tests/quality/test_annotations.py`
+
+- [ ] **Step 1: Failing tests**
+
+`tests/quality/test_annotations.py`:
+```python
+import json
+from pathlib import Path
+import pytest
+from makeit_pipeline.quality.annotations import (
+    load_annotations, add_annotation, delete_annotation, MAX_ANNOTATIONS_TOTAL,
+)
+
+
+def test_load_returns_empty_on_missing_file(tmp_path):
+    assert load_annotations(tmp_path / "x.json") == []
+
+
+def test_add_returns_annotation_with_uuid(tmp_path):
+    path = tmp_path / "a.json"
+    ann = add_annotation(path, occurred_at="2026-05-22T00:00:00Z", category="skill",
+                         scope="global", repos=None, title="t", desc="d")
+    assert "id" in ann
+    assert len(ann["id"]) == 36  # UUID v4
+    assert ann["category"] == "skill"
+    stored = load_annotations(path)
+    assert len(stored) == 1
+    assert stored[0]["id"] == ann["id"]
+
+
+def test_delete_by_id(tmp_path):
+    path = tmp_path / "a.json"
+    ann = add_annotation(path, occurred_at="2026-05-22T00:00:00Z", category="skill",
+                         scope="global", repos=None, title="t", desc="d")
+    assert delete_annotation(path, ann["id"]) is True
+    assert load_annotations(path) == []
+
+
+def test_delete_missing_returns_false(tmp_path):
+    path = tmp_path / "a.json"
+    assert delete_annotation(path, "00000000-0000-0000-0000-000000000000") is False
+
+
+def test_add_rejects_when_at_max(tmp_path, monkeypatch):
+    monkeypatch.setattr("makeit_pipeline.quality.annotations.MAX_ANNOTATIONS_TOTAL", 1)
+    path = tmp_path / "a.json"
+    add_annotation(path, occurred_at="2026-05-22T00:00:00Z", category="skill",
+                   scope="global", repos=None, title="t", desc="d")
+    with pytest.raises(ValueError, match="full"):
+        add_annotation(path, occurred_at="2026-05-23T00:00:00Z", category="skill",
+                       scope="global", repos=None, title="t2", desc="d2")
+```
+
+- [ ] **Step 2: Run, FAIL**
+
+`pytest tests/quality/test_annotations.py -v`
+
+- [ ] **Step 3: Implementation**
+
+`src/makeit_pipeline/quality/annotations.py`:
+```python
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+from .publish import write_json_atomic_local
+
+MAX_ANNOTATIONS_TOTAL = 5000
+SCHEMA_VERSION = 1
+
+
+def load_annotations(path: Path) -> list[dict]:
+    path = Path(path)
+    if not path.exists():
+        return []
+    data = json.loads(path.read_text())
+    if isinstance(data, list):
+        return data  # legacy shape
+    return data.get("annotations", [])
+
+
+def _save(path: Path, annotations: list[dict]) -> None:
+    write_json_atomic_local(path, {"schema_version": SCHEMA_VERSION, "annotations": annotations})
+
+
+def add_annotation(path: Path, *, occurred_at: str, category: str, scope: str,
+                   repos: list[str] | None, title: str, desc: str,
+                   created_by: str = "manual") -> dict:
+    annotations = load_annotations(path)
+    if len(annotations) >= MAX_ANNOTATIONS_TOTAL:
+        raise ValueError(f"Annotation store full (>{MAX_ANNOTATIONS_TOTAL})")
+    ann = {
+        "id": str(uuid4()),
+        "occurred_at": occurred_at,
+        "category": category,
+        "scope": scope,
+        "repos": repos,
+        "title": title,
+        "desc": desc,
+        "created_by": created_by,
+        "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    annotations.append(ann)
+    _save(path, annotations)
+    return ann
+
+
+def delete_annotation(path: Path, ann_id: str) -> bool:
+    annotations = load_annotations(path)
+    new_list = [a for a in annotations if a["id"] != ann_id]
+    if len(new_list) == len(annotations):
+        return False
+    _save(path, new_list)
+    return True
+```
+
+- [ ] **Step 4: Run, PASS**
+
+`pytest tests/quality/test_annotations.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/makeit_pipeline/quality/annotations.py tests/quality/test_annotations.py
+git commit -m "feat(quality): annotations store with UUID + scope + max-cap"
+```
+
+---
+
+### Task 12: FastAPI endpoints
+
+**Repo:** `makeit-pipeline`
+
+**Files:**
+- Modify: `src/makeit_pipeline/api.py`
+
+- [ ] **Step 1: Найти место в api.py для импорта/регистрации (обычно рядом с другими роутерами)**
+
+Файл уже существует, надо добавить endpoints. Сначала прочитать структуру:
+```bash
+head -50 src/makeit_pipeline/api.py
+```
+
+- [ ] **Step 2: Добавить роутер `/quality`**
+
+В `src/makeit_pipeline/api.py` добавить (после существующих routes):
+
+```python
+from typing import Literal
+from uuid import UUID
+import subprocess
+import json
+import logging
+from pathlib import Path
+from datetime import datetime
+from fastapi import HTTPException, Request
+from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel, Field
+from makeit_pipeline.quality.annotations import (
+    load_annotations, add_annotation, delete_annotation,
+)
+
+QUALITY_JSON_PATH = Path.home() / "data" / "codex-quality.json"
+ANNOT_PATH = Path.home() / "data" / "annotations.json"
+SWEEP_SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "codex_quality_sweep.py"
+MAX_BODY_SIZE = 4096
+
+SAFE_ERROR_CODES = {
+    "RATE_LIMITED": "GitHub API rate-limit. Дождитесь сброса.",
+    "REPO_NOT_FOUND": "Один из репо переименован/удалён. Проверьте config/quality_repos.json.",
+    "NETWORK": "Сетевая ошибка sweep'а. Проверьте Pipeline Mac.",
+    "ALREADY_RUNNING": "Sweep уже выполняется. Подождите ~5 минут.",
+    "INTERNAL": "Внутренняя ошибка. См. ~/logs/codex-quality-sweep.log.",
+    "NO_TOKEN": "GH_TOKEN не настроен.",
+}
+
+q_log = logging.getLogger("quality_api")
+
+
+class AnnotationCreate(BaseModel):
+    occurred_at: datetime
+    category: Literal["skill", "deploy", "manual"]
+    scope: Literal["global", "repo"] = "global"
+    repos: list[str] | None = Field(default=None, max_length=20)
+    title: str = Field(max_length=120)
+    desc: str = Field(default="", max_length=600)
+
+
+@app.post("/quality/refresh")
+def quality_refresh():
+    try:
+        result = subprocess.run(
+            ["python3", str(SWEEP_SCRIPT), "--force"],
+            capture_output=True, timeout=300, text=True,
+        )
+    except subprocess.TimeoutExpired:
+        return JSONResponse(status_code=504, content={"code": "TIMEOUT",
+                                                       "message": "Sweep > 5 минут"})
+    # Парсим stdout JSON (последняя строка скрипта при ошибке)
+    code = None
+    if result.returncode != 0:
+        try:
+            code = (json.loads(result.stdout.strip().splitlines()[-1])).get("code")
+        except Exception:
+            code = "INTERNAL"
+        status = 409 if code == "ALREADY_RUNNING" else 500
+        q_log.error("Sweep failed: code=%s, stderr=%s", code, result.stderr[:200])
+        return JSONResponse(status_code=status, content={
+            "code": code, "message": SAFE_ERROR_CODES.get(code, SAFE_ERROR_CODES["INTERNAL"]),
+        })
+    if not QUALITY_JSON_PATH.exists():
+        return JSONResponse(status_code=500, content={
+            "code": "INTERNAL", "message": "Sweep finished but JSON missing"
+        })
+    return FileResponse(QUALITY_JSON_PATH, media_type="application/json")
+
+
+@app.post("/annotations")
+def annotations_add(payload: AnnotationCreate, request: Request):
+    if int(request.headers.get("content-length", 0)) > MAX_BODY_SIZE:
+        raise HTTPException(413, "Payload too large")
+    if payload.scope == "repo" and not payload.repos:
+        raise HTTPException(422, "scope=repo требует repos[]")
+    try:
+        ann = add_annotation(
+            ANNOT_PATH,
+            occurred_at=payload.occurred_at.isoformat().replace("+00:00", "Z"),
+            category=payload.category,
+            scope=payload.scope,
+            repos=payload.repos,
+            title=payload.title,
+            desc=payload.desc,
+        )
+    except ValueError as e:
+        raise HTTPException(429, str(e))
+    return ann
+
+
+@app.delete("/annotations/{ann_id}")
+def annotations_delete(ann_id: UUID):
+    ok = delete_annotation(ANNOT_PATH, str(ann_id))
+    if not ok:
+        raise HTTPException(404, "Annotation not found")
+    return {"ok": True}
+
+
+@app.get("/annotations")
+def annotations_list():
+    return {"annotations": load_annotations(ANNOT_PATH)}
+```
+
+- [ ] **Step 3: Smoke-test локально**
+
+```bash
+# В одном окне:
+uvicorn makeit_pipeline.api:app --port 8766 --reload
+
+# В другом:
+curl -X POST http://localhost:8766/annotations \
+  -H 'Content-Type: application/json' \
+  -d '{"occurred_at":"2026-05-22T00:00:00Z","category":"skill","title":"test","desc":"d"}'
+# → {"id":"...", "category":"skill", ...}
+
+curl http://localhost:8766/annotations
+# → {"annotations":[{...}]}
+
+curl -X POST http://localhost:8766/quality/refresh
+# → 200 + JSON или 409/500 с кодом
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/makeit_pipeline/api.py
+git commit -m "feat(quality): FastAPI endpoints — POST /quality/refresh + CRUD /annotations with sanitized errors"
+```
+
+---
+
+## Phase E — VPS nginx
+
+### Task 13: nginx static route
+
+**Repo/Host:** VPS (89.167.17.79)
+
+**Files:**
+- Modify on VPS: `/opt/apps/nginx-proxy/conf.d/makeit.conf`
+- Create dir on VPS: `/opt/apps/makeit-stack/web/data/`
+
+- [ ] **Step 1: Создать data dir на VPS**
+
+```bash
+ssh root@89.167.17.79 'mkdir -p /opt/apps/makeit-stack/web/data && chmod 755 /opt/apps/makeit-stack/web/data'
+```
+
+- [ ] **Step 2: Добавить location в nginx-конфиг**
+
+```bash
+ssh root@89.167.17.79
+cd /opt/apps/nginx-proxy/conf.d
+cp makeit.conf makeit.conf.bak
+```
+
+Открыть `makeit.conf` и добавить внутрь основного `server { ... }`:
+```nginx
+location /data/ {
+    alias /opt/apps/makeit-stack/web/data/;
+    add_header Cache-Control "public, max-age=300";
+    add_header Access-Control-Allow-Origin "*";  # для GitHub Pages
+}
+```
+
+- [ ] **Step 3: Тест и reload**
+
+```bash
+nginx -t
+nginx -s reload
+```
+
+- [ ] **Step 4: Smoke test (после первого успешного sweep'а)**
+
+```bash
+# С Pipeline Mac или локально:
+curl -I https://your-dashboard-domain/data/codex-quality.json
+# → 200 OK + cache-control + cors header
+```
+
+- [ ] **Step 5: Commit (только если файл под git)**
+
+Если конфиг nginx версионируется отдельно — закоммитить в том репо. Иначе — note в DEPLOYMENT.md что было сделано.
+
+---
+
+## Phase F — Frontend types + data layer
+
+### Task 14: TypeScript types
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Create: `src/types/quality.ts`
+
+- [ ] **Step 1: Создать типы**
+
+```typescript
+export interface QualityBucket {
+  total_pr: number;
+  with_p0: number;           // PR с ≥1 P0 (BLOCKER, worst-wins absorbs P1+P2)
+  with_p1_only: number;      // PR с P1, без P0
+  with_p2_only: number;      // PR с P2, без P0 и P1
+}
+
+export interface RepoStatusEntry {
+  status: "ok" | "error" | "stale";
+  code?: string;
+  message?: string;
+}
+
+export interface RepoQualityData {
+  buckets: QualityBucket[];
+  codex_coverage_pct: number;
+  codex_first_seen: string | null;
+}
+
+export interface QualityBucketsMode {
+  labels: string[];
+  summary: QualityBucket[];
+  per_repo: Record<string, RepoQualityData>;
+}
+
+export interface QualityPayload {
+  schema_version: 1;
+  generated_at: string;
+  window_start: string;
+  window_end: string;
+  bucket_tz: "UTC";
+  repo_status: Record<string, RepoStatusEntry>;
+  buckets: {
+    "30d": QualityBucketsMode;
+    "12w": QualityBucketsMode;
+  };
+}
+
+export type PeriodMode = "30d" | "12w";
+
+export type AnnotationCategory = "skill" | "deploy" | "manual";
+export type AnnotationScope = "global" | "repo";
+
+export interface Annotation {
+  id: string;                              // UUID v4
+  occurred_at: string;                     // UTC ISO8601
+  category: AnnotationCategory;
+  scope: AnnotationScope;
+  repos: string[] | null;
+  title: string;
+  desc: string;
+  created_by: string;
+  created_at: string;
+}
+
+export interface AnnotationCreatePayload {
+  occurred_at: string;
+  category: AnnotationCategory;
+  scope: AnnotationScope;
+  repos?: string[];
+  title: string;
+  desc: string;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/types/quality.ts
+git commit -m "feat(quality): TypeScript types for QualityPayload + Annotation"
+```
+
+---
+
+### Task 15: Position math (pure functions, TDD)
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Create: `src/utils/quality-position.ts`
+- Create: `tests/quality/quality-position.test.ts`
+
+- [ ] **Step 1: Failing tests**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { isoMonday, annotationPositionPct } from "../../src/utils/quality-position";
+
+describe("isoMonday", () => {
+  it("snaps Wednesday to Monday of same week", () => {
+    expect(isoMonday(new Date("2026-05-13"))).toEqual(new Date("2026-05-11T00:00:00.000Z"));
+  });
+  it("snaps Sunday to Monday of same week (not next)", () => {
+    expect(isoMonday(new Date("2026-05-17"))).toEqual(new Date("2026-05-11T00:00:00.000Z"));
+  });
+  it("snaps Monday to itself", () => {
+    expect(isoMonday(new Date("2026-05-11"))).toEqual(new Date("2026-05-11T00:00:00.000Z"));
+  });
+});
+
+describe("annotationPositionPct", () => {
+  const today = new Date("2026-05-25T00:00:00Z");  // Monday
+  it("30d mode snaps to bar center", () => {
+    // Annotation on 2026-05-15 (10 days before today, day index 19 in 30-day series ending today)
+    const pct = annotationPositionPct(new Date("2026-05-15T08:00:00Z"), "30d", today, 30);
+    // (19 + 0.5) / 30 = 65%
+    expect(pct).toBeCloseTo(65);
+  });
+  it("12w mode positions proportionally within week", () => {
+    // Annotation on Wed 2026-05-13. Week 12 of 12 starts on Mon 2026-05-25.
+    // 2026-05-13 is in week starting 2026-05-11 — that's week index 10 (0-based) of 12.
+    // days from window start (2026-03-09) to 2026-05-13 = 65 days
+    // pct = 65 / (12*7) = 65/84 = 77.4%
+    const pct = annotationPositionPct(new Date("2026-05-13T00:00:00Z"), "12w", today, 12);
+    expect(pct).toBeCloseTo(77.38, 1);
+  });
+  it("returns null for date outside window", () => {
+    expect(annotationPositionPct(new Date("2025-01-01"), "30d", today, 30)).toBeNull();
+    expect(annotationPositionPct(new Date("2030-01-01"), "30d", today, 30)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run, FAIL**
+
+`npx vitest run tests/quality/quality-position.test.ts`
+
+- [ ] **Step 3: Implementation**
+
+`src/utils/quality-position.ts`:
+```typescript
+import type { PeriodMode } from "../types/quality";
+
+export function isoMonday(date: Date): Date {
+  const d = new Date(date);
+  d.setUTCHours(0, 0, 0, 0);
+  const day = d.getUTCDay();  // 0=Sun, 1=Mon, ...
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setUTCDate(d.getUTCDate() + diff);
+  return d;
+}
+
+const DAY_MS = 86400000;
+
+export function annotationPositionPct(
+  occurredAt: Date,
+  mode: PeriodMode,
+  today: Date,
+  bucketCount: number
+): number | null {
+  const occ = new Date(occurredAt);
+  occ.setUTCHours(0, 0, 0, 0);
+
+  if (mode === "30d") {
+    const start = new Date(today);
+    start.setUTCHours(0, 0, 0, 0);
+    start.setUTCDate(start.getUTCDate() - (bucketCount - 1));
+    const daysFromStart = Math.round((occ.getTime() - start.getTime()) / DAY_MS);
+    if (daysFromStart < 0 || daysFromStart >= bucketCount) return null;
+    return ((daysFromStart + 0.5) / bucketCount) * 100;
+  } else {
+    const todayMon = isoMonday(today);
+    const start = new Date(todayMon);
+    start.setUTCDate(start.getUTCDate() - (bucketCount - 1) * 7);
+    const totalDays = bucketCount * 7;
+    const daysFromStart = (occ.getTime() - start.getTime()) / DAY_MS;
+    if (daysFromStart < 0 || daysFromStart >= totalDays) return null;
+    return (daysFromStart / totalDays) * 100;
+  }
+}
+```
+
+- [ ] **Step 4: Run, PASS**
+
+`npx vitest run tests/quality/quality-position.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/quality-position.ts tests/quality/quality-position.test.ts
+git commit -m "feat(quality): isoMonday + annotation position math (daily snap, weekly proportional)"
+```
+
+---
+
+### Task 16: API client
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Create: `src/utils/quality.ts`
+
+- [ ] **Step 1: Реализация**
+
+```typescript
+import type { QualityPayload, Annotation, AnnotationCreatePayload } from "../types/quality";
+
+declare global {
+  interface Window {
+    __MAKEIT_CONFIG__?: { QUALITY_URL?: string; PIPELINE_URL?: string; ANNOT_URL?: string };
+  }
+}
+
+function qualityUrl(): string {
+  return window.__MAKEIT_CONFIG__?.QUALITY_URL ?? "/data/codex-quality.json";
+}
+function annotUrl(): string {
+  return window.__MAKEIT_CONFIG__?.ANNOT_URL ?? "/data/annotations.json";
+}
+function pipelineUrl(): string {
+  return window.__MAKEIT_CONFIG__?.PIPELINE_URL ?? "http://localhost:8766";
+}
+
+export async function fetchQualityData(): Promise<QualityPayload> {
+  const r = await fetch(qualityUrl(), { cache: "no-cache" });
+  if (!r.ok) throw new Error(`Quality fetch failed: ${r.status}`);
+  const data = await r.json();
+  if (data.schema_version !== 1) {
+    throw new Error(`Unknown schema_version: ${data.schema_version}`);
+  }
+  return data as QualityPayload;
+}
+
+export async function fetchAnnotations(): Promise<Annotation[]> {
+  const r = await fetch(annotUrl(), { cache: "no-cache" });
+  if (r.status === 404) return [];
+  if (!r.ok) throw new Error(`Annotations fetch failed: ${r.status}`);
+  const data = await r.json();
+  return Array.isArray(data) ? data : (data.annotations ?? []);
+}
+
+export async function forceQualityRefresh(): Promise<QualityPayload> {
+  const r = await fetch(`${pipelineUrl()}/quality/refresh`, { method: "POST" });
+  if (r.status === 409) throw new Error("Sweep уже выполняется — попробуйте через ~5 мин");
+  if (!r.ok) {
+    const err = await r.json().catch(() => ({}));
+    throw new Error(err.message || `Refresh failed: ${r.status}`);
+  }
+  return r.json();
+}
+
+export async function createAnnotation(p: AnnotationCreatePayload): Promise<Annotation> {
+  const r = await fetch(`${pipelineUrl()}/annotations`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(p),
+  });
+  if (!r.ok) {
+    const err = await r.json().catch(() => ({}));
+    throw new Error(err.message || `Create failed: ${r.status}`);
+  }
+  return r.json();
+}
+
+export async function deleteAnnotation(id: string): Promise<void> {
+  const r = await fetch(`${pipelineUrl()}/annotations/${id}`, { method: "DELETE" });
+  if (!r.ok) throw new Error(`Delete failed: ${r.status}`);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/utils/quality.ts
+git commit -m "feat(quality): API client (fetch JSON + force-refresh + annotations CRUD)"
+```
+
+---
+
+### Task 17: useQuality hook
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Create: `src/hooks/useQuality.ts`
+- Create: `tests/quality/useQuality.test.tsx`
+
+- [ ] **Step 1: Failing test (fake-fetch + render hook)**
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useQuality } from "../../src/hooks/useQuality";
+
+const STALE_HOURS = 30;
+const mockFetch = vi.fn();
+beforeEach(() => {
+  globalThis.fetch = mockFetch as any;
+  mockFetch.mockReset();
+});
+
+const samplePayload = {
+  schema_version: 1,
+  generated_at: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
+  window_start: "x", window_end: "y", bucket_tz: "UTC",
+  repo_status: {}, buckets: { "30d": { labels: [], summary: [], per_repo: {} },
+                              "12w": { labels: [], summary: [], per_repo: {} } },
+};
+
+describe("useQuality", () => {
+  it("loads data on mount", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => samplePayload });
+    const { result } = renderHook(() => useQuality());
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    expect(result.current.loading).toBe(false);
+    expect(result.current.isStale).toBe(false);
+  });
+  it("marks stale when generated_at > 30h old", async () => {
+    const old = { ...samplePayload, generated_at: new Date(Date.now() - (STALE_HOURS + 1) * 3.6e6).toISOString() };
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => old });
+    const { result } = renderHook(() => useQuality());
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    expect(result.current.isStale).toBe(true);
+  });
+  it("surfaces error on 404", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({}) });
+    const { result } = renderHook(() => useQuality());
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+  });
+});
+```
+
+- [ ] **Step 2: Run, FAIL**
+
+`npx vitest run tests/quality/useQuality.test.tsx`
+
+- [ ] **Step 3: Implementation**
+
+`src/hooks/useQuality.ts`:
+```typescript
+import { useEffect, useState, useCallback, useMemo } from "react";
+import type { QualityPayload, Annotation } from "../types/quality";
+import { fetchQualityData, fetchAnnotations, forceQualityRefresh } from "../utils/quality";
+
+const STALE_HOURS = 30;
+
+export function useQuality() {
+  const [data, setData] = useState<QualityPayload | null>(null);
+  const [annotations, setAnnotations] = useState<Annotation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (force = false) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [q, a] = await Promise.all([
+        force ? forceQualityRefresh() : fetchQualityData(),
+        fetchAnnotations(),
+      ]);
+      setData(q);
+      setAnnotations(a);
+    } catch (e: any) {
+      setError(e.message || String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(false); }, [load]);
+
+  const isStale = useMemo(() => {
+    if (!data) return false;
+    const ageHours = (Date.now() - new Date(data.generated_at).getTime()) / 3.6e6;
+    return ageHours > STALE_HOURS;
+  }, [data]);
+
+  return { data, annotations, loading, error, isStale, refresh: () => load(true), reloadAnnotations: () => load(false) };
+}
+```
+
+- [ ] **Step 4: Run, PASS**
+
+`npx vitest run tests/quality/useQuality.test.tsx`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useQuality.ts tests/quality/useQuality.test.tsx
+git commit -m "feat(quality): useQuality hook (fetch + isStale + refresh)"
+```
+
+---
+
+## Phase G — Frontend chart components
+
+### Task 18: QualityChart (reusable, main + compact)
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Create: `src/styles/v4-quality.css` (CSS из прототипа, ниже шорт-версия)
+- Create: `src/components/quality/QualityChart.tsx`
+- Create: `tests/quality/QualityChart.test.tsx`
+
+- [ ] **Step 1: Перенести CSS из прототипа**
+
+Создать `src/styles/v4-quality.css` — скопировать ВСЕ блоки `.chart`, `.bar*`, `.chart-tip*`, `.bar-chip`, `.annot*`, `.kpi*`, `.card*`, `.summary`, `.btn-add-event`, `.seg`, `.bar-clean`/`.bar-p1`/`.bar-p2` и keyframes (`q-chart-in`, `q-kpi-in`, `q-card-in`) из `quality-tab-prototype.html`. Префиксы оставить как есть — стили scoped через wrapping-div с классом `v4-quality-tab`.
+
+Также добавить в `:root` (в `v4.css`):
+```css
+--v4-clean-soft: #93C5FD;
+```
+
+- [ ] **Step 2: Failing test для QualityChart**
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { QualityChart } from "../../src/components/quality/QualityChart";
+
+const buckets = [
+  { total_pr: 10, with_p1: 1, with_p2_only: 2 },
+  { total_pr: 20, with_p1: 0, with_p2_only: 4 },
+];
+const labels = ["2026-05-23", "2026-05-24"];
+
+describe("QualityChart", () => {
+  it("renders one bar per bucket", () => {
+    const { container } = render(<QualityChart buckets={buckets} labels={labels} compact={false} />);
+    expect(container.querySelectorAll(".bar")).toHaveLength(2);
+  });
+  it("renders clean/p2/p1 segments correctly", () => {
+    const { container } = render(<QualityChart buckets={buckets} labels={labels} compact={false} />);
+    const firstBar = container.querySelector(".bar")!;
+    expect(firstBar.querySelector(".bar-p1")).toBeTruthy();
+    expect(firstBar.querySelector(".bar-p2")).toBeTruthy();
+    expect(firstBar.querySelector(".bar-clean")).toBeTruthy();
+  });
+  it("auto-scales y-axis", () => {
+    const { container } = render(<QualityChart buckets={buckets} labels={labels} compact={false} />);
+    // max=20 → niceCeil=20
+    const axis = container.querySelector(".chart-axis-label");
+    expect(axis?.textContent).toBe("20");
+  });
+});
+```
+
+- [ ] **Step 3: Run, FAIL**
+
+`npx vitest run tests/quality/QualityChart.test.tsx`
+
+- [ ] **Step 4: Implementation**
+
+`src/components/quality/QualityChart.tsx`:
+```tsx
+import { useRef, useEffect, useMemo } from "react";
+import type { QualityBucket } from "../../types/quality";
+
+interface Props {
+  buckets: QualityBucket[];
+  labels: string[];
+  compact: boolean;
+}
+
+function niceCeil(n: number): number {
+  if (n <= 5) return 5;
+  if (n <= 10) return 10;
+  if (n <= 20) return 20;
+  if (n <= 50) return 50;
+  if (n <= 100) return 100;
+  if (n <= 200) return 200;
+  return Math.ceil(n / 100) * 100;
+}
+
+const LOW_SAMPLE = 8;
+
+export function QualityChart({ buckets, labels, compact }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const tipRef = useRef<HTMLDivElement>(null);
+  const tipRefsObj = useRef<Record<string, HTMLElement>>({});
+
+  const scale = useMemo(() => {
+    const max = Math.max(1, ...buckets.map(b => b.total_pr));
+    return niceCeil(max);
+  }, [buckets]);
+
+  const handleEnter = (b: QualityBucket, label: string, barEl: HTMLDivElement) => {
+    const tip = tipRef.current!;
+    const refs = tipRefsObj.current;
+    const clean = Math.max(0, b.total_pr - b.with_p1 - b.with_p2_only);
+    const dirtyPct = b.total_pr > 0 ? ((b.with_p1 + b.with_p2_only) / b.total_pr * 100) : 0;
+    refs.label.textContent = label;
+    refs.total.textContent = String(b.total_pr);
+    refs.clean.textContent = String(clean);
+    refs.p2.textContent = String(b.with_p2_only);
+    refs.p1.textContent = String(b.with_p1);
+    refs.dirty.textContent = dirtyPct.toFixed(0) + "%";
+    const cRect = containerRef.current!.getBoundingClientRect();
+    const bRect = barEl.getBoundingClientRect();
+    const pctX = ((bRect.left + bRect.width / 2) - cRect.left) / cRect.width * 100;
+    if (compact) {
+      tip.style.left = `${pctX}%`;
+      tip.style.transform = "translateX(-50%) translateY(0)";
+    } else {
+      const flipLeft = pctX > 70;
+      tip.style.left = `calc(${pctX}% + 12px - ${flipLeft ? "208px" : "0px"})`;
+    }
+    tip.classList.add("show");
+    containerRef.current!.classList.add("is-hovering");
+    barEl.classList.add("is-active");
+  };
+
+  const handleLeave = (barEl: HTMLDivElement) => {
+    tipRef.current?.classList.remove("show");
+    containerRef.current?.classList.remove("is-hovering");
+    barEl.classList.remove("is-active");
+  };
+
+  return (
+    <div ref={containerRef} className={compact ? "card-chart" : "chart"}>
+      {!compact && (
+        <div className="chart-axis">
+          <span className="chart-axis-label" style={{ top: "-2px" }}>{scale}</span>
+          <span className="chart-axis-label" style={{ top: "calc(50% - 6px)" }}>{Math.round(scale / 2)}</span>
+        </div>
+      )}
+      {buckets.map((b, i) => {
+        const total = b.total_pr;
+        const heightPct = (total / scale) * 100;
+        // Worst-wins: P0+P1 объединены в crit-сегмент (один красный)
+        const critCount = b.with_p0 + b.with_p1_only;
+        const cleanCount = Math.max(0, total - critCount - b.with_p2_only);
+        const critPct = total > 0 ? (critCount / total) * heightPct : 0;
+        const p2Pct = total > 0 ? (b.with_p2_only / total) * heightPct : 0;
+        const cleanPct = heightPct - critPct - p2Pct;
+        const lowSample = total > 0 && total < LOW_SAMPLE;
+        return (
+          <div
+            key={`${labels[i]}-${i}`}
+            className={`bar ${lowSample ? "is-low-sample" : ""} ${b.with_p0 > 0 ? "has-p0" : ""}`}
+            ref={(el) => { if (el) {
+              el.onmouseenter = () => handleEnter(b, labels[i], el);
+              el.onmouseleave = () => handleLeave(el);
+            }}}
+          >
+            <div className="bar-stack" style={{ height: `${heightPct}%` }}>
+              {cleanPct > 0 && <div className="bar-clean" style={{ height: `${(cleanPct/heightPct)*100}%` }} />}
+              {p2Pct > 0 && <div className="bar-p2" style={{ height: `${(p2Pct/heightPct)*100}%` }} />}
+              {critPct > 0 && <div className="bar-crit" style={{ height: `${(critPct/heightPct)*100}%` }} />}
+            </div>
+            {heightPct === 0 && <div className="bar-empty" />}
+            <div className="bar-chip">
+              {total} PR{b.with_p0 > 0 && <> · <b style={{ color: "#fca5a5" }}>P0:{b.with_p0}</b></>}
+            </div>
+          </div>
+        );
+      })}
+      <div
+        ref={tipRef}
+        className={`chart-tip ${compact ? "chart-tip--compact" : ""}`}
+      >
+        {compact ? (
+          <>
+            <span ref={el => { if (el) tipRefsObj.current.label = el; }} className="ct-d" /> ·
+            <span ref={el => { if (el) tipRefsObj.current.total = el; }} className="ct-v" /> PR ·
+            <span ref={el => { if (el) tipRefsObj.current.clean = el; }} className="ct-c" />/
+            <span ref={el => { if (el) tipRefsObj.current.p2 = el; }} className="ct-p2" />/
+            <span ref={el => { if (el) tipRefsObj.current.p1 = el; }} className="ct-p1" />
+            <span ref={el => { if (el) tipRefsObj.current.dirty = el; }} className="ct-pct" />
+          </>
+        ) : (
+          <>
+            <div ref={el => { if (el) tipRefsObj.current.label = el; }} className="chart-tip-l" />
+            <div className="chart-tip-row">
+              <span ref={el => { if (el) tipRefsObj.current.total = el; }} className="chart-tip-v" />
+              <span className="chart-tip-u">PR в периоде</span>
+            </div>
+            <div className="chart-tip-foot">
+              <span className="chart-tip-seg"><i className="sw" style={{ background: "var(--v4-clean-soft)" }} /> чистые</span>
+              <span ref={el => { if (el) tipRefsObj.current.clean = el; }} className="chart-tip-tr" />
+            </div>
+            <div className="chart-tip-foot chart-tip-foot--tight">
+              <span className="chart-tip-seg"><i className="sw" style={{ background: "var(--v4-p2)" }} /> P2 only</span>
+              <span ref={el => { if (el) tipRefsObj.current.p2 = el; }} className="chart-tip-tr" style={{ color: "var(--v4-p2-text)" }} />
+            </div>
+            <div className="chart-tip-foot chart-tip-foot--tight">
+              <span className="chart-tip-seg"><i className="sw" style={{ background: "var(--v4-p1)" }} /> P1</span>
+              <span ref={el => { if (el) tipRefsObj.current.p1 = el; }} className="chart-tip-tr" style={{ color: "var(--v4-p1-text)" }} />
+            </div>
+            <div className="chart-tip-foot" style={{ borderTop: "1px solid var(--v4-line-soft)", paddingTop: 8, marginTop: 4 }}>
+              <span>Δ грязных</span>
+              <span ref={el => { if (el) tipRefsObj.current.dirty = el; }} className="chart-tip-tr" style={{ fontSize: 13 }} />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run, PASS**
+
+`npx vitest run tests/quality/QualityChart.test.tsx`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/styles/v4-quality.css src/components/quality/QualityChart.tsx tests/quality/QualityChart.test.tsx
+git commit -m "feat(quality): QualityChart component (main + compact) with hover behavior"
+```
+
+---
+
+### Task 19: QualityKPIs
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Create: `src/components/quality/QualityKPIs.tsx`
+
+- [ ] **Step 1: Implementation**
+
+```tsx
+import type { QualityPayload, PeriodMode } from "../../types/quality";
+
+interface Props { data: QualityPayload; mode: PeriodMode; }
+
+export function QualityKPIs({ data, mode }: Props) {
+  const buckets = data.buckets[mode].summary;
+  const total = buckets.reduce((a, b) => a + b.total_pr, 0);
+  const totalP0 = buckets.reduce((a, b) => a + b.with_p0, 0);
+  const totalP1 = buckets.reduce((a, b) => a + b.with_p1_only, 0);
+  const totalP2 = buckets.reduce((a, b) => a + b.with_p2_only, 0);
+  const dirty = totalP0 + totalP1 + totalP2;
+  const dirtyPct = total ? Math.round(dirty / total * 100) : 0;
+  const p1Pct = total ? Math.round(totalP1 / total * 100) : 0;
+  const p2Pct = total ? Math.round(totalP2 / total * 100) : 0;
+  const avgPerPeriod = buckets.length ? Math.round(total / buckets.length) : 0;
+  const periodLabel = mode === "12w" ? "за 12 нед." : "за 30 дней";
+
+  return (
+    <div className="kpis">
+      {/* P0-alert pill — pulse-плашка, видна только если есть блокеры в периоде */}
+      {totalP0 > 0 && (
+        <div className="kpi-p0-alert" title="Блокирующие баги от Codex. Требуют немедленного внимания.">
+          <span className="kpi-p0-icon">🔴</span>
+          <div className="kpi-p0-text">
+            <b>P0: {totalP0}</b>
+            <span>БЛОКЕРЫ {periodLabel}</span>
+          </div>
+        </div>
+      )}
+      <div className="kpi" style={{ ["--i" as any]: 0 }}>
+        <div className="kpi-lbl">% грязных PR · {periodLabel}</div>
+        <div className="kpi-v">{dirtyPct}%</div>
+        <div className="kpi-sub">{dirty} из {total} PR</div>
+      </div>
+      <div className="kpi" style={{ ["--i" as any]: 1 }}>
+        <div className="kpi-lbl">% P1 · {periodLabel}</div>
+        <div className="kpi-v" style={{ color: "var(--v4-p1-text)" }}>{p1Pct}%</div>
+      </div>
+      <div className="kpi" style={{ ["--i" as any]: 2 }}>
+        <div className="kpi-lbl">% P2 · {periodLabel}</div>
+        <div className="kpi-v" style={{ color: "var(--v4-p2-text)" }}>{p2Pct}%</div>
+      </div>
+      <div className="kpi" style={{ ["--i" as any]: 3 }}>
+        <div className="kpi-lbl">PR {periodLabel}</div>
+        <div className="kpi-v">{total}</div>
+        <div className="kpi-sub">{avgPerPeriod} в {mode === "12w" ? "среднем за неделю" : "среднем за день"}</div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/quality/QualityKPIs.tsx
+git commit -m "feat(quality): QualityKPIs (4 cards computed from current period summary)"
+```
+
+---
+
+### Task 20: QualityAnnotations
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Create: `src/components/quality/QualityAnnotations.tsx`
+
+- [ ] **Step 1: Implementation**
+
+```tsx
+import type { Annotation, PeriodMode } from "../../types/quality";
+import { annotationPositionPct } from "../../utils/quality-position";
+
+interface Props {
+  annotations: Annotation[];
+  mode: PeriodMode;
+  bucketCount: number;
+}
+
+export function QualityAnnotations({ annotations, mode, bucketCount }: Props) {
+  const today = new Date();
+  return (
+    <>
+      {annotations.map(a => {
+        const pct = annotationPositionPct(new Date(a.occurred_at), mode, today, bucketCount);
+        if (pct === null) return null;
+        return (
+          <div key={a.id} className={`annot is-${a.category}`} style={{ left: `${pct}%` }}>
+            <div className="annot-dot" />
+            <div className="annot-tip">
+              <span className="annot-tip-cat">{a.category}</span><br />
+              <b>{a.title}</b><br />
+              <span style={{ opacity: 0.8, whiteSpace: "normal" }}>{a.desc}</span>
+              <div className="annot-tip-date">
+                {new Date(a.occurred_at).toLocaleDateString("ru")}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/quality/QualityAnnotations.tsx
+git commit -m "feat(quality): QualityAnnotations renders vertical markers with hover tip"
+```
+
+---
+
+### Task 21: QualityProjectCard
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Create: `src/components/quality/QualityProjectCard.tsx`
+
+- [ ] **Step 1: Implementation**
+
+```tsx
+import type { QualityPayload, PeriodMode, RepoStatusEntry } from "../../types/quality";
+import { QualityChart } from "./QualityChart";
+
+interface Props {
+  repo: string;
+  client: string;
+  data: QualityPayload;
+  mode: PeriodMode;
+  index: number;
+}
+
+function severityBadge(dirtyPct: number): { label: string; cls: string } | null {
+  if (dirtyPct === 0 || Number.isNaN(dirtyPct)) return null;
+  if (dirtyPct >= 25) return { label: "высокий риск", cls: "tag-bad" };
+  if (dirtyPct >= 12) return { label: "средний", cls: "tag-warn" };
+  return { label: "чисто", cls: "tag-good" };
+}
+
+export function QualityProjectCard({ repo, client, data, mode, index }: Props) {
+  const status: RepoStatusEntry | undefined = data.repo_status[repo];
+  const repoData = data.buckets[mode].per_repo[repo];
+  const labels = data.buckets[mode].labels;
+
+  // Error state
+  if (status?.status === "error") {
+    return (
+      <div className="card" style={{ ["--i" as any]: index }}>
+        <div className="card-h">
+          <div>
+            <div className="card-name">{repo}</div>
+            <div className="card-client">{client}</div>
+          </div>
+          <span className="tag tag-bad">ошибка fetch</span>
+        </div>
+        <div className="card-empty">
+          <b>{status.code || "ERROR"}</b>
+          {status.message || "Sweep не смог получить данные"}
+        </div>
+      </div>
+    );
+  }
+
+  if (!repoData) {
+    return (
+      <div className="card" style={{ ["--i" as any]: index }}>
+        <div className="card-h">
+          <div className="card-name">{repo}</div>
+        </div>
+        <div className="card-empty">нет данных</div>
+      </div>
+    );
+  }
+
+  const totalPR = repoData.buckets.reduce((a, b) => a + b.total_pr, 0);
+  const totalP0 = repoData.buckets.reduce((a, b) => a + b.with_p0, 0);
+  const totalP1 = repoData.buckets.reduce((a, b) => a + b.with_p1_only, 0);
+  const totalP2 = repoData.buckets.reduce((a, b) => a + b.with_p2_only, 0);
+  const totalDirty = totalP0 + totalP1 + totalP2;
+
+  if (totalPR < 3) {
+    return (
+      <div className="card" style={{ ["--i" as any]: index }}>
+        <div className="card-h">
+          <div>
+            <div className="card-name">{repo}</div>
+            <div className="card-client">{client}</div>
+          </div>
+          <span className="tag">мало данных</span>
+        </div>
+        <div className="card-empty">
+          <b>{totalPR} PR за период</b>
+          Нужно ≥3 для расчёта
+        </div>
+      </div>
+    );
+  }
+
+  const dirtyPct = totalDirty / totalPR * 100;
+  const p1Pct = totalP1 / totalPR * 100;
+  const p2Pct = totalP2 / totalPR * 100;
+  const badge = severityBadge(dirtyPct);
+  const coverage = repoData.codex_coverage_pct;
+  const lowCoverage = coverage < 50;
+
+  return (
+    <div className="card" style={{ ["--i" as any]: index }}>
+      <div className="card-h">
+        <div>
+          <div className="card-name">{repo}</div>
+          <div className="card-client">{client}</div>
+        </div>
+        <div>
+          <div className="card-now">{dirtyPct.toFixed(0)}%</div>
+          <div className="card-now-sub">{totalDirty}/{totalPR} PR</div>
+        </div>
+      </div>
+      <QualityChart buckets={repoData.buckets} labels={labels} compact />
+      <div className="card-foot">
+        <div className="nums">
+          {totalP0 > 0 && (
+            <span className="num-p0" title="БЛОКЕР">
+              <b style={{ color: "var(--v4-p0-text)", background: "rgba(239,68,68,0.12)",
+                         padding: "1px 6px", borderRadius: 3, fontWeight: 700 }}>
+                🔴 P0: {totalP0}
+              </b>
+            </span>
+          )}
+          <span className="num-p1">P1 <b>{p1Pct.toFixed(0)}%</b></span>
+          <span className="num-p2">P2 <b>{p2Pct.toFixed(0)}%</b></span>
+          {lowCoverage && (
+            <span className="tag tag-warn" title="Codex ревьюил меньше половины PR">
+              Codex: {coverage}%
+            </span>
+          )}
+        </div>
+        {badge && <span className={`tag ${badge.cls}`}>{badge.label}</span>}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/quality/QualityProjectCard.tsx
+git commit -m "feat(quality): QualityProjectCard with error/empty/low-coverage states"
+```
+
+---
+
+### Task 22: QualitySummaryPanel + StaleBanner
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Create: `src/components/quality/QualitySummaryPanel.tsx`
+- Create: `src/components/quality/QualityStaleBanner.tsx`
+
+- [ ] **Step 1: StaleBanner**
+
+```tsx
+interface Props { generatedAt: string; onRefresh: () => void; }
+
+export function QualityStaleBanner({ generatedAt, onRefresh }: Props) {
+  const ageHours = Math.round((Date.now() - new Date(generatedAt).getTime()) / 3.6e6);
+  return (
+    <div className="quality-stale-banner">
+      <span>⚠ Данные не обновлялись {ageHours}ч. Проверь cron на Pipeline Mac.</span>
+      <button className="btn-refresh" onClick={onRefresh}>↻ Обновить сейчас</button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: SummaryPanel**
+
+```tsx
+import type { QualityPayload, Annotation, PeriodMode } from "../../types/quality";
+import { QualityChart } from "./QualityChart";
+import { QualityKPIs } from "./QualityKPIs";
+import { QualityAnnotations } from "./QualityAnnotations";
+
+interface Props {
+  data: QualityPayload;
+  annotations: Annotation[];
+  mode: PeriodMode;
+}
+
+export function QualitySummaryPanel({ data, annotations, mode }: Props) {
+  const buckets = data.buckets[mode].summary;
+  const labels = data.buckets[mode].labels;
+  const errored = Object.entries(data.repo_status).filter(([, s]) => s.status === "error");
+
+  return (
+    <div className="panel summary">
+      <div className="chartwrap">
+        <div className="panel-t" style={{ marginBottom: 14 }}>
+          Сводно по всем {Object.keys(data.repo_status).length} проектам
+          <span className="tag">All repos</span>
+          {errored.length > 0 && (
+            <span className="tag tag-bad" title={errored.map(([r, s]) => `${r}: ${s.code}`).join("\n")}>
+              ⚠ {errored.length} репо без данных
+            </span>
+          )}
+        </div>
+        <QualityChart buckets={buckets} labels={labels} compact={false} />
+        <QualityAnnotations annotations={annotations} mode={mode} bucketCount={buckets.length} />
+        <div className="chart-legend">
+          <span><i className="dot dot-p1" /> P1 (критическое)</span>
+          <span><i className="dot dot-p2" /> P2 (высокое)</span>
+          <span><i className="dot dot-clean" /> чистые PR</span>
+        </div>
+      </div>
+      <QualityKPIs data={data} mode={mode} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/quality/QualitySummaryPanel.tsx src/components/quality/QualityStaleBanner.tsx
+git commit -m "feat(quality): SummaryPanel (chart + KPIs + annotations + error badge) + StaleBanner"
+```
+
+---
+
+### Task 23: ProjectGrid + sort
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Create: `src/components/quality/QualityProjectGrid.tsx`
+
+- [ ] **Step 1: Implementation**
+
+```tsx
+import { useState, useMemo } from "react";
+import type { QualityPayload, PeriodMode } from "../../types/quality";
+import { PROJECTS } from "../../utils/config";
+import { QualityProjectCard } from "./QualityProjectCard";
+
+interface Props { data: QualityPayload; mode: PeriodMode; }
+
+type SortKey = "dirty" | "alpha" | "p1";
+
+export function QualityProjectGrid({ data, mode }: Props) {
+  const [sortKey, setSortKey] = useState<SortKey>("dirty");
+
+  const sorted = useMemo(() => {
+    return [...PROJECTS].sort((a, b) => {
+      if (sortKey === "alpha") return a.repo.localeCompare(b.repo);
+      const aD = computeDirtyPct(data, a.repo, mode);
+      const bD = computeDirtyPct(data, b.repo, mode);
+      const aP1 = computeP1Pct(data, a.repo, mode);
+      const bP1 = computeP1Pct(data, b.repo, mode);
+      if (sortKey === "p1") return bP1 - aP1;
+      return bD - aD;
+    });
+  }, [data, mode, sortKey]);
+
+  return (
+    <>
+      <div className="sect">
+        <h2>По проектам</h2>
+        <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+          <span className="meta">Сортировка:</span>
+          <div className="sort">
+            <button className={sortKey === "dirty" ? "active" : ""} onClick={() => setSortKey("dirty")}>по «грязи»</button>
+            <button className={sortKey === "alpha" ? "active" : ""} onClick={() => setSortKey("alpha")}>по алфавиту</button>
+            <button className={sortKey === "p1" ? "active" : ""} onClick={() => setSortKey("p1")}>по P1</button>
+          </div>
+        </div>
+      </div>
+      <div className="grid">
+        {sorted.map((p, idx) => (
+          <QualityProjectCard
+            key={p.repo}
+            repo={p.repo}
+            client={p.client}
+            data={data}
+            mode={mode}
+            index={idx}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+function computeDirtyPct(data: QualityPayload, repo: string, mode: PeriodMode): number {
+  const r = data.buckets[mode].per_repo[repo];
+  if (!r) return 0;
+  const tot = r.buckets.reduce((a, b) => a + b.total_pr, 0);
+  if (!tot) return 0;
+  const dirty = r.buckets.reduce((a, b) => a + b.with_p1 + b.with_p2_only, 0);
+  return dirty / tot * 100;
+}
+function computeP1Pct(data: QualityPayload, repo: string, mode: PeriodMode): number {
+  const r = data.buckets[mode].per_repo[repo];
+  if (!r) return 0;
+  const tot = r.buckets.reduce((a, b) => a + b.total_pr, 0);
+  if (!tot) return 0;
+  return r.buckets.reduce((a, b) => a + b.with_p1, 0) / tot * 100;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/quality/QualityProjectGrid.tsx
+git commit -m "feat(quality): QualityProjectGrid with sort by dirty/alpha/p1"
+```
+
+---
+
+### Task 24: AnnotationModal
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Create: `src/components/quality/AnnotationModal.tsx`
+- Create: `tests/quality/AnnotationModal.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { AnnotationModal } from "../../src/components/quality/AnnotationModal";
+
+describe("AnnotationModal", () => {
+  it("submits annotation with form values converted to UTC", async () => {
+    const onSubmit = vi.fn().mockResolvedValue({});
+    const { getByLabelText, getByText } = render(
+      <AnnotationModal onSubmit={onSubmit} onClose={vi.fn()} />
+    );
+    fireEvent.change(getByLabelText(/дата/i), { target: { value: "2026-05-22" } });
+    fireEvent.change(getByLabelText(/title/i), { target: { value: "test event" } });
+    fireEvent.click(getByText(/сохранить/i));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      occurred_at: "2026-05-22T00:00:00.000Z",
+      category: "skill",
+      scope: "global",
+      title: "test event",
+      desc: "",
+    }));
+  });
+});
+```
+
+- [ ] **Step 2: Run, FAIL**
+
+`npx vitest run tests/quality/AnnotationModal.test.tsx`
+
+- [ ] **Step 3: Implementation**
+
+```tsx
+import { useState } from "react";
+import type { AnnotationCreatePayload, AnnotationCategory } from "../../types/quality";
+
+interface Props {
+  onSubmit: (p: AnnotationCreatePayload) => Promise<void>;
+  onClose: () => void;
+}
+
+export function AnnotationModal({ onSubmit, onClose }: Props) {
+  const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
+  const [category, setCategory] = useState<AnnotationCategory>("skill");
+  const [title, setTitle] = useState("");
+  const [desc, setDesc] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setSubmitting(true);
+    try {
+      // Local midnight → UTC, либо берём дату как-есть UTC (упрощение для v1)
+      const occurredAt = new Date(date + "T00:00:00Z").toISOString();
+      await onSubmit({
+        occurred_at: occurredAt,
+        category,
+        scope: "global",
+        title: title.trim(),
+        desc: desc.trim(),
+      });
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="modal-bd" onClick={onClose}>
+      <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={handleSubmit}>
+        <h3>Добавить событие</h3>
+        <label>
+          <span>Дата (UTC)</span>
+          <input type="date" value={date} onChange={(e) => setDate(e.target.value)} required />
+        </label>
+        <label>
+          <span>Категория</span>
+          <select value={category} onChange={(e) => setCategory(e.target.value as AnnotationCategory)}>
+            <option value="skill">skill — обновление скилла разработки</option>
+            <option value="deploy">deploy — деплой инфраструктуры</option>
+            <option value="manual">manual — pair-сессия, ad-hoc</option>
+          </select>
+        </label>
+        <label>
+          <span>Title</span>
+          <input value={title} onChange={(e) => setTitle(e.target.value)} maxLength={120} required />
+        </label>
+        <label>
+          <span>Описание</span>
+          <textarea value={desc} onChange={(e) => setDesc(e.target.value)} maxLength={600} rows={3} />
+        </label>
+        <div className="modal-actions">
+          <button type="button" onClick={onClose}>Отмена</button>
+          <button type="submit" disabled={submitting}>Сохранить</button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run, PASS**
+
+`npx vitest run tests/quality/AnnotationModal.test.tsx`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/quality/AnnotationModal.tsx tests/quality/AnnotationModal.test.tsx
+git commit -m "feat(quality): AnnotationModal for + событие button"
+```
+
+---
+
+### Task 25: QualityTab (orchestrator)
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Create: `src/components/quality/QualityTab.tsx`
+
+- [ ] **Step 1: Implementation**
+
+```tsx
+import { useState } from "react";
+import { useQuality } from "../../hooks/useQuality";
+import type { PeriodMode, AnnotationCreatePayload } from "../../types/quality";
+import { QualitySummaryPanel } from "./QualitySummaryPanel";
+import { QualityProjectGrid } from "./QualityProjectGrid";
+import { QualityStaleBanner } from "./QualityStaleBanner";
+import { AnnotationModal } from "./AnnotationModal";
+import { createAnnotation } from "../../utils/quality";
+import "../../styles/v4-quality.css";
+
+export function QualityTab() {
+  const { data, annotations, loading, error, isStale, refresh, reloadAnnotations } = useQuality();
+  const [mode, setMode] = useState<PeriodMode>("12w");
+  const [showAddModal, setShowAddModal] = useState(false);
+
+  if (loading && !data) return <div className="v4-quality-tab">Загрузка…</div>;
+  if (error) {
+    return (
+      <div className="v4-quality-tab">
+        <div className="quality-error-panel">
+          <b>Ошибка загрузки данных:</b> {error}
+          <button onClick={() => refresh()}>Попробовать снова</button>
+        </div>
+      </div>
+    );
+  }
+  if (!data) return <div className="v4-quality-tab">Нет данных</div>;
+
+  const handleAddAnnotation = async (p: AnnotationCreatePayload) => {
+    await createAnnotation(p);
+    await reloadAnnotations();
+  };
+
+  return (
+    <div className="v4-quality-tab page">
+      <div className="pageH">
+        <div>
+          <h1>Качество кода и изменения</h1>
+          <div className="sub">
+            Доля PR с критическими/высокими замечаниями <b>chatgpt-codex-connector[bot]</b> от общего числа merged PR · события на временной оси
+          </div>
+        </div>
+        <div className="ctrls">
+          <div className="seg">
+            <button className={mode === "30d" ? "active" : ""} onClick={() => setMode("30d")}>30 дней · По дням</button>
+            <button className={mode === "12w" ? "active" : ""} onClick={() => setMode("12w")}>12 недель · По неделям</button>
+          </div>
+          <button className="btn-add-event" onClick={() => setShowAddModal(true)}>+ событие</button>
+          <div style={{ fontFamily: "var(--v4-mono)", fontSize: 10, color: "var(--v4-ink-500)", textAlign: "right" }}>
+            <div>Синхр. ежедневно · 03:00 Бали</div>
+            <div style={{ color: "var(--v4-ink-400)" }}>
+              последняя: {new Date(data.generated_at).toLocaleString("ru")}
+            </div>
+          </div>
+          <button className="btn-refresh" onClick={() => refresh()} disabled={loading}>↻ Сейчас</button>
+        </div>
+      </div>
+
+      {isStale && <QualityStaleBanner generatedAt={data.generated_at} onRefresh={() => refresh()} />}
+
+      <QualitySummaryPanel data={data} annotations={annotations} mode={mode} />
+      <QualityProjectGrid data={data} mode={mode} />
+
+      {showAddModal && (
+        <AnnotationModal
+          onSubmit={handleAddAnnotation}
+          onClose={() => setShowAddModal(false)}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/quality/QualityTab.tsx
+git commit -m "feat(quality): QualityTab orchestrator with mode toggle + add-event modal"
+```
+
+---
+
+### Task 26: Add tab to App.tsx
+
+**Repo:** `makeit-dashboard`
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Найти tab-button block в App.tsx**
+
+```bash
+grep -n "TabButton\|setTab\|tab ===" src/App.tsx | head -20
+```
+
+- [ ] **Step 2: Добавить вкладку**
+
+В блок с TabButtons (после последней):
+```tsx
+<TabButton id="quality" active={tab === "quality"} onClick={() => setTab("quality")}>
+  Качество
+</TabButton>
+```
+
+В render-блок (после последнего `{tab === "..." && ...}`):
+```tsx
+{tab === "quality" && (
+  <Suspense fallback={<div>Загрузка…</div>}>
+    <QualityTab />
+  </Suspense>
+)}
+```
+
+С import:
+```tsx
+const QualityTab = lazy(() => import("./components/quality/QualityTab").then(m => ({ default: m.QualityTab })));
+```
+
+- [ ] **Step 3: Manual test**
+
+```bash
+npm run dev
+# Открыть http://localhost:5173/makeit-dashboard/
+# Кликнуть «Качество» → увидеть вкладку
+# Проверить toggle 30d/12w, hover на бары, + событие
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat(quality): integrate Quality tab into App with lazy-load"
+```
+
+---
+
+## Phase H — Final integration
+
+### Task 27: End-to-end verification
+
+**Files:** none (manual)
+
+- [ ] **Step 1: Backend smoke (Pipeline Mac)**
+
+```bash
+ssh sergeymakarov
+cd ~/makeit-pipeline
+git pull && pip install -e . && pytest tests/quality/
+launchctl unload ~/Library/LaunchAgents/com.makeit.codex-quality-sweep.plist
+launchctl load ~/Library/LaunchAgents/com.makeit.codex-quality-sweep.plist
+launchctl start com.makeit.codex-quality-sweep
+sleep 60
+cat ~/data/codex-quality.json | jq '.schema_version, .repo_status'
+```
+Expected: schema_version=1, repo_status имеет 14 ключей с "ok" статусами.
+
+- [ ] **Step 2: VPS verify**
+
+```bash
+curl -s https://your-dashboard-domain/data/codex-quality.json | jq '.generated_at'
+```
+Expected: свежий timestamp.
+
+- [ ] **Step 3: Frontend e2e**
+
+```bash
+ssh root@89.167.17.79 'bash /opt/apps/makeit-stack/deploy.sh'  # стандартный deploy dashboard
+```
+Открыть дашборд в браузере, вкладка «Качество», проверить:
+- ✅ Чарт загружается, бары видны
+- ✅ Hover на бар → tooltip-card справа
+- ✅ Hover на mini-chart → compact tooltip + dim siblings
+- ✅ Toggle 30d/12w работает
+- ✅ + событие → модалка → submit → линия появилась
+- ✅ Если cron работает >30ч назад — баннер stale показан
+
+- [ ] **Step 4: Commit финальная заметка**
+
+В `docs/DEPLOYMENT.md` дописать секцию про Quality tab — где данные, где cron, как переустановить plist, где логи.
+
+```bash
+git add docs/DEPLOYMENT.md
+git commit -m "docs(quality): deployment notes for Quality tab + cron"
+```
+
+---
+
+## Self-Review
+
+Прошёлся по спецу. Каждый пункт раздела имеет соответствующую задачу:
+
+- ✅ Метрика + bucketize → Task 3
+- ✅ Per-chart auto-scaling → Task 18 (niceCeil per chart)
+- ✅ Worst-wins (P1+P2 → P1) → Task 2 (group_findings_per_pr)
+- ✅ Atomic remote publish → Task 4
+- ✅ Locking → Task 5
+- ✅ Retry с rate-limit headers → Task 6
+- ✅ GitHub API fix (early-exit без `?since`) → Task 7
+- ✅ Sweep с repo_status + coverage → Task 8
+- ✅ Sanitized errors → Task 9 + 12
+- ✅ Explicit quality_repos.json → Task 1
+- ✅ launchd plist → Task 10
+- ✅ Annotations с UUID + scope → Task 11 + 12
+- ✅ JSON schema metadata (window_start/end, bucket_tz, schema_version) → Task 8 (run_sweep payload)
+- ✅ Low-sample badge → Task 18 (is-low-sample class) + Task 21 (totalPR<3 empty state)
+- ✅ Codex coverage badge → Task 21 (lowCoverage condition)
+- ✅ POST/DELETE security → Task 12 (Pydantic + length limits)
+- ✅ Healthcheck + stale banner → Task 22
+- ✅ ISO-week UTC bucketing → Task 3 (bucketize_weekly_iso)
+- ✅ Annotation position math (snap/proportional) → Task 15
+- ✅ Hover behaviour identical main+compact → Task 18 (одна функция handleEnter, compact branching)
+- ✅ Reduced-motion + animations → CSS из прототипа (Task 18 step 1)
+
+Type consistency: QualityBucket, QualityPayload, Annotation определены в Task 14, использованы консистентно во всех task'ах далее.
+
+Placeholders: проверил — все шаги содержат полный код, нет "TBD"/"add error handling".
+
+Plan ready.
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-25-codex-quality-tab.md`.**
+
+Два варианта выполнения:
+
+**1. Subagent-Driven (рекомендуется)** — каждая task в свежий subagent, review между task'ами, быстрая итерация. Хорошо для длинного плана (27 tasks в двух репо).
+
+**2. Inline Execution** — выполнить в текущей сессии через executing-plans, чекпоинты для review между фазами.
+
+Что выбираешь?

--- a/docs/superpowers/specs/2026-05-25-codex-quality-tab-design.md
+++ b/docs/superpowers/specs/2026-05-25-codex-quality-tab-design.md
@@ -1,0 +1,708 @@
+# Вкладка «Качество кода и изменения» — Design
+
+**Date:** 2026-05-25
+**Status:** Spec v2 — после Codex code-review, готов к implementation plan
+**Owner:** sergey
+**Related:** reuses data-collection pattern from `~/.claude/skills/makeit-codexfeedback/SKILL.md`. Prototype: [`quality-tab-prototype.html`](../../../quality-tab-prototype.html). Vision: [`QUALITY-TELEMETRY-VISION.md`](../../QUALITY-TELEMETRY-VISION.md).
+
+**Changelog:**
+- **v1** (2026-05-25): первая версия после brainstorming + прототипа.
+- **v3** (2026-05-25): добавлена поддержка **P0 severity** (Codex emits P0=red blocker — проверено на реальных PR moliyakg#2282, #2332). Worst-wins: P0 > P1 > P2-only. Bar остаётся 3-color (P0+P1 объединены в красный crit-сегмент). Отдельный P0-alert pulse в KPI справа. Цветовая палитра сдвинута под shields.io semantics: P0=red, P1=orange, P2=yellow.
+- **v2** (2026-05-25): адаптированы все 13 findings из Codex code-review:
+  1. ❌ Исправлен **критический баг** в data fetch — у `/pulls` нет `since`-параметра (есть только у `/pulls/comments`, и там "updated_at"). Перешли на `sort=updated&direction=desc` с early-exit + клиентский фильтр по `merged_at`.
+  2. Atomic remote publish через rsync `.tmp` + ssh `mv`.
+  3. Locking через `flock` (предотвращает race cron × force-refresh).
+  4. Retry респектит `Retry-After` / `X-RateLimit-Reset` + jitter.
+  5. `repo_status` per-repo в JSON, partial failures не занижают summary.
+  6. Sanitized error codes в API (не raw stderr).
+  7. Repo list — explicit `config/quality_repos.json` (не regex по CLAUDE.md).
+  8. JSON schema metadata: `schema_version`, `window_start`, `window_end`, `bucket_tz`.
+  9. Annotations: `id` UUID v4 (не index), `scope` (global/repo) уже в v1 schema, `occurred_at` UTC явный.
+  10. `codex_coverage_pct` per repo-card (защита от фальшивого "100% clean" при недавнем включении бота).
+  11. Low-sample treatment (бейдж "малая выборка" при `total_pr < 8`).
+  12. POST/DELETE security: length-limits, max annotations, Pydantic strict types.
+  13. Archive immunity явно задокументирована (Project v2 status не влияет на sweep).
+
+---
+
+## Problem
+
+`chatgpt-codex-connector[bot]` оставляет line-level P1/P2 замечания на PR во всех 12 MakeIT-репо. Сейчас эти данные собираются только месячным sweep'ом (`makeit-codexfeedback` skill) для разовых отчётов. Нет постоянной картины «как меняется чистота кода во времени», нет сравнения проектов между собой, нет раннего сигнала о деградации.
+
+## Goal
+
+Добавить в дашборд 9-ю вкладку «Качество», которая показывает:
+
+- **Сводный график:** % "грязных" PR (с ≥1 P1/P2 находкой) по всем 12 репо во времени.
+- **Карточку на каждый проект** с мини-графиком той же метрики.
+- **Переключатель периода:** 30 дней (по дням) / 12 недель (по неделям).
+- **Daily sync** — данные обновляются раз в сутки в 03:00 по Бали (= 19:00 UTC), так что утром пользователь видит свежие "вчерашние" данные мгновенно (без ожидания фетча в браузере).
+
+## Non-goals
+
+- Не строим UI для просмотра конкретных PR/комментов — это делает GitHub UI (по ссылке из метаданных).
+- Не классифицируем находки по типу (security/perf/bug) — Codex даёт только severity.
+- Не делаем алёрты/нотификации при росте % — только визуализация.
+- Не показываем P3 — Codex его не использует.
+- Не переписываем `makeit-codexfeedback` skill — он остаётся для ручных месячных отчётов.
+- **Feature работает только на VPS-деплое.** GitHub Pages билд показывает баннер "Качество кода доступно на VPS-версии дашборда" — потому что JSON генерируется sweep'ом и хостится на VPS, на GH Pages его не существует.
+
+## Метрика и визуализация
+
+**Что считаем (3-level worst-wins):**
+- `total_pr` — все merged PR в бакете
+- `with_p0` — PR с ≥1 P0 находкой (БЛОКЕР). Worst-wins абсорбит P1 и P2 одного PR
+- `with_p1_only` — PR с ≥1 P1, но **без P0**
+- `with_p2_only` — PR с ≥1 P2, но **без P0 и без P1**
+- `clean = total_pr - with_p0 - with_p1_only - with_p2_only` — PR без находок (включая нетронутые Codex'ом)
+
+Гарантия: сумма всех четырёх категорий = `total_pr` без двойного счёта.
+
+Бакет = 1 день (режим 30d) или 1 неделя (режим 12w).
+
+**% грязных PR** = `(with_p0 + with_p1_only + with_p2_only) / total_pr × 100` — заголовочное число в KPI-блоке и на карточке проекта.
+
+**Бакетизация по времени (важно):**
+- **30d (по дням):** каждый бакет = 1 календарный день в UTC. `merged_at` PR попадает в бакет `[day 00:00 UTC, day+1 00:00 UTC)`. Series длиной 30 баров оканчивается **сегодняшним днём** в UTC.
+- **12w (по неделям):** каждый бакет = **ISO-неделя (пн-вс)**. `merged_at` PR попадает в бакет `[Mon 00:00 UTC, next Mon 00:00 UTC)`. Series длиной 12 баров оканчивается **текущей ISO-неделей** (понедельник = `isoMonday(today)` в UTC). Это даёт каноничную "неделю" одинаковую для всех таймзон команды.
+
+Использование локальной timezone было бы соблазнительно (особенно Бали где cron живёт), но проект распределённый — Codex-бот, GitHub Actions и команда работают в разных TZ. UTC даёт единый стабильный референс.
+
+**Как визуализируем (важно!):**
+- **Высота бара = `total_pr`** в бакете (абсолютная шкала, ось слева).
+- **Y-axis шкалируется per chart**, не глобально! Каждый чарт (сводный + 12 карточек) считает свой `max(total_pr)` в серии и округляет вверх до 5/10/20/50/100/200/... Иначе проекты с мало PR (Uchet_bot, Beer_bot) визуально прижимаются к земле общей шкалой `mankassa-app`/`makeit-pipeline` и теряют динамику.
+- **Внутри бара — 3-color стек снизу вверх:** crit (красный, P0+P1 объединены) → P2-only (жёлтый) → clean (голубой).
+- **Почему P0+P1 объединены в один сегмент:** 4 цвета в баре читать тяжело (особенно в mini 80px). P0 редкий — за активный репо обычно 0-2 за день. Чтобы P0 не "терялся" под P1 — отдельный **P0-alert pulse в KPI** (см. ниже).
+- **Tooltip** разбивает crit-сегмент: `P0: 1 (BLOCKER) · P1: 3 · P2 only: 2`.
+- Сразу видно **две вещи одновременно**: объём работы (высота) + долю проблем (цветные доли внизу).
+- **Семантическое следствие:** между разными чартами сравнивать **абсолютные высоты нельзя** (разные шкалы), сравнивать можно только **долю красно-жёлтого** в бару.
+
+**PR без ревью Codex** — считаются "чистыми" (входят в clean-сегмент). Знаменатель — все merged PR, включая нетронутые ботом. Бизнес-смысл бара: "сколько PR замержено и какая часть из них имеет дефекты".
+
+**Per-bar P0 visibility (КРИТИЧНО — без hover должно быть очевидно):**
+
+| Где | Что видно ВСЕГДА (без hover) |
+|---|---|
+| Главный чарт | (a) Колонка с P0 — красный vertical gradient на всю высоту чарта (`rgba(239,68,68, 0.18→0.02)`). (b) Mini-pill `P0:N` сверху над столбцом с pulse-анимацией translateY(0↔-2px) 2s loop |
+| Mini-чарт в карточке | Колонка — тот же gradient (но менее заметно из-за 80px). **Бар получает `border-top: 2px solid var(--v4-p0)`** — даёт чёткую красную полоску сверху бара. Топпер не показываем (нет места + border-top уже сигналит) |
+| Hover (оба) | Tooltip разбивает P0 отдельно с иконкой 🔴 и acid red колором |
+
+**Почему не просто tooltip:** P0 день встречается редко (1-2/неделя), но это блокер. Юзер должен сразу при беглом сканировании увидеть "ага, 27 апреля что-то взорвалось". Без always-visible-маркера для этого нужно ховерить каждый бар по очереди — плохой UX.
+
+**P0-alert pill (в правой KPI-панели):**
+- Видна **только** если `sum(with_p0) > 0` в текущем периоде. Иначе скрыта (не загромождаем счастливые периоды).
+- Большая красная плашка с pulse-анимацией (`box-shadow` ring expand 1.8s loop)
+- Текст: `🔴 P0: N · БЛОКЕРЫ за {период}`
+- На карточке проекта тоже отдельный inline-бейдж `🔴 P0: 2` рядом с P1/P2 в card-foot
+- Click (Phase 2 — не для v1) → раскроет список PR с P0 + ссылки на коммент
+
+**Цвета (align с shields.io semantics на самих Codex-бейджах в PR-комментах):**
+- P0: `--v4-p0` (#EF4444, **красный** — Codex использует `shields.io/badge/P0-red`)
+- P1: `--v4-p1` (#F59E0B, **оранжевый** — Codex использует `shields.io/badge/P1-orange`)
+- P2: `--v4-p2` (#EAB308, **жёлтый** — Codex использует `shields.io/badge/P2-yellow`)
+- Clean: `--v4-clean-soft` (#93C5FD, светло-голубой)
+- Text-colors (для контраста на белом): `--v4-p0-text: #991B1B`, `--v4-p1-text: #B45309`, `--v4-p2-text: #854D0E`
+- В баре: `bar-crit` использует `--v4-p0` (combined P0+P1 worst-wins). `bar-p2` использует `--v4-p2`.
+- Эта палитра **align с тем что юзер видит в самих PR-комментах** — нет когнитивного диссонанса "в дашборде красное, а в PR оранжевое".
+
+## Architecture
+
+```
+┌──────────────────────────────┐          ┌────────────────────────────────┐
+│ Pipeline Mac (sergeymakarov) │          │ VPS 89.167.17.79               │
+│ ┌──────────────────────────┐ │          │ ┌────────────────────────────┐ │
+│ │ launchd                  │ │          │ │ nginx (makeit dashboard)   │ │
+│ │ com.makeit.codex-quality-│ │          │ │   /                        │ │
+│ │   sweep                  │ │          │ │     → SPA                  │ │
+│ │ 03:00 Bali (19:00 UTC)   │ │          │ │   /data/codex-quality.json │ │
+│ └────────────┬─────────────┘ │          │ │     → static file          │ │
+│              ▼               │   rsync  │ └────────────────────────────┘ │
+│ ┌──────────────────────────┐ │  via SSH │              ▲                 │
+│ │ sweep.py                 │─┼──────────┼──► /opt/apps/makeit-stack/     │
+│ │  • gh api /pulls/comments│ │          │     web/data/codex-quality.json│
+│ │    /pulls (REST, 12 repo)│ │          │                                │
+│ │  • parse P1/P2 badges    │ │          └────────────────────────────────┘
+│ │  • aggregate per day/week│ │                          ▲
+│ │  • write JSON atomically │ │                          │  HTTPS GET
+│ │  • log to ~/logs/        │ │          ┌───────────────┴─────────────┐
+│ └────────────┬─────────────┘ │          │ Browser (dashboard)          │
+│              ▼               │          │ ┌──────────────────────────┐ │
+│ ┌──────────────────────────┐ │          │ │ <QualityTab>             │ │
+│ │ FastAPI /quality/refresh │◄┼──────────┼─┤ useQualityData() hook    │ │
+│ │   (force sweep on demand)│ │ tunnel   │ │   → fetch JSON           │ │
+│ │ Reuses pipeline FastAPI  │ │ via :8766│ │   → render charts        │ │
+│ └──────────────────────────┘ │          │ │   → healthcheck banner   │ │
+└──────────────────────────────┘          │ └──────────────────────────┘ │
+                                          └──────────────────────────────┘
+```
+
+**Поток данных:**
+1. В 03:00 Бали launchd запускает `sweep.py` на Pipeline Mac.
+2. Скрипт делает 12 × (2 REST-вызова) к GitHub API, агрегирует, пишет `codex-quality.tmp.json`, атомарно переименовывает в `codex-quality.json`.
+3. rsync (внутри скрипта, последний шаг) кладёт файл на VPS в `/opt/apps/makeit-stack/web/data/codex-quality.json`.
+4. Браузер при открытии вкладки фетчит `/data/codex-quality.json` (мгновенно, статика nginx).
+5. Если `generated_at` в JSON > 30 ч назад — UI показывает баннер «данные устарели».
+6. Кнопка «Обновить сейчас» → POST к Pipeline API `/quality/refresh` → синхронно запускает sweep → возвращает свежий JSON.
+
+## JSON schema
+
+`/data/codex-quality.json`:
+
+```jsonc
+{
+  "schema_version": 1,                            // bump при breaking change schema
+  "generated_at": "2026-05-25T19:03:14Z",         // UTC ISO8601
+  "window_start": "2026-03-02T00:00:00Z",         // ISO-Monday начала 12-нед окна
+  "window_end":   "2026-05-25T19:03:14Z",         // = generated_at (текущий момент)
+  "bucket_tz":    "UTC",                          // явно: бакеты UTC, не Bali
+  "sweep_duration_sec": 142,
+  "github_rate_limit_remaining": 4823,
+  "repo_status": {                                // per-repo состояние fetch'а
+    "Sewing-ERP":      { "status": "ok" },
+    "mankassa-app":    { "status": "ok" },
+    "solotax-kg":      { "status": "error", "code": "RATE_LIMITED", "message": "Retried 3x, exhausted" },
+    "Beer_bot":        { "status": "stale", "message": "Last good fetch 2 days ago — using cached" },
+    "makeit-pipeline": { "status": "ok" },
+    // ... все 12 репо
+  },
+  "buckets": {
+    "30d": {                                      // 30 daily buckets
+      "labels": ["2026-04-25", ..., "2026-05-24"],
+      "summary": [                                // aggregated across OK repos only
+        { "total_pr": 8, "with_p0": 0, "with_p1_only": 1, "with_p2_only": 2 },
+        ...
+      ],
+      "per_repo": {
+        "moliyakg": {
+          "buckets": [
+            { "total_pr": 5, "with_p0": 1, "with_p1_only": 0, "with_p2_only": 1 },  // ← P0 пример
+            ...
+          ],
+          "codex_coverage_pct": 67,             // % из total_pr где Codex оставил ≥1 коммент
+          "codex_first_seen": "2026-01-15T10:23:00Z"
+        },
+        ...
+      }
+    },
+    "12w": {
+      "labels": ["2026-03-09", ..., "2026-05-25"],   // ISO-Monday даты
+      "summary": [ ... ],
+      "per_repo": { ... }
+    }
+  }
+}
+```
+
+**Заметки про data integrity:**
+- `with_p0` = PR с ≥1 P0 находкой (worst-wins, может также иметь P1 и P2 — но засчитывается тут).
+- `with_p1_only` = PR с ≥1 P1, но **без P0**.
+- `with_p2_only` = PR с ≥1 P2, но **без P0 и без P1**.
+- `dirty = with_p0 + with_p1_only + with_p2_only` (вычисляется на фронте).
+- Гарантия: `with_p0 + with_p1_only + with_p2_only + clean === total_pr` (нет двойного счёта).
+- Бакетизация по `merged_at` в **UTC**, ISO-неделя пн-вс (см. секцию Метрика).
+- **Partial errors handling:** репо со `status: error` НЕ участвуют в `summary` (иначе 0/0 занизит dirty rate). На карточке проекта показывается состояние ошибки с last-good-data плашкой. На сводной — баннер "X из 12 репо без данных".
+- **Codex coverage** на repo-card нужен чтобы пользователь видел: репо где Codex включён 2 недели назад покажет "100% clean" за прошлый месяц фальшиво. Бейдж "Codex coverage: 23%" предупреждает.
+- **Archive immunity:** статус PR/repo в MakeIT Tracker (Project v2) не влияет на эти данные — мы запрашиваем напрямую `/repos/.../pulls`, не `/projects/...`.
+
+## Components
+
+### Backend: Pipeline Mac
+
+**`makeit-pipeline/scripts/codex_quality_sweep.py`** (новый файл в репо `makeit-pipeline`)
+
+```
+codex_quality_sweep.py
+  ├─ load_repos_from_config()               # читает config/quality_repos.json (не парсит CLAUDE.md regex'ом)
+  ├─ acquire_lock(path)                     # flock(2) на /tmp/codex-quality-sweep.lock
+  ├─ fetch_repo_merged_prs(repo, since)     # см. ниже — корректный fetch без несуществующего ?since
+  ├─ fetch_repo_review_comments(repo, since)# GET /pulls/comments?since=Y (paginate, since="updated_at >= Y")
+  ├─ parse_severity(body)                   # regex !\[P(\d) Badge\] → "P1"|"P2"|None
+  ├─ group_findings_per_pr(comments)        # → { pr_url: { has_p1, has_p2 } }
+  ├─ bucketize(prs, findings, mode)         # 30d daily / 12w weekly (UTC)
+  ├─ aggregate_summary(per_repo)            # суммирует per_repo (исключая failed!) по бакетам
+  ├─ write_json_atomic_local(path, data)    # write tmp + os.replace
+  ├─ publish_remote_atomic(local, remote)   # rsync to .tmp + ssh mv → final (см. ниже)
+  └─ main()                                 # orchestrate + retry-with-backoff + log
+```
+
+### ⚠ Корректный fetch merged PR'ов (исправление по итогам ревью)
+
+**Важно:** эндпоинт `GET /repos/{owner}/{repo}/pulls` **НЕ принимает параметр `since`** — только `state`, `head`, `base`, `sort`, `direction`, `per_page`, `page`. Эндпоинт `/pulls/comments?since=Y` принимает `since`, но это "updated_at >= Y" (а не "created_at"), что включает старые комменты с редакциями.
+
+**Правильный паттерн:**
+
+```python
+def fetch_repo_merged_prs(repo: str, since: datetime) -> list[dict]:
+    """Pull merged PRs since cutoff. Использует sort=updated+direction=desc + early-exit."""
+    merged_prs = []
+    page = 1
+    while True:
+        resp = gh_api_get(
+            f"/repos/{OWNER}/{repo}/pulls",
+            params={
+                "state": "closed",
+                "sort": "updated",
+                "direction": "desc",
+                "per_page": 100,
+                "page": page,
+            },
+        )
+        prs = resp.json()
+        if not prs:
+            break
+        for pr in prs:
+            updated_at = parse_iso(pr["updated_at"])
+            # Early-exit: страница отсортирована по updated_at desc.
+            # Если updated_at < since — все следующие тоже будут < since.
+            if updated_at < since:
+                return merged_prs
+            # Фильтруем по merged_at (не closed_at!) — closed_at включает закрытые без мержа
+            if pr.get("merged_at"):
+                merged_at = parse_iso(pr["merged_at"])
+                if merged_at >= since:
+                    merged_prs.append(pr)
+        page += 1
+        if page > MAX_PAGES:  # safety
+            log.warning(f"{repo}: hit MAX_PAGES, possibly missing older PRs")
+            break
+    return merged_prs
+```
+
+**Альтернатива (отвергнута):** Search API `q=is:pr+is:merged+merged:>=YYYY-MM-DD+repo:X` — лимит 30 req/min, на 12 репо + ретраи рискованно. REST с sort+early-exit использует базовый core-лимит 5000/час.
+
+### Retry-стратегия (исправлена)
+
+Не фиксированные 1s/4s/16s, а **respect GitHub rate-limit headers + jitter**:
+
+```python
+def request_with_retry(method, url, **kwargs) -> Response:
+    for attempt in range(3):
+        resp = httpx.request(method, url, **kwargs)
+        if resp.status_code < 400:
+            return resp
+        if resp.status_code in (429, 403):
+            # Respect Retry-After OR X-RateLimit-Reset (приоритет первому)
+            retry_after = resp.headers.get("Retry-After")
+            if retry_after:
+                wait = int(retry_after)
+            else:
+                reset = int(resp.headers.get("X-RateLimit-Reset", 0))
+                wait = max(1, reset - int(time.time()))
+            wait = min(wait, 300) + random.uniform(0, 2)   # cap 5 min, jitter 0-2s
+            log.warning(f"Rate-limit on {url}: sleep {wait:.1f}s")
+            time.sleep(wait)
+            continue
+        if resp.status_code >= 500:
+            wait = (2 ** attempt) + random.uniform(0, 1)   # 1, 2, 4 + jitter
+            time.sleep(wait)
+            continue
+        resp.raise_for_status()
+    resp.raise_for_status()
+    return resp
+```
+
+Логи: `~/logs/codex-quality-sweep.log` (один файл, ротация средствами macOS `newsyslog`). Лог пишется через `logging` module: INFO для прогресса, ERROR для падений.
+
+### Locking (предотвращает race cron × force-refresh)
+
+```python
+import fcntl
+LOCK_FILE = "/tmp/codex-quality-sweep.lock"
+
+def with_exclusive_lock(fn):
+    with open(LOCK_FILE, "w") as f:
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            raise SweepAlreadyRunning()
+        return fn()
+```
+
+API endpoint `POST /quality/refresh` ловит `SweepAlreadyRunning` → возвращает `409 Conflict` с сообщением "Sweep уже выполняется, попробуйте через ~5 минут".
+
+### Atomic remote publish
+
+```python
+def publish_remote_atomic(local_path: Path, remote_dir: str = "/opt/apps/makeit-stack/web/data"):
+    """rsync to .tmp on remote → ssh mv to final. Атомарно с точки зрения nginx."""
+    tmp_name = ".codex-quality.json.tmp"
+    final_name = "codex-quality.json"
+    subprocess.run([
+        "rsync", "-e", "ssh", str(local_path), f"vps:{remote_dir}/{tmp_name}"
+    ], check=True)
+    # mv на одном FS — atomic POSIX rename
+    subprocess.run([
+        "ssh", "vps", f"mv {remote_dir}/{tmp_name} {remote_dir}/{final_name}"
+    ], check=True)
+```
+
+Без этого nginx может в окне rsync'а отдать клиенту частично переписанный JSON → 500/parse-error в браузере.
+
+**`makeit-pipeline/api.py`** (добавить эндпоинты)
+
+```python
+SAFE_ERROR_CODES = {
+    "RATE_LIMITED": "GitHub API rate-limit. Дождитесь сброса.",
+    "REPO_NOT_FOUND": "Один из репо переименован/удалён. Проверьте config/quality_repos.json.",
+    "NETWORK": "Сетевая ошибка sweep'а. Проверьте Pipeline Mac.",
+    "ALREADY_RUNNING": "Sweep уже выполняется. Подождите ~5 минут.",
+    "INTERNAL": "Внутренняя ошибка. См. ~/logs/codex-quality-sweep.log на Pipeline Mac.",
+}
+
+@app.post("/quality/refresh")
+def quality_refresh():
+    """Force-run sweep on demand. Returns fresh JSON or sanitized error."""
+    try:
+        result = subprocess.run(
+            ["python3", "scripts/codex_quality_sweep.py", "--force"],
+            capture_output=True, timeout=300
+        )
+    except subprocess.TimeoutExpired:
+        return JSONResponse(status_code=504, content={"code": "TIMEOUT", "message": "Sweep > 5 минут"})
+
+    if result.returncode == EXIT_ALREADY_RUNNING:
+        return JSONResponse(status_code=409, content={
+            "code": "ALREADY_RUNNING", "message": SAFE_ERROR_CODES["ALREADY_RUNNING"]
+        })
+    if result.returncode != 0:
+        # НЕ возвращаем raw stderr — может содержать пути, env vars, токены
+        # Парсим стандартизованный exit-code из скрипта (skрипт пишет JSON-error в stdout последней строкой)
+        code = parse_sweep_error_code(result.stdout) or "INTERNAL"
+        log.error(f"Sweep failed: code={code}, stderr_sample={result.stderr[:200]}")
+        return JSONResponse(status_code=500, content={
+            "code": code, "message": SAFE_ERROR_CODES.get(code, SAFE_ERROR_CODES["INTERNAL"])
+        })
+    return FileResponse(QUALITY_JSON_PATH)
+```
+
+### Repo-list — explicit config (не regex по CLAUDE.md)
+
+```python
+# makeit-pipeline/config/quality_repos.json
+{
+  "owner": "Sergio1990-1",
+  "repos": [
+    "Sewing-ERP", "mankassa-app", "solotax-kg", "Business-News",
+    "Beer_bot", "Uchet_bot", "quiet-walls", "moliyakg",
+    "MyMoney", "makeit-auditor", "makeit-pipeline", "makeit-dashboard",
+    "makeit-knowledge", "MetaSellerSupplies"
+  ],
+  "_comment": "Source of truth для sweep. Синхронизировать с глобальным CLAUDE.md вручную при добавлении репо."
+}
+```
+
+Альтернатива (parse CLAUDE.md regex'ом — как в `makeit-codexfeedback` skill) **отвергнута**: хрупко, регэксп зависит от форматирования md-комментариев, может молча подхватить лишние строки или пропустить новые репо.
+
+### launchd: `com.makeit.codex-quality-sweep`
+
+`~/Library/LaunchAgents/com.makeit.codex-quality-sweep.plist`:
+
+```xml
+<dict>
+  <key>Label</key><string>com.makeit.codex-quality-sweep</string>
+  <key>ProgramArguments</key><array>
+    <string>/Users/sergeymakarov/.../codex_quality_sweep.py</string>
+  </array>
+  <key>StartCalendarInterval</key><dict>
+    <key>Hour</key><integer>19</integer>     <!-- 19:00 UTC = 03:00 Bali UTC+8 -->
+    <key>Minute</key><integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key><string>/Users/sergeymakarov/logs/codex-quality-sweep.log</string>
+  <key>StandardErrorPath</key><string>/Users/sergeymakarov/logs/codex-quality-sweep.log</string>
+  <key>EnvironmentVariables</key><dict>
+    <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <!-- GH_TOKEN НЕ в plist (plain-text disk). Скрипт сам читает .env через python-dotenv -->
+  </dict>
+</dict>
+```
+
+### VPS: nginx route
+
+`/opt/apps/nginx-proxy/conf.d/makeit.conf` (добавить локацию):
+
+```nginx
+location /data/ {
+    alias /opt/apps/makeit-stack/web/data/;
+    add_header Cache-Control "public, max-age=300";  # 5 min — на случай если sweep отстаёт
+}
+```
+
+Директория `/opt/apps/makeit-stack/web/data/` создаётся вручную при первом деплое + права для пользователя, под которым работает rsync.
+
+### Frontend: dashboard
+
+**`src/utils/quality.ts`** (новый) — клиент API + парсинг JSON:
+
+```ts
+export interface QualityBucket { total_pr: number; with_p1: number; with_p2_only: number; }
+export interface QualityPayload {
+  generated_at: string;
+  errors: Array<{ repo: string; message: string }>;
+  buckets: {
+    "30d": { labels: string[]; summary: QualityBucket[]; per_repo: Record<string, QualityBucket[]>; };
+    "12w": { labels: string[]; summary: QualityBucket[]; per_repo: Record<string, QualityBucket[]>; };
+  };
+}
+
+export async function fetchQualityData(): Promise<QualityPayload> {
+  const url = (window.__MAKEIT_CONFIG__?.QUALITY_URL ?? "/data/codex-quality.json");
+  const res = await fetch(url, { cache: "no-cache" });
+  if (!res.ok) throw new Error(`Quality data fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export async function forceQualityRefresh(): Promise<QualityPayload> {
+  const url = `${PIPELINE_URL}/quality/refresh`;
+  const res = await fetch(url, { method: "POST" });
+  if (!res.ok) throw new Error(`Refresh failed: ${res.status}`);
+  return res.json();
+}
+```
+
+**`src/hooks/useQuality.ts`** (новый):
+
+```ts
+export function useQuality() {
+  const [data, setData] = useState<QualityPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (forceRefresh = false) => { ... }, []);
+  useEffect(() => { load(false); }, [load]);
+
+  const isStale = useMemo(() => {
+    if (!data) return false;
+    const ageHours = (Date.now() - new Date(data.generated_at).getTime()) / 3.6e6;
+    return ageHours > 30;
+  }, [data]);
+
+  return { data, loading, error, isStale, refresh: () => load(true) };
+}
+```
+
+**`src/components/QualityTab.tsx`** (новый) — главный компонент вкладки:
+
+```
+QualityTab
+  ├─ QualityHeader           # title + period toggle + refresh button + last-sync info
+  ├─ QualityStaleBanner      # warn if isStale
+  ├─ QualitySummaryPanel     # большой график + 4 KPI справа
+  │   ├─ QualityChart        # переиспользуется и для карточек
+  │   └─ QualityKPIs
+  ├─ QualityProjectGrid      # responsive grid (auto-fill 320px)
+  │   └─ QualityProjectCard  # name, %, mini-chart, P1/P2 numbers, severity badge
+  └─ QualityNote             # ссылка на spec, объяснение метрики
+```
+
+**`src/components/QualityChart.tsx`** (новый) — переиспользуемый bar-chart:
+
+Props: `buckets: QualityBucket[]`, `labels: string[]`, `maxScale: number`, `showLabels: boolean`, `compact: boolean`. Чистый view-компонент. Точно такая же разметка как в прототипе.
+
+**`src/styles/v4.css`** — добавить:
+
+```css
+.v4-quality-chart { ... }
+.v4-quality-bar { ... }
+.v4-quality-bar-p1    { background: var(--v4-p1); }             /* красный */
+.v4-quality-bar-p2    { background: var(--v4-p2); }             /* оранжевый */
+.v4-quality-bar-clean { background: var(--v4-clean-soft); }     /* голубой */
+/* + добавить :root --v4-clean-soft: #93C5FD; */
+/* и т.д. — взять из прототипа */
+```
+
+**Анимации и interactions** — переиспользуют язык `wow-*` из дашборда (`v4.css` "Stagger entrance for grid items", "Closed-30d chart: left-to-right reveal", `v4-ClosedChart30d.tsx` hover-behavior). Один easing везде — `cubic-bezier(0.16, 1, 0.3, 1)`.
+
+| Элемент | На появление | Hover-эффект |
+|---|---|---|
+| Чарт целиком | `q-chart-in` (fade + translateY 6→0), 480ms | — |
+| Бары (главный + мини в карточках) | Появляются вместе с чартом (без per-bar stagger) | Активный бар имеет column-wide halo (`::before` с `--v4-accent-100`); все остальные бары → `opacity: 0.4` (через class toggle `is-hovering`/`is-active` — работает идентично в обоих) |
+| Value-chip над баром | — | opacity + translateY(2→0), 120/150ms |
+| Tooltip — main chart | — | Полноразмерная карточка `chart-tip`: дата, total PR, breakdown clean/P2/P1, % грязных. 180/220ms |
+| Tooltip — mini chart (карточки) | — | Компактная плашка `chart-tip--compact`, **2 строки**: line 1 — `DD.MM · X PR · Y%`. Line 2 — breakdown с цветными свотчами: `🔴P0:N · ▮P1:N · ▮P2:N · ▮clean:N`. P0-сегмент выделен ярко-красным и появляется только если `with_p0 > 0`. Те же 180/220ms |
+| Annotation-линии | inherits chart fade | Линия меняет цвет на ink-900, dot 1.2× |
+| KPI | `q-kpi-in` (fade + translateY 8→0 + scale 0.985→1), 520ms, stagger 60ms·i | translateY(-2px) + shadow |
+| Карточки проектов | `q-card-in` (fade + translateY 10→0), 420ms, stagger 45ms·i | translateY(-3px) + shadow |
+
+**Hover-experience должен быть consistent main vs mini** — пользователь видит одни и те же подсказки везде, только tooltip-форма адаптивная (полная вертикальная для main, узкая горизонтальная для mini где высоты 80px недостаточно для 5 строк). Селектор dim-эффекта `.is-hovering .bar:not(.is-active) .bar-stack` (без привязки к классу контейнера) покрывает оба случая.
+
+**Перформанс-критичные правила (вынесены из ошибок прототипа):**
+
+1. **НЕ использовать `transition: height`** — height триггерит layout recalc каждый кадр. Период-switch перемонтирует DOM с готовыми height-значениями. Если нужна именно height-анимация — использовать `transform: scaleY()` + `transform-origin: bottom`.
+2. **НЕ использовать `clip-path` для wipe-анимации** на контейнере с 30+ детьми — каждый ребёнок репейнтится. Использовать `opacity + translateY` всего контейнера.
+3. **НЕ использовать `:has(.bar:hover)`** для dim-эффекта остальных баров — `:has()` дорог. Использовать toggle CSS-класса (`is-hovering`/`is-active`) через JS-listener.
+4. **Tooltip-структуру создавать один раз** (одна `chart-tip` на чарт), на hover — обновлять только textContent. Никаких `innerHTML = ...` каждый мышиный движок.
+5. **GPU-friendly properties only** для transitions: `transform`, `opacity`. Никогда `width`, `height`, `top`, `left`, `padding` — это layout-property.
+
+**Period switch:** при клике 30d/12w компонент перемонтирует чарт — анимации играют заново. Альтернатива (плавный tween высот через React keyed-list + `transform: scaleY`) — отдельная задача оптимизации, не для v1.
+
+**Reduced motion:** блок `@media (prefers-reduced-motion: reduce)` отключает все `animation` и `transition: transform`, оставляя `opacity` для tooltip и annotation-tip. Паттерн идентичен `v4.css` строки 8425-8454.
+
+## Annotations / event markers (Фаза 1)
+
+**Зачем:** видеть корреляцию "после такой-то правки промпта качество просело/выросло". Сейчас если ты ночью обновил `/makeit-codereview`, через 3 дня в графике провал — без аннотаций ты не свяжешь причину со следствием.
+
+**Что:** вертикальные пунктирные линии на сводном чарте + dot сверху + tooltip при hover с описанием события и датой.
+
+**Категории (Фаза 1, ручной ввод через UI):**
+- `skill` (синий, `--v4-accent-600`) — обновление скилла разработки
+- `deploy` (зелёный, `--v4-success-500`) — деплой инфраструктуры / новой версии pipeline
+- `manual` (фиолетовый, `--v4-purple-500`) — pair-сессия с Codex, ad-hoc интервенция, прочее
+
+**Где живут данные:**
+```jsonc
+// /data/annotations.json — рядом с codex-quality.json на VPS
+{
+  "schema_version": 1,
+  "annotations": [
+    {
+      "id": "a3f8e9c2-7b4d-4f1a-9e8c-6d5b3a2f1e9d",   // UUID v4 — для DELETE/UPDATE
+      "occurred_at": "2026-04-13T00:00:00Z",          // явный UTC ISO8601 (не амбивалентный date)
+      "category": "skill",                            // skill | deploy | manual
+      "scope": "global",                              // global | repo
+      "repos": null,                                  // если scope=repo: ["makeit-pipeline", ...]
+      "title": "Refactor /makeit-dev",
+      "desc": "Уменьшен retry-rate на phase QA",
+      "created_by": "manual",                         // Phase 2: "pipeline:auto-tuning", "git:lessons-learned"
+      "created_at": "2026-04-13T15:23:00Z"            // UTC ISO8601
+    },
+    ...
+  ]
+}
+```
+
+**Почему `occurred_at` UTC, а не `date`:** "событие 22.05.2026" из браузера в Москве (UTC+3) и из браузера в Бали (UTC+8) парсилось бы по-разному. Локальная полночь Москвы = 21:00 UTC предыдущего дня → событие визуально попадёт на бар предыдущего дня. Решение: UI отдаёт `occurred_at` в UTC (либо берёт локальную полночь и конвертирует, либо пользователь явно выбирает время + TZ). v1 — UI ставит локальную полночь и переводит в UTC.
+
+**Почему `id` UUID, а не индекс:** при параллельных POST'ах (или после сортировки annotations по дате) индекс сдвигается. `DELETE /annotations/5` удалит не то что хотел пользователь. UUID решает проблему фундаментально.
+
+**Как добавить событие (UI):** кнопка `+ событие` в шапке Quality-вкладки → модалка с полями (дата+время picker, категория-select, scope-select, title, desc). На submit — `POST /annotations` к Pipeline API → запись в JSON → publish_remote_atomic.
+
+**Backend endpoint в `makeit-pipeline/api.py`:**
+```python
+from uuid import uuid4
+from pydantic import BaseModel, Field
+
+class AnnotationCreate(BaseModel):
+    occurred_at: datetime
+    category: Literal["skill", "deploy", "manual"]
+    scope: Literal["global", "repo"] = "global"
+    repos: list[str] | None = Field(default=None, max_length=20)
+    title: str = Field(max_length=120)
+    desc: str = Field(max_length=600)
+
+MAX_ANNOTATIONS_TOTAL = 5000   # защита от unbounded growth
+MAX_BODY_SIZE_BYTES = 4096
+
+@app.post("/annotations")
+def add_annotation(payload: AnnotationCreate, request: Request):
+    if int(request.headers.get("content-length", 0)) > MAX_BODY_SIZE_BYTES:
+        raise HTTPException(413, "Payload too large")
+    with_exclusive_lock(ANNOT_LOCK)
+    annotations = load_annotations()
+    if len(annotations) >= MAX_ANNOTATIONS_TOTAL:
+        raise HTTPException(429, "Annotation store full — выгрузите старые")
+    new_ann = {
+        "id": str(uuid4()),
+        **payload.model_dump(mode="json"),
+        "created_by": "manual",
+        "created_at": datetime.utcnow().isoformat() + "Z",
+    }
+    annotations.append(new_ann)
+    save_and_publish(annotations)
+    return new_ann
+
+@app.delete("/annotations/{ann_id}")
+def delete_annotation(ann_id: UUID):
+    with_exclusive_lock(ANNOT_LOCK)
+    annotations = load_annotations()
+    before = len(annotations)
+    annotations = [a for a in annotations if a["id"] != str(ann_id)]
+    if len(annotations) == before:
+        raise HTTPException(404, "Annotation not found")
+    save_and_publish(annotations)
+    return {"ok": True, "remaining": len(annotations)}
+```
+
+**Базовая защита POST/DELETE** (Codex п.12): length-limits (4 KB body, max 600 chars desc, max 120 title), Pydantic strict types, max 20 repos per annotation, ограничение общего числа annotations 5000. Auth через тот же Basic Auth nginx, что и весь дашборд — отдельный CSRF-token не нужен для one-user setup, но length-limits — must.
+
+**Frontend:** `<QualityAnnotations>` компонент — fetch + render. Линии позиционируются по `left: %` через маппинг date → x. Логика зависит от режима:
+
+- **30d (по дням):** маркер **снапится к центру бара того дня** (1 бар = 1 день, нет внутридневной подвижности). `pct = (dayIdx + 0.5) / barCount × 100`. Иначе маркер встанет на ЛЕВЫЙ край бара и визуально будет казаться "не привязан к этому дню".
+- **12w (по неделям):** маркер позиционируется **пропорционально дню внутри периода** (`pct = daysFromStart / totalDays × 100`). Внутринедельная позиция несёт смысл — "событие в понедельник" vs "в пятницу" одной и той же недели видны как разные точки. Маркер не обязан совпадать с центром week-bar'а.
+
+`date` хранится как ISO date (без time) — событие = "случилось в этот день целиком". Если в будущем понадобится точность до часа — поменять schema на `datetime` + соответствующую позиционирующую логику (для weekly это уже работает корректно, для daily — добавить долю внутри дня).
+
+На period-switch компонент перерендеривает маркеры (DOM перемонтируется вместе с чартом).
+
+**Out of scope для Фазы 1:** edit existing annotations (только add/delete), фильтрация по категории, batching/grouping близких событий, связь с конкретным репо (annotation глобальна для всех проектов).
+
+**`src/App.tsx`** — добавить 9-ю вкладку:
+
+```tsx
+<TabButton id="quality" active={tab === "quality"} onClick={() => setTab("quality")}>
+  Качество
+</TabButton>
+...
+{tab === "quality" && <QualityTab />}
+```
+
+### Конфигурация
+
+**`public/config.js`** — добавить `QUALITY_URL` (опционально, если default `/data/codex-quality.json` не подходит):
+
+```js
+window.__MAKEIT_CONFIG__ = {
+  AUDITOR_URL: "...",
+  PIPELINE_URL: "...",
+  QUALITY_URL: "/data/codex-quality.json",  // default; на VPS можно переопределить
+};
+```
+
+## Healthcheck + error states
+
+Сценарии и UX:
+
+| Состояние | Триггер | UI |
+|---|---|---|
+| ✅ Свежо | `generated_at` < 30 ч | Норма, без баннера |
+| ⚠ Устарело | `generated_at` ≥ 30 ч | Жёлтый баннер сверху: "Данные не обновлялись 30+ часов. Проверь cron на Pipeline Mac." + кнопка "Обновить сейчас" |
+| ❌ JSON не найден | `fetch` 404 | Red panel: "Файл `/data/codex-quality.json` не найден. Cron ещё ни разу не запускался?" + кнопка "Запустить sweep сейчас" |
+| ❌ Pipeline Mac офлайн | `forceRefresh` fails | Toast: "Pipeline Mac недоступен. Sweep не запущен, ждём cron в 03:00 Бали." |
+| ⚠ Частичный sweep | `repo_status[X].status === "error"` для ≥1 репо | Малый бейдж "⚠ 2 репо без данных" над сводным графиком, hover — список репо + код ошибки (sanitized) + last-good timestamp |
+| ⚠ Sweep уже идёт | `/quality/refresh` → 409 | Toast: "Sweep уже выполняется. Попробуйте через ~5 минут." |
+| ⚠ Низкая выборка (low-sample) | бакет с `total_pr < LOW_SAMPLE_THRESHOLD` (8) | На баре — серая штриховка вместо плотного fill; в tooltip приписка "малая выборка"; на repo-card если **все** бакеты low-sample — бейдж "мало данных" |
+| ⚠ Низкое покрытие Codex | `codex_coverage_pct < 50%` на repo-card | Бейдж "Codex coverage: X%" в card-foot с warn-цветом. "Цифры основаны на половине PR" |
+
+**LOW_SAMPLE_THRESHOLD = 8 PR** — компромисс. Меньше — % становится "драматичным" (1/2=50% и т.д.). Больше 8 — слишком агрессивно скрываем данные. Можно сделать настройкой в settings store позже.
+
+## Testing
+
+- **sweep.py:** unit-тесты на `parse_severity`, `group_findings_per_pr`, `bucketize` (фиксированные входные данные → ожидаемая агрегация).
+- **sweep.py end-to-end:** ручной запуск против реальных репо, проверка JSON-схемы, время выполнения < 5 мин.
+- **launchd:** `launchctl load ...plist`, `launchctl start com.makeit.codex-quality-sweep`, проверка лога.
+- **Frontend:** Vitest для `useQuality` (mocked fetch). Snapshot для `QualityChart` рендеринга. Ручная проверка через `npm run dev`.
+- **Integration:** прогон полного цикла — cron triggers sweep → JSON appears on VPS → dashboard fetches and renders.
+
+## Implementation order
+
+1. **Backend skeleton:** `sweep.py` с моковыми данными (фейковый GitHub-fetch, реальная агрегация), JSON-output. → можно тестировать локально без квот.
+2. **Real GitHub fetch:** подключить `gh api` calls, retry, errors[]. → ручной прогон, проверить полный sweep.
+3. **launchd + rsync:** plist, `.htaccess` для пути, rsync-команда внутри скрипта, проверить cron.
+4. **VPS nginx config:** добавить `/data/` location, redeploy.
+5. **Frontend types + utils:** `quality.ts`, `useQuality.ts` hooks.
+6. **Frontend компоненты:** `QualityChart`, `QualityProjectCard`, `QualitySummaryPanel`, `QualityTab`.
+7. **Стили:** перенести из прототипа в `v4.css`.
+8. **App.tsx интеграция:** новая вкладка.
+9. **Healthcheck + force-refresh:** баннер, кнопка, FastAPI endpoint.
+10. **Тесты + ручная проверка через `npm run dev`.**
+11. **Деплой:** redeploy dashboard + (отдельно) перезапуск launchd.
+
+## Open questions
+
+Нет открытых вопросов — все архитектурные решения зафиксированы выше.
+
+## Risks
+
+- **GH_TOKEN в launchd plist** — секрет в plain-text plist. Mitigation: использовать `.env` файл, который читается скриптом через `python-dotenv` (паттерн уже есть в Pipeline API). Plist хранит только путь к скрипту.
+- **rsync ключ** — Pipeline Mac уже имеет SSH-доступ к VPS (паттерн `git@github.com:...` deploy). Mitigation: переиспользуем тот же ключ.
+- **GitHub API quota** — 12 repo × ~3 страниц pagination = ~36 calls + ещё ~36 за merged PR list = ~72 calls. REST core 5000/час — запас гигантский. Quota check внутри sweep, лог если осталось < 1000.
+- **Pipeline Mac офлайн в 03:00** — sweep не запускается, на утро JSON старый, баннер показывается, пользователь жмёт "Обновить сейчас" → тоже ошибка → ждёт пока хост поднимется. Mitigation: уведомление о sleep'е Pipeline Mac уже в makeit-monitoring (см. дашборд `Мониторинг`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.60.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -28,6 +31,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^29.1.1",
         "openapi-typescript": "^7.13.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
@@ -35,6 +39,13 @@
         "vite-plugin-pwa": "^1.2.0",
         "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.80.0",
@@ -72,6 +83,57 @@
       "peerDependencies": {
         "ajv": ">=8"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1596,6 +1658,159 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
@@ -2227,6 +2442,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -3250,6 +3483,91 @@
         "string.prototype.matchall": "^4.0.6"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3260,6 +3578,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3877,6 +4202,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3898,6 +4233,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -4051,6 +4396,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -4344,12 +4699,85 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4423,6 +4851,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -4486,6 +4921,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4495,6 +4940,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.3.3",
@@ -4542,6 +4994,19 @@
       "integrity": "sha512-vFU34OcrvMcH66T+dYC3G4nURmgfDVewMIu6Q2urXpumAPSMmzvcn04KVVV8Opikq8Vs5nUbO/8laNhNRqSzYw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -5519,6 +5984,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -5575,6 +6053,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/index-to-position": {
@@ -5859,6 +6347,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6102,6 +6597,95 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -6543,6 +7127,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -6573,6 +7167,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -6835,6 +7446,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7045,6 +7669,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7084,6 +7736,27 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -7360,6 +8033,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7759,6 +8445,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7817,6 +8516,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/temp-dir": {
       "version": "2.0.0",
@@ -7925,6 +8631,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.1.2.tgz",
+      "integrity": "sha512-RUX5sQm8bl03ycwQ6nSgJiKw9FZWhA8GBzxX6X1lsG3xKzFIW+lYLLpM30FQbDD6XjTWa/VkF15VxjnAMWYJAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.1.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.1.2.tgz",
+      "integrity": "sha512-26EbERPLf5wkNFKW+7egxArSPN1Nqipe/PIe1nvhpNu8HqQeY2pYdOeQk4sAiADv/e03VzHkLY0PPohKv1JMAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -8123,6 +8862,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -8713,12 +9462,35 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
@@ -9107,6 +9879,23 @@
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "7.4.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1",
-        "vite-plugin-pwa": "^1.2.0"
+        "vite-plugin-pwa": "^1.2.0",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -1629,6 +1630,448 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -2444,6 +2887,356 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -2467,6 +3260,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/dompurify": {
       "version": "3.0.5",
@@ -2861,6 +3672,151 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2980,6 +3936,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -3139,6 +4105,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -3220,6 +4196,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3243,6 +4236,16 @@
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3418,6 +4421,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -3619,6 +4632,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3664,6 +4684,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -3878,6 +4940,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5454,6 +6526,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5808,6 +6887,23 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -6440,6 +7536,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6513,6 +7616,20 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6655,6 +7772,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6729,6 +7866,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6744,6 +7895,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tr46": {
@@ -7155,6 +8336,149 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite-plugin-pwa": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.2.0.tgz",
@@ -7182,6 +8506,209 @@
       },
       "peerDependenciesMeta": {
         "@vite-pwa/assets-generator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
           "optional": true
         }
       }
@@ -7308,6 +8835,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:typecheck": "tsc -p tsconfig.e2e.json --noEmit",
     "gen:api-types:pipeline": "openapi-typescript src/types/generated/pipeline.openapi.json -o src/types/generated/pipeline.ts",
@@ -42,6 +44,7 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1",
-    "vite-plugin-pwa": "^1.2.0"
+    "vite-plugin-pwa": "^1.2.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.60.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -40,6 +43,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^29.1.1",
     "openapi-typescript": "^7.13.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",

--- a/quality-tab-prototype.html
+++ b/quality-tab-prototype.html
@@ -1,0 +1,1457 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Прототип: вкладка «Качество кода»</title>
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
+/>
+<style>
+  :root {
+    --v4-bg: #F6F7F9;
+    --v4-paper: #FFFFFF;
+    --v4-surface-2: #F4F5F8;
+    --v4-surface-3: #EDEFF3;
+    --v4-ink-900: #0E1320;
+    --v4-ink-800: #1B2235;
+    --v4-ink-700: #2F3850;
+    --v4-ink-600: #4A5570;
+    --v4-ink-500: #6B7691;
+    --v4-ink-400: #94A0B8;
+    --v4-ink-300: #C5CCDA;
+    --v4-line: #E4E8EF;
+    --v4-line-soft: #EEF1F6;
+    --v4-line-strong: #D6DBE5;
+    --v4-accent-50: #EEF4FF;
+    --v4-accent-500: #2563EB;
+    --v4-accent-600: #1D4ED8;
+    --v4-accent-700: #1E40AF;
+    --v4-success-50: #ECFDF3;
+    --v4-success-500: #12B76A;
+    --v4-success-700: #067647;
+    --v4-warn-50: #FFFAEB;
+    --v4-warn-500: #F79009;
+    --v4-warn-700: #B54708;
+    --v4-danger-50: #FEF2F2;
+    --v4-danger-500: #EF4444;
+    --v4-danger-700: #B91C1C;
+    /* Codex severity palette — align с shields.io бейджами на самих PR-коммитах */
+    --v4-p0: #EF4444;             /* красный — БЛОКЕР (Codex использует P0-red) */
+    --v4-p1: #F59E0B;             /* оранжевый — высокое (Codex использует P1-orange) */
+    --v4-p2: #EAB308;             /* жёлтый — среднее (Codex использует P2-yellow) */
+    --v4-clean: #2563EB;          /* --v4-accent-500 синий — чистые PR */
+    --v4-clean-soft: #93C5FD;     /* голубой для светлого фона */
+    --v4-p0-text: #991B1B;        /* dark red для текста на белом */
+    --v4-p1-text: #B45309;        /* dark amber */
+    --v4-p2-text: #854D0E;        /* dark yellow-amber */
+    --v4-clean-text: #1D4ED8;
+    --v4-r-sm: 6px;
+    --v4-r-md: 8px;
+    --v4-r-lg: 12px;
+    --v4-r-xl: 16px;
+    --v4-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+    --v4-mono: 'JetBrains Mono', "SF Mono", ui-monospace, monospace;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--v4-bg);
+    color: var(--v4-ink-800);
+    font-family: var(--v4-sans);
+    font-size: 13px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+  .mono, .num { font-family: var(--v4-mono); font-variant-numeric: tabular-nums; }
+
+  /* Mock tab bar */
+  .topbar {
+    background: var(--v4-paper);
+    border-bottom: 1px solid var(--v4-line);
+    padding: 0 24px;
+    display: flex;
+    gap: 4px;
+    overflow-x: auto;
+  }
+  .tab {
+    padding: 14px 16px;
+    font-weight: 500;
+    color: var(--v4-ink-500);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    white-space: nowrap;
+    font-size: 13px;
+  }
+  .tab.active {
+    color: var(--v4-ink-900);
+    border-bottom-color: var(--v4-accent-500);
+    font-weight: 600;
+  }
+  .tab .badge-new {
+    margin-left: 6px;
+    font-size: 9px;
+    background: var(--v4-accent-500);
+    color: #fff;
+    padding: 1px 5px;
+    border-radius: 99px;
+    font-family: var(--v4-mono);
+    letter-spacing: 0.04em;
+    font-weight: 600;
+    vertical-align: 1px;
+  }
+
+  /* Page */
+  .page { padding: 24px; max-width: 1480px; margin: 0 auto; }
+
+  .pageH {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 18px;
+    gap: 18px;
+    flex-wrap: wrap;
+  }
+  .pageH h1 {
+    font-size: 22px;
+    margin: 0 0 4px 0;
+    letter-spacing: -0.01em;
+    color: var(--v4-ink-900);
+    font-weight: 700;
+  }
+  .pageH .sub {
+    color: var(--v4-ink-500);
+    font-size: 13px;
+  }
+  .pageH .sub b { color: var(--v4-ink-700); font-weight: 600; }
+
+  .ctrls { display: flex; gap: 10px; align-items: center; }
+  .seg {
+    display: inline-flex;
+    background: var(--v4-paper);
+    border: 1px solid var(--v4-line);
+    border-radius: var(--v4-r-md);
+    padding: 3px;
+  }
+  .seg button {
+    border: 0;
+    background: transparent;
+    padding: 6px 12px;
+    font: inherit;
+    font-size: 12px;
+    color: var(--v4-ink-500);
+    border-radius: 5px;
+    cursor: pointer;
+    font-weight: 500;
+  }
+  .seg button.active {
+    background: var(--v4-ink-900);
+    color: #fff;
+    font-weight: 600;
+  }
+  .btn-refresh {
+    border: 1px solid var(--v4-line);
+    background: var(--v4-paper);
+    border-radius: var(--v4-r-md);
+    padding: 7px 12px;
+    font: inherit;
+    font-size: 12px;
+    color: var(--v4-ink-700);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 500;
+  }
+  .btn-refresh:hover { background: var(--v4-surface-2); }
+
+  /* Panel */
+  .panel {
+    background: var(--v4-paper);
+    border: 1px solid var(--v4-line);
+    border-radius: var(--v4-r-lg);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+  .panel-h {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--v4-line-soft);
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .panel-t {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--v4-ink-900);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .panel-b { padding: 18px; }
+
+  .tag {
+    font-family: var(--v4-mono);
+    font-size: 9px;
+    font-weight: 600;
+    background: var(--v4-surface-2);
+    color: var(--v4-ink-500);
+    padding: 2px 7px;
+    border-radius: 99px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .tag-warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+  .tag-good { background: var(--v4-success-50); color: var(--v4-success-700); }
+  .tag-bad  { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+
+  /* Summary panel */
+  .summary {
+    margin-bottom: 18px;
+    display: grid;
+    grid-template-columns: 1fr 280px;
+    gap: 0;
+  }
+  .summary .chartwrap {
+    padding: 18px 18px 18px;
+    border-right: 1px solid var(--v4-line-soft);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+  .summary .kpis {
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    background: var(--v4-surface-2);
+  }
+  /* P0-alert pill — большая красная плашка с пульсацией, видна сразу.
+     Скрывается если with_p0 === 0 (счастливые периоды не загромождаем). */
+  .kpi-p0-alert {
+    background: var(--v4-p0);
+    color: #fff;
+    border-radius: var(--v4-r-md);
+    padding: 14px 16px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.45);
+    animation: q-p0-pulse 1.8s ease-in-out infinite;
+  }
+  @keyframes q-p0-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.45); }
+    50%      { box-shadow: 0 0 0 10px rgba(239, 68, 68, 0); }
+  }
+  .kpi-p0-icon { font-size: 22px; line-height: 1; }
+  .kpi-p0-text { display: flex; flex-direction: column; }
+  .kpi-p0-text b { font-family: var(--v4-mono); font-size: 18px; line-height: 1.1; }
+  .kpi-p0-text span { font-size: 11px; opacity: 0.9; margin-top: 2px; }
+
+  .kpi {
+    background: var(--v4-paper);
+    border: 1px solid var(--v4-line);
+    border-radius: var(--v4-r-md);
+    padding: 12px 14px;
+    /* fade-up entrance со stagger 60ms · i — как wow-kpi-in в дашборде */
+    animation: q-kpi-in 520ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation-delay: calc(var(--i, 0) * 60ms + 200ms);
+    transition: transform .22s cubic-bezier(0.16, 1, 0.3, 1),
+                box-shadow .22s ease, border-color .2s ease;
+  }
+  .kpi:hover {
+    transform: translateY(-2px);
+    border-color: var(--v4-line-strong);
+    box-shadow: 0 10px 28px rgba(11, 16, 32, 0.07);
+  }
+  @keyframes q-kpi-in {
+    from { opacity: 0; transform: translateY(8px) scale(0.985); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+  }
+  .kpi-lbl {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--v4-ink-500);
+    font-family: var(--v4-mono);
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+  .kpi-v {
+    font-size: 26px;
+    font-weight: 700;
+    color: var(--v4-ink-900);
+    font-family: var(--v4-mono);
+    line-height: 1;
+    letter-spacing: -0.02em;
+  }
+  .kpi-v.dirty { color: var(--v4-ink-900); }
+  .kpi-sub { font-size: 11px; color: var(--v4-ink-500); margin-top: 4px; }
+  .delta { font-size: 11px; font-family: var(--v4-mono); font-weight: 600; }
+  .delta.up { color: var(--v4-danger-600, var(--v4-danger-700)); }
+  .delta.down { color: var(--v4-success-700); }
+  .delta.flat { color: var(--v4-ink-400); }
+
+  /* Chart — vertical bars */
+  .chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    flex: 1;
+    min-height: 220px;
+    border-bottom: 1px dashed var(--v4-line);
+    position: relative;
+    /* Coordinated reveal — opacity + translateY (GPU, дёшево) вместо clip-path,
+       который заставляет репейнтить 30 детей каждый кадр */
+    animation: q-chart-in 480ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation-delay: 80ms;
+  }
+  @keyframes q-chart-in {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  /* Dim non-hovered bars: через class toggle (JS), не :has() — последний дорогой.
+     Селектор покрывает оба контейнера — .chart (главный) и .card-chart (мини). */
+  .is-hovering .bar:not(.is-active) .bar-stack { opacity: 0.4; }
+  .chart-axis {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+  .chart-axis::before,
+  .chart-axis::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    border-top: 1px dashed var(--v4-line-soft);
+  }
+  .chart-axis::before { top: 50%; }
+  .chart-axis::after  { top: 0; }
+  .chart-axis-label {
+    position: absolute;
+    right: 4px;
+    font-family: var(--v4-mono);
+    font-size: 9px;
+    color: var(--v4-ink-400);
+    background: var(--v4-paper);
+    padding: 0 3px;
+  }
+
+  .bar {
+    flex: 1;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    position: relative;
+    cursor: crosshair;
+    min-width: 4px;
+  }
+  /* Column-wide подсветка за активным баром (как в v4-ClosedChart30d) */
+  .bar::before {
+    content: '';
+    position: absolute;
+    inset: -6px -4px -4px -4px;
+    background: var(--v4-accent-100);
+    border-radius: 4px;
+    opacity: 0;
+    transition: opacity .15s ease;
+    pointer-events: none;
+  }
+  .bar:hover::before { opacity: 0.45; }
+
+  /* P0 day — ВСЕГДА видимая подсветка колонки (не только при hover).
+     Юзер должен сразу увидеть "тут был блокер" без интеракции. */
+  .bar.has-p0 {
+    background: linear-gradient(to bottom,
+      rgba(239, 68, 68, 0.18) 0%,
+      rgba(239, 68, 68, 0.08) 60%,
+      rgba(239, 68, 68, 0.02) 100%);
+  }
+  /* В mini-чарте дополнительно border-top на самом баре (визуальный акцент,
+     потому что 80px высоты — gradient слабо читается на маленьком масштабе) */
+  .card-chart .bar.has-p0 .bar-stack {
+    border-top: 2px solid var(--v4-p0);
+  }
+  /* На главном чарте — mini-pill "P0:N" сверху столбца, ВСЕГДА видна */
+  .bar-topper-p0 {
+    position: absolute;
+    top: -22px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--v4-p0);
+    color: #fff;
+    font-family: var(--v4-mono);
+    font-size: 9px;
+    font-weight: 700;
+    padding: 2px 6px;
+    border-radius: 3px;
+    white-space: nowrap;
+    pointer-events: none;
+    box-shadow: 0 2px 6px rgba(239, 68, 68, 0.45);
+    /* лёгкая pulse-анимация чтобы цепляло глаз */
+    animation: q-p0-topper-pulse 2s ease-in-out infinite;
+  }
+  @keyframes q-p0-topper-pulse {
+    0%, 100% { transform: translateX(-50%) translateY(0); }
+    50%      { transform: translateX(-50%) translateY(-2px); }
+  }
+  /* В mini-чарте топпер прячем — нет места + border-top уже сигналит */
+  .card-chart .bar-topper-p0 { display: none; }
+  .bar-stack {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    border-radius: 3px 3px 0 0;
+    overflow: hidden;
+    transition: opacity .15s ease;
+    /* НЕ анимируем height — он триггерит layout каждый кадр. На period switch
+       DOM пересоздаётся (.bar-stack рождается с правильной высотой). */
+  }
+  /* Dashed guide line от верха активного бара до базы */
+  .bar:hover .bar-stack::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background-image: linear-gradient(to bottom, var(--v4-accent-700) 50%, transparent 50%);
+    background-size: 1px 4px;
+    opacity: 0.5;
+    pointer-events: none;
+  }
+  /* Маленький value-chip над активным баром */
+  .bar-chip {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%) translateY(2px);
+    background: var(--v4-ink-900);
+    color: #fff;
+    font-family: var(--v4-mono);
+    font-size: 11px;
+    font-weight: 700;
+    padding: 3px 8px;
+    border-radius: 4px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity .12s ease, transform .15s cubic-bezier(0.16, 1, 0.3, 1);
+    margin-bottom: 6px;
+    white-space: nowrap;
+  }
+  .bar:hover .bar-chip {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+  /* Red сегмент = P0+P1 worst-wins (выделено критическое в одну категорию для читабельности).
+     Tooltip разбивает: "P0: 1 · P1: 3". Отдельный P0-alert pulse выше в KPI если with_p0 > 0. */
+  .bar-crit {
+    background: var(--v4-p0);
+    width: 100%;
+  }
+  .bar-p2 {
+    background: var(--v4-p2);
+    width: 100%;
+  }
+  .bar-clean {
+    background: var(--v4-clean-soft);
+    width: 100%;
+    border-radius: 3px 3px 0 0;
+  }
+  .bar-empty {
+    background: var(--v4-line-soft);
+    width: 100%;
+    height: 1px;
+    margin-top: auto;
+  }
+  /* Annotation markers: вертикальные пунктирные линии на чарте + chip с иконкой сверху */
+  .annot {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background-image: linear-gradient(to bottom,
+      var(--v4-purple-500, #7C3AED) 50%,
+      transparent 50%);
+    background-size: 1px 6px;
+    pointer-events: auto;
+    cursor: help;
+    z-index: 2;
+  }
+  .annot-dot {
+    position: absolute;
+    top: -3px;
+    left: -5px;
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    background: var(--v4-purple-500, #7C3AED);
+    border: 2px solid var(--v4-paper);
+    box-shadow: 0 0 0 1px var(--v4-purple-500, #7C3AED);
+  }
+  .annot.is-skill .annot-dot { background: var(--v4-accent-600); box-shadow: 0 0 0 1px var(--v4-accent-600); }
+  .annot.is-deploy .annot-dot { background: var(--v4-success-500); box-shadow: 0 0 0 1px var(--v4-success-500); }
+  .annot.is-manual .annot-dot { background: var(--v4-purple-500, #7C3AED); }
+  .annot:hover { background-image: linear-gradient(to bottom, var(--v4-ink-900) 50%, transparent 50%); }
+  .annot:hover .annot-dot { transform: scale(1.2); transition: transform .12s; }
+
+  .annot-tip {
+    position: absolute;
+    top: 22px;
+    left: 0;
+    transform: translateX(-50%) translateY(2px);
+    background: var(--v4-ink-900);
+    color: #fff;
+    font-size: 11px;
+    line-height: 1.4;
+    padding: 8px 10px;
+    border-radius: 6px;
+    white-space: nowrap;
+    max-width: 260px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity .15s ease, transform .18s cubic-bezier(0.16, 1, 0.3, 1);
+    z-index: 6;
+    box-shadow: 0 6px 16px rgba(11, 16, 32, 0.25);
+  }
+  .annot-tip-cat {
+    display: inline-block;
+    font-family: var(--v4-mono);
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    background: rgba(255,255,255,0.15);
+    padding: 1px 5px;
+    border-radius: 3px;
+    margin-bottom: 4px;
+  }
+  .annot-tip-date { font-family: var(--v4-mono); font-size: 10px; color: rgba(255,255,255,0.65); margin-top: 4px; }
+  .annot:hover .annot-tip { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+  /* Add-event кнопка */
+  .btn-add-event {
+    border: 1px dashed var(--v4-line-strong);
+    background: transparent;
+    border-radius: var(--v4-r-md);
+    padding: 6px 10px;
+    font: inherit;
+    font-size: 11px;
+    color: var(--v4-ink-500);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    transition: all .15s ease;
+  }
+  .btn-add-event:hover { color: var(--v4-purple-500, #7C3AED); border-color: var(--v4-purple-500, #7C3AED); background: var(--v4-purple-50, #F5F0FF); }
+
+  /* Tooltip card — стиль v4-closed-tip из дашборда */
+  .chart-tip {
+    position: absolute;
+    top: 8px;
+    background: var(--v4-paper);
+    border: 1px solid var(--v4-line-strong);
+    box-shadow: 0 8px 24px rgba(11, 16, 32, 0.12), 0 2px 6px rgba(11, 16, 32, 0.06);
+    border-radius: 8px;
+    padding: 10px 12px;
+    min-width: 180px;
+    pointer-events: none;
+    font-size: 12px;
+    z-index: 5;
+    opacity: 0;
+    transform: translateY(4px);
+    transition: opacity .18s ease, transform .22s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  .chart-tip.show { opacity: 1; transform: translateY(0); }
+  .chart-tip-l {
+    font-family: var(--v4-mono);
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--v4-ink-500);
+    margin-bottom: 6px;
+  }
+  .chart-tip-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+  .chart-tip-v {
+    font-family: var(--v4-mono);
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--v4-ink-900);
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+  .chart-tip-u { color: var(--v4-ink-500); font-size: 12px; }
+  .chart-tip-foot {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+    padding-top: 8px;
+    border-top: 1px solid var(--v4-line-soft);
+    color: var(--v4-ink-500);
+    font-size: 11px;
+  }
+  .chart-tip-foot--tight { padding-top: 4px; border-top: 0; }
+  .chart-tip-tr {
+    font-family: var(--v4-mono);
+    font-weight: 600;
+    color: var(--v4-ink-700);
+  }
+  .chart-tip-seg {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-family: var(--v4-mono);
+    font-weight: 600;
+  }
+  .chart-tip-seg .sw { width: 8px; height: 8px; border-radius: 2px; }
+
+  /* Compact tooltip — для миничартов в карточках проектов. Multiline для читабельности. */
+  .chart-tip--compact {
+    min-width: 160px;
+    padding: 8px 10px;
+    font-size: 11px;
+    background: var(--v4-ink-900);
+    color: #fff;
+    border: 0;
+    box-shadow: 0 8px 20px rgba(11, 16, 32, 0.32);
+    top: auto;
+    bottom: calc(100% + 8px);
+    white-space: nowrap;
+    line-height: 1.45;
+    font-family: var(--v4-mono);
+  }
+  .chart-tip--compact .ct-line1 {
+    display: flex; align-items: baseline; gap: 6px; margin-bottom: 4px;
+    padding-bottom: 4px; border-bottom: 1px solid rgba(255,255,255,0.12);
+  }
+  .chart-tip--compact .ct-line2 {
+    display: flex; gap: 10px; align-items: center;
+  }
+  .chart-tip--compact .ct-d  { color: rgba(255,255,255,0.7); font-size: 10px; }
+  .chart-tip--compact .ct-v  { font-weight: 700; font-size: 13px; }
+  .chart-tip--compact .ct-u  { color: rgba(255,255,255,0.6); font-size: 10px; }
+  .chart-tip--compact .ct-pct { font-weight: 700; margin-left: auto; font-size: 12px; }
+  .chart-tip--compact .ct-seg { display: inline-flex; align-items: center; gap: 3px; font-size: 10px; }
+  .chart-tip--compact .ct-seg .sw {
+    width: 7px; height: 7px; border-radius: 2px; display: inline-block;
+  }
+  .chart-tip--compact .ct-seg b { font-weight: 700; color: #fff; }
+  .chart-tip--compact .ct-p0-wrap { color: #fecaca; font-weight: 800; }
+  .chart-tip--compact .ct-p0-wrap b { color: #fff; }
+  .bar:hover .bar-tip { opacity: 1; }
+
+  /* Period toggle button — плавный sliding background */
+  .seg button { transition: background .18s ease, color .18s ease; }
+
+  /* Refresh button */
+  .btn-refresh { transition: background .15s ease, border-color .15s ease, transform .12s ease; }
+  .btn-refresh:active { transform: scale(0.97); }
+
+  /* ──── REDUCED MOTION GUARD ────
+     Обязательно: пользователи с prefers-reduced-motion отключают всю кинетику.
+     Так же сделано в дашборде (@media-блок в v4.css). */
+  @media (prefers-reduced-motion: reduce) {
+    .chart, .card, .kpi { animation: none !important; clip-path: none !important; }
+    .bar-stack, .chart-tip, .bar-chip { transition: none !important; }
+    .card:hover, .kpi:hover { transform: none !important; }
+  }
+  .bar-tip::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 4px solid transparent;
+    border-top-color: var(--v4-ink-900);
+  }
+
+  .chart-labels {
+    display: flex;
+    margin-top: 6px;
+    gap: 2px;
+  }
+  .chart-label {
+    flex: 1;
+    text-align: center;
+    font-family: var(--v4-mono);
+    font-size: 9px;
+    color: var(--v4-ink-400);
+    min-width: 4px;
+    overflow: hidden;
+  }
+  .chart-legend {
+    display: flex;
+    gap: 14px;
+    margin-top: 14px;
+    font-size: 11px;
+    color: var(--v4-ink-500);
+    font-family: var(--v4-mono);
+    font-weight: 500;
+  }
+  .chart-legend span { display: inline-flex; align-items: center; gap: 6px; }
+  .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 2px;
+    display: inline-block;
+  }
+  .dot-p1    { background: var(--v4-p1); }
+  .dot-p2    { background: var(--v4-p2); }
+  .dot-clean { background: var(--v4-clean-soft); }
+
+  /* Grid of project cards */
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 14px;
+  }
+  .card {
+    background: var(--v4-paper);
+    border: 1px solid var(--v4-line);
+    border-radius: var(--v4-r-lg);
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    will-change: transform;
+    /* Stagger entrance — как wow-card-in в дашборде */
+    animation: q-card-in 420ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation-delay: calc(var(--i, 0) * 45ms + 300ms);
+    transition:
+      transform 220ms cubic-bezier(0.16, 1, 0.3, 1),
+      box-shadow 220ms ease,
+      border-color 200ms ease;
+  }
+  .card:hover {
+    transform: translateY(-3px);
+    border-color: var(--v4-line-strong);
+    box-shadow: 0 14px 32px -14px rgba(11, 16, 32, 0.18),
+                0 4px 12px -4px rgba(11, 16, 32, 0.08);
+  }
+  @keyframes q-card-in {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  .card-h {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 8px;
+  }
+  .card-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--v4-ink-900);
+    font-family: var(--v4-mono);
+  }
+  .card-client {
+    font-size: 10px;
+    color: var(--v4-ink-500);
+    font-weight: 500;
+    margin-top: 1px;
+  }
+  .card-now {
+    font-size: 22px;
+    font-weight: 700;
+    font-family: var(--v4-mono);
+    color: var(--v4-ink-900);
+    letter-spacing: -0.02em;
+    line-height: 1;
+    text-align: right;
+  }
+  .card-now-sub {
+    font-size: 10px;
+    color: var(--v4-ink-400);
+    margin-top: 2px;
+    font-family: var(--v4-mono);
+    text-align: right;
+  }
+
+  .card-chart {
+    height: 80px;
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    border-bottom: 1px dashed var(--v4-line-soft);
+    position: relative;     /* для абсолютного позиционирования .chart-tip и .bar-chip */
+  }
+
+  .card-foot {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-top: 1px solid var(--v4-line-soft);
+    padding-top: 8px;
+    font-size: 11px;
+    font-family: var(--v4-mono);
+    color: var(--v4-ink-500);
+  }
+  .card-foot .nums { display: flex; gap: 12px; }
+  .card-foot .nums b { color: var(--v4-ink-800); font-weight: 600; }
+  .card-foot .num-p1 b { color: var(--v4-p1-text); }
+  .card-foot .num-p2 b { color: var(--v4-p2-text); }
+
+  .card-empty {
+    color: var(--v4-ink-400);
+    text-align: center;
+    padding: 24px 8px;
+    font-size: 11px;
+    font-family: var(--v4-mono);
+  }
+  .card-empty b { display: block; font-size: 14px; color: var(--v4-ink-500); margin-bottom: 4px; }
+
+  .note {
+    margin-top: 18px;
+    padding: 14px 18px;
+    background: var(--v4-accent-50);
+    border: 1px solid #c5d6f7;
+    border-radius: var(--v4-r-md);
+    font-size: 12px;
+    color: var(--v4-ink-700);
+  }
+  .note b { color: var(--v4-ink-900); }
+  .note ul { margin: 6px 0 0 0; padding-left: 18px; }
+  .note li { margin: 3px 0; }
+
+  /* Section heading */
+  .sect {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin: 8px 0 12px;
+  }
+  .sect h2 {
+    margin: 0;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--v4-ink-500);
+    font-family: var(--v4-mono);
+    font-weight: 600;
+  }
+  .sect .meta { font-size: 11px; color: var(--v4-ink-400); font-family: var(--v4-mono); }
+
+  /* Sort */
+  .sort {
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+    background: var(--v4-paper);
+    border: 1px solid var(--v4-line);
+    border-radius: var(--v4-r-md);
+    padding: 3px;
+  }
+  .sort button {
+    border: 0;
+    background: transparent;
+    padding: 5px 10px;
+    font: inherit;
+    font-size: 11px;
+    color: var(--v4-ink-500);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .sort button.active {
+    background: var(--v4-surface-2);
+    color: var(--v4-ink-900);
+    font-weight: 600;
+  }
+</style>
+</head>
+<body>
+
+<div class="topbar">
+  <div class="tab">Дашборд</div>
+  <div class="tab">Проекты</div>
+  <div class="tab">Milestones</div>
+  <div class="tab">Завершённые</div>
+  <div class="tab">Мониторинг</div>
+  <div class="tab">Pipeline</div>
+  <div class="tab">Транскрипты</div>
+  <div class="tab">Аудит</div>
+  <div class="tab active">Качество <span class="badge-new">NEW</span></div>
+</div>
+
+<div class="page">
+
+  <div class="pageH">
+    <div>
+      <h1>Качество кода и изменения</h1>
+      <div class="sub">Доля PR с критическими/высокими замечаниями <b>chatgpt-codex-connector[bot]</b> от общего числа merged PR · события на временной оси</div>
+    </div>
+    <div class="ctrls">
+      <div class="seg" id="seg-period">
+        <button data-mode="30d">30 дней · По дням</button>
+        <button class="active" data-mode="12w">12 недель · По неделям</button>
+      </div>
+      <button class="btn-add-event" title="Добавить событие на ось времени (Фаза 1 — ручные аннотации)">
+        + событие
+      </button>
+      <div style="font-family: var(--v4-mono); font-size: 10px; color: var(--v4-ink-500); text-align: right; line-height: 1.35;">
+        <div>Синхр. ежедневно · 03:00 Бали</div>
+        <div style="color: var(--v4-ink-400)">последняя: сегодня, 03:02 (24.05)</div>
+      </div>
+      <button class="btn-refresh" title="Принудительно обновить сейчас">
+        ↻ Сейчас
+      </button>
+    </div>
+  </div>
+
+  <!-- Summary panel -->
+  <div class="panel summary">
+    <div class="chartwrap">
+      <div class="panel-t" style="margin-bottom: 14px;">
+        Сводно по всем 12 проектам
+        <span class="tag">All repos</span>
+      </div>
+      <div class="chart" id="summary-chart">
+        <div class="chart-axis">
+          <span class="chart-axis-label" style="top:-2px">40%</span>
+          <span class="chart-axis-label" style="top:calc(50% - 6px)">20%</span>
+        </div>
+      </div>
+      <div class="chart-labels" id="summary-labels"></div>
+      <div class="chart-legend">
+        <span><i class="dot" style="background:var(--v4-p0)"></i> P0+P1 (критическое)</span>
+        <span><i class="dot" style="background:var(--v4-p2)"></i> P2 (высокое)</span>
+        <span><i class="dot" style="background:var(--v4-clean-soft)"></i> чистые PR</span>
+        <span style="margin-left:auto; color: var(--v4-ink-400)">P0 (блокеры) объединены с P1 в красный — детально в tooltip и pulse-плашке.</span>
+      </div>
+    </div>
+    <div class="kpis">
+      <!-- P0 alert pill — рендерится JS-ом если есть P0 в сводном периоде -->
+      <div id="kpi-p0-alert-slot"></div>
+      <div class="kpi" style="--i: 0">
+        <div class="kpi-lbl">% грязных PR · текущая неделя</div>
+        <div class="kpi-v dirty">17%</div>
+        <div class="kpi-sub">
+          <span class="delta down">▼ -4 пп</span> vs прошлая неделя · 24 из 138 PR
+        </div>
+      </div>
+      <div class="kpi" style="--i: 1">
+        <div class="kpi-lbl">% P1 · средн. за 12 нед.</div>
+        <div class="kpi-v" style="color: var(--v4-p1-text)">8%</div>
+        <div class="kpi-sub"><span class="delta down">▼ -2 пп</span> vs первая неделя периода</div>
+      </div>
+      <div class="kpi" style="--i: 2">
+        <div class="kpi-lbl">% P2 · средн. за 12 нед.</div>
+        <div class="kpi-v" style="color: var(--v4-p2-text)">13%</div>
+        <div class="kpi-sub"><span class="delta flat">— без изменений</span></div>
+      </div>
+      <div class="kpi" style="--i: 3">
+        <div class="kpi-lbl">PR за 12 нед.</div>
+        <div class="kpi-v">1487</div>
+        <div class="kpi-sub">123 в среднем за неделю</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="sect">
+    <h2>По проектам</h2>
+    <div style="display: flex; gap: 10px; align-items: center;">
+      <span class="meta">Сортировка:</span>
+      <div class="sort">
+        <button class="active">по «грязи»</button>
+        <button>по алфавиту</button>
+        <button>по P1</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid" id="project-grid"></div>
+
+  <div class="note">
+    <b>📝 Заметки к прототипу</b>
+    <ul>
+      <li><b>Высота бара = всего merged PR в бакете</b> (абсолютная шкала, ось слева). Это даёт сразу две информации в одном виде: <i>объём работы</i> + <i>доля проблемных</i>.</li>
+      <li><b>Стек снизу вверх:</b> P1 (красный) → P2-only (жёлтый) → чистые PR (голубой). Глаз цепляется за красное внизу — там самое важное; чистый объём наверху как "фон/итог".</li>
+      <li><b>Worst-wins для overlapping PR:</b> PR с одновременно P1+P2 учитывается в P1 (чтобы сумма сегментов точно равнялась total PR без двойного счёта).</li>
+      <li><b>% грязных PR</b> = (P1 + P2-only) / total — заголовочная цифра в правом блоке KPI и в карточке проекта.</li>
+      <li><b>Tooltip</b>: дата периода, всего PR, чистых, P1, P2-only, % грязных.</li>
+      <li><b>Пустые проекты:</b> если за период &lt; 3 merged PR — карточка серая (см. Beer_bot).</li>
+      <li><b>Цвета</b>: <code>--v4-p1</code> #EF4444, <code>--v4-p2</code> #F79009, <code>--v4-clean-soft</code> #93C5FD (lighter <code>--v4-accent-500</code>).</li>
+      <li><b>Синхронизация</b>: раз в сутки в 03:00 по Бали (UTC+8 → 19:00 UTC). Открываешь дашборд утром — видишь уже агрегированные данные за вчера. Архитектура обсуждается отдельно (см. ответ ниже).</li>
+    </ul>
+  </div>
+
+</div>
+
+<script>
+// ─────────────────────────────────────────
+// Mock data — реалистичный спред
+// ─────────────────────────────────────────
+const seed = (s) => () => (s = (s * 9301 + 49297) % 233280) / 233280;
+
+// Mock annotations — будут жить в JSON на VPS (Фаза 1: ручные через UI; Фаза 2: + auto из pipeline)
+const ANNOTATIONS = [
+  { date: '2026-03-23', category: 'skill',  title: 'Обновлён /makeit-codereview', desc: 'Усилена detection security-issues' },
+  { date: '2026-04-16', category: 'skill',  title: 'Refactor /makeit-dev',         desc: 'Уменьшен retry-rate на phase QA (чт)' },
+  { date: '2026-04-30', category: 'deploy', title: 'Pipeline v3.4 → prod',         desc: 'AutoTuner Tier-2 включён по всем репо (чт)' },
+  { date: '2026-05-22', category: 'manual', title: 'Pair-сессия с Codex',          desc: 'Прошли весь legacy auth (пт)' },
+];
+
+// Snap к понедельнику текущей ISO-недели (пн=1...вс=7 в ISO; JS getDay() возвращает вс=0, пн=1...сб=6)
+function isoMonday(date) {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  const day = d.getDay();              // 0=вс, 1=пн, ... 6=сб
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  return d;
+}
+
+// Округление вверх до "красивого" числа для шкалы оси
+function niceCeil(n) {
+  if (n <= 5)   return 5;
+  if (n <= 10)  return 10;
+  if (n <= 20)  return 20;
+  if (n <= 50)  return 50;
+  if (n <= 100) return 100;
+  if (n <= 200) return 200;
+  return Math.ceil(n / 100) * 100;
+}
+
+function makeSeries(weeks, baseP0, baseP1, baseP2, prMean, trend = 0, rngSeed = 1) {
+  const r = seed(rngSeed);
+  return Array.from({ length: weeks }, (_, i) => {
+    const t = i / (weeks - 1);
+    const totalPR = Math.max(1, Math.round(prMean * (0.6 + r() * 0.8)));
+    // P0 редкий — Poisson-like с малым средним
+    const p0Count = baseP0 > 0 && r() < baseP0 / 100 * totalPR ? Math.max(1, Math.round(baseP0 / 100 * totalPR + (r() - 0.5))) : 0;
+    const p1pct = Math.max(0, Math.min(35, baseP1 + (r() - 0.5) * 8 + trend * t));
+    const p2pct = Math.max(0, Math.min(35, baseP2 + (r() - 0.5) * 7 + trend * t * 0.5));
+    let p1Count = Math.round((p1pct / 100) * totalPR);
+    let p2Count = Math.round((p2pct / 100) * totalPR);
+    // Worst-wins: PR с P0 не учитываются в P1/P2; P1 не учитывается в P2.
+    // Гарантируем что сумма (p0 + p1_only + p2_only) <= totalPR
+    p1Count = Math.max(0, Math.min(p1Count, totalPR - p0Count));
+    const onlyP2 = Math.max(0, Math.min(p2Count - Math.round(p1Count * 0.4), totalPR - p0Count - p1Count));
+    return {
+      label: `н${i + 1}`,
+      totalPR,
+      withP0: p0Count,
+      withP1only: p1Count,
+      withP2only: onlyP2,
+      dirty: p0Count + p1Count + onlyP2,
+    };
+  });
+}
+
+const projects = [
+  // [repo, client, baseP0, baseP1, baseP2, prMean, trend, seed]
+  // baseP0 — редкое (0-2), реальные P0 за вчера были в moliyakg
+  ["mankassa-app",     "Сергей",       0, 14, 22, 18, -10, 7],
+  ["quiet-walls",      "Тихие Стены",  0, 11, 19, 9,   -6, 13],
+  ["makeit-pipeline",  "Свой проект",  0,  9, 12, 14,   3, 21],
+  ["Business-News",    "Свой проект",  0,  3, 18, 11,   0, 5],
+  ["makeit-auditor",   "Свой проект",  0, 10,  5, 8,   -4, 3],
+  ["moliyakg",         "Свой проект",  2,  6, 14, 5,    1, 17],  // ← реальные P0 здесь
+  ["makeit-dashboard", "Свой проект",  0,  4, 12, 19,   2, 29],
+  ["MyMoney",          "Свой проект",  0,  4, 11, 6,   -2, 11],
+  ["solotax-kg",       "Свой проект",  0,  3,  9, 16,  -1, 23],
+  ["Uchet_bot",        "Кристина",     0,  2, 11, 4,    0, 31],
+  ["Sewing-ERP",       "Свой проект",  0,  2,  6, 22,  -3, 19],
+  ["Beer_bot",         "Тенгри Бир",   0,  0,  0, 0.4,  0, 41],
+];
+
+// ─────────────────────────────────────────
+// Render
+// ─────────────────────────────────────────
+const PERIOD = { mode: "12w", buckets: 12 };
+
+function renderChart(container, labelsContainer, series, opts = {}) {
+  const { maxScale: explicitScale, showLabels = true, compact = false } = opts;
+  container.innerHTML = '';
+  // Y-axis шкалируем по реальному max total PR в серии (с округлением вверх до удобного числа)
+  const maxTotal = Math.max(1, ...series.map(d => d.totalPR));
+  const scale = explicitScale ?? niceCeil(maxTotal);
+  if (!compact) {
+    const axis = document.createElement('div');
+    axis.className = 'chart-axis';
+    axis.innerHTML = `
+      <span class="chart-axis-label" style="top:-2px">${scale}</span>
+      <span class="chart-axis-label" style="top:calc(50% - 6px)">${Math.round(scale/2)}</span>
+    `;
+    container.appendChild(axis);
+  }
+
+  // Один tooltip на весь чарт. Структура создаётся РАЗ, на hover обновляются
+  // только текстовые ноды — не пересоздаём innerHTML каждый раз (дорого).
+  // Compact: маленький tooltip в одну строку (большая карточка не влезет в 80px чарт).
+  let tip = document.createElement('div');
+  let tipRefs;
+  if (compact) {
+    tip.className = 'chart-tip chart-tip--compact';
+    tip.innerHTML = `
+      <div class="ct-line1">
+        <span class="ct-d"></span>
+        <span class="ct-v"></span>
+        <span class="ct-u">PR</span>
+        <span class="ct-pct"></span>
+      </div>
+      <div class="ct-line2">
+        <span class="ct-p0-wrap" style="display:none">🔴<b class="ct-p0"></b></span>
+        <span class="ct-seg" style="color:#fcd34d"><i class="sw" style="background:var(--v4-p1)"></i>P1:<b class="ct-p1"></b></span>
+        <span class="ct-seg" style="color:#fde68a"><i class="sw" style="background:var(--v4-p2)"></i>P2:<b class="ct-p2"></b></span>
+        <span class="ct-seg" style="color:#93C5FD"><i class="sw" style="background:var(--v4-clean-soft)"></i><b class="ct-c"></b></span>
+      </div>`;
+    tipRefs = {
+      label: tip.querySelector('.ct-d'),
+      total: tip.querySelector('.ct-v'),
+      clean: tip.querySelector('.ct-c'),
+      p2:    tip.querySelector('.ct-p2'),
+      p1:    tip.querySelector('.ct-p1'),
+      p0:    tip.querySelector('.ct-p0'),
+      p0Wrap: tip.querySelector('.ct-p0-wrap'),
+      dirty: tip.querySelector('.ct-pct'),
+    };
+  } else {
+    tip.className = 'chart-tip';
+    tip.innerHTML = `
+      <div class="chart-tip-l"></div>
+      <div class="chart-tip-row">
+        <span class="chart-tip-v"></span>
+        <span class="chart-tip-u">PR в периоде</span>
+      </div>
+      <div class="chart-tip-foot">
+        <span class="chart-tip-seg"><i class="sw" style="background:var(--v4-clean-soft)"></i> чистые</span>
+        <span class="chart-tip-tr js-clean"></span>
+      </div>
+      <div class="chart-tip-foot chart-tip-foot--tight">
+        <span class="chart-tip-seg"><i class="sw" style="background:var(--v4-p2)"></i> P2 only</span>
+        <span class="chart-tip-tr js-p2" style="color: var(--v4-p2-text)"></span>
+      </div>
+      <div class="chart-tip-foot chart-tip-foot--tight">
+        <span class="chart-tip-seg"><i class="sw" style="background:var(--v4-p1)"></i> P1</span>
+        <span class="chart-tip-tr js-p1" style="color: var(--v4-p1-text)"></span>
+      </div>
+      <div class="chart-tip-foot chart-tip-foot--tight js-p0-row" style="display:none">
+        <span class="chart-tip-seg"><i class="sw" style="background:var(--v4-p0)"></i> <b>P0 BLOCKER</b></span>
+        <span class="chart-tip-tr js-p0" style="color: var(--v4-p0-text); font-weight: 800"></span>
+      </div>
+      <div class="chart-tip-foot" style="border-top: 1px solid var(--v4-line-soft); padding-top: 8px; margin-top: 4px">
+        <span>Δ грязных</span>
+        <span class="chart-tip-tr js-dirty" style="font-size: 13px"></span>
+      </div>`;
+    tipRefs = {
+      label: tip.querySelector('.chart-tip-l'),
+      total: tip.querySelector('.chart-tip-v'),
+      clean: tip.querySelector('.js-clean'),
+      p2:    tip.querySelector('.js-p2'),
+      p1:    tip.querySelector('.js-p1'),
+      p0:    tip.querySelector('.js-p0'),
+      p0Row: tip.querySelector('.js-p0-row'),
+      dirty: tip.querySelector('.js-dirty'),
+    };
+  }
+  container.appendChild(tip);
+
+  series.forEach((d, idx) => {
+    const total = d.totalPR;
+    const heightPct = (total / scale) * 100;
+    // Worst-wins: P0+P1 объединены в crit-сегмент. P2-only отдельно. Clean = остальное.
+    const critCount = d.withP0 + d.withP1only;
+    const cleanCount = Math.max(0, total - critCount - d.withP2only);
+    const critShareOfBar = total > 0 ? (critCount / total) * heightPct : 0;
+    const p2ShareOfBar = total > 0 ? (d.withP2only / total) * heightPct : 0;
+    const cleanShareOfBar = heightPct - critShareOfBar - p2ShareOfBar;
+    const dirtyPct = total > 0 ? ((critCount + d.withP2only) / total) * 100 : 0;
+
+    const bar = document.createElement('div');
+    bar.className = 'bar';
+    // Mark bar with P0 для возможной кастомизации (например border-top accent)
+    if (d.withP0 > 0) bar.classList.add('has-p0');
+    bar.innerHTML = `
+      ${d.withP0 > 0 ? `<div class="bar-topper-p0">P0:${d.withP0}</div>` : ''}
+      <div class="bar-stack" style="height:${heightPct}%">
+        ${cleanShareOfBar > 0 ? `<div class="bar-clean" style="height:${(cleanShareOfBar / heightPct) * 100}%"></div>` : ''}
+        ${p2ShareOfBar > 0 ? `<div class="bar-p2" style="height:${(p2ShareOfBar / heightPct) * 100}%"></div>` : ''}
+        ${critShareOfBar > 0 ? `<div class="bar-crit" style="height:${(critShareOfBar / heightPct) * 100}%"></div>` : ''}
+      </div>
+      ${heightPct === 0 ? '<div class="bar-empty"></div>' : ''}
+      <div class="bar-chip">${total} PR${d.withP0 > 0 ? ` · <b style="color:#fca5a5">P0:${d.withP0}</b>` : ''}</div>
+    `;
+
+    // Hover handler. Дёшево: меняем только textContent + 2 класса, без innerHTML.
+    bar.addEventListener('mouseenter', () => {
+      tipRefs.label.textContent = d.label;
+      tipRefs.total.textContent = total;
+      tipRefs.clean.textContent = cleanCount;
+      tipRefs.p2.textContent    = d.withP2only;
+      tipRefs.p1.textContent    = d.withP1only;
+      tipRefs.p0.textContent    = d.withP0;
+      tipRefs.dirty.textContent = dirtyPct.toFixed(0) + '%';
+      // P0-row показываем только если есть
+      if (compact) {
+        tipRefs.p0Wrap.style.display = d.withP0 > 0 ? '' : 'none';
+      } else {
+        tipRefs.p0Row.style.display = d.withP0 > 0 ? '' : 'none';
+      }
+      const cRect = container.getBoundingClientRect();
+      const bRect = bar.getBoundingClientRect();
+      const pctX = ((bRect.left + bRect.width / 2) - cRect.left) / cRect.width * 100;
+      if (compact) {
+        // Compact: позиционируем строго над баром, центрируем + flip если у края
+        tip.style.left = `${pctX}%`;
+        tip.style.transform = `translateX(-50%) translateY(0)`;
+        // Защита от overflow по горизонтали — после render проверяем bbox
+        requestAnimationFrame(() => {
+          const tRect = tip.getBoundingClientRect();
+          if (tRect.left < cRect.left + 4) {
+            tip.style.transform = `translateX(0) translateY(0)`;
+            tip.style.left = '0%';
+          } else if (tRect.right > cRect.right - 4) {
+            tip.style.transform = `translateX(-100%) translateY(0)`;
+            tip.style.left = '100%';
+          }
+        });
+      } else {
+        // Main: tooltip-card сбоку от бара, flip если близко к правому краю
+        const flipLeft = pctX > 70;
+        tip.style.left = `calc(${pctX}% + 12px - ${flipLeft ? '208px' : '0px'})`;
+      }
+      tip.classList.add('show');
+      container.classList.add('is-hovering');
+      bar.classList.add('is-active');
+    });
+    bar.addEventListener('mouseleave', () => {
+      tip.classList.remove('show');
+      container.classList.remove('is-hovering');
+      bar.classList.remove('is-active');
+    });
+
+    container.appendChild(bar);
+  });
+  if (labelsContainer && showLabels) {
+    labelsContainer.innerHTML = '';
+    series.forEach((d, i) => {
+      const lab = document.createElement('div');
+      lab.className = 'chart-label';
+      // show every 2nd label for compactness
+      lab.textContent = (i === 0 || i === series.length - 1 || i % 2 === 0) ? d.label : '';
+      labelsContainer.appendChild(lab);
+    });
+  }
+}
+
+function severityBadge(dirtyPct) {
+  if (dirtyPct === 0 || isNaN(dirtyPct)) return '';
+  if (dirtyPct >= 25) return '<span class="tag tag-bad">высокий риск</span>';
+  if (dirtyPct >= 12) return '<span class="tag tag-warn">средний</span>';
+  return '<span class="tag tag-good">чисто</span>';
+}
+
+// Перезаписать лейблы серии реальными датами (Понедельники для weekly, дни для daily)
+function applyDateLabels(series) {
+  const today = new Date();
+  const todayMonday = isoMonday(today);
+  series.forEach((d, i) => {
+    let date;
+    if (PERIOD.mode === '12w') {
+      date = new Date(todayMonday);
+      date.setDate(date.getDate() - (series.length - 1 - i) * 7);
+    } else {
+      date = new Date(today);
+      date.setDate(date.getDate() - (series.length - 1 - i));
+    }
+    d.label = `${date.getDate()}.${String(date.getMonth() + 1).padStart(2, '0')}`;
+  });
+  return series;
+}
+
+function renderProjectCard(p) {
+  const [repo, client, baseP0, baseP1, baseP2, prMean, trend, seedV] = p;
+  const series = applyDateLabels(makeSeries(PERIOD.buckets, baseP0, baseP1, baseP2, prMean, trend, seedV));
+  const totalPR = series.reduce((a, x) => a + x.totalPR, 0);
+  const totalDirty = series.reduce((a, x) => a + x.dirty, 0);
+  const totalP1 = series.reduce((a, x) => a + x.withP1only, 0);
+  const totalP2only = series.reduce((a, x) => a + x.withP2only, 0);
+  // totalDirty считается ниже из P0+P1+P2-only
+
+  const card = document.createElement('div');
+  card.className = 'card';
+
+  if (totalPR < 3) {
+    card.innerHTML = `
+      <div class="card-h">
+        <div>
+          <div class="card-name">${repo}</div>
+          <div class="card-client">${client}</div>
+        </div>
+        <span class="tag">мало данных</span>
+      </div>
+      <div class="card-empty">
+        <b>${totalPR} PR за период</b>
+        Нужно ≥3 PR чтобы считать %
+      </div>
+    `;
+    return card;
+  }
+
+  const totalP0 = series.reduce((a, x) => a + x.withP0, 0);
+  const dirtyPct = (totalDirty / totalPR) * 100;
+  const p1Pct = (totalP1 / totalPR) * 100;
+  const p2Pct = (totalP2only / totalPR) * 100;
+
+  card.innerHTML = `
+    <div class="card-h">
+      <div>
+        <div class="card-name">${repo}</div>
+        <div class="card-client">${client}</div>
+      </div>
+      <div>
+        <div class="card-now">${dirtyPct.toFixed(0)}%</div>
+        <div class="card-now-sub">${totalDirty}/${totalPR} PR</div>
+      </div>
+    </div>
+    <div class="card-chart"></div>
+    <div class="card-foot">
+      <div class="nums">
+        ${totalP0 > 0 ? `<span class="num-p0" title="БЛОКЕР"><b style="color:var(--v4-p0-text);background:rgba(239,68,68,0.12);padding:1px 6px;border-radius:3px;font-weight:700">🔴 P0: ${totalP0}</b></span>` : ''}
+        <span class="num-p1">P1 <b>${p1Pct.toFixed(0)}%</b></span>
+        <span class="num-p2">P2 <b>${p2Pct.toFixed(0)}%</b></span>
+      </div>
+      ${severityBadge(dirtyPct)}
+    </div>
+  `;
+  const chart = card.querySelector('.card-chart');
+  // Auto-scale per card: проекты с мало PR не должны быть прижаты к земле общей шкалой
+  renderChart(chart, null, series, { compact: true, showLabels: false });
+  card.dataset.dirty = dirtyPct;
+  card.dataset.p1 = p1Pct;
+  card.dataset.name = repo;
+  return card;
+}
+
+// Раскладка событий-аннотаций на чарте.
+// Daily mode (30d): маркер снапится к ЦЕНТРУ бара того дня (1 бар = 1 день).
+// Weekly mode (12w): маркер позиционируется ПРОПОРЦИОНАЛЬНО внутри ISO-недели (пн-вс).
+//   Каждый бар покрывает 7 дней. Полный охват чарта = buckets × 7 = 84 дня.
+function renderAnnotations(container, series) {
+  container.querySelectorAll('.annot').forEach(n => n.remove());
+  if (!series.length) return;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  let startDate, totalDays;
+  if (PERIOD.mode === '12w') {
+    // Start = понедельник самой ранней недели в чарте
+    const todayMonday = isoMonday(today);
+    startDate = new Date(todayMonday);
+    startDate.setDate(startDate.getDate() - (series.length - 1) * 7);
+    totalDays = series.length * 7;          // полный охват 12 недель × 7 дней = 84
+  } else {
+    // Start = bar 0 = today - 29 дней
+    startDate = new Date(today);
+    startDate.setDate(today.getDate() - (series.length - 1));
+    totalDays = series.length;              // полный охват 30 дней
+  }
+
+  ANNOTATIONS.forEach(a => {
+    const date = new Date(a.date);
+    date.setHours(0, 0, 0, 0);
+    const daysFromStart = (date - startDate) / 86400000;
+    if (daysFromStart < 0 || daysFromStart >= totalDays) return;
+
+    let pct;
+    if (PERIOD.mode === '30d') {
+      // Snap к центру бара того дня
+      const dayIdx = Math.round(daysFromStart);
+      pct = ((dayIdx + 0.5) / series.length) * 100;
+    } else {
+      // Внутри ISO-недели: позиция пропорциональна дню (пн=0/7, вт=1/7, ..., вс=6/7 внутри своей недели)
+      pct = (daysFromStart / totalDays) * 100;
+    }
+
+    const el = document.createElement('div');
+    el.className = `annot is-${a.category}`;
+    el.style.left = `${pct}%`;
+    el.innerHTML = `
+      <div class="annot-dot"></div>
+      <div class="annot-tip">
+        <span class="annot-tip-cat">${a.category}</span><br>
+        <b>${a.title}</b><br>
+        <span style="opacity: 0.8; white-space: normal;">${a.desc}</span>
+        <div class="annot-tip-date">${date.toLocaleDateString('ru')}</div>
+      </div>`;
+    container.appendChild(el);
+  });
+}
+
+// Initial render
+function render() {
+  // Summary — aggregate of all. Лейблы: weekly = ISO-понедельники, daily = дни.
+  const allSeries = applyDateLabels(makeSeries(PERIOD.buckets, 0.3, 8, 13, 123, -2, 99));
+  renderChart(
+    document.getElementById('summary-chart'),
+    document.getElementById('summary-labels'),
+    allSeries,
+    {}   // auto-scale по реальному max total_pr
+  );
+  renderAnnotations(document.getElementById('summary-chart'), allSeries);
+  // P0-alert pill — сумма P0 за весь период всех проектов в сводке
+  // В реальной импл: сумма with_p0 за текущую неделю (а не за весь period)
+  const totalP0Summary = projects.reduce((acc, p) => {
+    const s = makeSeries(PERIOD.buckets, p[2], p[3], p[4], p[5], p[6], p[7]);
+    return acc + s.reduce((a, x) => a + x.withP0, 0);
+  }, 0);
+  const slot = document.getElementById('kpi-p0-alert-slot');
+  if (totalP0Summary > 0) {
+    slot.innerHTML = `
+      <div class="kpi-p0-alert" title="Блокирующие баги от Codex за период. Требуют немедленного внимания.">
+        <span class="kpi-p0-icon">🔴</span>
+        <div class="kpi-p0-text">
+          <b>P0: ${totalP0Summary}</b>
+          <span>БЛОКЕРЫ за ${PERIOD.mode === '12w' ? '12 недель' : '30 дней'}</span>
+        </div>
+      </div>`;
+  } else {
+    slot.innerHTML = '';
+  }
+
+  // Grid
+  const grid = document.getElementById('project-grid');
+  grid.innerHTML = '';
+  const sorted = [...projects].sort((a, b) => {
+    const aSeries = makeSeries(PERIOD.buckets, a[2], a[3], a[4], a[5], a[6]);
+    const bSeries = makeSeries(PERIOD.buckets, b[2], b[3], b[4], b[5], b[6]);
+    const aDirty = aSeries.reduce((s, x) => s + x.dirty, 0) / Math.max(1, aSeries.reduce((s, x) => s + x.totalPR, 0));
+    const bDirty = bSeries.reduce((s, x) => s + x.dirty, 0) / Math.max(1, bSeries.reduce((s, x) => s + x.totalPR, 0));
+    return bDirty - aDirty;
+  });
+  sorted.forEach((p, idx) => {
+    const card = renderProjectCard(p);
+    card.style.setProperty('--i', idx);   // stagger для q-card-in
+    grid.appendChild(card);
+  });
+}
+
+// Period toggle
+document.getElementById('seg-period').addEventListener('click', (e) => {
+  if (e.target.tagName !== 'BUTTON') return;
+  document.querySelectorAll('#seg-period button').forEach(b => b.classList.remove('active'));
+  e.target.classList.add('active');
+  PERIOD.mode = e.target.dataset.mode;
+  PERIOD.buckets = PERIOD.mode === '12w' ? 12 : 30;
+  render();
+});
+
+render();
+</script>
+</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { TranscriptsView } from "./components/v4/transcripts/TranscriptsView";
 import { ResearchView } from "./components/v4/research/ResearchView";
 import { SpecsView } from "./components/v4/specs/SpecsView";
 import { QualityView } from "./components/v4/quality/QualityView";
+import { QualityTab } from "./components/quality/QualityTab";
 import { DebateView } from "./components/v4/debate/DebateView";
 import { Sidebar } from "./components/v4/Sidebar";
 import { Topbar } from "./components/v4/Topbar";
@@ -57,6 +58,7 @@ const TAB_CRUMBS: Record<TabId, string> = {
   research: "Research",
   specs: "Specs",
   quality: "Quality",
+  "codex-quality": "Качество кода и изменения",
   debate: "Debate",
 };
 
@@ -140,7 +142,7 @@ function AppInner({ onFirstFetchDone }: AppInnerProps = {}) {
 
   const VALID_TABS: TabId[] = [
     "dashboard", "projects", "milestones", "uptime", "audit",
-    "pipeline", "transcripts", "research", "specs", "quality", "debate",
+    "pipeline", "transcripts", "research", "specs", "quality", "codex-quality", "debate",
   ];
   const ACTIVE_TAB_KEY = "makeit.activeTab";
   const [tab, setTabRaw] = useState<TabId>(() => {
@@ -678,6 +680,13 @@ function AppInner({ onFirstFetchDone }: AppInnerProps = {}) {
           {visitedTabs.has("quality") && (
             <ErrorBoundary fallback="Ошибка вкладки Quality">
               <QualityView />
+            </ErrorBoundary>
+          )}
+        </div>
+        <div style={{ display: tab === "codex-quality" ? undefined : "none" }}>
+          {visitedTabs.has("codex-quality") && (
+            <ErrorBoundary fallback="Ошибка вкладки «Качество кода и изменения»">
+              <QualityTab />
             </ErrorBoundary>
           )}
         </div>

--- a/src/components/quality/AnnotationModal.tsx
+++ b/src/components/quality/AnnotationModal.tsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import type { AnnotationCreatePayload, AnnotationCategory } from "../../types/quality";
+
+interface Props {
+  onSubmit: (p: AnnotationCreatePayload) => Promise<void>;
+  onClose: () => void;
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(0, 0, 0, 0.45)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+};
+
+const modalStyle: React.CSSProperties = {
+  background: "#fff",
+  borderRadius: 8,
+  boxShadow: "0 10px 40px rgba(0, 0, 0, 0.2)",
+  padding: 20,
+  width: "100%",
+  maxWidth: 480,
+  display: "flex",
+  flexDirection: "column",
+  gap: 12,
+};
+
+const labelStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 4,
+  fontSize: 14,
+};
+
+const labelTextStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: "#666",
+  textTransform: "uppercase",
+  letterSpacing: 0.4,
+};
+
+const inputStyle: React.CSSProperties = {
+  fontSize: 14,
+  padding: "6px 8px",
+  border: "1px solid #ccc",
+  borderRadius: 4,
+};
+
+const actionsStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "flex-end",
+  gap: 8,
+  marginTop: 4,
+};
+
+export function AnnotationModal({ onSubmit, onClose }: Props) {
+  const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
+  const [category, setCategory] = useState<AnnotationCategory>("skill");
+  const [title, setTitle] = useState("");
+  const [desc, setDesc] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setSubmitting(true);
+    try {
+      const occurredAt = new Date(date + "T00:00:00Z").toISOString();
+      await onSubmit({
+        occurred_at: occurredAt,
+        category,
+        scope: "global",
+        title: title.trim(),
+        desc: desc.trim(),
+      });
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="modal-bd" style={overlayStyle} onClick={onClose}>
+      <form
+        className="modal"
+        style={modalStyle}
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={handleSubmit}
+      >
+        <h3 style={{ margin: 0 }}>Добавить событие</h3>
+        <label style={labelStyle}>
+          <span style={labelTextStyle}>Дата (UTC)</span>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            required
+            style={inputStyle}
+          />
+        </label>
+        <label style={labelStyle}>
+          <span style={labelTextStyle}>Категория</span>
+          <select
+            value={category}
+            onChange={(e) => setCategory(e.target.value as AnnotationCategory)}
+            style={inputStyle}
+          >
+            <option value="skill">skill — обновление скилла разработки</option>
+            <option value="deploy">deploy — деплой инфраструктуры</option>
+            <option value="manual">manual — pair-сессия, ad-hoc</option>
+          </select>
+        </label>
+        <label style={labelStyle}>
+          <span style={labelTextStyle}>Title</span>
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={120}
+            required
+            style={inputStyle}
+          />
+        </label>
+        <label style={labelStyle}>
+          <span style={labelTextStyle}>Описание</span>
+          <textarea
+            value={desc}
+            onChange={(e) => setDesc(e.target.value)}
+            maxLength={600}
+            rows={3}
+            style={inputStyle}
+          />
+        </label>
+        <div className="modal-actions" style={actionsStyle}>
+          <button type="button" onClick={onClose}>
+            Отмена
+          </button>
+          <button type="submit" disabled={submitting}>
+            Сохранить
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/quality/AnnotationModal.tsx
+++ b/src/components/quality/AnnotationModal.tsx
@@ -62,11 +62,13 @@ export function AnnotationModal({ onSubmit, onClose }: Props) {
   const [title, setTitle] = useState("");
   const [desc, setDesc] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
     setSubmitting(true);
+    setErrorMsg(null);
     try {
       const occurredAt = new Date(date + "T00:00:00Z").toISOString();
       await onSubmit({
@@ -77,6 +79,8 @@ export function AnnotationModal({ onSubmit, onClose }: Props) {
         desc: desc.trim(),
       });
       onClose();
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : String(err));
     } finally {
       setSubmitting(false);
     }
@@ -133,6 +137,21 @@ export function AnnotationModal({ onSubmit, onClose }: Props) {
             style={inputStyle}
           />
         </label>
+        {errorMsg && (
+          <div
+            role="alert"
+            style={{
+              padding: "8px 10px",
+              background: "#fef2f2",
+              border: "1px solid #fecaca",
+              borderRadius: 4,
+              color: "#991b1b",
+              fontSize: 12,
+            }}
+          >
+            Не удалось сохранить: {errorMsg}
+          </div>
+        )}
         <div className="modal-actions" style={actionsStyle}>
           <button type="button" onClick={onClose}>
             Отмена

--- a/src/components/quality/QualityAnnotations.tsx
+++ b/src/components/quality/QualityAnnotations.tsx
@@ -1,0 +1,35 @@
+import type { Annotation, PeriodMode } from "../../types/quality";
+import { annotationPositionPct } from "../../utils/quality-position";
+
+interface Props {
+  annotations: Annotation[];
+  mode: PeriodMode;
+  bucketCount: number;
+}
+
+export function QualityAnnotations({ annotations, mode, bucketCount }: Props) {
+  const today = new Date();
+  return (
+    <>
+      {annotations.map((a) => {
+        const pct = annotationPositionPct(new Date(a.occurred_at), mode, today, bucketCount);
+        if (pct === null) return null;
+        return (
+          <div key={a.id} className={`annot is-${a.category}`} style={{ left: `${pct}%` }}>
+            <div className="annot-dot" />
+            <div className="annot-tip">
+              <span className="annot-tip-cat">{a.category}</span>
+              <br />
+              <b>{a.title}</b>
+              <br />
+              <span style={{ opacity: 0.8, whiteSpace: "normal" }}>{a.desc}</span>
+              <div className="annot-tip-date">
+                {new Date(a.occurred_at).toLocaleDateString("ru")}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/quality/QualityChart.tsx
+++ b/src/components/quality/QualityChart.tsx
@@ -1,0 +1,355 @@
+import { useMemo, useRef } from "react";
+import type { QualityBucket } from "../../types/quality";
+
+/**
+ * QualityChart — переиспользуемый чарт качества (main panel + mini в карточках).
+ *
+ * Префиксы CSS-классов (`.chart`, `.bar`, `.chart-tip` и т.д.) портированы из
+ * прототипа `docs/superpowers/specs/quality-tab-prototype.html` и scoped
+ * через `.v4-quality-tab` (см. `src/styles/v4-quality.css`).
+ *
+ * Перформанс-критичные решения (см. spec section "Перформанс-критичные правила"):
+ *  - tooltip-структура создаётся один раз, на hover обновляются только textContent
+ *    (refs → tipRefsObj), никаких `innerHTML = ...`;
+ *  - dim non-hovered баров — через class toggle `is-hovering`/`is-active`, НЕ `:has()`;
+ *  - height баров не анимируется (transition: height триггерит layout) —
+ *    высоты выставляются в style на mount, на period switch DOM пересоздаётся;
+ *  - hover-эффекты — только opacity / transform.
+ *
+ * Метрика (worst-wins, см. spec):
+ *  - crit = with_p0 + with_p1_only     → красный сегмент (.bar-crit)
+ *  - p2   = with_p2_only               → жёлтый сегмент (.bar-p2)
+ *  - clean = total_pr - crit - p2      → голубой сегмент (.bar-clean)
+ *  - has-p0: bucket с ≥1 P0 → постоянный gradient + topper-pill (main only)
+ */
+
+export interface QualityChartProps {
+  buckets: QualityBucket[];
+  labels: string[];
+  compact: boolean;
+}
+
+const LOW_SAMPLE = 8;
+
+export function niceCeil(n: number): number {
+  if (n <= 5) return 5;
+  if (n <= 10) return 10;
+  if (n <= 20) return 20;
+  if (n <= 50) return 50;
+  if (n <= 100) return 100;
+  if (n <= 200) return 200;
+  return Math.ceil(n / 100) * 100;
+}
+
+interface TipRefs {
+  label?: HTMLElement;
+  total?: HTMLElement;
+  clean?: HTMLElement;
+  p2?: HTMLElement;
+  p1?: HTMLElement;
+  p0?: HTMLElement;
+  dirty?: HTMLElement;
+}
+
+export function QualityChart({ buckets, labels, compact }: QualityChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const tipRef = useRef<HTMLDivElement>(null);
+  const tipRefsObj = useRef<TipRefs>({});
+
+  const scale = useMemo(() => {
+    const max = Math.max(1, ...buckets.map((b) => b.total_pr));
+    return niceCeil(max);
+  }, [buckets]);
+
+  const handleEnter = (
+    b: QualityBucket,
+    label: string,
+    barEl: HTMLDivElement,
+  ) => {
+    const tip = tipRef.current;
+    const refs = tipRefsObj.current;
+    if (!tip || !containerRef.current) return;
+
+    const crit = b.with_p0 + b.with_p1_only;
+    const clean = Math.max(0, b.total_pr - crit - b.with_p2_only);
+    const dirtyPct =
+      b.total_pr > 0 ? ((crit + b.with_p2_only) / b.total_pr) * 100 : 0;
+
+    // textContent only — no innerHTML (perf rule #4)
+    if (refs.label) refs.label.textContent = label;
+    if (refs.total) refs.total.textContent = String(b.total_pr);
+    if (refs.clean) refs.clean.textContent = String(clean);
+    if (refs.p2) refs.p2.textContent = String(b.with_p2_only);
+    if (refs.p1) refs.p1.textContent = String(b.with_p1_only);
+    if (refs.p0) refs.p0.textContent = String(b.with_p0);
+    if (refs.dirty) refs.dirty.textContent = dirtyPct.toFixed(0) + "%";
+
+    const cRect = containerRef.current.getBoundingClientRect();
+    const bRect = barEl.getBoundingClientRect();
+    const pctX =
+      ((bRect.left + bRect.width / 2 - cRect.left) / cRect.width) * 100;
+
+    if (compact) {
+      // Compact: tooltip над баром, центрируется по X.
+      tip.style.left = `${pctX}%`;
+      tip.style.transform = "translateX(-50%)";
+    } else {
+      // Main: справа от бара, flip-left у правого края (>70%).
+      const flipLeft = pctX > 70;
+      tip.style.left = `calc(${pctX}% + 12px - ${flipLeft ? "208px" : "0px"})`;
+    }
+    tip.classList.add("show");
+    containerRef.current.classList.add("is-hovering");
+    barEl.classList.add("is-active");
+  };
+
+  const handleLeave = (barEl: HTMLDivElement) => {
+    tipRef.current?.classList.remove("show");
+    containerRef.current?.classList.remove("is-hovering");
+    barEl.classList.remove("is-active");
+  };
+
+  return (
+    <div ref={containerRef} className={compact ? "card-chart" : "chart"}>
+      {!compact && (
+        <div className="chart-axis">
+          <span className="chart-axis-label" style={{ top: "-2px" }}>
+            {scale}
+          </span>
+          <span
+            className="chart-axis-label"
+            style={{ top: "calc(50% - 6px)" }}
+          >
+            {Math.round(scale / 2)}
+          </span>
+        </div>
+      )}
+
+      {buckets.map((b, i) => {
+        const total = b.total_pr;
+        const heightPct = (total / scale) * 100;
+        // worst-wins: P0+P1 объединены в crit (один красный сегмент)
+        const critCount = b.with_p0 + b.with_p1_only;
+        const cleanCount = Math.max(0, total - critCount - b.with_p2_only);
+        const critPct = total > 0 ? (critCount / total) * heightPct : 0;
+        const p2Pct = total > 0 ? (b.with_p2_only / total) * heightPct : 0;
+        const cleanPct = heightPct - critPct - p2Pct;
+        const lowSample = total > 0 && total < LOW_SAMPLE;
+        const hasP0 = b.with_p0 > 0;
+
+        const classNames = [
+          "bar",
+          lowSample ? "is-low-sample" : "",
+          hasP0 ? "has-p0" : "",
+        ]
+          .filter(Boolean)
+          .join(" ");
+
+        return (
+          <div
+            key={`${labels[i] ?? "i"}-${i}`}
+            className={classNames}
+            ref={(el) => {
+              if (!el) return;
+              el.onmouseenter = () => handleEnter(b, labels[i], el);
+              el.onmouseleave = () => handleLeave(el);
+            }}
+          >
+            {!compact && hasP0 && (
+              <div className="bar-topper-p0">P0:{b.with_p0}</div>
+            )}
+            <div className="bar-stack" style={{ height: `${heightPct}%` }}>
+              {cleanPct > 0 && (
+                <div
+                  className="bar-clean"
+                  style={{ height: `${(cleanCount / total) * 100}%` }}
+                />
+              )}
+              {p2Pct > 0 && (
+                <div
+                  className="bar-p2"
+                  style={{ height: `${(b.with_p2_only / total) * 100}%` }}
+                />
+              )}
+              {critPct > 0 && (
+                <div
+                  className="bar-crit"
+                  style={{ height: `${(critCount / total) * 100}%` }}
+                />
+              )}
+            </div>
+            {heightPct === 0 && <div className="bar-empty" />}
+            <div className="bar-chip">
+              {total} PR
+              {hasP0 && (
+                <>
+                  {" · "}
+                  <b style={{ color: "#fca5a5" }}>P0:{b.with_p0}</b>
+                </>
+              )}
+            </div>
+          </div>
+        );
+      })}
+
+      {/* Pre-created tooltip — refs обновляют только textContent (perf rule #4) */}
+      <div
+        ref={tipRef}
+        className={`chart-tip ${compact ? "chart-tip--compact" : ""}`}
+      >
+        {compact ? (
+          <>
+            <div className="ct-line1">
+              <span
+                ref={(el) => {
+                  if (el) tipRefsObj.current.label = el;
+                }}
+                className="ct-d"
+              />
+              <span
+                ref={(el) => {
+                  if (el) tipRefsObj.current.total = el;
+                }}
+                className="ct-v"
+              />
+              <span className="ct-u">PR</span>
+              <span
+                ref={(el) => {
+                  if (el) tipRefsObj.current.dirty = el;
+                }}
+                className="ct-pct"
+              />
+            </div>
+            <div className="ct-line2">
+              <span className="ct-seg ct-p0-wrap">
+                🔴<b
+                  ref={(el) => {
+                    if (el) tipRefsObj.current.p0 = el;
+                  }}
+                />
+              </span>
+              <span className="ct-seg">
+                <i className="sw" style={{ background: "var(--v4-p1)" }} />
+                P1:
+                <b
+                  ref={(el) => {
+                    if (el) tipRefsObj.current.p1 = el;
+                  }}
+                />
+              </span>
+              <span className="ct-seg">
+                <i className="sw" style={{ background: "var(--v4-p2)" }} />
+                P2:
+                <b
+                  ref={(el) => {
+                    if (el) tipRefsObj.current.p2 = el;
+                  }}
+                />
+              </span>
+              <span className="ct-seg">
+                <i
+                  className="sw"
+                  style={{ background: "var(--v4-clean-soft)" }}
+                />
+                clean:
+                <b
+                  ref={(el) => {
+                    if (el) tipRefsObj.current.clean = el;
+                  }}
+                />
+              </span>
+            </div>
+          </>
+        ) : (
+          <>
+            <div
+              ref={(el) => {
+                if (el) tipRefsObj.current.label = el;
+              }}
+              className="chart-tip-l"
+            />
+            <div className="chart-tip-row">
+              <span
+                ref={(el) => {
+                  if (el) tipRefsObj.current.total = el;
+                }}
+                className="chart-tip-v"
+              />
+              <span className="chart-tip-u">PR в периоде</span>
+            </div>
+            <div className="chart-tip-foot">
+              <span className="chart-tip-seg">
+                <i
+                  className="sw"
+                  style={{ background: "var(--v4-clean-soft)" }}
+                />{" "}
+                чистые
+              </span>
+              <span
+                ref={(el) => {
+                  if (el) tipRefsObj.current.clean = el;
+                }}
+                className="chart-tip-tr"
+              />
+            </div>
+            <div className="chart-tip-foot chart-tip-foot--tight">
+              <span className="chart-tip-seg">
+                <i className="sw" style={{ background: "var(--v4-p2)" }} /> P2
+                only
+              </span>
+              <span
+                ref={(el) => {
+                  if (el) tipRefsObj.current.p2 = el;
+                }}
+                className="chart-tip-tr"
+                style={{ color: "var(--v4-p2-text)" }}
+              />
+            </div>
+            <div className="chart-tip-foot chart-tip-foot--tight">
+              <span className="chart-tip-seg">
+                <i className="sw" style={{ background: "var(--v4-p1)" }} /> P1
+              </span>
+              <span
+                ref={(el) => {
+                  if (el) tipRefsObj.current.p1 = el;
+                }}
+                className="chart-tip-tr"
+                style={{ color: "var(--v4-p1-text)" }}
+              />
+            </div>
+            <div className="chart-tip-foot chart-tip-foot--tight">
+              <span className="chart-tip-seg">
+                <i className="sw" style={{ background: "var(--v4-p0)" }} /> P0
+                (blockers)
+              </span>
+              <span
+                ref={(el) => {
+                  if (el) tipRefsObj.current.p0 = el;
+                }}
+                className="chart-tip-tr"
+                style={{ color: "var(--v4-p0-text)" }}
+              />
+            </div>
+            <div
+              className="chart-tip-foot"
+              style={{
+                borderTop: "1px solid var(--v4-line-soft)",
+                paddingTop: 8,
+                marginTop: 4,
+              }}
+            >
+              <span>% грязных</span>
+              <span
+                ref={(el) => {
+                  if (el) tipRefsObj.current.dirty = el;
+                }}
+                className="chart-tip-tr"
+                style={{ fontSize: 13 }}
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/quality/QualityChart.tsx
+++ b/src/components/quality/QualityChart.tsx
@@ -31,7 +31,7 @@ export interface QualityChartProps {
 
 const LOW_SAMPLE = 8;
 
-export function niceCeil(n: number): number {
+function niceCeil(n: number): number {
   if (n <= 5) return 5;
   if (n <= 10) return 10;
   if (n <= 20) return 20;

--- a/src/components/quality/QualityKPIs.tsx
+++ b/src/components/quality/QualityKPIs.tsx
@@ -1,0 +1,56 @@
+import type { CSSProperties } from "react";
+import type { QualityPayload, PeriodMode } from "../../types/quality";
+
+interface Props {
+  data: QualityPayload;
+  mode: PeriodMode;
+}
+
+export function QualityKPIs({ data, mode }: Props) {
+  const buckets = data.buckets[mode].summary;
+  const total = buckets.reduce((a, b) => a + b.total_pr, 0);
+  const totalP0 = buckets.reduce((a, b) => a + b.with_p0, 0);
+  const totalP1 = buckets.reduce((a, b) => a + b.with_p1_only, 0);
+  const totalP2 = buckets.reduce((a, b) => a + b.with_p2_only, 0);
+  const dirty = totalP0 + totalP1 + totalP2;
+  const dirtyPct = total ? Math.round((dirty / total) * 100) : 0;
+  const p1Pct = total ? Math.round((totalP1 / total) * 100) : 0;
+  const p2Pct = total ? Math.round((totalP2 / total) * 100) : 0;
+  const avgPerPeriod = buckets.length ? Math.round(total / buckets.length) : 0;
+  const periodLabel = mode === "12w" ? "за 12 нед." : "за 30 дней";
+  const avgLabel = mode === "12w" ? "среднем за неделю" : "среднем за день";
+
+  const kpiStyle = (i: number): CSSProperties => ({ ["--i" as string]: i } as CSSProperties);
+
+  return (
+    <div className="kpis">
+      {totalP0 > 0 && (
+        <div className="kpi-p0-alert" title="Блокирующие баги от Codex. Требуют немедленного внимания.">
+          <span className="kpi-p0-icon">🔴</span>
+          <div className="kpi-p0-text">
+            <b>P0: {totalP0}</b>
+            <span>БЛОКЕРЫ {periodLabel}</span>
+          </div>
+        </div>
+      )}
+      <div className="kpi" style={kpiStyle(0)}>
+        <div className="kpi-lbl">% грязных PR · {periodLabel}</div>
+        <div className="kpi-v">{dirtyPct}%</div>
+        <div className="kpi-sub">{dirty} из {total} PR</div>
+      </div>
+      <div className="kpi" style={kpiStyle(1)}>
+        <div className="kpi-lbl">% P1 · {periodLabel}</div>
+        <div className="kpi-v" style={{ color: "var(--v4-p1-text)" }}>{p1Pct}%</div>
+      </div>
+      <div className="kpi" style={kpiStyle(2)}>
+        <div className="kpi-lbl">% P2 · {periodLabel}</div>
+        <div className="kpi-v" style={{ color: "var(--v4-p2-text)" }}>{p2Pct}%</div>
+      </div>
+      <div className="kpi" style={kpiStyle(3)}>
+        <div className="kpi-lbl">PR {periodLabel}</div>
+        <div className="kpi-v">{total}</div>
+        <div className="kpi-sub">{avgPerPeriod} в {avgLabel}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/quality/QualityProjectCard.tsx
+++ b/src/components/quality/QualityProjectCard.tsx
@@ -1,0 +1,129 @@
+import type { CSSProperties } from "react";
+import type { QualityPayload, PeriodMode, RepoStatusEntry } from "../../types/quality";
+import { QualityChart } from "./QualityChart";
+
+interface Props {
+  repo: string;
+  client: string;
+  data: QualityPayload;
+  mode: PeriodMode;
+  index: number;
+}
+
+function severityBadge(dirtyPct: number): { label: string; cls: string } | null {
+  if (dirtyPct === 0 || Number.isNaN(dirtyPct)) return null;
+  if (dirtyPct >= 25) return { label: "высокий риск", cls: "tag-bad" };
+  if (dirtyPct >= 12) return { label: "средний", cls: "tag-warn" };
+  return { label: "чисто", cls: "tag-good" };
+}
+
+const cardStyle = (i: number): CSSProperties => ({ ["--i" as string]: i } as CSSProperties);
+
+export function QualityProjectCard({ repo, client, data, mode, index }: Props) {
+  const status: RepoStatusEntry | undefined = data.repo_status[repo];
+  const repoData = data.buckets[mode].per_repo[repo];
+  const labels = data.buckets[mode].labels;
+
+  if (status?.status === "error") {
+    return (
+      <div className="card" style={cardStyle(index)}>
+        <div className="card-h">
+          <div>
+            <div className="card-name">{repo}</div>
+            <div className="card-client">{client}</div>
+          </div>
+          <span className="tag tag-bad">ошибка fetch</span>
+        </div>
+        <div className="card-empty">
+          <b>{status.code || "ERROR"}</b>
+          {status.message || "Sweep не смог получить данные"}
+        </div>
+      </div>
+    );
+  }
+
+  if (!repoData) {
+    return (
+      <div className="card" style={cardStyle(index)}>
+        <div className="card-h">
+          <div className="card-name">{repo}</div>
+        </div>
+        <div className="card-empty">нет данных</div>
+      </div>
+    );
+  }
+
+  const totalPR = repoData.buckets.reduce((a, b) => a + b.total_pr, 0);
+  const totalP0 = repoData.buckets.reduce((a, b) => a + b.with_p0, 0);
+  const totalP1 = repoData.buckets.reduce((a, b) => a + b.with_p1_only, 0);
+  const totalP2 = repoData.buckets.reduce((a, b) => a + b.with_p2_only, 0);
+  const totalDirty = totalP0 + totalP1 + totalP2;
+
+  if (totalPR < 3) {
+    return (
+      <div className="card" style={cardStyle(index)}>
+        <div className="card-h">
+          <div>
+            <div className="card-name">{repo}</div>
+            <div className="card-client">{client}</div>
+          </div>
+          <span className="tag">мало данных</span>
+        </div>
+        <div className="card-empty">
+          <b>{totalPR} PR за период</b>
+          Нужно ≥3 для расчёта
+        </div>
+      </div>
+    );
+  }
+
+  const dirtyPct = (totalDirty / totalPR) * 100;
+  const p1Pct = (totalP1 / totalPR) * 100;
+  const p2Pct = (totalP2 / totalPR) * 100;
+  const badge = severityBadge(dirtyPct);
+  const coverage = repoData.codex_coverage_pct;
+  const lowCoverage = coverage < 50;
+
+  return (
+    <div className="card" style={cardStyle(index)}>
+      <div className="card-h">
+        <div>
+          <div className="card-name">{repo}</div>
+          <div className="card-client">{client}</div>
+        </div>
+        <div>
+          <div className="card-now">{dirtyPct.toFixed(0)}%</div>
+          <div className="card-now-sub">{totalDirty}/{totalPR} PR</div>
+        </div>
+      </div>
+      <QualityChart buckets={repoData.buckets} labels={labels} compact />
+      <div className="card-foot">
+        <div className="nums">
+          {totalP0 > 0 && (
+            <span className="num-p0" title="БЛОКЕР">
+              <b
+                style={{
+                  color: "var(--v4-p0-text)",
+                  background: "rgba(239,68,68,0.12)",
+                  padding: "1px 6px",
+                  borderRadius: 3,
+                  fontWeight: 700,
+                }}
+              >
+                🔴 P0: {totalP0}
+              </b>
+            </span>
+          )}
+          <span className="num-p1">P1 <b>{p1Pct.toFixed(0)}%</b></span>
+          <span className="num-p2">P2 <b>{p2Pct.toFixed(0)}%</b></span>
+          {lowCoverage && (
+            <span className="tag tag-warn" title="Codex ревьюил меньше половины PR">
+              Codex: {coverage}%
+            </span>
+          )}
+        </div>
+        {badge && <span className={`tag ${badge.cls}`}>{badge.label}</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/quality/QualityProjectGrid.tsx
+++ b/src/components/quality/QualityProjectGrid.tsx
@@ -1,0 +1,81 @@
+import { useState, useMemo } from "react";
+import type { QualityPayload, PeriodMode } from "../../types/quality";
+import { PROJECTS } from "../../utils/config";
+import { QualityProjectCard } from "./QualityProjectCard";
+
+interface Props {
+  data: QualityPayload;
+  mode: PeriodMode;
+}
+
+type SortKey = "dirty" | "alpha" | "p1";
+
+function totals(data: QualityPayload, repo: string, mode: PeriodMode) {
+  const r = data.buckets[mode].per_repo[repo];
+  if (!r) return { total: 0, p0: 0, p1: 0, p2: 0 };
+  return r.buckets.reduce(
+    (acc, b) => ({
+      total: acc.total + b.total_pr,
+      p0: acc.p0 + b.with_p0,
+      p1: acc.p1 + b.with_p1_only,
+      p2: acc.p2 + b.with_p2_only,
+    }),
+    { total: 0, p0: 0, p1: 0, p2: 0 },
+  );
+}
+
+function dirtyPct(data: QualityPayload, repo: string, mode: PeriodMode) {
+  const { total, p0, p1, p2 } = totals(data, repo, mode);
+  return total ? ((p0 + p1 + p2) / total) * 100 : 0;
+}
+
+function p1Pct(data: QualityPayload, repo: string, mode: PeriodMode) {
+  const { total, p1 } = totals(data, repo, mode);
+  return total ? (p1 / total) * 100 : 0;
+}
+
+export function QualityProjectGrid({ data, mode }: Props) {
+  const [sortKey, setSortKey] = useState<SortKey>("dirty");
+
+  const sorted = useMemo(() => {
+    return [...PROJECTS].sort((a, b) => {
+      if (sortKey === "alpha") return a.repo.localeCompare(b.repo);
+      if (sortKey === "p1") return p1Pct(data, b.repo, mode) - p1Pct(data, a.repo, mode);
+      return dirtyPct(data, b.repo, mode) - dirtyPct(data, a.repo, mode);
+    });
+  }, [data, mode, sortKey]);
+
+  return (
+    <>
+      <div className="sect">
+        <h2>По проектам</h2>
+        <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+          <span className="meta">Сортировка:</span>
+          <div className="sort">
+            <button className={sortKey === "dirty" ? "active" : ""} onClick={() => setSortKey("dirty")}>
+              по «грязи»
+            </button>
+            <button className={sortKey === "alpha" ? "active" : ""} onClick={() => setSortKey("alpha")}>
+              по алфавиту
+            </button>
+            <button className={sortKey === "p1" ? "active" : ""} onClick={() => setSortKey("p1")}>
+              по P1
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="grid">
+        {sorted.map((p, idx) => (
+          <QualityProjectCard
+            key={p.repo}
+            repo={p.repo}
+            client={p.client}
+            data={data}
+            mode={mode}
+            index={idx}
+          />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/quality/QualityStaleBanner.tsx
+++ b/src/components/quality/QualityStaleBanner.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  generatedAt: string;
+  onRefresh: () => void;
+}
+
+export function QualityStaleBanner({ generatedAt, onRefresh }: Props) {
+  const ageHours = Math.round((Date.now() - new Date(generatedAt).getTime()) / 3.6e6);
+  return (
+    <div className="quality-stale-banner">
+      <span>⚠ Данные не обновлялись {ageHours}ч. Проверь cron на Pipeline Mac.</span>
+      <button className="btn-refresh" onClick={onRefresh}>↻ Обновить сейчас</button>
+    </div>
+  );
+}

--- a/src/components/quality/QualityStaleBanner.tsx
+++ b/src/components/quality/QualityStaleBanner.tsx
@@ -1,10 +1,13 @@
+import { useState } from "react";
+
 interface Props {
   generatedAt: string;
   onRefresh: () => void;
 }
 
 export function QualityStaleBanner({ generatedAt, onRefresh }: Props) {
-  const ageHours = Math.round((Date.now() - new Date(generatedAt).getTime()) / 3.6e6);
+  const [mountedAt] = useState(() => Date.now());
+  const ageHours = Math.round((mountedAt - new Date(generatedAt).getTime()) / 3.6e6);
   return (
     <div className="quality-stale-banner">
       <span>⚠ Данные не обновлялись {ageHours}ч. Проверь cron на Pipeline Mac.</span>

--- a/src/components/quality/QualitySummaryPanel.tsx
+++ b/src/components/quality/QualitySummaryPanel.tsx
@@ -29,8 +29,10 @@ export function QualitySummaryPanel({ data, annotations, mode }: Props) {
             </span>
           )}
         </div>
-        <QualityChart buckets={buckets} labels={labels} compact={false} />
-        <QualityAnnotations annotations={annotations} mode={mode} bucketCount={buckets.length} />
+        <div className="chart-area">
+          <QualityChart buckets={buckets} labels={labels} compact={false} />
+          <QualityAnnotations annotations={annotations} mode={mode} bucketCount={buckets.length} />
+        </div>
         <div className="chart-legend">
           <span><i className="dot dot-p1" /> P1 (критическое)</span>
           <span><i className="dot dot-p2" /> P2 (высокое)</span>

--- a/src/components/quality/QualitySummaryPanel.tsx
+++ b/src/components/quality/QualitySummaryPanel.tsx
@@ -1,0 +1,43 @@
+import type { QualityPayload, Annotation, PeriodMode } from "../../types/quality";
+import { QualityChart } from "./QualityChart";
+import { QualityKPIs } from "./QualityKPIs";
+import { QualityAnnotations } from "./QualityAnnotations";
+
+interface Props {
+  data: QualityPayload;
+  annotations: Annotation[];
+  mode: PeriodMode;
+}
+
+export function QualitySummaryPanel({ data, annotations, mode }: Props) {
+  const buckets = data.buckets[mode].summary;
+  const labels = data.buckets[mode].labels;
+  const errored = Object.entries(data.repo_status).filter(([, s]) => s.status === "error");
+
+  return (
+    <div className="panel summary">
+      <div className="chartwrap">
+        <div className="panel-t" style={{ marginBottom: 14 }}>
+          Сводно по всем {Object.keys(data.repo_status).length} проектам
+          <span className="tag">All repos</span>
+          {errored.length > 0 && (
+            <span
+              className="tag tag-bad"
+              title={errored.map(([r, s]) => `${r}: ${s.code ?? "ERROR"}`).join("\n")}
+            >
+              ⚠ {errored.length} репо без данных
+            </span>
+          )}
+        </div>
+        <QualityChart buckets={buckets} labels={labels} compact={false} />
+        <QualityAnnotations annotations={annotations} mode={mode} bucketCount={buckets.length} />
+        <div className="chart-legend">
+          <span><i className="dot dot-p1" /> P1 (критическое)</span>
+          <span><i className="dot dot-p2" /> P2 (высокое)</span>
+          <span><i className="dot dot-clean" /> чистые PR</span>
+        </div>
+      </div>
+      <QualityKPIs data={data} mode={mode} />
+    </div>
+  );
+}

--- a/src/components/quality/QualityTab.tsx
+++ b/src/components/quality/QualityTab.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { useCodexQuality } from "../../hooks/useCodexQuality";
+import type { PeriodMode, AnnotationCreatePayload } from "../../types/quality";
+import { QualitySummaryPanel } from "./QualitySummaryPanel";
+import { QualityProjectGrid } from "./QualityProjectGrid";
+import { QualityStaleBanner } from "./QualityStaleBanner";
+import { AnnotationModal } from "./AnnotationModal";
+import { createAnnotation } from "../../utils/codex-quality";
+import "../../styles/v4-quality.css";
+
+export function QualityTab() {
+  const { data, annotations, loading, error, isStale, refresh, reloadAnnotations } = useCodexQuality();
+  const [mode, setMode] = useState<PeriodMode>("12w");
+  const [showAddModal, setShowAddModal] = useState(false);
+
+  if (loading && !data) return <div className="v4-quality-tab">Загрузка…</div>;
+  if (error) {
+    return (
+      <div className="v4-quality-tab">
+        <div className="quality-error-panel">
+          <b>Ошибка загрузки данных:</b> {error}
+          <button onClick={() => refresh()}>Попробовать снова</button>
+        </div>
+      </div>
+    );
+  }
+  if (!data) return <div className="v4-quality-tab">Нет данных</div>;
+
+  const handleAddAnnotation = async (p: AnnotationCreatePayload) => {
+    await createAnnotation(p);
+    await reloadAnnotations();
+  };
+
+  return (
+    <div className="v4-quality-tab page">
+      <div className="pageH">
+        <div>
+          <h1>Качество кода и изменения</h1>
+          <div className="sub">
+            Доля PR с критическими/высокими замечаниями <b>chatgpt-codex-connector[bot]</b> от общего числа merged PR · события на временной оси
+          </div>
+        </div>
+        <div className="ctrls">
+          <div className="seg">
+            <button className={mode === "30d" ? "active" : ""} onClick={() => setMode("30d")}>30 дней · По дням</button>
+            <button className={mode === "12w" ? "active" : ""} onClick={() => setMode("12w")}>12 недель · По неделям</button>
+          </div>
+          <button className="btn-add-event" onClick={() => setShowAddModal(true)}>+ событие</button>
+          <div style={{ fontFamily: "var(--v4-mono)", fontSize: 10, color: "var(--v4-ink-500)", textAlign: "right" }}>
+            <div>Синхр. ежедневно · 03:00 Бали</div>
+            <div style={{ color: "var(--v4-ink-400)" }}>
+              последняя: {new Date(data.generated_at).toLocaleString("ru")}
+            </div>
+          </div>
+          <button className="btn-refresh" onClick={() => refresh()} disabled={loading}>↻ Сейчас</button>
+        </div>
+      </div>
+
+      {isStale && <QualityStaleBanner generatedAt={data.generated_at} onRefresh={() => refresh()} />}
+
+      <QualitySummaryPanel data={data} annotations={annotations} mode={mode} />
+      <QualityProjectGrid data={data} mode={mode} />
+
+      {showAddModal && (
+        <AnnotationModal
+          onSubmit={handleAddAnnotation}
+          onClose={() => setShowAddModal(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/v4/CommandPalette.tsx
+++ b/src/components/v4/CommandPalette.tsx
@@ -38,6 +38,7 @@ const TAB_LABEL: Record<TabId, string> = {
   research: "Research",
   specs: "Specs",
   quality: "Quality",
+  "codex-quality": "Качество кода и изменения",
   debate: "Debate",
 };
 

--- a/src/components/v4/Sidebar.tsx
+++ b/src/components/v4/Sidebar.tsx
@@ -103,6 +103,12 @@ const ICON_DEBATE = (
     <path d="M21 11.5a8.38 8.38 0 01-9 8.5 8.5 8.5 0 01-7.6-4.7L3 21l1.7-2.4A8.5 8.5 0 0121 11.5z" />
   </svg>
 );
+const ICON_CODEX_QUALITY = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M3 3v18h18" />
+    <path d="M7 15l4-4 3 3 5-6" />
+  </svg>
+);
 
 export function Sidebar({
   activeTab,
@@ -152,6 +158,7 @@ export function Sidebar({
       items: [
         { id: "audit", label: "Аудит", badge: auditAlerts, icon: ICON_AUDIT, pulse: p.audit },
         { id: "quality", label: "Quality", icon: ICON_QUALITY, pulse: p.quality },
+        { id: "codex-quality", label: "Качество кода и изменения", icon: ICON_CODEX_QUALITY, pulse: p["codex-quality"] },
         { id: "debate", label: "Debate", icon: ICON_DEBATE, pulse: p.debate },
       ],
     },

--- a/src/hooks/useCodexQuality.ts
+++ b/src/hooks/useCodexQuality.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState, useCallback, useMemo } from "react";
+import type { QualityPayload, Annotation } from "../types/quality";
+import { fetchQualityData, fetchAnnotations, forceQualityRefresh } from "../utils/codex-quality";
+
+const STALE_HOURS = 30;
+
+export function useCodexQuality() {
+  const [data, setData] = useState<QualityPayload | null>(null);
+  const [annotations, setAnnotations] = useState<Annotation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (force = false) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [q, a] = await Promise.all([
+        force ? forceQualityRefresh() : fetchQualityData(),
+        fetchAnnotations(),
+      ]);
+      setData(q);
+      setAnnotations(a);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(false);
+  }, [load]);
+
+  const isStale = useMemo(() => {
+    if (!data) return false;
+    const ageHours = (Date.now() - new Date(data.generated_at).getTime()) / 3.6e6;
+    return ageHours > STALE_HOURS;
+  }, [data]);
+
+  return {
+    data,
+    annotations,
+    loading,
+    error,
+    isStale,
+    refresh: () => load(true),
+    reloadAnnotations: () => load(false),
+  };
+}

--- a/src/hooks/useCodexQuality.ts
+++ b/src/hooks/useCodexQuality.ts
@@ -27,6 +27,14 @@ export function useCodexQuality() {
     }
   }, []);
 
+  const reloadAnnotations = useCallback(async () => {
+    try {
+      setAnnotations(await fetchAnnotations());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
   useEffect(() => {
     load(false);
   }, [load]);
@@ -44,6 +52,6 @@ export function useCodexQuality() {
     error,
     isStale,
     refresh: () => load(true),
-    reloadAnnotations: () => load(false),
+    reloadAnnotations,
   };
 }

--- a/src/styles/v4-quality.css
+++ b/src/styles/v4-quality.css
@@ -1,0 +1,558 @@
+/* ============================================================
+ * v4-quality.css — стили вкладки «Качество кода».
+ * Портировано из docs/superpowers/specs/quality-tab-prototype.html (Task 18).
+ *
+ * Scope: все правила обёрнуты в `.v4-quality-tab`, чтобы:
+ *  - переопределение `--v4-p1`/`--v4-p2` (теперь оранж/жёлтый по shields.io,
+ *    а не red/orange как в v4.css) не утекало в остальной UI;
+ *  - блок-классы из прототипа (`.chart`, `.bar`, `.kpi` и т.д.) не
+ *    конфликтовали с одноимёнными элементами других секций (если такие есть).
+ *
+ * Перформанс-критичные правила (см. specs section "Перформанс"):
+ *   1) NO `transition: height` — height триггерит layout; меняем opacity/transform.
+ *   2) NO `:has(.bar:hover)` — toggle class `is-hovering`/`is-active` через JS.
+ *   3) NO `clip-path` на контейнере с десятками детей — opacity + translateY.
+ *   4) NO `innerHTML = ...` на hover — pre-create структуру, обновлять textContent.
+ *   5) GPU-friendly transitions only: transform / opacity.
+ * ============================================================ */
+
+.v4-quality-tab {
+  /* Codex severity palette — align с shields.io бейджами в PR-коммитах */
+  --v4-p0: #EF4444;             /* red — БЛОКЕР */
+  --v4-p1: #F59E0B;             /* orange — высокое */
+  --v4-p2: #EAB308;             /* yellow — среднее */
+  --v4-clean: #2563EB;          /* синий — чистые PR */
+  --v4-clean-soft: #93C5FD;     /* голубой для светлого фона */
+  --v4-p0-text: #991B1B;        /* dark red для текста на белом */
+  --v4-p1-text: #B45309;        /* dark amber */
+  --v4-p2-text: #854D0E;        /* dark yellow-amber */
+  --v4-clean-text: #1D4ED8;
+}
+
+/* ──── KPI · P0 alert pill ──── */
+.v4-quality-tab .kpi-p0-alert {
+  background: var(--v4-p0);
+  color: #fff;
+  border-radius: var(--v4-r-md);
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.45);
+  animation: q-p0-pulse 1.8s ease-in-out infinite;
+}
+@keyframes q-p0-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.45); }
+  50%      { box-shadow: 0 0 0 10px rgba(239, 68, 68, 0); }
+}
+.v4-quality-tab .kpi-p0-icon { font-size: 22px; line-height: 1; }
+.v4-quality-tab .kpi-p0-text { display: flex; flex-direction: column; }
+.v4-quality-tab .kpi-p0-text b { font-family: var(--v4-mono); font-size: 18px; line-height: 1.1; }
+.v4-quality-tab .kpi-p0-text span { font-size: 11px; opacity: 0.9; margin-top: 2px; }
+
+/* ──── KPI cards ──── */
+.v4-quality-tab .kpi {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  padding: 12px 14px;
+  animation: q-kpi-in 520ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: calc(var(--i, 0) * 60ms + 200ms);
+  transition: transform .22s cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow .22s ease,
+              border-color .2s ease;
+}
+.v4-quality-tab .kpi:hover {
+  transform: translateY(-2px);
+  border-color: var(--v4-line-strong);
+  box-shadow: 0 10px 28px rgba(11, 16, 32, 0.07);
+}
+@keyframes q-kpi-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.985); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+.v4-quality-tab .kpi-lbl {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+.v4-quality-tab .kpi-v {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--v4-ink-900);
+  font-family: var(--v4-mono);
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+.v4-quality-tab .kpi-v.dirty { color: var(--v4-ink-900); }
+.v4-quality-tab .kpi-sub { font-size: 11px; color: var(--v4-ink-500); margin-top: 4px; }
+
+/* ──── Chart — vertical bars (main) ──── */
+.v4-quality-tab .chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  flex: 1;
+  min-height: 220px;
+  border-bottom: 1px dashed var(--v4-line);
+  position: relative;
+  /* Coordinated reveal — opacity + translateY (GPU). НЕ clip-path
+     (репейнтит N детей каждый кадр). */
+  animation: q-chart-in 480ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: 80ms;
+}
+@keyframes q-chart-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Dim non-hovered bars: через class toggle (JS), не :has() — последний дорогой.
+   Селектор покрывает оба контейнера — .chart (главный) и .card-chart (мини). */
+.v4-quality-tab .is-hovering .bar:not(.is-active) .bar-stack { opacity: 0.4; }
+
+.v4-quality-tab .chart-axis {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.v4-quality-tab .chart-axis::before,
+.v4-quality-tab .chart-axis::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  border-top: 1px dashed var(--v4-line-soft);
+}
+.v4-quality-tab .chart-axis::before { top: 50%; }
+.v4-quality-tab .chart-axis::after  { top: 0; }
+.v4-quality-tab .chart-axis-label {
+  position: absolute;
+  right: 4px;
+  font-family: var(--v4-mono);
+  font-size: 9px;
+  color: var(--v4-ink-400);
+  background: var(--v4-paper);
+  padding: 0 3px;
+}
+
+/* ──── Bar ──── */
+.v4-quality-tab .bar {
+  flex: 1;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  position: relative;
+  cursor: crosshair;
+  min-width: 4px;
+}
+/* Column-wide подсветка за активным баром (як v4-ClosedChart30d) */
+.v4-quality-tab .bar::before {
+  content: '';
+  position: absolute;
+  inset: -6px -4px -4px -4px;
+  background: var(--v4-accent-100);
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity .15s ease;
+  pointer-events: none;
+}
+.v4-quality-tab .bar.is-active::before,
+.v4-quality-tab .bar:hover::before { opacity: 0.45; }
+
+/* P0 day — ВСЕГДА видимая подсветка колонки (без hover).
+   Юзер должен сразу видеть "тут был блокер". */
+.v4-quality-tab .bar.has-p0 {
+  background: linear-gradient(to bottom,
+    rgba(239, 68, 68, 0.18) 0%,
+    rgba(239, 68, 68, 0.08) 60%,
+    rgba(239, 68, 68, 0.02) 100%);
+}
+/* В mini-чарте дополнительно border-top — gradient слабо читается на 80px. */
+.v4-quality-tab .card-chart .bar.has-p0 .bar-stack {
+  border-top: 2px solid var(--v4-p0);
+}
+
+/* Mini-pill "P0:N" сверху столбца, ВСЕГДА видна (только main chart). */
+.v4-quality-tab .bar-topper-p0 {
+  position: absolute;
+  top: -22px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--v4-p0);
+  color: #fff;
+  font-family: var(--v4-mono);
+  font-size: 9px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+  pointer-events: none;
+  box-shadow: 0 2px 6px rgba(239, 68, 68, 0.45);
+  animation: q-p0-topper-pulse 2s ease-in-out infinite;
+}
+@keyframes q-p0-topper-pulse {
+  0%, 100% { transform: translateX(-50%) translateY(0); }
+  50%      { transform: translateX(-50%) translateY(-2px); }
+}
+/* В mini-чарте топпер прячем — нет места + border-top уже сигналит */
+.v4-quality-tab .card-chart .bar-topper-p0 { display: none; }
+
+.v4-quality-tab .bar-stack {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border-radius: 3px 3px 0 0;
+  overflow: hidden;
+  transition: opacity .15s ease;
+  /* NO transition: height — height триггерит layout. На period switch DOM
+     пересоздаётся, .bar-stack рождается с правильной высотой. */
+}
+
+/* Dashed guide line от верха активного бара до базы */
+.v4-quality-tab .bar.is-active .bar-stack::after,
+.v4-quality-tab .bar:hover .bar-stack::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background-image: linear-gradient(to bottom, var(--v4-accent-700) 50%, transparent 50%);
+  background-size: 1px 4px;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+/* Value-chip над активным баром */
+.v4-quality-tab .bar-chip {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(2px);
+  background: var(--v4-ink-900);
+  color: #fff;
+  font-family: var(--v4-mono);
+  font-size: 11px;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 4px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .12s ease, transform .15s cubic-bezier(0.16, 1, 0.3, 1);
+  margin-bottom: 6px;
+  white-space: nowrap;
+}
+.v4-quality-tab .bar.is-active .bar-chip,
+.v4-quality-tab .bar:hover .bar-chip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Red сегмент = P0+P1 worst-wins (одна красная категория для читабельности).
+   Tooltip разбивает их отдельно. P0-alert pulse — в KPI выше. */
+.v4-quality-tab .bar-crit {
+  background: var(--v4-p0);
+  width: 100%;
+}
+.v4-quality-tab .bar-p2 {
+  background: var(--v4-p2);
+  width: 100%;
+}
+.v4-quality-tab .bar-clean {
+  background: var(--v4-clean-soft);
+  width: 100%;
+  border-radius: 3px 3px 0 0;
+}
+.v4-quality-tab .bar-empty {
+  background: var(--v4-line-soft);
+  width: 100%;
+  height: 1px;
+  margin-top: auto;
+}
+
+/* Low-sample флаг — приглушаем бар, total_pr < 8 (LOW_SAMPLE) */
+.v4-quality-tab .bar.is-low-sample .bar-stack { opacity: 0.55; }
+
+/* ──── Card chart (mini) ──── */
+.v4-quality-tab .card-chart {
+  height: 80px;
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  border-bottom: 1px dashed var(--v4-line-soft);
+  position: relative;
+}
+
+/* ──── Tooltip — main chart card ──── */
+.v4-quality-tab .chart-tip {
+  position: absolute;
+  top: 8px;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line-strong);
+  box-shadow: 0 8px 24px rgba(11, 16, 32, 0.12), 0 2px 6px rgba(11, 16, 32, 0.06);
+  border-radius: 8px;
+  padding: 10px 12px;
+  min-width: 180px;
+  pointer-events: none;
+  font-size: 12px;
+  z-index: 5;
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity .18s ease, transform .22s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.v4-quality-tab .chart-tip.show { opacity: 1; transform: translateY(0); }
+.v4-quality-tab .chart-tip-l {
+  font-family: var(--v4-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--v4-ink-500);
+  margin-bottom: 6px;
+}
+.v4-quality-tab .chart-tip-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.v4-quality-tab .chart-tip-v {
+  font-family: var(--v4-mono);
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--v4-ink-900);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.v4-quality-tab .chart-tip-u { color: var(--v4-ink-500); font-size: 12px; }
+.v4-quality-tab .chart-tip-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  padding-top: 8px;
+  border-top: 1px solid var(--v4-line-soft);
+  color: var(--v4-ink-500);
+  font-size: 11px;
+}
+.v4-quality-tab .chart-tip-foot--tight { padding-top: 4px; border-top: 0; }
+.v4-quality-tab .chart-tip-tr {
+  font-family: var(--v4-mono);
+  font-weight: 600;
+  color: var(--v4-ink-700);
+}
+.v4-quality-tab .chart-tip-seg {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--v4-mono);
+  font-weight: 600;
+}
+.v4-quality-tab .chart-tip-seg .sw { width: 8px; height: 8px; border-radius: 2px; }
+
+/* ──── Tooltip — compact (для миничартов в карточках) ──── */
+.v4-quality-tab .chart-tip--compact {
+  min-width: 160px;
+  padding: 8px 10px;
+  font-size: 11px;
+  background: var(--v4-ink-900);
+  color: #fff;
+  border: 0;
+  box-shadow: 0 8px 20px rgba(11, 16, 32, 0.32);
+  top: auto;
+  bottom: calc(100% + 8px);
+  white-space: nowrap;
+  line-height: 1.45;
+  font-family: var(--v4-mono);
+}
+.v4-quality-tab .chart-tip--compact .ct-line1 {
+  display: flex; align-items: baseline; gap: 6px; margin-bottom: 4px;
+  padding-bottom: 4px; border-bottom: 1px solid rgba(255,255,255,0.12);
+}
+.v4-quality-tab .chart-tip--compact .ct-line2 {
+  display: flex; gap: 10px; align-items: center;
+}
+.v4-quality-tab .chart-tip--compact .ct-d  { color: rgba(255,255,255,0.7); font-size: 10px; }
+.v4-quality-tab .chart-tip--compact .ct-v  { font-weight: 700; font-size: 13px; }
+.v4-quality-tab .chart-tip--compact .ct-u  { color: rgba(255,255,255,0.6); font-size: 10px; }
+.v4-quality-tab .chart-tip--compact .ct-pct { font-weight: 700; margin-left: auto; font-size: 12px; }
+.v4-quality-tab .chart-tip--compact .ct-seg { display: inline-flex; align-items: center; gap: 3px; font-size: 10px; }
+.v4-quality-tab .chart-tip--compact .ct-seg .sw {
+  width: 7px; height: 7px; border-radius: 2px; display: inline-block;
+}
+.v4-quality-tab .chart-tip--compact .ct-seg b { font-weight: 700; color: #fff; }
+.v4-quality-tab .chart-tip--compact .ct-p0-wrap { color: #fecaca; font-weight: 800; }
+.v4-quality-tab .chart-tip--compact .ct-p0-wrap b { color: #fff; }
+
+/* ──── Chart labels / legend (under main chart) ──── */
+.v4-quality-tab .chart-labels {
+  display: flex;
+  margin-top: 6px;
+  gap: 2px;
+}
+.v4-quality-tab .chart-label {
+  flex: 1;
+  text-align: center;
+  font-family: var(--v4-mono);
+  font-size: 9px;
+  color: var(--v4-ink-400);
+  min-width: 4px;
+  overflow: hidden;
+}
+.v4-quality-tab .chart-legend {
+  display: flex;
+  gap: 14px;
+  margin-top: 14px;
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
+  font-weight: 500;
+}
+.v4-quality-tab .chart-legend span { display: inline-flex; align-items: center; gap: 6px; }
+.v4-quality-tab .chart-legend .dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 2px;
+  display: inline-block;
+}
+
+/* ──── Annotation markers ──── */
+.v4-quality-tab .annot {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background-image: linear-gradient(to bottom,
+    var(--v4-purple-500, #7C3AED) 50%,
+    transparent 50%);
+  background-size: 1px 6px;
+  pointer-events: auto;
+  cursor: help;
+  z-index: 2;
+}
+.v4-quality-tab .annot-dot {
+  position: absolute;
+  top: -3px;
+  left: -5px;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--v4-purple-500, #7C3AED);
+  border: 2px solid var(--v4-paper);
+  box-shadow: 0 0 0 1px var(--v4-purple-500, #7C3AED);
+}
+.v4-quality-tab .annot.is-skill  .annot-dot { background: var(--v4-accent-600);  box-shadow: 0 0 0 1px var(--v4-accent-600); }
+.v4-quality-tab .annot.is-deploy .annot-dot { background: var(--v4-success-500); box-shadow: 0 0 0 1px var(--v4-success-500); }
+.v4-quality-tab .annot.is-manual .annot-dot { background: var(--v4-purple-500, #7C3AED); }
+.v4-quality-tab .annot:hover { background-image: linear-gradient(to bottom, var(--v4-ink-900) 50%, transparent 50%); }
+.v4-quality-tab .annot:hover .annot-dot { transform: scale(1.2); transition: transform .12s; }
+
+.v4-quality-tab .annot-tip {
+  position: absolute;
+  top: 22px;
+  left: 0;
+  transform: translateX(-50%) translateY(2px);
+  background: var(--v4-ink-900);
+  color: #fff;
+  font-size: 11px;
+  line-height: 1.4;
+  padding: 8px 10px;
+  border-radius: 6px;
+  white-space: nowrap;
+  max-width: 260px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .15s ease, transform .18s cubic-bezier(0.16, 1, 0.3, 1);
+  z-index: 6;
+  box-shadow: 0 6px 16px rgba(11, 16, 32, 0.25);
+}
+.v4-quality-tab .annot-tip-cat {
+  display: inline-block;
+  font-family: var(--v4-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: rgba(255,255,255,0.15);
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-bottom: 4px;
+}
+.v4-quality-tab .annot-tip-date { font-family: var(--v4-mono); font-size: 10px; color: rgba(255,255,255,0.65); margin-top: 4px; }
+.v4-quality-tab .annot:hover .annot-tip { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+/* ──── Add-event button ──── */
+.v4-quality-tab .btn-add-event {
+  border: 1px dashed var(--v4-line-strong);
+  background: transparent;
+  border-radius: var(--v4-r-md);
+  padding: 6px 10px;
+  font: inherit;
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: all .15s ease;
+}
+.v4-quality-tab .btn-add-event:hover {
+  color: var(--v4-purple-500, #7C3AED);
+  border-color: var(--v4-purple-500, #7C3AED);
+  background: var(--v4-purple-50, #F5F0FF);
+}
+
+/* ──── Project card (grid) ──── */
+.v4-quality-tab .card {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  will-change: transform;
+  animation: q-card-in 420ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: calc(var(--i, 0) * 45ms + 300ms);
+  transition:
+    transform 220ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 220ms ease,
+    border-color 200ms ease;
+}
+.v4-quality-tab .card:hover {
+  transform: translateY(-3px);
+  border-color: var(--v4-line-strong);
+  box-shadow: 0 14px 32px -14px rgba(11, 16, 32, 0.18),
+              0 4px 12px -4px rgba(11, 16, 32, 0.08);
+}
+@keyframes q-card-in {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ──── REDUCED MOTION GUARD ────
+ * Пользователи с prefers-reduced-motion отключают всю кинетику.
+ * (Аналог @media-блока в v4.css.) */
+@media (prefers-reduced-motion: reduce) {
+  .v4-quality-tab .chart,
+  .v4-quality-tab .card,
+  .v4-quality-tab .kpi,
+  .v4-quality-tab .kpi-p0-alert,
+  .v4-quality-tab .bar-topper-p0 {
+    animation: none !important;
+    clip-path: none !important;
+  }
+  .v4-quality-tab .bar-stack,
+  .v4-quality-tab .chart-tip,
+  .v4-quality-tab .bar-chip,
+  .v4-quality-tab .annot-tip {
+    transition: opacity .15s ease !important;
+  }
+  .v4-quality-tab .card:hover,
+  .v4-quality-tab .kpi:hover {
+    transform: none !important;
+  }
+}

--- a/src/styles/v4-quality.css
+++ b/src/styles/v4-quality.css
@@ -533,6 +533,288 @@
   to   { opacity: 1; transform: translateY(0); }
 }
 
+/* ──── PAGE / HEADER / CONTROLS ──── */
+.v4-quality-tab.page { max-width: 1480px; margin: 0 auto; }
+.v4-quality-tab .pageH {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 18px;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.v4-quality-tab .pageH h1 {
+  font-size: 22px;
+  margin: 0 0 4px 0;
+  letter-spacing: -0.01em;
+  color: var(--v4-ink-900);
+  font-weight: 700;
+}
+.v4-quality-tab .pageH .sub { color: var(--v4-ink-500); font-size: 13px; }
+.v4-quality-tab .pageH .sub b { color: var(--v4-ink-700); font-weight: 600; }
+.v4-quality-tab .ctrls { display: flex; gap: 10px; align-items: center; }
+.v4-quality-tab .seg {
+  display: inline-flex;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  padding: 3px;
+}
+.v4-quality-tab .seg button {
+  border: 0;
+  background: transparent;
+  padding: 6px 12px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--v4-ink-500);
+  border-radius: 5px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background .18s ease, color .18s ease;
+}
+.v4-quality-tab .seg button.active {
+  background: var(--v4-ink-900);
+  color: #fff;
+  font-weight: 600;
+}
+.v4-quality-tab .btn-refresh {
+  border: 1px solid var(--v4-line);
+  background: var(--v4-paper);
+  border-radius: var(--v4-r-md);
+  padding: 7px 12px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--v4-ink-700);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 500;
+}
+.v4-quality-tab .btn-refresh:hover { background: var(--v4-surface-2); }
+.v4-quality-tab .btn-refresh:disabled { opacity: 0.55; cursor: progress; }
+
+/* ──── PANEL containers ──── */
+.v4-quality-tab .panel {
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.v4-quality-tab .panel-t {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* ──── SUMMARY panel (2-column: chart + KPI stack) ──── */
+.v4-quality-tab .summary {
+  margin-bottom: 18px;
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 0;
+}
+.v4-quality-tab .summary .chartwrap {
+  padding: 18px;
+  border-right: 1px solid var(--v4-line-soft);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.v4-quality-tab .chart-area {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+}
+.v4-quality-tab .summary .kpis {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background: var(--v4-surface-2);
+}
+
+/* На узких экранах summary сваливается в один столбец, чтобы карты не сжимались */
+@media (max-width: 900px) {
+  .v4-quality-tab .summary { grid-template-columns: 1fr; }
+  .v4-quality-tab .summary .chartwrap { border-right: 0; border-bottom: 1px solid var(--v4-line-soft); }
+}
+
+/* ──── TAGS ──── */
+.v4-quality-tab .tag {
+  font-family: var(--v4-mono);
+  font-size: 9px;
+  font-weight: 600;
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-500);
+  padding: 2px 7px;
+  border-radius: 99px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.v4-quality-tab .tag-warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-quality-tab .tag-good { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-quality-tab .tag-bad  { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+
+/* ──── SECTION heading + sort toggle (project grid header) ──── */
+.v4-quality-tab .sect {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin: 8px 0 12px;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.v4-quality-tab .sect h2 {
+  margin: 0;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
+  font-weight: 600;
+}
+.v4-quality-tab .sect .meta { font-size: 11px; color: var(--v4-ink-400); font-family: var(--v4-mono); }
+.v4-quality-tab .sort {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  padding: 3px;
+}
+.v4-quality-tab .sort button {
+  border: 0;
+  background: transparent;
+  padding: 5px 10px;
+  font: inherit;
+  font-size: 11px;
+  color: var(--v4-ink-500);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.v4-quality-tab .sort button.active {
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
+  font-weight: 600;
+}
+
+/* ──── GRID of project cards ──── */
+.v4-quality-tab .grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 14px;
+}
+
+/* ──── CARD internals (header / metrics / footer) ──── */
+.v4-quality-tab .card-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+.v4-quality-tab .card-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+  font-family: var(--v4-mono);
+}
+.v4-quality-tab .card-client {
+  font-size: 10px;
+  color: var(--v4-ink-500);
+  font-weight: 500;
+  margin-top: 1px;
+}
+.v4-quality-tab .card-now {
+  font-size: 22px;
+  font-weight: 700;
+  font-family: var(--v4-mono);
+  color: var(--v4-ink-900);
+  letter-spacing: -0.02em;
+  line-height: 1;
+  text-align: right;
+}
+.v4-quality-tab .card-now-sub {
+  font-size: 10px;
+  color: var(--v4-ink-400);
+  margin-top: 2px;
+  font-family: var(--v4-mono);
+  text-align: right;
+}
+.v4-quality-tab .card-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-top: 1px solid var(--v4-line-soft);
+  padding-top: 8px;
+  font-size: 11px;
+  font-family: var(--v4-mono);
+  color: var(--v4-ink-500);
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.v4-quality-tab .card-foot .nums { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+.v4-quality-tab .card-foot .nums b { color: var(--v4-ink-800); font-weight: 600; }
+.v4-quality-tab .card-foot .num-p1 b { color: var(--v4-p1-text); }
+.v4-quality-tab .card-foot .num-p2 b { color: var(--v4-p2-text); }
+.v4-quality-tab .card-empty {
+  color: var(--v4-ink-400);
+  text-align: center;
+  padding: 24px 8px;
+  font-size: 11px;
+  font-family: var(--v4-mono);
+}
+.v4-quality-tab .card-empty b { display: block; font-size: 14px; color: var(--v4-ink-500); margin-bottom: 4px; }
+
+/* ──── BANNERS (stale data / fetch error) ──── */
+.v4-quality-tab .quality-stale-banner {
+  margin-bottom: 14px;
+  padding: 10px 14px;
+  background: var(--v4-warn-50);
+  border: 1px solid var(--v4-warn-200, #fde68a);
+  border-radius: var(--v4-r-md);
+  color: var(--v4-warn-700);
+  font-size: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.v4-quality-tab .quality-error-panel {
+  padding: 24px;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+  color: var(--v4-ink-700);
+  font-size: 14px;
+}
+.v4-quality-tab .quality-error-panel button {
+  border: 1px solid var(--v4-line);
+  background: var(--v4-paper);
+  border-radius: var(--v4-r-md);
+  padding: 7px 14px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--v4-ink-700);
+  cursor: pointer;
+  font-weight: 500;
+}
+.v4-quality-tab .quality-error-panel button:hover { background: var(--v4-surface-2); }
+
 /* ──── REDUCED MOTION GUARD ────
  * Пользователи с prefers-reduced-motion отключают всю кинетику.
  * (Аналог @media-блока в v4.css.) */

--- a/src/styles/v4-quality.css
+++ b/src/styles/v4-quality.css
@@ -142,7 +142,7 @@
 /* ──── Bar ──── */
 .v4-quality-tab .bar {
   flex: 1;
-  height: 100%;
+  align-self: stretch;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,7 +109,7 @@ export interface Filters {
   status: IssueStatus | null;
 }
 
-export type TabId = "dashboard" | "projects" | "milestones" | "uptime" | "audit" | "pipeline" | "transcripts" | "research" | "specs" | "quality" | "debate";
+export type TabId = "dashboard" | "projects" | "milestones" | "uptime" | "audit" | "pipeline" | "transcripts" | "research" | "specs" | "quality" | "codex-quality" | "debate";
 
 // ── Research / Discovery ──
 

--- a/src/types/quality.ts
+++ b/src/types/quality.ts
@@ -1,0 +1,63 @@
+export interface QualityBucket {
+  total_pr: number;
+  with_p0: number;           // PR с ≥1 P0 (BLOCKER, worst-wins absorbs P1+P2)
+  with_p1_only: number;      // PR с P1, без P0
+  with_p2_only: number;      // PR с P2, без P0 и P1
+}
+
+export interface RepoStatusEntry {
+  status: "ok" | "error" | "stale";
+  code?: string;
+  message?: string;
+}
+
+export interface RepoQualityData {
+  buckets: QualityBucket[];
+  codex_coverage_pct: number;
+  codex_first_seen: string | null;
+}
+
+export interface QualityBucketsMode {
+  labels: string[];
+  summary: QualityBucket[];
+  per_repo: Record<string, RepoQualityData>;
+}
+
+export interface QualityPayload {
+  schema_version: 1;
+  generated_at: string;
+  window_start: string;
+  window_end: string;
+  bucket_tz: "UTC";
+  repo_status: Record<string, RepoStatusEntry>;
+  buckets: {
+    "30d": QualityBucketsMode;
+    "12w": QualityBucketsMode;
+  };
+}
+
+export type PeriodMode = "30d" | "12w";
+
+export type AnnotationCategory = "skill" | "deploy" | "manual";
+export type AnnotationScope = "global" | "repo";
+
+export interface Annotation {
+  id: string;                              // UUID v4
+  occurred_at: string;                     // UTC ISO8601
+  category: AnnotationCategory;
+  scope: AnnotationScope;
+  repos: string[] | null;
+  title: string;
+  desc: string;
+  created_by: string;
+  created_at: string;
+}
+
+export interface AnnotationCreatePayload {
+  occurred_at: string;
+  category: AnnotationCategory;
+  scope: AnnotationScope;
+  repos?: string[];
+  title: string;
+  desc: string;
+}

--- a/src/utils/codex-quality.ts
+++ b/src/utils/codex-quality.ts
@@ -36,14 +36,16 @@ function pipelineUrl(): string {
   return window.__MAKEIT_CONFIG__?.PIPELINE_URL ?? "http://localhost:8766";
 }
 
+function parseQualityPayload(data: unknown): QualityPayload {
+  const v = (data as { schema_version?: unknown })?.schema_version;
+  if (v !== 1) throw new Error(`Unknown schema_version: ${String(v)}`);
+  return data as QualityPayload;
+}
+
 export async function fetchQualityData(): Promise<QualityPayload> {
   const r = await fetch(qualityUrl(), { cache: "no-cache" });
   if (!r.ok) throw new Error(`Quality fetch failed: ${r.status}`);
-  const data = await r.json();
-  if (data.schema_version !== 1) {
-    throw new Error(`Unknown schema_version: ${data.schema_version}`);
-  }
-  return data as QualityPayload;
+  return parseQualityPayload(await r.json());
 }
 
 export async function fetchAnnotations(): Promise<Annotation[]> {
@@ -63,7 +65,7 @@ export async function forceQualityRefresh(): Promise<QualityPayload> {
     const err = await r.json().catch(() => ({}));
     throw new Error(err.message || `Refresh failed: ${r.status}`);
   }
-  return r.json();
+  return parseQualityPayload(await r.json());
 }
 
 export async function createAnnotation(

--- a/src/utils/codex-quality.ts
+++ b/src/utils/codex-quality.ts
@@ -1,0 +1,89 @@
+/**
+ * API client for the «Качество кода и изменения» tab (Codex Quality).
+ *
+ * Separate from `quality.ts` (legacy AutoTuner/KPI client) to keep
+ * the two conceptually-different APIs in their own modules. Types live
+ * in `src/types/quality.ts`.
+ *
+ * URL resolution uses runtime `window.__MAKEIT_CONFIG__` so the same
+ * bundle can point at the local Pipeline API (8766) or VPS aggregator.
+ */
+import type {
+  QualityPayload,
+  Annotation,
+  AnnotationCreatePayload,
+} from "../types/quality";
+
+declare global {
+  interface Window {
+    __MAKEIT_CONFIG__?: {
+      QUALITY_URL?: string;
+      PIPELINE_URL?: string;
+      ANNOT_URL?: string;
+    };
+  }
+}
+
+function qualityUrl(): string {
+  return window.__MAKEIT_CONFIG__?.QUALITY_URL ?? "/data/codex-quality.json";
+}
+
+function annotUrl(): string {
+  return window.__MAKEIT_CONFIG__?.ANNOT_URL ?? "/data/annotations.json";
+}
+
+function pipelineUrl(): string {
+  return window.__MAKEIT_CONFIG__?.PIPELINE_URL ?? "http://localhost:8766";
+}
+
+export async function fetchQualityData(): Promise<QualityPayload> {
+  const r = await fetch(qualityUrl(), { cache: "no-cache" });
+  if (!r.ok) throw new Error(`Quality fetch failed: ${r.status}`);
+  const data = await r.json();
+  if (data.schema_version !== 1) {
+    throw new Error(`Unknown schema_version: ${data.schema_version}`);
+  }
+  return data as QualityPayload;
+}
+
+export async function fetchAnnotations(): Promise<Annotation[]> {
+  const r = await fetch(annotUrl(), { cache: "no-cache" });
+  if (r.status === 404) return [];
+  if (!r.ok) throw new Error(`Annotations fetch failed: ${r.status}`);
+  const data = await r.json();
+  return Array.isArray(data) ? data : (data.annotations ?? []);
+}
+
+export async function forceQualityRefresh(): Promise<QualityPayload> {
+  const r = await fetch(`${pipelineUrl()}/quality/refresh`, { method: "POST" });
+  if (r.status === 409) {
+    throw new Error("Sweep уже выполняется — попробуйте через ~5 мин");
+  }
+  if (!r.ok) {
+    const err = await r.json().catch(() => ({}));
+    throw new Error(err.message || `Refresh failed: ${r.status}`);
+  }
+  return r.json();
+}
+
+export async function createAnnotation(
+  p: AnnotationCreatePayload,
+): Promise<Annotation> {
+  const r = await fetch(`${pipelineUrl()}/annotations`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(p),
+  });
+  if (!r.ok) {
+    const err = await r.json().catch(() => ({}));
+    throw new Error(err.message || `Create failed: ${r.status}`);
+  }
+  return r.json();
+}
+
+export async function deleteAnnotation(id: string): Promise<void> {
+  const r = await fetch(`${pipelineUrl()}/annotations/${id}`, {
+    method: "DELETE",
+  });
+  if (!r.ok) throw new Error(`Delete failed: ${r.status}`);
+}

--- a/src/utils/quality-position.ts
+++ b/src/utils/quality-position.ts
@@ -5,12 +5,8 @@
  *   - "30d": daily buckets, annotations snap to bar center.
  *   - "12w": ISO-week buckets, annotations positioned proportionally
  *           within the (bucketCount * 7)-day window.
- *
- * NOTE: `PeriodMode` is intentionally defined locally here. When
- * `src/types/quality.ts` lands (separate task), this local type can be
- * replaced with `import type { PeriodMode } from "../types/quality"`.
  */
-export type PeriodMode = "30d" | "12w";
+import type { PeriodMode } from "../types/quality";
 
 /**
  * Snap any date to the Monday of its ISO week (in UTC).

--- a/src/utils/quality-position.ts
+++ b/src/utils/quality-position.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure position math for the Codex Quality tab annotation overlay.
+ *
+ * Two modes:
+ *   - "30d": daily buckets, annotations snap to bar center.
+ *   - "12w": ISO-week buckets, annotations positioned proportionally
+ *           within the (bucketCount * 7)-day window.
+ *
+ * NOTE: `PeriodMode` is intentionally defined locally here. When
+ * `src/types/quality.ts` lands (separate task), this local type can be
+ * replaced with `import type { PeriodMode } from "../types/quality"`.
+ */
+export type PeriodMode = "30d" | "12w";
+
+/**
+ * Snap any date to the Monday of its ISO week (in UTC).
+ * Sunday belongs to the *previous* ISO week (so 2026-05-17 Sun → 2026-05-11 Mon).
+ */
+export function isoMonday(date: Date): Date {
+  const d = new Date(date);
+  d.setUTCHours(0, 0, 0, 0);
+  const day = d.getUTCDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setUTCDate(d.getUTCDate() + diff);
+  return d;
+}
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Compute the X-axis position (in %) for an annotation marker on the
+ * quality chart, or `null` if the date falls outside the visible window.
+ *
+ *   - 30d mode: snap to bar center → ((dayIdx + 0.5) / bucketCount) * 100
+ *   - 12w mode: proportional inside the ISO-week window of bucketCount*7 days
+ *
+ * @param occurredAt   When the annotated event happened.
+ * @param mode         Period mode.
+ * @param today        Reference date — the right edge of the window.
+ * @param bucketCount  Number of buckets visible (e.g. 30 days or 12 weeks).
+ */
+export function annotationPositionPct(
+  occurredAt: Date,
+  mode: PeriodMode,
+  today: Date,
+  bucketCount: number,
+): number | null {
+  const occ = new Date(occurredAt);
+  occ.setUTCHours(0, 0, 0, 0);
+
+  if (mode === "30d") {
+    const start = new Date(today);
+    start.setUTCHours(0, 0, 0, 0);
+    start.setUTCDate(start.getUTCDate() - (bucketCount - 1));
+    const daysFromStart = Math.round((occ.getTime() - start.getTime()) / DAY_MS);
+    if (daysFromStart < 0 || daysFromStart >= bucketCount) return null;
+    return ((daysFromStart + 0.5) / bucketCount) * 100;
+  } else {
+    const todayMon = isoMonday(today);
+    const start = new Date(todayMon);
+    start.setUTCDate(start.getUTCDate() - (bucketCount - 1) * 7);
+    const totalDays = bucketCount * 7;
+    const daysFromStart = (occ.getTime() - start.getTime()) / DAY_MS;
+    if (daysFromStart < 0 || daysFromStart >= totalDays) return null;
+    return (daysFromStart / totalDays) * 100;
+  }
+}

--- a/src/utils/quality.ts
+++ b/src/utils/quality.ts
@@ -17,22 +17,7 @@ import type {
   ApplyPreview,
   BulkRejectResult,
 } from "../types";
-import type {
-  QualityPayload,
-  Annotation,
-  AnnotationCreatePayload,
-} from "../types/quality";
 import { PIPELINE_BASE_URL } from "./config";
-
-declare global {
-  interface Window {
-    __MAKEIT_CONFIG__?: {
-      QUALITY_URL?: string;
-      PIPELINE_URL?: string;
-      ANNOT_URL?: string;
-    };
-  }
-}
 
 // ── Quality KPI ──────────────────────────────────────────────────────
 
@@ -264,76 +249,4 @@ export async function runRetro(period?: string): Promise<RetroRunResult> {
     throw new Error((err as { detail: string }).detail ?? `HTTP ${res.status}`);
   }
   return res.json();
-}
-
-// ── Codex Quality Tab (Task 16) ──────────────────────────────────────
-//
-// New API surface for the «Качество кода и изменения» tab. Lives alongside
-// the legacy AutoTuner/quality-KPI client above because both belong to the
-// same conceptual "quality" namespace; types come from `src/types/quality.ts`
-// (Task 14). URL resolution uses runtime `window.__MAKEIT_CONFIG__` so the
-// same bundle can point at local pipeline (8766) or a VPS-side aggregator.
-
-function qualityUrl(): string {
-  return window.__MAKEIT_CONFIG__?.QUALITY_URL ?? "/data/codex-quality.json";
-}
-
-function annotUrl(): string {
-  return window.__MAKEIT_CONFIG__?.ANNOT_URL ?? "/data/annotations.json";
-}
-
-function pipelineUrl(): string {
-  return window.__MAKEIT_CONFIG__?.PIPELINE_URL ?? "http://localhost:8766";
-}
-
-export async function fetchQualityData(): Promise<QualityPayload> {
-  const r = await fetch(qualityUrl(), { cache: "no-cache" });
-  if (!r.ok) throw new Error(`Quality fetch failed: ${r.status}`);
-  const data = await r.json();
-  if (data.schema_version !== 1) {
-    throw new Error(`Unknown schema_version: ${data.schema_version}`);
-  }
-  return data as QualityPayload;
-}
-
-export async function fetchAnnotations(): Promise<Annotation[]> {
-  const r = await fetch(annotUrl(), { cache: "no-cache" });
-  if (r.status === 404) return [];
-  if (!r.ok) throw new Error(`Annotations fetch failed: ${r.status}`);
-  const data = await r.json();
-  return Array.isArray(data) ? data : (data.annotations ?? []);
-}
-
-export async function forceQualityRefresh(): Promise<QualityPayload> {
-  const r = await fetch(`${pipelineUrl()}/quality/refresh`, { method: "POST" });
-  if (r.status === 409) {
-    throw new Error("Sweep уже выполняется — попробуйте через ~5 мин");
-  }
-  if (!r.ok) {
-    const err = await r.json().catch(() => ({}));
-    throw new Error(err.message || `Refresh failed: ${r.status}`);
-  }
-  return r.json();
-}
-
-export async function createAnnotation(
-  p: AnnotationCreatePayload,
-): Promise<Annotation> {
-  const r = await fetch(`${pipelineUrl()}/annotations`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(p),
-  });
-  if (!r.ok) {
-    const err = await r.json().catch(() => ({}));
-    throw new Error(err.message || `Create failed: ${r.status}`);
-  }
-  return r.json();
-}
-
-export async function deleteAnnotation(id: string): Promise<void> {
-  const r = await fetch(`${pipelineUrl()}/annotations/${id}`, {
-    method: "DELETE",
-  });
-  if (!r.ok) throw new Error(`Delete failed: ${r.status}`);
 }

--- a/src/utils/quality.ts
+++ b/src/utils/quality.ts
@@ -17,7 +17,22 @@ import type {
   ApplyPreview,
   BulkRejectResult,
 } from "../types";
+import type {
+  QualityPayload,
+  Annotation,
+  AnnotationCreatePayload,
+} from "../types/quality";
 import { PIPELINE_BASE_URL } from "./config";
+
+declare global {
+  interface Window {
+    __MAKEIT_CONFIG__?: {
+      QUALITY_URL?: string;
+      PIPELINE_URL?: string;
+      ANNOT_URL?: string;
+    };
+  }
+}
 
 // ── Quality KPI ──────────────────────────────────────────────────────
 
@@ -249,4 +264,76 @@ export async function runRetro(period?: string): Promise<RetroRunResult> {
     throw new Error((err as { detail: string }).detail ?? `HTTP ${res.status}`);
   }
   return res.json();
+}
+
+// ── Codex Quality Tab (Task 16) ──────────────────────────────────────
+//
+// New API surface for the «Качество кода и изменения» tab. Lives alongside
+// the legacy AutoTuner/quality-KPI client above because both belong to the
+// same conceptual "quality" namespace; types come from `src/types/quality.ts`
+// (Task 14). URL resolution uses runtime `window.__MAKEIT_CONFIG__` so the
+// same bundle can point at local pipeline (8766) or a VPS-side aggregator.
+
+function qualityUrl(): string {
+  return window.__MAKEIT_CONFIG__?.QUALITY_URL ?? "/data/codex-quality.json";
+}
+
+function annotUrl(): string {
+  return window.__MAKEIT_CONFIG__?.ANNOT_URL ?? "/data/annotations.json";
+}
+
+function pipelineUrl(): string {
+  return window.__MAKEIT_CONFIG__?.PIPELINE_URL ?? "http://localhost:8766";
+}
+
+export async function fetchQualityData(): Promise<QualityPayload> {
+  const r = await fetch(qualityUrl(), { cache: "no-cache" });
+  if (!r.ok) throw new Error(`Quality fetch failed: ${r.status}`);
+  const data = await r.json();
+  if (data.schema_version !== 1) {
+    throw new Error(`Unknown schema_version: ${data.schema_version}`);
+  }
+  return data as QualityPayload;
+}
+
+export async function fetchAnnotations(): Promise<Annotation[]> {
+  const r = await fetch(annotUrl(), { cache: "no-cache" });
+  if (r.status === 404) return [];
+  if (!r.ok) throw new Error(`Annotations fetch failed: ${r.status}`);
+  const data = await r.json();
+  return Array.isArray(data) ? data : (data.annotations ?? []);
+}
+
+export async function forceQualityRefresh(): Promise<QualityPayload> {
+  const r = await fetch(`${pipelineUrl()}/quality/refresh`, { method: "POST" });
+  if (r.status === 409) {
+    throw new Error("Sweep уже выполняется — попробуйте через ~5 мин");
+  }
+  if (!r.ok) {
+    const err = await r.json().catch(() => ({}));
+    throw new Error(err.message || `Refresh failed: ${r.status}`);
+  }
+  return r.json();
+}
+
+export async function createAnnotation(
+  p: AnnotationCreatePayload,
+): Promise<Annotation> {
+  const r = await fetch(`${pipelineUrl()}/annotations`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(p),
+  });
+  if (!r.ok) {
+    const err = await r.json().catch(() => ({}));
+    throw new Error(err.message || `Create failed: ${r.status}`);
+  }
+  return r.json();
+}
+
+export async function deleteAnnotation(id: string): Promise<void> {
+  const r = await fetch(`${pipelineUrl()}/annotations/${id}`, {
+    method: "DELETE",
+  });
+  if (!r.ok) throw new Error(`Delete failed: ${r.status}`);
 }

--- a/tests/quality/AnnotationModal.test.tsx
+++ b/tests/quality/AnnotationModal.test.tsx
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import { AnnotationModal } from "../../src/components/quality/AnnotationModal";
+
+afterEach(cleanup);
 
 describe("AnnotationModal", () => {
   it("submits annotation with form values converted to UTC", async () => {
@@ -20,5 +22,18 @@ describe("AnnotationModal", () => {
         desc: "",
       })
     );
+  });
+
+  it("surfaces submit failure inline and keeps modal open", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error("HTTP 500"));
+    const onClose = vi.fn();
+    const { getByLabelText, getByText, findByRole } = render(
+      <AnnotationModal onSubmit={onSubmit} onClose={onClose} />
+    );
+    fireEvent.change(getByLabelText(/title/i), { target: { value: "test" } });
+    fireEvent.click(getByText(/сохранить/i));
+    const alert = await findByRole("alert");
+    expect(alert.textContent).toMatch(/HTTP 500/);
+    await waitFor(() => expect(onClose).not.toHaveBeenCalled());
   });
 });

--- a/tests/quality/AnnotationModal.test.tsx
+++ b/tests/quality/AnnotationModal.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { AnnotationModal } from "../../src/components/quality/AnnotationModal";
+
+describe("AnnotationModal", () => {
+  it("submits annotation with form values converted to UTC", async () => {
+    const onSubmit = vi.fn().mockResolvedValue({});
+    const { getByLabelText, getByText } = render(
+      <AnnotationModal onSubmit={onSubmit} onClose={vi.fn()} />
+    );
+    fireEvent.change(getByLabelText(/дата/i), { target: { value: "2026-05-22" } });
+    fireEvent.change(getByLabelText(/title/i), { target: { value: "test event" } });
+    fireEvent.click(getByText(/сохранить/i));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        occurred_at: "2026-05-22T00:00:00.000Z",
+        category: "skill",
+        scope: "global",
+        title: "test event",
+        desc: "",
+      })
+    );
+  });
+});

--- a/tests/quality/QualityChart.test.tsx
+++ b/tests/quality/QualityChart.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { QualityChart } from "../../src/components/quality/QualityChart";
+import type { QualityBucket } from "../../src/types/quality";
+
+const buckets: QualityBucket[] = [
+  { total_pr: 10, with_p0: 0, with_p1_only: 1, with_p2_only: 2 },
+  { total_pr: 20, with_p0: 0, with_p1_only: 0, with_p2_only: 4 },
+];
+const labels = ["2026-05-23", "2026-05-24"];
+
+describe("QualityChart", () => {
+  it("renders one bar per bucket", () => {
+    const { container } = render(
+      <QualityChart buckets={buckets} labels={labels} compact={false} />
+    );
+    expect(container.querySelectorAll(".bar")).toHaveLength(2);
+  });
+
+  it("renders crit/p2/clean segments for non-empty bucket", () => {
+    const { container } = render(
+      <QualityChart buckets={buckets} labels={labels} compact={false} />
+    );
+    const firstBar = container.querySelector(".bar")!;
+    expect(firstBar.querySelector(".bar-crit")).toBeTruthy();
+    expect(firstBar.querySelector(".bar-p2")).toBeTruthy();
+    expect(firstBar.querySelector(".bar-clean")).toBeTruthy();
+  });
+
+  it("auto-scales y-axis via niceCeil (max=20 → 20)", () => {
+    const { container } = render(
+      <QualityChart buckets={buckets} labels={labels} compact={false} />
+    );
+    const axis = container.querySelector(".chart-axis-label");
+    expect(axis?.textContent).toBe("20");
+  });
+
+  it("applies has-p0 class to buckets with P0 findings", () => {
+    const withP0: QualityBucket[] = [
+      { total_pr: 5, with_p0: 1, with_p1_only: 0, with_p2_only: 1 },
+      { total_pr: 5, with_p0: 0, with_p1_only: 0, with_p2_only: 0 },
+    ];
+    const { container } = render(
+      <QualityChart buckets={withP0} labels={labels} compact={false} />
+    );
+    const bars = container.querySelectorAll(".bar");
+    expect(bars[0].classList.contains("has-p0")).toBe(true);
+    expect(bars[1].classList.contains("has-p0")).toBe(false);
+  });
+
+  it("renders bar-topper-p0 for non-compact when with_p0 > 0", () => {
+    const withP0: QualityBucket[] = [
+      { total_pr: 5, with_p0: 2, with_p1_only: 0, with_p2_only: 0 },
+    ];
+    const { container } = render(
+      <QualityChart buckets={withP0} labels={["2026-05-23"]} compact={false} />
+    );
+    const topper = container.querySelector(".bar-topper-p0");
+    expect(topper).toBeTruthy();
+    expect(topper?.textContent).toContain("P0:2");
+  });
+
+  it("does NOT render bar-topper-p0 in compact mode", () => {
+    const withP0: QualityBucket[] = [
+      { total_pr: 5, with_p0: 2, with_p1_only: 0, with_p2_only: 0 },
+    ];
+    const { container } = render(
+      <QualityChart buckets={withP0} labels={["2026-05-23"]} compact={true} />
+    );
+    expect(container.querySelector(".bar-topper-p0")).toBeNull();
+  });
+
+  it("uses card-chart wrapper class in compact mode", () => {
+    const { container } = render(
+      <QualityChart buckets={buckets} labels={labels} compact={true} />
+    );
+    expect(container.querySelector(".card-chart")).toBeTruthy();
+    expect(container.querySelector(".chart-axis")).toBeNull();
+  });
+
+  it("applies is-low-sample class when total_pr < LOW_SAMPLE (8)", () => {
+    const lowSample: QualityBucket[] = [
+      { total_pr: 3, with_p0: 0, with_p1_only: 0, with_p2_only: 1 },
+      { total_pr: 12, with_p0: 0, with_p1_only: 0, with_p2_only: 0 },
+    ];
+    const { container } = render(
+      <QualityChart buckets={lowSample} labels={labels} compact={false} />
+    );
+    const bars = container.querySelectorAll(".bar");
+    expect(bars[0].classList.contains("is-low-sample")).toBe(true);
+    expect(bars[1].classList.contains("is-low-sample")).toBe(false);
+  });
+
+  it("renders single tooltip element per chart (perf — pre-created structure)", () => {
+    const { container } = render(
+      <QualityChart buckets={buckets} labels={labels} compact={false} />
+    );
+    expect(container.querySelectorAll(".chart-tip")).toHaveLength(1);
+  });
+
+  it("renders chart-tip--compact in compact mode", () => {
+    const { container } = render(
+      <QualityChart buckets={buckets} labels={labels} compact={true} />
+    );
+    expect(container.querySelector(".chart-tip--compact")).toBeTruthy();
+  });
+});

--- a/tests/quality/quality-position.test.ts
+++ b/tests/quality/quality-position.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { isoMonday, annotationPositionPct } from "../../src/utils/quality-position";
+
+describe("isoMonday", () => {
+  it("snaps Wednesday to Monday of same week", () => {
+    expect(isoMonday(new Date("2026-05-13"))).toEqual(new Date("2026-05-11T00:00:00.000Z"));
+  });
+  it("snaps Sunday to Monday of same week (not next)", () => {
+    expect(isoMonday(new Date("2026-05-17"))).toEqual(new Date("2026-05-11T00:00:00.000Z"));
+  });
+  it("snaps Monday to itself", () => {
+    expect(isoMonday(new Date("2026-05-11"))).toEqual(new Date("2026-05-11T00:00:00.000Z"));
+  });
+});
+
+describe("annotationPositionPct", () => {
+  const today = new Date("2026-05-25T00:00:00Z"); // Monday
+  it("30d mode snaps to bar center", () => {
+    // Annotation on 2026-05-15 (10 days before today, day index 19 in 30-day series ending today)
+    const pct = annotationPositionPct(new Date("2026-05-15T08:00:00Z"), "30d", today, 30);
+    // (19 + 0.5) / 30 = 65%
+    expect(pct).toBeCloseTo(65);
+  });
+  it("12w mode positions proportionally within week", () => {
+    // Annotation on Wed 2026-05-13. Week 12 of 12 starts on Mon 2026-05-25.
+    // 2026-05-13 is in week starting 2026-05-11 — that's week index 10 (0-based) of 12.
+    // days from window start (2026-03-09) to 2026-05-13 = 65 days
+    // pct = 65 / (12*7) = 65/84 = 77.4%
+    const pct = annotationPositionPct(new Date("2026-05-13T00:00:00Z"), "12w", today, 12);
+    expect(pct).toBeCloseTo(77.38, 1);
+  });
+  it("returns null for date outside window", () => {
+    expect(annotationPositionPct(new Date("2025-01-01"), "30d", today, 30)).toBeNull();
+    expect(annotationPositionPct(new Date("2030-01-01"), "30d", today, 30)).toBeNull();
+  });
+});

--- a/tests/quality/useCodexQuality.test.tsx
+++ b/tests/quality/useCodexQuality.test.tsx
@@ -45,4 +45,22 @@ describe("useCodexQuality", () => {
     const { result } = renderHook(() => useCodexQuality());
     await waitFor(() => expect(result.current.error).not.toBeNull());
   });
+
+  it("rejects payload with unknown schema_version", async () => {
+    const v2 = { ...samplePayload, schema_version: 2 };
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => v2 });
+    const { result } = renderHook(() => useCodexQuality());
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error).toMatch(/schema_version/);
+    expect(result.current.data).toBeNull();
+  });
+
+  it("reloadAnnotations only fetches annotations, not the quality payload", async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => samplePayload });
+    const { result } = renderHook(() => useCodexQuality());
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    const callsAfterMount = mockFetch.mock.calls.length;
+    await result.current.reloadAnnotations();
+    expect(mockFetch.mock.calls.length - callsAfterMount).toBe(1);
+  });
 });

--- a/tests/quality/useCodexQuality.test.tsx
+++ b/tests/quality/useCodexQuality.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useCodexQuality } from "../../src/hooks/useCodexQuality";
+
+const STALE_HOURS = 30;
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
+  mockFetch.mockReset();
+});
+
+const samplePayload = {
+  schema_version: 1,
+  generated_at: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
+  window_start: "x",
+  window_end: "y",
+  bucket_tz: "UTC",
+  repo_status: {},
+  buckets: {
+    "30d": { labels: [], summary: [], per_repo: {} },
+    "12w": { labels: [], summary: [], per_repo: {} },
+  },
+};
+
+describe("useCodexQuality", () => {
+  it("loads data on mount", async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => samplePayload });
+    const { result } = renderHook(() => useCodexQuality());
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    expect(result.current.loading).toBe(false);
+    expect(result.current.isStale).toBe(false);
+  });
+
+  it("marks stale when generated_at > 30h old", async () => {
+    const old = { ...samplePayload, generated_at: new Date(Date.now() - (STALE_HOURS + 1) * 3.6e6).toISOString() };
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => old });
+    const { result } = renderHook(() => useCodexQuality());
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    expect(result.current.isStale).toBe(true);
+  });
+
+  it("surfaces error on 404", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+    const { result } = renderHook(() => useCodexQuality());
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+  });
+});

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -13,5 +13,5 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },
-  "include": ["tests", "playwright.config.ts"]
+  "include": ["tests/e2e", "playwright.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Vitest config — kept separate from `vite.config.ts` so PWA / build plugins
+ * don't run during unit tests, and Playwright e2e specs in `tests/e2e/**`
+ * stay isolated from Vitest (they have their own runner / `test` import).
+ */
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.{ts,tsx}"],
+    exclude: ["tests/e2e/**", "node_modules/**", "dist/**"],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,8 +6,14 @@ import { defineConfig } from "vitest/config";
  * stay isolated from Vitest (they have their own runner / `test` import).
  */
 export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
   test: {
     include: ["tests/**/*.test.{ts,tsx}"],
     exclude: ["tests/e2e/**", "node_modules/**", "dist/**"],
+    environmentMatchGlobs: [
+      ["tests/**/*.test.tsx", "jsdom"],
+    ],
   },
 });


### PR DESCRIPTION
## Зачем

Live-вкладка по дашборду: видно динамику чистоты PR от `chatgpt-codex-connector[bot]` по всем проектам сразу, чтобы:
- ловить регрессии качества в моменте, а не на ретро;
- видеть P0-блокеры по столбцам с подсветкой и pulse-pill;
- связывать всплески «грязи» с событиями (релизы, инциденты, обучение) через ручные аннотации.

Пока **только frontend** — backend (sweep cron, JSON-publisher, nginx) отложен по решению. Без `/data/codex-quality.json` вкладка показывает корректный error-state с «Попробовать снова».

## Что внутри

- **TabId `codex-quality`** в App + Sidebar (соседствует с легаси AutoTuner Quality, не вытесняет).
- **Hook `useCodexQuality`** — fetch payload + аннотации, `isStale` если данные > 30ч, `refresh()`.
- **Summary panel** — 2-колонка `1fr / 280px`: чарт слева (worst-wins стэк crit/P2/clean, P0-колонки с pulse-pill, dotted axis, 30д/12нед toggle, аннотации поверх баров) + KPI стек справа (P0-alert pill, % грязных / % P1 / % P2 / общее PR).
- **Project grid** `repeat(auto-fill, minmax(320px, 1fr))`: на карточку — мини-чарт, % dirty, P0/P1/P2 разбивка, low-coverage tag, severity badge. Error и empty states рендерятся отдельно.
- **AnnotationModal** «+ событие» (date / category / title / desc → POST `/annotations`).
- **Тесты** Vitest + @testing-library: 20/20 проходят (`useCodexQuality`, `QualityChart`, `AnnotationModal`, `quality-position`).

## Структура

```
src/
  components/quality/    AnnotationModal · QualityAnnotations · QualityChart
                         · QualityKPIs · QualityProjectCard · QualityProjectGrid
                         · QualityStaleBanner · QualitySummaryPanel · QualityTab
  hooks/useCodexQuality.ts
  styles/v4-quality.css  (полный port из quality-tab-prototype.html)
  types/quality.ts
  utils/codex-quality.ts
  utils/quality-position.ts
tests/quality/           4 файла, 20 кейсов
docs/superpowers/specs/2026-05-25-codex-quality-tab-design.md
docs/superpowers/plans/2026-05-25-codex-quality-tab.md
quality-tab-prototype.html  (референсный HTML/JS/CSS прототип)
```

## Контракт данных (для будущего бэкенда)

`per_repo` keys должны быть **short repo name** (`makeit-dashboard`, не `Sergio1990-1/makeit-dashboard`) — `PROJECTS.repo` в `src/utils/config.ts` хранит короткое имя. Это нужно учесть в sweep-публикаторе Pipeline-Mac.

## Что НЕ сделано (отложено / баклог)

- `▲ -4 пп vs прошлая неделя` дельты в KPI — нужен previous-period compute pass.
- «P0+P1 объединены в красный» подпись в легенде — мелочь, можно доформулировать.
- Backend (sweep, atomic publish, flock, retry на 429, launchd plist) — Phase A-D плана.
- VPS nginx config (Phase E).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 20/20 passing
- [x] E2E в браузерном превью (mock fetch): чарт рендерится, P0-pill виден, аннотации поверх баров, period toggle переключает 30/12 (12→30 баров), «+ событие» открывает модалку с date/category/title/desc, sort toggle по проектам работает, error/empty/low-coverage state корректные.
- [ ] Реальные данные — после деплоя бэкенд-фазы и появления `/data/codex-quality.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)