### PR TITLE
chore(quality): rename tab «Качество кода и изменения» → «Качество кода»

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,7 @@ const TAB_CRUMBS: Record<TabId, string> = {
   research: "Research",
   specs: "Specs",
   quality: "Quality",
-  "codex-quality": "Качество кода и изменения",
+  "codex-quality": "Качество кода",
   debate: "Debate",
 };
 
@@ -685,7 +685,7 @@ function AppInner({ onFirstFetchDone }: AppInnerProps = {}) {
         </div>
         <div style={{ display: tab === "codex-quality" ? undefined : "none" }}>
           {visitedTabs.has("codex-quality") && (
-            <ErrorBoundary fallback="Ошибка вкладки «Качество кода и изменения»">
+            <ErrorBoundary fallback="Ошибка вкладки «Качество кода»">
               <QualityTab />
             </ErrorBoundary>
           )}

--- a/src/components/quality/QualityTab.tsx
+++ b/src/components/quality/QualityTab.tsx
@@ -35,7 +35,7 @@ export function QualityTab() {
     <div className="v4-quality-tab page">
       <div className="pageH">
         <div>
-          <h1>Качество кода и изменения</h1>
+          <h1>Качество кода</h1>
           <div className="sub">
             Доля PR с критическими/высокими замечаниями <b>chatgpt-codex-connector[bot]</b> от общего числа merged PR · события на временной оси
           </div>

--- a/src/components/v4/CommandPalette.tsx
+++ b/src/components/v4/CommandPalette.tsx
@@ -38,7 +38,7 @@ const TAB_LABEL: Record<TabId, string> = {
   research: "Research",
   specs: "Specs",
   quality: "Quality",
-  "codex-quality": "Качество кода и изменения",
+  "codex-quality": "Качество кода",
   debate: "Debate",
 };
 

--- a/src/components/v4/Sidebar.tsx
+++ b/src/components/v4/Sidebar.tsx
@@ -158,7 +158,7 @@ export function Sidebar({
       items: [
         { id: "audit", label: "Аудит", badge: auditAlerts, icon: ICON_AUDIT, pulse: p.audit },
         { id: "quality", label: "Quality", icon: ICON_QUALITY, pulse: p.quality },
-        { id: "codex-quality", label: "Качество кода и изменения", icon: ICON_CODEX_QUALITY, pulse: p["codex-quality"] },
+        { id: "codex-quality", label: "Качество кода", icon: ICON_CODEX_QUALITY, pulse: p["codex-quality"] },
         { id: "debate", label: "Debate", icon: ICON_DEBATE, pulse: p.debate },
       ],
     },

--- a/src/utils/codex-quality.ts
+++ b/src/utils/codex-quality.ts
@@ -1,5 +1,5 @@
 /**
- * API client for the «Качество кода и изменения» tab (Codex Quality).
+ * API client for the «Качество кода» tab (Codex Quality).
  *
  * Separate from `quality.ts` (legacy AutoTuner/KPI client) to keep
  * the two conceptually-different APIs in their own modules. Types live


### PR DESCRIPTION
## Summary

- Sidebar, breadcrumb, command-palette, ErrorBoundary, page h1 и комментарий в `codex-quality.ts` — везде «Качество кода и изменения» → «Качество кода»
- `TabId` остаётся `"codex-quality"` (storage-friendly, ничего не ломает в localStorage у пользователей)

## Test plan

- [x] `npm run build` (tsc -b + vite) clean
- [x] `npx vitest run` 23/23 pass
- [x] `npx eslint .` clean
- [x] `grep -rn "Качество кода и изменения" src/` → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)