### PR TITLE
fix(quality): friendly empty state when backend not deployed + reorder sidebar

### DIFF
--- a/src/components/quality/QualityTab.tsx
+++ b/src/components/quality/QualityTab.tsx
@@ -9,11 +9,34 @@ import { createAnnotation } from "../../utils/codex-quality";
 import "../../styles/v4-quality.css";
 
 export function QualityTab() {
-  const { data, annotations, loading, error, isStale, refresh, reloadAnnotations } = useCodexQuality();
+  const { data, annotations, loading, error, unavailable, isStale, refresh, reloadAnnotations } = useCodexQuality();
   const [mode, setMode] = useState<PeriodMode>("12w");
   const [showAddModal, setShowAddModal] = useState(false);
 
   if (loading && !data) return <div className="v4-quality-tab">Загрузка…</div>;
+  if (unavailable) {
+    return (
+      <div className="v4-quality-tab page">
+        <div className="pageH">
+          <div>
+            <h1>Качество кода</h1>
+            <div className="sub">
+              Доля PR с критическими/высокими замечаниями <b>chatgpt-codex-connector[bot]</b> от общего числа merged PR · события на временной оси
+            </div>
+          </div>
+        </div>
+        <div className="quality-empty-panel">
+          <div className="quality-empty-icon">📊</div>
+          <h2>Данные ещё не собираются</h2>
+          <p>
+            Sweep-бэкенд на Pipeline Mac не задеплоен — нет источника для <code>/data/codex-quality.json</code>.
+            После настройки cron здесь появится недельная динамика P0/P1/P2 находок Codex по всем 12 проектам.
+          </p>
+          <button className="btn-refresh" onClick={() => refresh()} disabled={loading}>↻ Проверить ещё раз</button>
+        </div>
+      </div>
+    );
+  }
   if (error) {
     return (
       <div className="v4-quality-tab">

--- a/src/components/v4/Sidebar.tsx
+++ b/src/components/v4/Sidebar.tsx
@@ -141,6 +141,7 @@ export function Sidebar({
         },
         { id: "projects", label: "Проекты", count: projectsCount, nba: nbaBadge, icon: ICON_LIST, pulse: p.projects },
         { id: "milestones", label: "Milestones", count: milestonesCount, icon: ICON_CLOCK, pulse: p.milestones },
+        { id: "codex-quality", label: "Качество кода", icon: ICON_CODEX_QUALITY, pulse: p["codex-quality"] },
         { id: "uptime", label: "Мониторинг", count: monitorsCount || undefined, icon: ICON_MONITOR, pulse: p.uptime },
       ],
     },
@@ -158,7 +159,6 @@ export function Sidebar({
       items: [
         { id: "audit", label: "Аудит", badge: auditAlerts, icon: ICON_AUDIT, pulse: p.audit },
         { id: "quality", label: "Quality", icon: ICON_QUALITY, pulse: p.quality },
-        { id: "codex-quality", label: "Качество кода", icon: ICON_CODEX_QUALITY, pulse: p["codex-quality"] },
         { id: "debate", label: "Debate", icon: ICON_DEBATE, pulse: p.debate },
       ],
     },

--- a/src/hooks/useCodexQuality.ts
+++ b/src/hooks/useCodexQuality.ts
@@ -1,6 +1,11 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
 import type { QualityPayload, Annotation } from "../types/quality";
-import { fetchQualityData, fetchAnnotations, forceQualityRefresh } from "../utils/codex-quality";
+import {
+  fetchQualityData,
+  fetchAnnotations,
+  forceQualityRefresh,
+  QualityBackendUnavailableError,
+} from "../utils/codex-quality";
 
 const STALE_HOURS = 30;
 
@@ -9,10 +14,12 @@ export function useCodexQuality() {
   const [annotations, setAnnotations] = useState<Annotation[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
 
   const load = useCallback(async (force = false) => {
     setLoading(true);
     setError(null);
+    setUnavailable(false);
     try {
       const [q, a] = await Promise.all([
         force ? forceQualityRefresh() : fetchQualityData(),
@@ -21,7 +28,11 @@ export function useCodexQuality() {
       setData(q);
       setAnnotations(a);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      if (e instanceof QualityBackendUnavailableError) {
+        setUnavailable(true);
+      } else {
+        setError(e instanceof Error ? e.message : String(e));
+      }
     } finally {
       setLoading(false);
     }
@@ -31,7 +42,9 @@ export function useCodexQuality() {
     try {
       setAnnotations(await fetchAnnotations());
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      if (!(e instanceof QualityBackendUnavailableError)) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
     }
   }, []);
 
@@ -50,6 +63,7 @@ export function useCodexQuality() {
     annotations,
     loading,
     error,
+    unavailable,
     isStale,
     refresh: () => load(true),
     reloadAnnotations,

--- a/src/styles/v4-quality.css
+++ b/src/styles/v4-quality.css
@@ -815,6 +815,47 @@
 }
 .v4-quality-tab .quality-error-panel button:hover { background: var(--v4-surface-2); }
 
+/* Soft empty state when backend (sweep cron / JSON publisher) isn't deployed yet.
+   Distinct from .quality-error-panel — this is not an error, just an awaiting state. */
+.v4-quality-tab .quality-empty-panel {
+  margin: 40px auto 0;
+  max-width: 520px;
+  padding: 40px 32px;
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
+  text-align: center;
+  color: var(--v4-ink-700);
+}
+.v4-quality-tab .quality-empty-icon {
+  font-size: 40px;
+  margin-bottom: 12px;
+  opacity: 0.85;
+}
+.v4-quality-tab .quality-empty-panel h2 {
+  margin: 0 0 10px;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--v4-ink-900);
+}
+.v4-quality-tab .quality-empty-panel p {
+  margin: 0 0 20px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--v4-ink-500);
+}
+.v4-quality-tab .quality-empty-panel code {
+  font-family: var(--v4-mono);
+  font-size: 12px;
+  background: var(--v4-surface-2);
+  padding: 1px 5px;
+  border-radius: 3px;
+  color: var(--v4-ink-700);
+}
+.v4-quality-tab .quality-empty-panel .btn-refresh {
+  margin: 0 auto;
+}
+
 /* ──── REDUCED MOTION GUARD ────
  * Пользователи с prefers-reduced-motion отключают всю кинетику.
  * (Аналог @media-блока в v4.css.) */

--- a/src/utils/codex-quality.ts
+++ b/src/utils/codex-quality.ts
@@ -24,6 +24,20 @@ declare global {
   }
 }
 
+/**
+ * Thrown when the JSON publisher or `/quality/refresh` endpoint isn't
+ * deployed yet — common on prod before the sweep backend lands. UI uses
+ * this to render a soft "data not collected yet" state instead of a
+ * scary parse error (nginx SPA-fallback serves index.html for missing
+ * static files, so a missing JSON shows up as `<!doctype …` not 404).
+ */
+export class QualityBackendUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QualityBackendUnavailableError";
+  }
+}
+
 function qualityUrl(): string {
   return window.__MAKEIT_CONFIG__?.QUALITY_URL ?? "/data/codex-quality.json";
 }
@@ -42,22 +56,49 @@ function parseQualityPayload(data: unknown): QualityPayload {
   return data as QualityPayload;
 }
 
+/**
+ * Read a JSON body but bail out if nginx returned an HTML fallback page
+ * (which it does on 200 when the requested static file is missing).
+ */
+async function readJson(r: Response, label: string): Promise<unknown> {
+  const ct = r.headers.get("content-type") ?? "";
+  if (ct.includes("text/html")) {
+    throw new QualityBackendUnavailableError(`${label}: HTML fallback served`);
+  }
+  const text = await r.text();
+  if (text.trim().startsWith("<")) {
+    throw new QualityBackendUnavailableError(`${label}: HTML fallback served`);
+  }
+  return JSON.parse(text);
+}
+
 export async function fetchQualityData(): Promise<QualityPayload> {
   const r = await fetch(qualityUrl(), { cache: "no-cache" });
+  if (r.status === 404) {
+    throw new QualityBackendUnavailableError("Quality data file not published");
+  }
   if (!r.ok) throw new Error(`Quality fetch failed: ${r.status}`);
-  return parseQualityPayload(await r.json());
+  return parseQualityPayload(await readJson(r, "Quality fetch"));
 }
 
 export async function fetchAnnotations(): Promise<Annotation[]> {
   const r = await fetch(annotUrl(), { cache: "no-cache" });
   if (r.status === 404) return [];
   if (!r.ok) throw new Error(`Annotations fetch failed: ${r.status}`);
-  const data = await r.json();
-  return Array.isArray(data) ? data : (data.annotations ?? []);
+  try {
+    const data = await readJson(r, "Annotations fetch");
+    return Array.isArray(data) ? data : ((data as { annotations?: Annotation[] }).annotations ?? []);
+  } catch (e) {
+    if (e instanceof QualityBackendUnavailableError) return [];
+    throw e;
+  }
 }
 
 export async function forceQualityRefresh(): Promise<QualityPayload> {
   const r = await fetch(`${pipelineUrl()}/quality/refresh`, { method: "POST" });
+  if (r.status === 404) {
+    throw new QualityBackendUnavailableError("Refresh endpoint not available");
+  }
   if (r.status === 409) {
     throw new Error("Sweep уже выполняется — попробуйте через ~5 мин");
   }
@@ -65,7 +106,7 @@ export async function forceQualityRefresh(): Promise<QualityPayload> {
     const err = await r.json().catch(() => ({}));
     throw new Error(err.message || `Refresh failed: ${r.status}`);
   }
-  return parseQualityPayload(await r.json());
+  return parseQualityPayload(await readJson(r, "Refresh"));
 }
 
 export async function createAnnotation(
@@ -76,6 +117,9 @@ export async function createAnnotation(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(p),
   });
+  if (r.status === 404) {
+    throw new QualityBackendUnavailableError("Annotations endpoint not available");
+  }
   if (!r.ok) {
     const err = await r.json().catch(() => ({}));
     throw new Error(err.message || `Create failed: ${r.status}`);

--- a/tests/quality/useCodexQuality.test.tsx
+++ b/tests/quality/useCodexQuality.test.tsx
@@ -23,32 +23,69 @@ const samplePayload = {
   },
 };
 
+function jsonResp(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function mockAlways(body: unknown, init: ResponseInit = {}) {
+  // Fresh Response per call — Response bodies are single-use; reusing one
+  // throws "Body has already been read" on the second fetch.
+  mockFetch.mockImplementation(() => Promise.resolve(jsonResp(body, init)));
+}
+
 describe("useCodexQuality", () => {
   it("loads data on mount", async () => {
-    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => samplePayload });
+    mockAlways(samplePayload);
     const { result } = renderHook(() => useCodexQuality());
     await waitFor(() => expect(result.current.data).not.toBeNull());
     expect(result.current.loading).toBe(false);
     expect(result.current.isStale).toBe(false);
+    expect(result.current.unavailable).toBe(false);
   });
 
   it("marks stale when generated_at > 30h old", async () => {
     const old = { ...samplePayload, generated_at: new Date(Date.now() - (STALE_HOURS + 1) * 3.6e6).toISOString() };
-    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => old });
+    mockAlways(old);
     const { result } = renderHook(() => useCodexQuality());
     await waitFor(() => expect(result.current.data).not.toBeNull());
     expect(result.current.isStale).toBe(true);
   });
 
-  it("surfaces error on 404", async () => {
-    mockFetch.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+  it("marks unavailable on 404 (backend not deployed)", async () => {
+    mockAlways({}, { status: 404 });
+    const { result } = renderHook(() => useCodexQuality());
+    await waitFor(() => expect(result.current.unavailable).toBe(true));
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toBeNull();
+  });
+
+  it("marks unavailable when nginx SPA-fallback serves HTML for missing JSON", async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response("<!doctype html><html><body>404</body></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+      ),
+    );
+    const { result } = renderHook(() => useCodexQuality());
+    await waitFor(() => expect(result.current.unavailable).toBe(true));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces non-unavailable error (e.g. 500)", async () => {
+    mockAlways({ detail: "broken" }, { status: 500 });
     const { result } = renderHook(() => useCodexQuality());
     await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.unavailable).toBe(false);
   });
 
   it("rejects payload with unknown schema_version", async () => {
-    const v2 = { ...samplePayload, schema_version: 2 };
-    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => v2 });
+    mockAlways({ ...samplePayload, schema_version: 2 });
     const { result } = renderHook(() => useCodexQuality());
     await waitFor(() => expect(result.current.error).not.toBeNull());
     expect(result.current.error).toMatch(/schema_version/);
@@ -56,7 +93,7 @@ describe("useCodexQuality", () => {
   });
 
   it("reloadAnnotations only fetches annotations, not the quality payload", async () => {
-    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => samplePayload });
+    mockAlways(samplePayload);
     const { result } = renderHook(() => useCodexQuality());
     await waitFor(() => expect(result.current.data).not.toBeNull());
     const callsAfterMount = mockFetch.mock.calls.length;


### PR DESCRIPTION
## Что сломалось

После #500 на проде вкладка показывает «Ошибка загрузки данных: Unexpected token '<', "<!doctype "...». Причина: nginx SPA-fallback отдаёт `index.html` (200 OK) для несуществующего `/data/codex-quality.json` (sweep backend ещё не задеплоен — это известно), `r.json()` падает на парсинге HTML.

## Что меняется

1. **`QualityBackendUnavailableError`** — отдельный класс ошибки для случая «бэкенд ещё не задеплоен». Детектится по: 404, content-type=`text/html`, тело начинается с `<`. Применяется в `fetchQualityData` / `fetchAnnotations` / `forceQualityRefresh` / `createAnnotation`.
2. **`useCodexQuality`** — новый флаг `unavailable: boolean` отдельно от `error`.
3. **`QualityTab`** — мягкий empty-state с иконкой 📊, заголовком «Данные ещё не собираются» и пояснением про sweep-backend; кнопка «↻ Проверить ещё раз». Не путается с реальной ошибкой.
4. **Sidebar** — пункт «Качество кода» перенесён из «Контроль» в основную секцию, под Milestones.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run` 25/25 pass (+3 новых: 404, HTML fallback, non-unavailable 500)
- [x] `npx eslint .` clean
- [x] Локальный preview: empty-state виден, в sidebar порядок `Milestones → Качество кода → Мониторинг`, JS-крашей нет
- [ ] Прод-проверка после деплоя

🤖 Generated with [Claude Code](https://claude.com/claude-code)