### PR TITLE
fix(quality): align tab layout with rest of dashboard

### DIFF
--- a/src/components/quality/QualitySummaryPanel.tsx
+++ b/src/components/quality/QualitySummaryPanel.tsx
@@ -18,7 +18,7 @@ export function QualitySummaryPanel({ data, annotations, mode }: Props) {
     <div className="panel summary">
       <div className="chartwrap">
         <div className="panel-t" style={{ marginBottom: 14 }}>
-          Сводно по всем {Object.keys(data.repo_status).length} проектам
+          Сводная по всем {Object.keys(data.repo_status).length} проектам
           <span className="tag">All repos</span>
           {errored.length > 0 && (
             <span

--- a/src/components/quality/QualityTab.tsx
+++ b/src/components/quality/QualityTab.tsx
@@ -18,7 +18,11 @@ export function QualityTab() {
     await reloadAnnotations();
   };
 
-  if (loading && !data) return <div className="v4-quality-tab">Загрузка…</div>;
+  // All branches use `v4-quality-tab page` so they inherit the same
+  // padding/max-width as the populated state — otherwise a quick error
+  // or loading flash shows content flush against the top-left edge of
+  // the content area, off-grid relative to every other tab.
+  if (loading && !data) return <div className="v4-quality-tab page">Загрузка…</div>;
   if (unavailable) {
     // Sweep aggregate (/data/codex-quality.json) hasn't been published yet —
     // either the GitHub Actions workflow hasn't run for the first time, or
@@ -76,7 +80,13 @@ export function QualityTab() {
   }
   if (error) {
     return (
-      <div className="v4-quality-tab">
+      <div className="v4-quality-tab page">
+        <div className="pageH">
+          <div>
+            <h1>Качество кода</h1>
+            <div className="sub">Не удалось загрузить данные — попробуйте обновить.</div>
+          </div>
+        </div>
         <div className="quality-error-panel">
           <b>Ошибка загрузки данных:</b> {error}
           <button onClick={() => refresh()}>Попробовать снова</button>
@@ -84,7 +94,7 @@ export function QualityTab() {
       </div>
     );
   }
-  if (!data) return <div className="v4-quality-tab">Нет данных</div>;
+  if (!data) return <div className="v4-quality-tab page">Нет данных</div>;
 
   return (
     <div className="v4-quality-tab page">

--- a/src/styles/v4-quality.css
+++ b/src/styles/v4-quality.css
@@ -534,8 +534,20 @@
   to   { opacity: 1; transform: translateY(0); }
 }
 
-/* ──── PAGE / HEADER / CONTROLS ──── */
-.v4-quality-tab.page { max-width: 1480px; margin: 0 auto; }
+/* ──── PAGE / HEADER / CONTROLS ────
+ *
+ * Padding mirrors `.v4-content` in v4.css (28px horizontal, 14px top,
+ * 40px bottom) so this tab sits on the same visual grid as Pipeline /
+ * Milestones / Monitoring / etc. Previously this rule only set
+ * max-width + auto margins, leaving the heading flush against the top
+ * edge — every nested `.pageH` / `.sect` then inherited that flush
+ * because their own flex `space-between` aligns to the parent's box.
+ */
+.v4-quality-tab.page {
+  max-width: 1480px;
+  margin: 0 auto;
+  padding: 14px 28px 40px;
+}
 .v4-quality-tab .pageH {
   display: flex;
   justify-content: space-between;
@@ -545,9 +557,12 @@
   flex-wrap: wrap;
 }
 .v4-quality-tab .pageH h1 {
-  font-size: 22px;
+  /* Match `.v4-ph h1` (24px) so tab titles look identical across the
+   * sidebar regardless of which view you're on. 22 was a leftover from
+   * the HTML prototype. */
+  font-size: 24px;
   margin: 0 0 4px 0;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
   color: var(--v4-ink-900);
   font-weight: 700;
 }
@@ -634,6 +649,11 @@
   display: flex;
   flex-direction: column;
   min-height: 220px;
+  /* `.bar-topper-p0` floats at top: -22px from each bar; for tall bars
+   * the topper would bleed into the panel title above. Reserving 28px
+   * inside chart-area keeps the topper visually "inside" the chart
+   * rather than overlapping «Сводная по всем N проектам». */
+  padding-top: 28px;
 }
 .v4-quality-tab .summary .kpis {
   padding: 18px;


### PR DESCRIPTION
## Summary

Five small cosmetic fixes to make «Качество кода» sit on the same visual grid as Дашборд / Pipeline / Milestones. Verified live in preview against real prod JSON pulled from VPS.

| # | Fix | File:line |
|---|-----|-----------|
| 1 | Add `padding: 14px 28px 40px` to `.v4-quality-tab.page` so heading + section row stop hugging the top-left edge | v4-quality.css |
| 2 | h1 22 → 24px to match `.v4-ph h1` | v4-quality.css |
| 3 | Loading / error / no-data branches now use `.page` class + proper header in the error case (was off-grid) | QualityTab.tsx |
| 4 | `.chart-area` gains `padding-top: 28px` so the P0:N chip (absolutely-positioned `top: -22px` on tall bars) stops overlapping «Сводная по всем N проектам» | v4-quality.css |
| 5 | "Сводно" → "Сводная" — proper feminine agreement with implied noun | QualitySummaryPanel.tsx |

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 40/40
- [x] Live preview check: heading aligned with other tabs, P0 chips contained inside chart, sect/sort row inset by 28px, empty-state still works with "+ событие" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)