### PR TITLE
Revert Sessions J+K (для ревью миграции дизайн-токенов)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,7 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 export default defineConfig([
   // `src/types/generated/**` is machine-generated from backend OpenAPI
   // (npm run gen:api-types) — lint it as the generator emits it.
-  globalIgnores(['dist', 'src/types/generated', '.claude/worktrees']),
+  globalIgnores(['dist', 'src/types/generated']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/App.css
+++ b/src/App.css
@@ -1,9 +1,11 @@
 /* ══════════════════════════════════════════
-   MakeIT Dashboard — global styles & legacy selectors
-   Light theme only. Design tokens — src/styles/tokens.css
-   (--mk-*). Bridge palettes (--color-*, --gray-*, --v4-*)
-   removed in Session K — все потребители теперь ссылаются
-   на --mk-* напрямую.
+   MakeIT Dashboard — Legacy bridge layer
+   Light theme only. All shared design tokens
+   come from src/styles/tokens.css (--mk-*).
+   Local --color-* / --gray-* names below are
+   bridge aliases preserved for legacy selectors;
+   they will be retired during the styleguide
+   migration.
    ══════════════════════════════════════════ */
 
 /* Responsive breakpoint contract (issue #490) defined in
@@ -13,9 +15,108 @@
    legacy content stayed desktop until 1024). */
 
 :root {
-  /* Decorative dot-pattern background. Не вынесен в tokens.css —
-     единственный потребитель ниже, не палитра. */
+  /* Gray scale (light) — TODO: consolidate with --mk-gray-* */
+  --gray-0: #f7f9fc;
+  --gray-100: rgba(255, 255, 255, 0.85); /* Frosty surface */
+  --gray-200: rgba(255, 255, 255, 1);
+  --gray-300: rgba(0, 0, 0, 0.06);
+  --gray-400: rgba(0, 0, 0, 0.12);
+  --gray-500: #475569;
+  --gray-600: #334155;
+  --gray-700: #334155;
+  --gray-800: #1e293b;
+  --gray-900: #0f172a;
+  --gray-950: #020617;
+
+  /* Accent (aligned with --mk-brand-*) */
+  --blue-500: var(--mk-brand-500);
+  --blue-400: var(--mk-brand-400);
+  --blue-600: var(--mk-brand-600);
+
+  /* Semantic raw — TODO: consolidate with --mk-* status tokens */
+  --green-500: #059669;
+  --green-400: #10b981;
+  --red-500: #dc2626;
+  --orange-500: #d97706;
+  --yellow-500: #eab308;
+  --purple-500: #7c3aed;
+  --cyan-500: #06b6d4;
+
+  /* Mapped surface / text tokens */
+  --color-bg: var(--gray-0);
+  --color-surface: var(--gray-100);
+  --color-surface-hover: var(--gray-200);
+  --color-surface-solid: #ffffff;
+  --color-border: var(--gray-300);
+  --color-border-subtle: var(--gray-400);
+  --color-text: var(--gray-900);
+  --color-text-secondary: var(--gray-600);
+  --color-text-muted: var(--gray-500);
+  --color-text-faint: rgba(0, 0, 0, 0.3);
+  --color-primary: var(--blue-500);
+  --color-primary-active: var(--blue-600);
+  --color-success: var(--green-500);
+  --color-danger: var(--red-500);
+  --color-warning: var(--orange-500);
+  --color-caution: var(--yellow-500);
+  --color-review: var(--purple-500);
+
+  /* Ambient glow tints (light theme). Warning glow removed — was dead.
+     For new tinted variants prefer color-mix() over adding a new slot. */
+  --color-glow-primary: var(--mk-glow-primary);
+  --color-glow-success: var(--mk-glow-success);
+  --color-glow-danger: var(--mk-glow-danger);
+  --color-glow-accent: var(--mk-glow-primary);
+
+  /* Priority */
+  --color-p1: var(--red-500);
+  --color-p2: var(--orange-500);
+  --color-p3: var(--gray-600);
+  --color-p4: var(--green-500);
+  --color-done: var(--green-400);
+  --color-todo: var(--gray-600);
+  --color-in-progress: var(--blue-500);
+
+  /* Typography (bridge → mk-tokens) */
+  --font-sans: var(--mk-font-sans);
+  --font-mono: var(--mk-font-mono);
+  --text-xs: var(--mk-text-xs);
+  --text-sm: var(--mk-text-sm);
+  --text-base: var(--mk-text-base);
+  --text-md: var(--mk-text-md);
+  --text-lg: var(--mk-text-lg);
+  --text-xl: var(--mk-text-xl);
+  --text-data: var(--mk-text-data);
+
+  /* Spacing (bridge → mk-tokens) */
+  --sp-1: var(--mk-sp-1);
+  --sp-2: var(--mk-sp-2);
+  --sp-3: var(--mk-sp-3);
+  --sp-4: var(--mk-sp-4);
+  --sp-5: var(--mk-sp-5);
+  --sp-6: var(--mk-sp-6);
+  --sp-8: var(--mk-sp-8);
+  --sp-10: var(--mk-sp-10);
+
+  /* Radius (legacy 8/16/24 mapping kept until styleguide picks one scale) */
+  --radius-sm: var(--mk-r-md);   /* legacy 8px */
+  --radius-md: var(--mk-r-xl);   /* legacy 16px */
+  --radius-lg: 24px;  /* legacy 24px, не унифицирован — оставлен литералом до миграции потребителей */
+  --radius-full: var(--mk-r-full);
+
+  /* Shadows (light theme — bridge → mk-tokens) */
+  --shadow-sm: var(--mk-shadow-sm);
+  --shadow-md: var(--mk-shadow-md);
+  --shadow-lg: var(--mk-shadow-lg);
+
+  /* Decorative background pattern */
   --bg-pattern: radial-gradient(circle, rgba(0,0,0,0.05) 1px, transparent 1px);
+
+  /* Semantic utility tokens. Tint slots 1/3/4 removed as dead;
+     tint-2 stays (referenced by .pc-stats-group). */
+  --color-on-primary: var(--mk-on-primary);
+  --color-overlay: var(--mk-overlay);
+  --color-neutral-tint-2: var(--mk-neutral-tint-2);
 }
 
 /* ── Reset ── */
@@ -26,12 +127,12 @@
 }
 
 body {
-  font-family: var(--mk-font-sans);
-  font-size: var(--mk-text-base);
-  background-color: var(--mk-bg);
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  background-color: var(--color-bg);
   background-image: var(--bg-pattern);
   background-size: 24px 24px;
-  color: var(--mk-ink-900);
+  color: var(--color-text);
   line-height: 1.45;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -57,7 +158,7 @@ body::before {
   width: 70vw;
   height: 70vw;
   border-radius: 50%;
-  background: radial-gradient(circle, var(--mk-glow-primary) 0%, transparent 60%);
+  background: radial-gradient(circle, var(--color-glow-primary) 0%, transparent 60%);
   filter: blur(80px);
   z-index: -1;
   opacity: 0.5;
@@ -70,14 +171,14 @@ body::after {
   width: 60vw;
   height: 60vw;
   border-radius: 50%;
-  background: radial-gradient(circle, var(--mk-glow-primary) 0%, transparent 60%);
+  background: radial-gradient(circle, var(--color-glow-accent) 0%, transparent 60%);
   filter: blur(100px);
   z-index: -1;
 }
 
 /* ── Utility: monospace numbers ── */
 .mono {
-  font-family: var(--mk-font-mono);
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
 }
 
@@ -86,7 +187,7 @@ body::after {
    ══════════════════════════════════════════ */
 
 .app {
-  padding-bottom: max(var(--mk-sp-4), env(safe-area-inset-bottom));
+  padding-bottom: max(var(--sp-4), env(safe-area-inset-bottom));
   max-width: 1200px; /* Aligned with standard desktop */
   margin: 0 auto;
   width: 100%;
@@ -96,8 +197,8 @@ body::after {
 .bento-grid {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
-  gap: var(--mk-sp-4);
-  padding: 0 var(--mk-sp-5) var(--mk-sp-8);
+  gap: var(--sp-4);
+  padding: 0 var(--sp-5) var(--sp-8);
   align-items: stretch;
 }
 
@@ -124,10 +225,10 @@ body::after {
 }
 
 .bento-panel {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: 24px;
-  padding: var(--mk-sp-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-4);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   box-shadow: 0 4px 24px rgba(0,0,0,0.06);
@@ -140,7 +241,7 @@ body::after {
   content: '';
   position: absolute;
   top: 0; left: 0; right: 0; height: 100px;
-  background: radial-gradient(circle at 50% -100%, var(--mk-primary), transparent);
+  background: radial-gradient(circle at 50% -100%, var(--color-primary), transparent);
   opacity: 0.08;
   pointer-events: none;
 }
@@ -154,26 +255,26 @@ body::after {
   position: absolute;
   top: 0; left: 0; right: 0;
   height: 1px;
-  background: linear-gradient(90deg, transparent, var(--mk-line-soft), transparent);
+  background: linear-gradient(90deg, transparent, var(--color-border-subtle), transparent);
   opacity: 0.5;
 }
 
 .bento-panel:hover {
   transform: translateY(-4px);
-  border-color: var(--mk-line-soft);
+  border-color: var(--color-border-subtle);
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.1); /* Soft premium shadow per audit */
 }
 
 .bento-panel-title {
-  font-size: var(--mk-text-xs); /* Scaled down for professional high-density look */
+  font-size: var(--text-xs); /* Scaled down for professional high-density look */
   font-weight: 700;
-  color: var(--mk-ink-500);
+  color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin: 0 0 var(--mk-sp-4) 0;
+  margin: 0 0 var(--sp-4) 0;
   height: 20px;
   line-height: 1;
 }
@@ -191,90 +292,90 @@ body::after {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  border-radius: var(--mk-r-xl);
-  border: 1px solid var(--mk-line);
-  background: var(--mk-paper);
-  color: var(--mk-ink-900);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
   cursor: pointer;
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
   font-family: inherit;
   font-weight: 500;
   min-height: 44px;
   transition: transform 0.1s ease-out, background 0.15s;
   -webkit-tap-highlight-color: transparent;
 }
-.btn:hover { background: var(--mk-paper); }
+.btn:hover { background: var(--color-surface-hover); }
 .btn:active { transform: scale(0.97); }
 .btn:disabled { opacity: 0.4; cursor: not-allowed; transform: none; }
 .btn-primary {
-  background: var(--mk-primary);
-  color: var(--mk-on-primary);
-  border-color: var(--mk-primary);
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  border-color: var(--color-primary);
 }
-.btn-primary:active { background: var(--mk-primary-active); }
+.btn-primary:active { background: var(--color-primary-active); }
 .btn-danger {
   background: transparent;
-  color: var(--mk-danger);
-  border-color: color-mix(in srgb, var(--mk-danger) 40%, transparent);
+  color: var(--color-danger);
+  border-color: color-mix(in srgb, var(--color-danger) 40%, transparent);
 }
 .btn-sm {
-  padding: var(--mk-sp-1) var(--mk-sp-2);
-  font-size: var(--mk-text-xs);
+  padding: var(--sp-1) var(--sp-2);
+  font-size: var(--text-xs);
   min-height: 32px;
 }
 
 /* ── Input ── */
 .input {
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  border-radius: var(--mk-r-xl);
-  border: 1px solid var(--mk-line);
-  background: var(--mk-bg);
-  color: var(--mk-ink-900);
-  font-size: var(--mk-text-sm);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: var(--text-sm);
   font-family: inherit;
   min-width: 0;
   width: 100%;
 }
 .input:focus {
   outline: none;
-  border-color: var(--mk-primary);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--mk-primary) 20%, transparent);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 /* ── Token Form ── */
 .token-form {
   text-align: center;
-  padding: var(--mk-sp-8) var(--mk-sp-4);
+  padding: var(--sp-8) var(--sp-4);
 }
 .token-form h2 {
-  font-size: var(--mk-text-md);
+  font-size: var(--text-md);
   font-weight: 600;
-  margin-bottom: var(--mk-sp-2);
+  margin-bottom: var(--sp-2);
 }
 .token-form p {
-  color: var(--mk-ink-500);
-  font-size: var(--mk-text-sm);
-  margin-bottom: var(--mk-sp-4);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  margin-bottom: var(--sp-4);
 }
 .token-form code {
-  font-family: var(--mk-font-mono);
-  font-size: var(--mk-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   padding: 1px 5px;
-  background: var(--mk-paper);
-  border-radius: var(--mk-r-md);
+  background: var(--color-surface);
+  border-radius: var(--radius-sm);
 }
 .token-input-row {
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
 }
 .token-status {
   display: flex;
   align-items: center;
-  gap: var(--mk-sp-2);
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
+  gap: var(--sp-2);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
 }
 .token-status span { display: none; }
 
@@ -288,7 +389,7 @@ body::after {
   grid-auto-rows: min-content !important;
   align-content: start !important;
   align-items: start !important; /* Prevent cards from stretching in height */
-  gap: 8px var(--mk-sp-4) !important; /* Tighter vertical gap, maintained horizontal */
+  gap: 8px var(--sp-4) !important; /* Tighter vertical gap, maintained horizontal */
   /* Removed flex: 1 to prevent stretching to parent panel height */
 }
 
@@ -309,7 +410,7 @@ body::after {
   display: flex !important;
   flex-direction: column !important;
   justify-content: flex-start !important; /* Stay at the top */
-  gap: var(--mk-sp-2) !important;
+  gap: var(--sp-2) !important;
 }
 
 .pc-slot--issues {
@@ -358,14 +459,14 @@ body::after {
     grid-template-rows: unset;
     display: flex;
     flex-direction: column;
-    gap: var(--mk-sp-3);
+    gap: var(--sp-3);
   }
 }
 
 .pc {
-  background: var(--mk-paper);
+  background: var(--color-surface-solid);
   border: 1px solid rgba(0, 0, 0, 0.05);
-  border-radius: var(--mk-r-xl);
+  border-radius: var(--radius-md);
   padding: 10px 14px;
   display: flex !important;
   flex-direction: column !important;
@@ -391,29 +492,29 @@ body::after {
   position: absolute;
   top: 0; left: 0; bottom: 0;
   width: 3px;
-  background: var(--mk-line-soft);
+  background: var(--color-border-subtle);
   border-radius: 3px 0 0 3px;
 }
-.pc--phase-development::before { background: var(--mk-success); }
-.pc--phase-support::before { background: var(--mk-primary); }
-.pc--phase-pre-dev::before { background: var(--mk-ink-500); }
-.pc--stale::before { background: var(--mk-severity-medium); }
-.pc--risk-high::before { background: var(--mk-warn); }
-.pc--risk-critical::before { background: var(--mk-danger); }
+.pc--phase-development::before { background: var(--color-success); }
+.pc--phase-support::before { background: var(--color-primary); }
+.pc--phase-pre-dev::before { background: var(--gray-500); }
+.pc--stale::before { background: var(--color-caution); }
+.pc--risk-high::before { background: var(--color-warning); }
+.pc--risk-critical::before { background: var(--color-danger); }
 
 /* Header row */
 .pc-header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
   margin-bottom: 2px; /* Pull content closer to name */
 }
 .pc-name {
-  font-size: var(--mk-text-lg);
+  font-size: var(--text-lg);
   font-weight: 800;
   letter-spacing: -0.03em;
-  color: var(--mk-ink-900);
+  color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -428,32 +529,32 @@ body::after {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--mk-r-full);
+  border-radius: var(--radius-full);
   flex-shrink: 0;
 }
 .pc-phase-icon--development {
-  color: var(--mk-success);
-  background: color-mix(in srgb, var(--mk-success) 12%, transparent);
+  color: var(--green-500);
+  background: color-mix(in srgb, var(--color-success) 12%, transparent);
 }
 .pc-phase-icon--support {
-  color: var(--mk-brand-500);
-  background: color-mix(in srgb, var(--mk-primary) 12%, transparent);
+  color: var(--blue-500);
+  background: color-mix(in srgb, var(--color-primary) 12%, transparent);
 }
 .pc-phase-icon--pre-dev {
-  color: var(--mk-ink-500);
-  background: color-mix(in srgb, var(--mk-ink-500) 12%, transparent);
+  color: var(--color-text-muted);
+  background: color-mix(in srgb, var(--color-text-muted) 12%, transparent);
 }
 
 /* Legacy: used by AuditProjectCard */
 .pc-name-row {
   display: flex;
   align-items: center;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
   min-width: 0;
   flex: 1;
 }
 .pc-phase {
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -465,7 +566,7 @@ body::after {
 .pc-badges {
   display: flex;
   align-items: center;
-  gap: var(--mk-sp-1);
+  gap: var(--sp-1);
   flex-shrink: 0;
 }
 
@@ -473,59 +574,59 @@ body::after {
   font-size: 0.5625rem;
   font-weight: 500;
   padding: 2px 6px;
-  border-radius: var(--mk-r-full);
+  border-radius: var(--radius-full);
   white-space: nowrap;
 }
-.pc-risk--low { color: var(--mk-success); background: color-mix(in srgb, var(--mk-success) 10%, transparent); }
-.pc-risk--medium { color: var(--mk-severity-medium); background: color-mix(in srgb, var(--mk-severity-medium) 10%, transparent); }
-.pc-risk--high { color: var(--mk-warn); background: color-mix(in srgb, var(--mk-warn) 10%, transparent); }
-.pc-risk--critical { color: var(--mk-danger); background: color-mix(in srgb, var(--mk-danger) 10%, transparent); }
+.pc-risk--low { color: var(--color-success); background: color-mix(in srgb, var(--color-success) 10%, transparent); }
+.pc-risk--medium { color: var(--color-caution); background: color-mix(in srgb, var(--color-caution) 10%, transparent); }
+.pc-risk--high { color: var(--color-warning); background: color-mix(in srgb, var(--color-warning) 10%, transparent); }
+.pc-risk--critical { color: var(--color-danger); background: color-mix(in srgb, var(--color-danger) 10%, transparent); }
 
 .pc-monitor {
   font-size: 0.5625rem;
   font-weight: 500;
   padding: 2px 6px;
-  border-radius: var(--mk-r-full);
+  border-radius: var(--radius-full);
   display: inline-flex;
   align-items: center;
   gap: 3px;
   white-space: nowrap;
 }
-.pc-monitor--up { color: var(--mk-success); background: color-mix(in srgb, var(--mk-success) 10%, transparent); }
-.pc-monitor--down { color: var(--mk-danger); background: color-mix(in srgb, var(--mk-danger) 10%, transparent); }
+.pc-monitor--up { color: var(--color-success); background: color-mix(in srgb, var(--color-success) 10%, transparent); }
+.pc-monitor--down { color: var(--color-danger); background: color-mix(in srgb, var(--color-danger) 10%, transparent); }
 .pc-monitor-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
 }
-.pc-monitor-dot--up { background: var(--mk-success); }
-.pc-monitor-dot--down { background: var(--mk-danger); }
+.pc-monitor-dot--up { background: var(--color-success); }
+.pc-monitor-dot--down { background: var(--color-danger); }
 
 /* Progress bar */
 .pc-progress {
   display: flex;
   align-items: center;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
 }
 .pc-bar {
   flex: 1;
   height: 6px; /* Increased from 4px for better presence */
-  background: var(--mk-line);
-  border-radius: var(--mk-r-full);
+  background: var(--color-border);
+  border-radius: var(--radius-full);
   overflow: hidden;
 }
 .pc-bar-fill {
   height: 100%;
   background: linear-gradient(90deg, #10b981, #34d399); /* Glossy emerald gradient */
-  border-radius: var(--mk-r-full);
+  border-radius: var(--radius-full);
   transition: width 0.4s ease-out;
 }
 .pc-pct {
-  font-family: var(--mk-font-mono);
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   font-weight: 600;
-  color: var(--mk-success);
+  color: var(--color-success);
   min-width: 28px;
   text-align: right;
 }
@@ -535,38 +636,38 @@ body::after {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--mk-sp-2);
-  font-size: var(--mk-text-sm);
+  gap: var(--sp-2);
+  font-size: var(--text-sm);
 }
 .pc-total {
-  font-size: var(--mk-text-lg);
+  font-size: var(--text-lg);
   font-weight: 700;
-  font-family: var(--mk-font-mono);
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
-  color: var(--mk-ink-900);
+  color: var(--color-text);
   white-space: nowrap;
 }
 .pc-total-label {
-  font-family: var(--mk-font-sans);
+  font-family: var(--font-sans);
   font-weight: 400;
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
 }
 .pc-pri-group {
   display: flex;
   align-items: center;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
 }
 .pc-pri {
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  color: var(--mk-ink-500);
-  font-size: var(--mk-text-xs);
-  font-family: var(--mk-font-mono);
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
 }
-.pc-pri--none { color: var(--mk-ink-400); }
+.pc-pri--none { color: var(--color-text-faint); }
 .pc-pri-dot {
   width: 7px;
   height: 7px;
@@ -584,29 +685,29 @@ body::after {
 .pc-finance-group {
   display: flex;
   align-items: baseline;
-  gap: var(--mk-sp-1);
+  gap: var(--sp-1);
 }
 .pc-finance-label {
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   font-weight: 500;
-  color: var(--mk-ink-400);
+  color: var(--color-text-faint);
   text-transform: uppercase;
   letter-spacing: 0.03em;
 }
-.pc-finance-paid { font-weight: 600; color: var(--mk-success); font-size: var(--mk-text-xs); font-family: var(--mk-font-mono); font-variant-numeric: tabular-nums; }
-.pc-finance-sep { color: var(--mk-ink-400); font-size: var(--mk-text-xs); font-family: var(--mk-font-mono); }
-.pc-finance-total { color: var(--mk-ink-500); font-size: var(--mk-text-xs); font-family: var(--mk-font-mono); font-variant-numeric: tabular-nums; }
-.pc-finance-remaining { font-weight: 600; color: var(--mk-severity-medium); font-size: var(--mk-text-xs); font-family: var(--mk-font-mono); font-variant-numeric: tabular-nums; }
+.pc-finance-paid { font-weight: 600; color: var(--color-success); font-size: var(--text-xs); font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.pc-finance-sep { color: var(--color-text-faint); font-size: var(--text-xs); font-family: var(--font-mono); }
+.pc-finance-total { color: var(--color-text-muted); font-size: var(--text-xs); font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.pc-finance-remaining { font-weight: 600; color: var(--color-caution); font-size: var(--text-xs); font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 .pc-finance-bar {
   height: 6px; /* Synchronized with main progress bar thickness */
-  background: var(--mk-line);
-  border-radius: var(--mk-r-full);
+  background: var(--color-border);
+  border-radius: var(--radius-full);
   overflow: hidden;
 }
 .pc-finance-fill {
   height: 100%;
-  background: linear-gradient(90deg, var(--mk-brand-500), var(--mk-brand-400));
-  border-radius: var(--mk-r-full);
+  background: linear-gradient(90deg, var(--blue-500), var(--blue-400));
+  border-radius: var(--radius-full);
   transition: width 0.4s ease-out;
 }
 
@@ -614,11 +715,11 @@ body::after {
 .pc-stats {
   display: flex;
   align-items: center;
-  gap: var(--mk-sp-2);
-  padding: var(--mk-sp-1) var(--mk-sp-2);
+  gap: var(--sp-2);
+  padding: var(--sp-1) var(--sp-2);
   margin-top: 0; /* Margin managed by group flex */
-  border-radius: var(--mk-r-md);
-  background: var(--mk-neutral-tint-2);
+  border-radius: var(--radius-sm);
+  background: var(--color-neutral-tint-2);
   flex-wrap: nowrap; /* Force 1 line as requested before */
 }
 .pc-stat {
@@ -629,29 +730,29 @@ body::after {
 }
 .pc-stat--eta { margin-left: auto; }
 .pc-stat-label {
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
   font-weight: 400;
   white-space: nowrap;
 }
 .pc-stat-value {
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
   font-weight: 600;
-  color: var(--mk-ink-900);
-  font-family: var(--mk-font-mono);
+  color: var(--color-text);
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
-.pc-stat-value--eta { color: var(--mk-success); }
-.pc-stat-value--warn { color: var(--mk-severity-medium); }
-.pc-stat-value--danger { color: var(--mk-danger); }
+.pc-stat-value--eta { color: var(--color-success); }
+.pc-stat-value--warn { color: var(--color-caution); }
+.pc-stat-value--danger { color: var(--color-danger); }
 .pc-stat-days {
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   font-weight: 400;
-  color: var(--mk-ink-500);
+  color: var(--color-text-muted);
 }
-.pc-stat-days.val-danger { color: var(--mk-danger); font-weight: 600; }
-.pc-stat-days.val-success { color: var(--mk-success); font-weight: 600; }
+.pc-stat-days.val-danger { color: var(--color-danger); font-weight: 600; }
+.pc-stat-days.val-success { color: var(--color-success); font-weight: 600; }
 
 /* Legacy velocity */
 .pc-velocity { display: none; }
@@ -660,41 +761,41 @@ body::after {
 .pc-risk-factors {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--mk-sp-1);
-  margin-top: var(--mk-sp-1);
+  gap: var(--sp-1);
+  margin-top: var(--sp-1);
 }
 
 /* Heatmap toggle */
 .pc-heatmap-toggle {
   display: inline-flex;
   align-items: center;
-  gap: var(--mk-sp-1);
+  gap: var(--sp-1);
   padding: 2px 0;
   background: none;
   border: none;
-  color: var(--mk-ink-500);
-  font-size: var(--mk-text-xs);
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
   cursor: pointer;
   font-family: inherit;
   -webkit-tap-highlight-color: transparent;
   margin-top: auto;
 }
-.pc-heatmap-toggle:active { color: var(--mk-ink-900); }
+.pc-heatmap-toggle:active { color: var(--color-text); }
 .pc-heatmap-arrow {
   font-size: 0.5rem;
   transition: transform 0.2s;
   display: inline-block;
 }
 .pc-heatmap-arrow.open { transform: rotate(90deg); }
-.pc-heatmap-count { color: var(--mk-ink-400); }
+.pc-heatmap-count { color: var(--color-text-faint); }
 
 /* Description */
 .pc-desc {
-  font-size: var(--mk-text-sm);
-  color: var(--mk-ink-500);
-  border-top: 1px solid var(--mk-line);
-  padding-top: var(--mk-sp-2);
-  margin-top: var(--mk-sp-2);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--sp-2);
+  margin-top: var(--sp-2);
   line-height: 1.4;
 }
 
@@ -707,39 +808,39 @@ body::after {
 .ms-label {
   display: inline-flex;
   align-items: center;
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   font-weight: 500;
-  padding: 2px var(--mk-sp-2);
-  border-radius: var(--mk-r-md);
+  padding: 2px var(--sp-2);
+  border-radius: var(--radius-sm);
   white-space: nowrap;
   line-height: 1.4;
 }
 
 .phase-badge { font-size: 0.625rem; text-transform: uppercase; letter-spacing: 0.03em; }
-.phase-pre-dev { background: var(--mk-line); color: var(--mk-ink-700); }
-.phase-development { background: color-mix(in srgb, var(--mk-success) 15%, var(--mk-paper)); color: var(--mk-success); }
-.phase-support { background: color-mix(in srgb, var(--mk-primary) 15%, var(--mk-paper)); color: var(--mk-primary); }
+.phase-pre-dev { background: var(--gray-300); color: var(--gray-600); }
+.phase-development { background: color-mix(in srgb, var(--color-success) 15%, var(--color-surface)); color: var(--color-success); }
+.phase-support { background: color-mix(in srgb, var(--color-primary) 15%, var(--color-surface)); color: var(--color-primary); }
 
 .risk-badge {
-  border-radius: var(--mk-r-full);
-  gap: var(--mk-sp-1);
+  border-radius: var(--radius-full);
+  gap: var(--sp-1);
   min-width: 0;
   font-size: 0.625rem;
 }
-.risk-badge--low { color: var(--mk-success); background: color-mix(in srgb, var(--mk-success) 10%, transparent); }
-.risk-badge--medium { color: var(--mk-severity-medium); background: color-mix(in srgb, var(--mk-severity-medium) 10%, transparent); }
-.risk-badge--high { color: var(--mk-warn); background: color-mix(in srgb, var(--mk-warn) 10%, transparent); }
-.risk-badge--critical { color: var(--mk-danger); background: color-mix(in srgb, var(--mk-danger) 10%, transparent); }
+.risk-badge--low { color: var(--color-success); background: color-mix(in srgb, var(--color-success) 10%, transparent); }
+.risk-badge--medium { color: var(--color-caution); background: color-mix(in srgb, var(--color-caution) 10%, transparent); }
+.risk-badge--high { color: var(--color-warning); background: color-mix(in srgb, var(--color-warning) 10%, transparent); }
+.risk-badge--critical { color: var(--color-danger); background: color-mix(in srgb, var(--color-danger) 10%, transparent); }
 
 .deadline-badge {
-  border-radius: var(--mk-r-full);
+  border-radius: var(--radius-full);
   flex-shrink: 0;
 }
-.deadline-badge.overdue { color: var(--mk-danger); background: color-mix(in srgb, var(--mk-danger) 12%, transparent); }
-.deadline-badge.warning { color: var(--mk-severity-medium); background: color-mix(in srgb, var(--mk-severity-medium) 12%, transparent); }
-.deadline-badge.info { color: var(--mk-primary); background: color-mix(in srgb, var(--mk-primary) 12%, transparent); }
-.deadline-badge.neutral { color: var(--mk-ink-500); background: color-mix(in srgb, var(--mk-ink-500) 12%, transparent); }
-.deadline-badge.done-badge { color: var(--mk-success); background: color-mix(in srgb, var(--mk-success) 12%, transparent); }
+.deadline-badge.overdue { color: var(--color-danger); background: color-mix(in srgb, var(--color-danger) 12%, transparent); }
+.deadline-badge.warning { color: var(--color-caution); background: color-mix(in srgb, var(--color-caution) 12%, transparent); }
+.deadline-badge.info { color: var(--color-primary); background: color-mix(in srgb, var(--color-primary) 12%, transparent); }
+.deadline-badge.neutral { color: var(--color-text-muted); background: color-mix(in srgb, var(--color-text-muted) 12%, transparent); }
+.deadline-badge.done-badge { color: var(--color-success); background: color-mix(in srgb, var(--color-success) 12%, transparent); }
 
 @keyframes pulse {
   0%, 100% { opacity: 1; }
@@ -748,15 +849,15 @@ body::after {
 .deadline-badge.overdue { animation: pulse 2s infinite; }
 
 .monitor-badge {
-  border-radius: var(--mk-r-full);
-  gap: var(--mk-sp-1);
+  border-radius: var(--radius-full);
+  gap: var(--sp-1);
   min-width: 0;
   font-size: 0.625rem;
 }
-.monitor-badge--up { color: var(--mk-success); background: color-mix(in srgb, var(--mk-success) 10%, transparent); }
-.monitor-badge--down { color: var(--mk-danger); background: color-mix(in srgb, var(--mk-danger) 10%, transparent); }
-.monitor-badge--paused { color: var(--mk-ink-500); background: color-mix(in srgb, var(--mk-ink-500) 10%, transparent); }
-.monitor-badge--pending { color: var(--mk-severity-medium); background: color-mix(in srgb, var(--mk-severity-medium) 10%, transparent); }
+.monitor-badge--up { color: var(--color-success); background: color-mix(in srgb, var(--color-success) 10%, transparent); }
+.monitor-badge--down { color: var(--color-danger); background: color-mix(in srgb, var(--color-danger) 10%, transparent); }
+.monitor-badge--paused { color: var(--color-text-muted); background: color-mix(in srgb, var(--color-text-muted) 10%, transparent); }
+.monitor-badge--pending { color: var(--color-caution); background: color-mix(in srgb, var(--color-caution) 10%, transparent); }
 
 .monitor-status-dot {
   display: inline-block;
@@ -765,14 +866,14 @@ body::after {
   border-radius: 50%;
   flex-shrink: 0;
 }
-.monitor-status-dot--up { background: var(--mk-success); box-shadow: 0 0 4px color-mix(in srgb, var(--mk-success) 50%, transparent); }
-.monitor-status-dot--down { background: var(--mk-danger); box-shadow: 0 0 4px color-mix(in srgb, var(--mk-danger) 50%, transparent); }
-.monitor-status-dot--paused { background: var(--mk-ink-500); }
-.monitor-status-dot--pending { background: var(--mk-severity-medium); }
+.monitor-status-dot--up { background: var(--color-success); box-shadow: 0 0 4px color-mix(in srgb, var(--color-success) 50%, transparent); }
+.monitor-status-dot--down { background: var(--color-danger); box-shadow: 0 0 4px color-mix(in srgb, var(--color-danger) 50%, transparent); }
+.monitor-status-dot--paused { background: var(--color-text-muted); }
+.monitor-status-dot--pending { background: var(--color-caution); }
 
 .priority-tag {
   font-size: 10px;
-  color: var(--mk-on-primary);
+  color: var(--color-on-primary);
   font-weight: 700;
   padding: 2px 6px;
   border-radius: 4px; /* Harder edge per senior audit */
@@ -783,23 +884,23 @@ body::after {
   justify-content: center;
   min-width: 24px;
 }
-.priority-tag.priority-p1 { background: var(--mk-priority-p1); box-shadow: 0 0 8px color-mix(in srgb, var(--mk-priority-p1) 30%, transparent); }
-.priority-tag.priority-p2 { background: var(--mk-priority-p2); }
-.priority-tag.priority-p3 { background: var(--mk-priority-p3); }
-.priority-tag.priority-p4 { background: var(--mk-priority-p4); }
+.priority-tag.priority-p1 { background: var(--color-p1); box-shadow: 0 0 8px color-mix(in srgb, var(--color-p1) 30%, transparent); }
+.priority-tag.priority-p2 { background: var(--color-p2); }
+.priority-tag.priority-p3 { background: var(--color-p3); }
+.priority-tag.priority-p4 { background: var(--color-p4); }
 
 /* ── Progress Bar (unified) ── */
 .progress-bar-container {
   height: 4px;
-  background: var(--mk-line);
-  border-radius: var(--mk-r-full);
+  background: var(--color-border);
+  border-radius: var(--radius-full);
   overflow: hidden;
-  margin-bottom: var(--mk-sp-2);
+  margin-bottom: var(--sp-2);
 }
 .progress-bar-fill {
   height: 100%;
-  background: var(--mk-success);
-  border-radius: var(--mk-r-full);
+  background: var(--color-success);
+  border-radius: var(--radius-full);
   transition: width 0.4s ease-out;
   box-shadow: 0 0 4px color-mix(in srgb, currentColor 35%, transparent);
 }
@@ -807,58 +908,58 @@ body::after {
 .project-progress-row {
   display: flex;
   align-items: center;
-  gap: var(--mk-sp-2);
-  margin-bottom: var(--mk-sp-2);
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-2);
 }
 .project-progress-row .progress-bar-container { flex: 1; margin-bottom: 0; }
 .project-progress-pct {
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
   font-weight: 700;
-  font-family: var(--mk-font-mono);
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
-  color: var(--mk-success);
+  color: var(--color-success);
   min-width: 32px;
   text-align: right;
 }
 
 /* ── Finance row in card ── */
-.project-finance { margin-top: var(--mk-sp-2); }
+.project-finance { margin-top: var(--sp-2); }
 .section-label {
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--mk-ink-500);
+  color: var(--color-text-muted);
 }
 .finance-amounts {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  font-size: var(--mk-text-sm);
-  margin-bottom: var(--mk-sp-1);
+  font-size: var(--text-sm);
+  margin-bottom: var(--sp-1);
 }
 .finance-paid {
-  color: var(--mk-success);
+  color: var(--color-success);
   font-weight: 600;
-  font-family: var(--mk-font-mono);
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
 }
-.finance-sep { color: var(--mk-ink-400); }
+.finance-sep { color: var(--color-text-faint); }
 .finance-budget {
-  color: var(--mk-ink-500);
-  font-family: var(--mk-font-mono);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
 }
 .finance-left, .finance-right {
   display: flex;
   align-items: baseline;
-  gap: var(--mk-sp-1);
+  gap: var(--sp-1);
 }
 .finance-remaining {
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
   font-weight: 600;
-  color: var(--mk-severity-medium);
-  font-family: var(--mk-font-mono);
+  color: var(--color-caution);
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
 }
 .finance-bar { height: 3px; margin-bottom: 0; }
@@ -868,17 +969,17 @@ body::after {
    ══════════════════════════════════════════ */
 
 .error-banner {
-  background: color-mix(in srgb, var(--mk-danger) 8%, var(--mk-paper));
-  border-bottom: 1px solid var(--mk-danger);
-  color: var(--mk-danger);
-  padding: var(--mk-sp-3) var(--mk-sp-4);
-  font-size: var(--mk-text-sm);
+  background: color-mix(in srgb, var(--color-danger) 8%, var(--color-surface));
+  border-bottom: 1px solid var(--color-danger);
+  color: var(--color-danger);
+  padding: var(--sp-3) var(--sp-4);
+  font-size: var(--text-sm);
 }
 .empty-state {
   text-align: center;
-  padding: var(--mk-sp-10) var(--mk-sp-4);
-  color: var(--mk-ink-500);
-  font-size: var(--mk-text-base);
+  padding: var(--sp-10) var(--sp-4);
+  color: var(--color-text-muted);
+  font-size: var(--text-base);
 }
 
 /* ══════════════════════════════════════════
@@ -887,19 +988,19 @@ body::after {
 
 .chat-fab {
   position: fixed;
-  bottom: max(var(--mk-sp-4), env(safe-area-inset-bottom));
-  right: var(--mk-sp-4);
+  bottom: max(var(--sp-4), env(safe-area-inset-bottom));
+  right: var(--sp-4);
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  background: var(--mk-primary);
-  color: var(--mk-on-primary);
+  background: var(--color-primary);
+  color: var(--color-on-primary);
   border: none;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: var(--mk-shadow-md);
+  box-shadow: var(--shadow-md);
   transition: transform 0.15s ease-out;
   z-index: 100;
   -webkit-tap-highlight-color: transparent;
@@ -914,7 +1015,7 @@ body::after {
   width: 100%;
   height: 100vh;
   height: 100dvh;
-  background: var(--mk-paper);
+  background: var(--color-surface);
   display: flex;
   flex-direction: column;
   z-index: 200;
@@ -929,19 +1030,19 @@ body::after {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: max(var(--mk-sp-3), env(safe-area-inset-top)) var(--mk-sp-4) var(--mk-sp-3);
-  border-bottom: 1px solid var(--mk-line);
+  padding: max(var(--sp-3), env(safe-area-inset-top)) var(--sp-4) var(--sp-3);
+  border-bottom: 1px solid var(--color-border);
 }
-.chat-title { font-weight: 600; font-size: var(--mk-text-base); }
-.chat-header-actions { display: flex; gap: var(--mk-sp-2); }
+.chat-title { font-weight: 600; font-size: var(--text-base); }
+.chat-header-actions { display: flex; gap: var(--sp-2); }
 .chat-btn-clear, .chat-btn-close {
   background: transparent;
   border: none;
-  color: var(--mk-ink-500);
+  color: var(--color-text-muted);
   cursor: pointer;
   font-size: 1.1rem;
-  padding: var(--mk-sp-1) var(--mk-sp-2);
-  border-radius: var(--mk-r-md);
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
   min-height: 44px;
   min-width: 44px;
   display: flex;
@@ -949,143 +1050,143 @@ body::after {
   justify-content: center;
   -webkit-tap-highlight-color: transparent;
 }
-.chat-btn-clear:active, .chat-btn-close:active { background: var(--mk-paper); }
+.chat-btn-clear:active, .chat-btn-close:active { background: var(--color-surface-hover); }
 
 .chat-key-form {
-  padding: var(--mk-sp-10) var(--mk-sp-6);
+  padding: var(--sp-10) var(--sp-6);
   text-align: center;
 }
-.chat-key-form p { color: var(--mk-ink-500); margin-bottom: var(--mk-sp-4); font-size: var(--mk-text-sm); }
-.chat-key-form form { display: flex; gap: var(--mk-sp-2); }
+.chat-key-form p { color: var(--color-text-muted); margin-bottom: var(--sp-4); font-size: var(--text-sm); }
+.chat-key-form form { display: flex; gap: var(--sp-2); }
 .chat-key-form .input { flex: 1; min-width: 0; }
 
 .chat-messages {
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  padding: var(--mk-sp-4);
+  padding: var(--sp-4);
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-3);
+  gap: var(--sp-3);
 }
 .chat-empty {
   text-align: center;
-  color: var(--mk-ink-500);
-  padding: var(--mk-sp-8) 0;
-  font-size: var(--mk-text-sm);
+  color: var(--color-text-muted);
+  padding: var(--sp-8) 0;
+  font-size: var(--text-sm);
 }
-.chat-empty p { margin-bottom: var(--mk-sp-2); }
+.chat-empty p { margin-bottom: var(--sp-2); }
 .chat-quick-actions {
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-2);
-  margin-top: var(--mk-sp-4);
+  gap: var(--sp-2);
+  margin-top: var(--sp-4);
 }
 .chat-quick-btn {
-  background: var(--mk-bg);
-  border: 1px solid var(--mk-line);
-  color: var(--mk-primary);
-  padding: var(--mk-sp-3);
-  border-radius: var(--mk-r-xl);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  color: var(--color-primary);
+  padding: var(--sp-3);
+  border-radius: var(--radius-md);
   cursor: pointer;
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
   text-align: left;
   font-family: inherit;
   -webkit-tap-highlight-color: transparent;
   min-height: 44px;
 }
-.chat-quick-btn:active { background: var(--mk-paper); }
+.chat-quick-btn:active { background: var(--color-surface-hover); }
 .chat-quick-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
 .chat-msg { max-width: 88%; }
 .chat-msg-user { align-self: flex-end; }
 .chat-msg-assistant { align-self: flex-start; }
 .chat-msg-content {
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  border-radius: var(--mk-sp-3);
-  font-size: var(--mk-text-sm);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--sp-3);
+  font-size: var(--text-sm);
   line-height: 1.5;
   overflow-wrap: break-word;
   word-break: break-word;
 }
 .chat-msg-user .chat-msg-content {
-  background: var(--mk-primary);
-  color: var(--mk-on-primary);
-  border-bottom-right-radius: var(--mk-sp-1);
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  border-bottom-right-radius: var(--sp-1);
   white-space: pre-wrap;
 }
 .chat-msg-assistant .chat-msg-content {
-  background: var(--mk-bg);
-  border: 1px solid var(--mk-line);
-  border-bottom-left-radius: var(--mk-sp-1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-bottom-left-radius: var(--sp-1);
 }
 .chat-msg-time {
   display: block;
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-400);
+  font-size: var(--text-xs);
+  color: var(--color-text-faint);
   margin-top: 2px;
 }
 .chat-msg-user .chat-msg-time { text-align: right; }
 
 /* Markdown in chat */
 .chat-md { overflow: hidden; }
-.chat-md h2 { font-size: var(--mk-text-sm); font-weight: 600; margin: var(--mk-sp-2) 0 var(--mk-sp-1); }
-.chat-md h3 { font-size: var(--mk-text-sm); font-weight: 600; margin: var(--mk-sp-2) 0 var(--mk-sp-1); }
+.chat-md h2 { font-size: var(--text-sm); font-weight: 600; margin: var(--sp-2) 0 var(--sp-1); }
+.chat-md h3 { font-size: var(--text-sm); font-weight: 600; margin: var(--sp-2) 0 var(--sp-1); }
 .chat-md p { margin: 2px 0; }
-.chat-md ul, .chat-md ol { margin: 2px 0; padding-left: var(--mk-sp-4); }
+.chat-md ul, .chat-md ol { margin: 2px 0; padding-left: var(--sp-4); }
 .chat-md li { margin: 1px 0; }
 .chat-md strong { font-weight: 600; }
 .chat-md code {
-  font-family: var(--mk-font-mono);
-  background: color-mix(in srgb, var(--mk-ink-500) 15%, transparent);
+  font-family: var(--font-mono);
+  background: color-mix(in srgb, var(--color-text-muted) 15%, transparent);
   padding: 1px 4px;
   border-radius: 3px;
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   word-break: break-all;
 }
 .chat-md pre {
-  background: var(--mk-bg);
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  border-radius: var(--mk-r-xl);
+  background: var(--color-bg);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--radius-md);
   overflow-x: auto;
-  margin: var(--mk-sp-1) 0;
-  font-size: var(--mk-text-xs);
+  margin: var(--sp-1) 0;
+  font-size: var(--text-xs);
   line-height: 1.4;
 }
 .chat-md pre code { background: none; padding: 0; word-break: normal; }
-.chat-md hr { border: none; border-top: 1px solid var(--mk-line); margin: var(--mk-sp-2) 0; }
-.chat-md table { width: 100%; border-collapse: collapse; font-size: var(--mk-text-xs); margin: var(--mk-sp-1) 0; }
-.chat-md th, .chat-md td { border: 1px solid var(--mk-line); padding: 3px var(--mk-sp-2); text-align: left; }
-.chat-md th { background: var(--mk-bg); font-weight: 600; }
+.chat-md hr { border: none; border-top: 1px solid var(--color-border); margin: var(--sp-2) 0; }
+.chat-md table { width: 100%; border-collapse: collapse; font-size: var(--text-xs); margin: var(--sp-1) 0; }
+.chat-md th, .chat-md td { border: 1px solid var(--color-border); padding: 3px var(--sp-2); text-align: left; }
+.chat-md th { background: var(--color-bg); font-weight: 600; }
 
 .chat-loading {
   text-align: center;
-  color: var(--mk-ink-500);
-  font-size: var(--mk-text-sm);
-  padding: var(--mk-sp-2);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  padding: var(--sp-2);
   animation: pulse 1.5s infinite;
 }
 .chat-error {
   text-align: center;
-  color: var(--mk-danger);
-  font-size: var(--mk-text-sm);
-  padding: var(--mk-sp-2);
+  color: var(--color-danger);
+  font-size: var(--text-sm);
+  padding: var(--sp-2);
 }
 
 .chat-input-row {
   display: flex;
-  gap: var(--mk-sp-2);
-  padding: var(--mk-sp-3) var(--mk-sp-4) max(var(--mk-sp-3), env(safe-area-inset-bottom));
-  border-top: 1px solid var(--mk-line);
+  gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-4) max(var(--sp-3), env(safe-area-inset-bottom));
+  border-top: 1px solid var(--color-border);
 }
 .chat-input {
   flex: 1;
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  border-radius: var(--mk-r-full);
-  border: 1px solid var(--mk-line);
-  background: var(--mk-bg);
-  color: var(--mk-ink-900);
-  font-size: var(--mk-text-sm);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: var(--text-sm);
   font-family: inherit;
   outline: none;
   resize: none;
@@ -1094,14 +1195,14 @@ body::after {
   max-height: 120px;
   line-height: 1.4;
 }
-.chat-input:focus { border-color: var(--mk-primary); }
+.chat-input:focus { border-color: var(--color-primary); }
 .chat-send {
   width: 44px;
   height: 44px;
   border-radius: 50%;
   border: none;
-  background: var(--mk-primary);
-  color: var(--mk-on-primary);
+  background: var(--color-primary);
+  color: var(--color-on-primary);
   cursor: pointer;
   font-size: 1rem;
   display: flex;
@@ -1110,7 +1211,7 @@ body::after {
   -webkit-tap-highlight-color: transparent;
   flex-shrink: 0;
 }
-.chat-send:active { background: var(--mk-primary-active); }
+.chat-send:active { background: var(--color-primary-active); }
 .chat-send:disabled { opacity: 0.3; cursor: not-allowed; }
 
 /* ══════════════════════════════════════════
@@ -1120,7 +1221,7 @@ body::after {
 .finance-overlay {
   position: fixed;
   inset: 0;
-  background: var(--mk-overlay);
+  background: var(--color-overlay);
   display: flex;
   align-items: flex-end;
   justify-content: center;
@@ -1129,10 +1230,10 @@ body::after {
   backdrop-filter: blur(4px);
 }
 .finance-modal {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-xl) var(--mk-r-xl) 0 0;
-  padding: var(--mk-sp-6) var(--mk-sp-4) max(var(--mk-sp-6), env(safe-area-inset-bottom));
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  padding: var(--sp-6) var(--sp-4) max(var(--sp-6), env(safe-area-inset-bottom));
   width: 100%;
   max-height: 85vh;
   overflow-y: auto;
@@ -1142,42 +1243,42 @@ body::after {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: var(--mk-sp-5);
+  margin-bottom: var(--sp-5);
 }
-.finance-header h2 { font-size: var(--mk-text-md); font-weight: 600; }
+.finance-header h2 { font-size: var(--text-md); font-weight: 600; }
 .finance-table { width: 100%; border-collapse: collapse; }
 .finance-table th {
   text-align: left;
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   font-weight: 500;
-  color: var(--mk-ink-500);
-  padding: var(--mk-sp-2) var(--mk-sp-1);
-  border-bottom: 1px solid var(--mk-line);
+  color: var(--color-text-muted);
+  padding: var(--sp-2) var(--sp-1);
+  border-bottom: 1px solid var(--color-border);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.finance-table td { padding: var(--mk-sp-1); border-bottom: 1px solid var(--mk-line); }
-.finance-table tfoot td { border-bottom: none; padding-top: var(--mk-sp-3); }
-.finance-repo { font-weight: 600; font-size: var(--mk-text-sm); }
-.finance-client { font-size: var(--mk-text-xs); color: var(--mk-ink-500); }
+.finance-table td { padding: var(--sp-1); border-bottom: 1px solid var(--color-border); }
+.finance-table tfoot td { border-bottom: none; padding-top: var(--sp-3); }
+.finance-repo { font-weight: 600; font-size: var(--text-sm); }
+.finance-client { font-size: var(--text-xs); color: var(--color-text-muted); }
 .finance-input {
   width: 80px;
-  padding: var(--mk-sp-1) var(--mk-sp-2);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
-  background: var(--mk-bg);
-  color: var(--mk-ink-900);
-  font-size: var(--mk-text-sm);
-  font-family: var(--mk-font-mono);
+  padding: var(--sp-1) var(--sp-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
 }
-.finance-input:focus { outline: none; border-color: var(--mk-primary); }
-.finance-remaining { font-size: var(--mk-text-sm); color: var(--mk-ink-500); }
-.finance-remaining.positive { color: var(--mk-danger); }
+.finance-input:focus { outline: none; border-color: var(--color-primary); }
+.finance-remaining { font-size: var(--text-sm); color: var(--color-text-muted); }
+.finance-remaining.positive { color: var(--color-danger); }
 .finance-actions {
   display: flex;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
   justify-content: flex-end;
-  margin-top: var(--mk-sp-5);
+  margin-top: var(--sp-5);
 }
 
 /* ══════════════════════════════════════════
@@ -1185,16 +1286,16 @@ body::after {
    ══════════════════════════════════════════ */
 
 .error-boundary {
-  background: color-mix(in srgb, var(--mk-danger) 6%, var(--mk-paper));
-  border: 1px dashed var(--mk-danger);
-  border-radius: var(--mk-r-xl);
-  padding: var(--mk-sp-4);
+  background: color-mix(in srgb, var(--color-danger) 6%, var(--color-surface));
+  border: 1px dashed var(--color-danger);
+  border-radius: var(--radius-md);
+  padding: var(--sp-4);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  color: var(--mk-ink-500);
-  font-size: var(--mk-text-sm);
-  margin-bottom: var(--mk-sp-4);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  margin-bottom: var(--sp-4);
 }
 
 /* ══════════════════════════════════════════
@@ -1223,92 +1324,92 @@ body::after {
   .app {
     max-width: 1200px;
     margin: 0 auto;
-    padding: var(--mk-sp-6);
+    padding: var(--sp-6);
   }
 
   .header {
     position: static;
-    padding: var(--mk-sp-6) var(--mk-sp-5) var(--mk-sp-4);
+    padding: var(--sp-6) var(--sp-5) var(--sp-4);
     margin-bottom: 0;
     background: transparent;
     backdrop-filter: none;
   }
-  .header h1 { font-size: var(--mk-text-lg); }
+  .header h1 { font-size: var(--text-lg); }
   .header-logo { width: 36px; height: 36px; }
   .token-input-row { flex-direction: row; justify-content: center; }
   .input { min-width: 240px; width: auto; }
 
-  .hero { padding: var(--mk-sp-6); }
-  .hero-top { gap: var(--mk-sp-5); }
+  .hero { padding: var(--sp-6); }
+  .hero-top { gap: var(--sp-5); }
   .hero-ring { width: 96px; height: 96px; }
-  .ring-pct { font-size: var(--mk-text-lg); }
+  .ring-pct { font-size: var(--text-lg); }
   .hero-tiles { grid-template-columns: repeat(4, 1fr); }
   .hero-tile-value { font-size: 1.75rem; }
   .hero-finance-tiles { grid-template-columns: repeat(3, 1fr); }
   .hero-tile--finance .hero-tile-value { font-size: 1.25rem; }
 
-  .deadlines { padding: 0 var(--mk-sp-6); margin-bottom: var(--mk-sp-5); }
+  .deadlines { padding: 0 var(--sp-6); margin-bottom: var(--sp-5); }
   .stale-banner {
-    border-radius: var(--mk-r-xl);
-    border: 1px solid color-mix(in srgb, var(--mk-severity-medium) 25%, transparent);
-    margin-bottom: var(--mk-sp-5);
+    border-radius: var(--radius-md);
+    border: 1px solid color-mix(in srgb, var(--color-caution) 25%, transparent);
+    margin-bottom: var(--sp-5);
   }
 
 
   .blocked-section {
-    border: 1px solid var(--mk-danger);
-    border-radius: var(--mk-r-xl);
-    margin-top: var(--mk-sp-8);
-    padding: var(--mk-sp-5);
+    border: 1px solid var(--color-danger);
+    border-radius: var(--radius-md);
+    margin-top: var(--sp-8);
+    padding: var(--sp-5);
   }
   .chart-section {
-    border: 1px solid var(--mk-line);
-    border-radius: var(--mk-r-xl);
-    margin-top: var(--mk-sp-8);
-    padding: var(--mk-sp-5);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    margin-top: var(--sp-8);
+    padding: var(--sp-5);
   }
   .chart-bar { height: 24px; }
   .chart-label { min-width: 120px; }
 
   .closed-chart-section {
-    border: 1px solid var(--mk-line);
-    border-radius: var(--mk-r-xl);
-    margin-top: var(--mk-sp-4);
-    padding: var(--mk-sp-5);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    margin-top: var(--sp-4);
+    padding: var(--sp-5);
   }
   .closed-chart-day { min-width: 120px; }
   .closed-chart-bar-track { height: 28px; }
 
-  .milestones-grouped { padding: 0 var(--mk-sp-6); }
+  .milestones-grouped { padding: 0 var(--sp-6); }
   .milestones-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-    gap: var(--mk-sp-3);
+    gap: var(--sp-3);
   }
-  .milestone-card { padding: var(--mk-sp-4); }
+  .milestone-card { padding: var(--sp-4); }
 
   .chat-panel {
     width: 420px;
-    border-left: 1px solid var(--mk-line);
-    box-shadow: var(--mk-shadow-lg);
+    border-left: 1px solid var(--color-border);
+    box-shadow: var(--shadow-lg);
   }
 
   .finance-overlay { align-items: center; }
   .finance-modal {
-    border-radius: var(--mk-r-xl);
+    border-radius: var(--radius-md);
     max-width: 800px;
     width: 90%;
     max-height: 80vh;
-    padding: var(--mk-sp-6);
+    padding: var(--sp-6);
   }
 
   .monitor-list__header,
   .monitor-row {
     grid-template-columns: 14px 1fr 2fr 80px 70px 120px;
-    gap: var(--mk-sp-3);
-    padding: var(--mk-sp-2) var(--mk-sp-4);
+    gap: var(--sp-3);
+    padding: var(--sp-2) var(--sp-4);
   }
-  .monitor-row { font-size: var(--mk-text-base); }
+  .monitor-row { font-size: var(--text-base); }
 }
 
 /* ══════════════════════════════════════════
@@ -1319,18 +1420,18 @@ body::after {
 .dialog-overlay {
   position: fixed;
   inset: 0;
-  background: var(--mk-overlay);
+  background: var(--color-overlay);
   z-index: 1000;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--mk-sp-4);
+  padding: var(--sp-4);
 }
 .dialog {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: 24px;
-  box-shadow: var(--mk-shadow-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
   width: 100%;
   max-width: 640px;
   max-height: 80vh;
@@ -1339,28 +1440,28 @@ body::after {
   overflow: hidden;
 }
 .dialog-header {
-  padding: var(--mk-sp-4) var(--mk-sp-5);
-  border-bottom: 1px solid var(--mk-line);
+  padding: var(--sp-4) var(--sp-5);
+  border-bottom: 1px solid var(--color-border);
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
-.dialog-title { margin: 0; font-size: var(--mk-text-md); font-weight: 700; }
+.dialog-title { margin: 0; font-size: var(--text-md); font-weight: 700; }
 .dialog-close {
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--mk-ink-500);
-  font-size: var(--mk-text-lg);
+  color: var(--color-text-muted);
+  font-size: var(--text-lg);
   line-height: 1;
-  padding: var(--mk-sp-1);
+  padding: var(--sp-1);
 }
-.dialog-body { flex: 1; overflow-y: auto; padding: var(--mk-sp-5); }
+.dialog-body { flex: 1; overflow-y: auto; padding: var(--sp-5); }
 .dialog-footer {
-  padding: var(--mk-sp-3) var(--mk-sp-5);
-  border-top: 1px solid var(--mk-line);
+  padding: var(--sp-3) var(--sp-5);
+  border-top: 1px solid var(--color-border);
   display: flex;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
 }
 .dialog-footer--end { justify-content: flex-end; }
 
@@ -1369,100 +1470,100 @@ body::after {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
-.dialog-spinner-wrap { text-align: center; padding: var(--mk-sp-10) 0; }
+.dialog-spinner-wrap { text-align: center; padding: var(--sp-10) 0; }
 .dialog-spinner {
   width: 32px;
   height: 32px;
-  border: 3px solid var(--mk-primary);
+  border: 3px solid var(--color-primary);
   border-top-color: transparent;
   border-radius: 50%;
   animation: spin 1s linear infinite;
-  margin: 0 auto var(--mk-sp-4);
+  margin: 0 auto var(--sp-4);
 }
-.dialog-hint { color: var(--mk-ink-500); font-size: var(--mk-text-base); }
+.dialog-hint { color: var(--color-text-muted); font-size: var(--text-base); }
 
 /* Dialog: preview list */
 .issues-meta {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: var(--mk-sp-3);
+  margin-bottom: var(--sp-3);
 }
-.issues-meta-count { font-size: var(--mk-text-sm); color: var(--mk-ink-500); }
+.issues-meta-count { font-size: var(--text-sm); color: var(--color-text-muted); }
 .issues-toggle-all {
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--mk-primary);
-  font-size: var(--mk-text-xs);
-  padding: var(--mk-sp-1) var(--mk-sp-2);
+  color: var(--color-primary);
+  font-size: var(--text-xs);
+  padding: var(--sp-1) var(--sp-2);
 }
-.issues-list { display: flex; flex-direction: column; gap: var(--mk-sp-1); }
+.issues-list { display: flex; flex-direction: column; gap: var(--sp-1); }
 .issue-row {
   display: flex;
   align-items: flex-start;
-  gap: var(--mk-sp-2);
-  padding: var(--mk-sp-2) var(--mk-sp-2);
-  border-radius: var(--mk-r-xl);
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-2);
+  border-radius: var(--radius-md);
   cursor: pointer;
-  border: 1px solid var(--mk-line);
+  border: 1px solid var(--color-border);
   transition: background 0.15s;
 }
-.issue-row--selected { background: var(--mk-paper); }
+.issue-row--selected { background: var(--color-surface-hover); }
 .issue-row input[type="checkbox"] { margin-top: 2px; flex-shrink: 0; }
 .issue-severity {
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   font-weight: 700;
-  font-family: var(--mk-font-mono);
+  font-family: var(--font-mono);
   flex-shrink: 0;
   min-width: 34px;
 }
-.issue-title { font-size: var(--mk-text-sm); color: var(--mk-ink-900); line-height: 1.4; word-break: break-word; }
+.issue-title { font-size: var(--text-sm); color: var(--color-text); line-height: 1.4; word-break: break-word; }
 
 /* Dialog: creating progress */
-.dialog-progress-wrap { padding: var(--mk-sp-5) 0; }
+.dialog-progress-wrap { padding: var(--sp-5) 0; }
 .dialog-progress-header {
   display: flex;
   justify-content: space-between;
-  margin-bottom: var(--mk-sp-2);
-  font-size: var(--mk-text-sm);
+  margin-bottom: var(--sp-2);
+  font-size: var(--text-sm);
 }
-.dialog-progress-label { color: var(--mk-ink-500); }
-.dialog-progress-count { font-family: var(--mk-font-mono); font-weight: 700; }
+.dialog-progress-label { color: var(--color-text-muted); }
+.dialog-progress-count { font-family: var(--font-mono); font-weight: 700; }
 .dialog-progress-track {
   height: 8px;
-  background: var(--mk-line);
-  border-radius: var(--mk-r-full);
+  background: var(--color-border);
+  border-radius: var(--radius-full);
   overflow: hidden;
 }
 .dialog-progress-fill {
   height: 100%;
-  background: var(--mk-primary);
-  border-radius: var(--mk-r-full);
+  background: var(--color-primary);
+  border-radius: var(--radius-full);
   transition: width 0.3s ease-out;
 }
 .dialog-progress-title {
-  margin-top: var(--mk-sp-3);
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
-  font-family: var(--mk-font-mono);
+  margin-top: var(--sp-3);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.dialog-error { color: var(--mk-danger); font-size: var(--mk-text-sm); line-height: 1.5; }
+.dialog-error { color: var(--color-danger); font-size: var(--text-sm); line-height: 1.5; }
 
 /* ── AuditConfirmDialog ── */
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: var(--mk-overlay);
+  background: var(--color-overlay);
   backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  padding: var(--mk-sp-4);
+  padding: var(--sp-4);
 }
 @keyframes modalSlideUp {
   from { opacity: 0; transform: translateY(20px); }
@@ -1471,100 +1572,100 @@ body::after {
 .modal-panel {
   max-width: 480px;
   width: 100%;
-  padding: var(--mk-sp-6);
+  padding: var(--sp-6);
   animation: modalSlideUp 0.3s ease-out;
   box-shadow: 0 20px 50px color-mix(in srgb, #000 30%, transparent);
 }
-.modal-title { font-size: var(--mk-text-lg); font-weight: 700; margin-bottom: var(--mk-sp-2); color: var(--mk-ink-900); }
-.modal-desc { color: var(--mk-ink-500); margin-bottom: var(--mk-sp-6); font-size: var(--mk-text-base); line-height: 1.5; }
+.modal-title { font-size: var(--text-lg); font-weight: 700; margin-bottom: var(--sp-2); color: var(--color-text); }
+.modal-desc { color: var(--color-text-muted); margin-bottom: var(--sp-6); font-size: var(--text-base); line-height: 1.5; }
 .modal-info-block {
-  background: var(--mk-bg);
-  border-radius: 24px;
-  padding: var(--mk-sp-4);
-  margin-bottom: var(--mk-sp-6);
-  border: 1px solid var(--mk-line);
+  background: var(--color-bg);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-4);
+  margin-bottom: var(--sp-6);
+  border: 1px solid var(--color-border);
 }
 .modal-info-row {
   display: flex;
   justify-content: space-between;
-  margin-bottom: var(--mk-sp-3);
+  margin-bottom: var(--sp-3);
 }
 .modal-info-row:last-child { margin-bottom: 0; }
-.modal-info-label { color: var(--mk-ink-400); font-size: var(--mk-text-xs); text-transform: uppercase; }
-.modal-actions { display: flex; gap: var(--mk-sp-3); }
+.modal-info-label { color: var(--color-text-faint); font-size: var(--text-xs); text-transform: uppercase; }
+.modal-actions { display: flex; gap: var(--sp-3); }
 .modal-btn-primary { flex: 2; }
 
 /* ── Audit verification ── */
 .apc-verify-summary {
   display: flex;
-  gap: var(--mk-sp-3);
+  gap: var(--sp-3);
   align-items: center;
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  font-size: var(--mk-text-xs);
-  background: var(--mk-surface-2);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--text-xs);
+  background: var(--color-surface-subtle, rgba(0,0,0,0.03));
   border-radius: 4px;
-  margin-top: var(--mk-sp-2);
+  margin-top: var(--sp-2);
 }
-.apc-verify-label { color: var(--mk-ink-500); font-weight: 600; }
+.apc-verify-label { color: var(--color-text-muted); font-weight: 600; }
 .apc-verify-stat { font-weight: 600; }
 
 .verify-summary {
   display: flex;
-  gap: var(--mk-sp-4);
-  padding: var(--mk-sp-3);
-  border-bottom: 1px solid var(--mk-line);
-  margin-bottom: var(--mk-sp-3);
+  gap: var(--sp-4);
+  padding: var(--sp-3);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--sp-3);
 }
 .verify-summary-item { flex: 1; text-align: center; }
-.verify-summary-count { font-size: 1.25rem; font-weight: 700; line-height: 1; }
+.verify-summary-count { font-size: var(--text-2xl); font-weight: 700; line-height: 1; }
 .verify-summary-label {
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   text-transform: uppercase;
-  color: var(--mk-ink-500);
-  margin-top: var(--mk-sp-1);
+  color: var(--color-text-muted);
+  margin-top: var(--sp-1);
 }
 
 .verify-tabs {
   display: flex;
-  gap: var(--mk-sp-1);
-  border-bottom: 1px solid var(--mk-line);
-  margin-bottom: var(--mk-sp-3);
+  gap: var(--sp-1);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--sp-3);
 }
 .verify-tab {
-  padding: var(--mk-sp-2) var(--mk-sp-3);
+  padding: var(--sp-2) var(--sp-3);
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  color: var(--mk-ink-500);
-  font-size: var(--mk-text-sm);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
 }
-.verify-tab--active { color: var(--mk-ink-900); }
+.verify-tab--active { color: var(--color-text); }
 
 .verify-results {
   max-height: 400px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
 }
 .verify-result {
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  background: var(--mk-surface-2);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--color-surface-subtle, rgba(0,0,0,0.03));
   border-radius: 4px;
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
 }
 .verify-result summary { cursor: pointer; }
 .verify-result summary code { font-weight: 600; }
-.verify-result-reason { color: var(--mk-ink-500); }
+.verify-result-reason { color: var(--color-text-muted); }
 .verify-result-code {
-  margin-top: var(--mk-sp-2);
-  padding: var(--mk-sp-2);
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  margin-top: var(--sp-2);
+  padding: var(--sp-2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   overflow-x: auto;
   white-space: pre;
 }
@@ -1575,8 +1676,8 @@ body::after {
   align-items: center;
   justify-content: center;
   min-height: 100dvh;
-  padding: var(--mk-sp-4);
-  background: var(--mk-bg);
+  padding: var(--sp-4);
+  background: var(--color-bg);
 }
 .password-gate-card {
   text-align: center;
@@ -1584,64 +1685,64 @@ body::after {
   width: 100%;
 }
 .password-gate-title {
-  font-size: 1.25rem;
+  font-size: var(--text-2xl);
   font-weight: 800;
-  color: var(--mk-ink-900);
-  margin-bottom: var(--mk-sp-1);
+  color: var(--color-text);
+  margin-bottom: var(--sp-1);
 }
 .password-gate-subtitle {
-  color: var(--mk-ink-500);
-  margin-bottom: var(--mk-sp-6);
+  color: var(--color-text-muted);
+  margin-bottom: var(--sp-6);
 }
 .password-gate-form {
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-3);
+  gap: var(--sp-3);
 }
 .password-gate-error {
-  color: var(--mk-danger);
-  font-size: var(--mk-text-sm);
+  color: var(--color-danger);
+  font-size: var(--text-sm);
 }
 .input-error {
-  border-color: var(--mk-danger) !important;
+  border-color: var(--color-danger) !important;
 }
 
 .tpc-brief-content {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: 24px;
-  padding: var(--mk-sp-4) var(--mk-sp-5);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-4) var(--sp-5);
   line-height: 1.7;
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
   overflow-x: auto;
 }
 .tpc-brief-content h1,
 .tpc-brief-content h2,
 .tpc-brief-content h3 {
-  margin-top: var(--mk-sp-4);
-  margin-bottom: var(--mk-sp-2);
-  color: var(--mk-ink-900);
+  margin-top: var(--sp-4);
+  margin-bottom: var(--sp-2);
+  color: var(--color-text);
 }
-.tpc-brief-content h1 { font-size: var(--mk-text-lg); }
-.tpc-brief-content h2 { font-size: var(--mk-text-base); }
-.tpc-brief-content p { margin: var(--mk-sp-2) 0; }
+.tpc-brief-content h1 { font-size: var(--text-lg); }
+.tpc-brief-content h2 { font-size: var(--text-base); }
+.tpc-brief-content p { margin: var(--sp-2) 0; }
 .tpc-brief-content ul,
 .tpc-brief-content ol {
-  padding-left: var(--mk-sp-5);
-  margin: var(--mk-sp-2) 0;
+  padding-left: var(--sp-5);
+  margin: var(--sp-2) 0;
 }
 .tpc-brief-content code {
-  font-family: var(--mk-font-mono);
-  background: color-mix(in srgb, var(--mk-ink-900) 8%, transparent);
+  font-family: var(--font-mono);
+  background: color-mix(in srgb, var(--color-text) 8%, transparent);
   padding: 1px 4px;
   border-radius: 3px;
   font-size: 0.9em;
 }
 .tpc-brief-content blockquote {
-  border-left: 3px solid var(--mk-primary);
-  margin: var(--mk-sp-2) 0;
-  padding: var(--mk-sp-2) var(--mk-sp-4);
-  color: var(--mk-ink-500);
+  border-left: 3px solid var(--color-primary);
+  margin: var(--sp-2) 0;
+  padding: var(--sp-2) var(--sp-4);
+  color: var(--color-text-muted);
 }
 
 /* Marker highlights */
@@ -1651,37 +1752,37 @@ body::after {
   font-weight: 600;
 }
 .tpc-marker--unclear {
-  background: color-mix(in srgb, var(--mk-warn) 20%, transparent);
-  color: var(--mk-warn);
+  background: color-mix(in srgb, var(--color-warning) 20%, transparent);
+  color: var(--color-warning);
 }
 .tpc-marker--conflict {
-  background: color-mix(in srgb, var(--mk-danger) 20%, transparent);
-  color: var(--mk-danger);
+  background: color-mix(in srgb, var(--color-danger) 20%, transparent);
+  color: var(--color-danger);
 }
 /* ── Audit Sub-tabs (Code / UX) ── */
 .audit-sub-tabs {
   display: flex;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
 }
 .audit-sub-tab {
-  padding: var(--mk-sp-1) var(--mk-sp-4);
-  font-size: var(--mk-text-sm);
+  padding: var(--sp-1) var(--sp-4);
+  font-size: var(--text-sm);
   font-weight: 600;
-  color: var(--mk-ink-500);
+  color: var(--color-text-muted);
   background: none;
   border: 1px solid transparent;
-  border-radius: var(--mk-r-md);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s;
 }
 .audit-sub-tab:hover {
-  color: var(--mk-ink-900);
-  background: var(--mk-paper);
+  color: var(--color-text);
+  background: var(--gray-100);
 }
 .audit-sub-tab-active {
-  color: var(--mk-ink-900);
-  background: var(--mk-paper);
-  border-color: var(--mk-line);
+  color: var(--color-text);
+  background: var(--gray-100);
+  border-color: var(--color-border);
 }
 
 /* ── Research: Start Modal ── */
@@ -1694,61 +1795,61 @@ body::after {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: var(--mk-sp-4);
+  margin-bottom: var(--sp-4);
 }
 .srm-form {
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-4);
-  margin-bottom: var(--mk-sp-4);
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-4);
 }
 .srm-label {
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-2);
-  font-size: var(--mk-text-sm);
+  gap: var(--sp-2);
+  font-size: var(--text-sm);
   font-weight: 500;
-  color: var(--mk-ink-900);
+  color: var(--color-text);
 }
 .srm-required {
-  color: var(--mk-danger);
+  color: var(--color-danger);
 }
 .srm-select,
 .srm-textarea {
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  font-size: var(--mk-text-sm);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--text-sm);
   font-family: inherit;
-  background: var(--mk-bg);
-  color: var(--mk-ink-900);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-xl);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
   transition: border-color 0.15s;
 }
 .srm-select:focus,
 .srm-textarea:focus {
   outline: none;
-  border-color: var(--mk-primary);
+  border-color: var(--color-primary);
 }
 .srm-textarea {
   resize: vertical;
   min-height: 64px;
 }
 .srm-hint {
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
   font-weight: 400;
 }
 .srm-hint--error {
-  color: var(--mk-danger);
+  color: var(--color-danger);
 }
 .srm-info {
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
   line-height: 1.5;
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  background: var(--mk-paper);
-  border-radius: var(--mk-r-md);
-  margin-bottom: var(--mk-sp-4);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--color-surface);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--sp-4);
 }
 
 @media (max-width: 768px) {
@@ -1758,14 +1859,14 @@ body::after {
   .rsh-project-actions {
     width: 100%;
     margin-left: 0;
-    margin-top: var(--mk-sp-2);
+    margin-top: var(--sp-2);
   }
   .rsh-project-actions .btn {
     flex: 1;
   }
   .srm-panel {
     max-width: 100%;
-    margin: var(--mk-sp-2);
+    margin: var(--sp-2);
   }
 }
 
@@ -1775,24 +1876,24 @@ body::after {
 
 .debate-empty {
   text-align: center;
-  padding: var(--mk-sp-10) var(--mk-sp-4);
-  color: var(--mk-ink-500);
+  padding: var(--sp-10) var(--sp-4);
+  color: var(--color-text-muted);
 }
 .debate-empty-icon {
-  margin-bottom: var(--mk-sp-4);
-  color: var(--mk-ink-400);
+  margin-bottom: var(--sp-4);
+  color: var(--color-text-faint);
 }
 .debate-empty h3 {
-  font-size: var(--mk-text-lg);
+  font-size: var(--text-lg);
   font-weight: 600;
-  color: var(--mk-ink-900);
-  margin: 0 0 var(--mk-sp-2);
+  color: var(--color-text);
+  margin: 0 0 var(--sp-2);
 }
 .debate-empty p {
   max-width: 480px;
   margin: 0 auto;
   line-height: 1.6;
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
 }
 
 .debate-list {
@@ -1802,21 +1903,21 @@ body::after {
 .debate-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
 }
 .debate-table th {
   text-align: left;
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  color: var(--mk-ink-500);
+  padding: var(--sp-2) var(--sp-3);
+  color: var(--color-text-muted);
   font-weight: 500;
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  border-bottom: 1px solid var(--mk-line);
+  border-bottom: 1px solid var(--color-border);
 }
 .debate-table td {
-  padding: var(--mk-sp-3);
-  border-bottom: 1px solid var(--mk-line);
+  padding: var(--sp-3);
+  border-bottom: 1px solid var(--color-border);
   vertical-align: middle;
 }
 
@@ -1827,26 +1928,26 @@ body::after {
   cursor: pointer;
 }
 .debate-row.debate-row--clickable:hover {
-  background: var(--mk-paper);
+  background: var(--color-surface-hover);
 }
 
 .debate-topic {
   font-weight: 500;
-  color: var(--mk-ink-900);
+  color: var(--color-text);
   max-width: 320px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .debate-project {
-  color: var(--mk-ink-700);
+  color: var(--color-text-secondary);
 }
 .debate-cost {
   font-variant-numeric: tabular-nums;
-  color: var(--mk-ink-700);
+  color: var(--color-text-secondary);
 }
 .debate-date {
-  color: var(--mk-ink-500);
+  color: var(--color-text-muted);
   white-space: nowrap;
 }
 
@@ -1854,40 +1955,40 @@ body::after {
 .debate-badge {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: var(--mk-r-full);
-  font-size: var(--mk-text-xs);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.03em;
   white-space: nowrap;
 }
 .badge-queued {
-  background: var(--mk-glow-primary);
-  color: var(--mk-primary);
+  background: var(--color-glow-primary);
+  color: var(--color-primary);
 }
 .badge-running {
   background: rgba(139, 92, 246, 0.15);
-  color: var(--mk-purple-500);
+  color: var(--purple-500);
   animation: debate-pulse 2s ease-in-out infinite;
 }
 .badge-done {
   background: rgba(16, 185, 129, 0.15);
-  color: var(--mk-success);
+  color: var(--green-500);
 }
 .badge-error {
-  background: var(--mk-glow-danger);
-  color: var(--mk-danger);
+  background: var(--color-glow-danger);
+  color: var(--color-danger);
 }
 .badge-unanimous {
   background: rgba(16, 185, 129, 0.15);
-  color: var(--mk-success);
+  color: var(--green-500);
 }
 .badge-majority {
   background: rgba(245, 158, 11, 0.15);
-  color: var(--mk-warn);
+  color: var(--orange-500);
 }
 .badge-contested {
-  background: var(--mk-glow-danger);
-  color: var(--mk-danger);
+  background: var(--color-glow-danger);
+  color: var(--color-danger);
 }
 
 @keyframes debate-pulse {
@@ -1905,12 +2006,12 @@ body::after {
 
 .sdm-panel {
   max-width: 620px;
-  width: calc(100% - var(--mk-sp-8));
+  width: calc(100% - var(--sp-8));
   max-height: 85vh;
   overflow-y: auto;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: 24px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
 }
@@ -1918,42 +2019,42 @@ body::after {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: var(--mk-sp-4);
+  margin-bottom: var(--sp-4);
 }
 .sdm-form {
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-4);
-  margin-bottom: var(--mk-sp-4);
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-4);
 }
 .sdm-label {
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-2);
-  font-size: var(--mk-text-sm);
+  gap: var(--sp-2);
+  font-size: var(--text-sm);
   font-weight: 500;
-  color: var(--mk-ink-900);
+  color: var(--color-text);
 }
 .sdm-required {
-  color: var(--mk-danger);
+  color: var(--color-danger);
 }
 .sdm-input,
 .sdm-select,
 .sdm-textarea {
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  font-size: var(--mk-text-sm);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--text-sm);
   font-family: inherit;
-  background: var(--mk-bg);
-  color: var(--mk-ink-900);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-xl);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
   transition: border-color 0.15s;
 }
 .sdm-input:focus,
 .sdm-select:focus,
 .sdm-textarea:focus {
   outline: none;
-  border-color: var(--mk-primary);
+  border-color: var(--color-primary);
 }
 .sdm-textarea {
   resize: vertical;
@@ -1963,34 +2064,34 @@ body::after {
   flex: 1;
 }
 .sdm-hint {
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
   font-weight: 400;
 }
 .sdm-brief-meta {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
 }
 .sdm-char-count {
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
   font-weight: 400;
 }
 .sdm-char-warn {
-  font-size: var(--mk-text-xs);
-  color: var(--mk-warn);
+  font-size: var(--text-xs);
+  color: var(--color-warning);
   font-weight: 600;
 }
 .sdm-participants {
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
 }
 .sdm-participant-row {
   display: flex;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
   align-items: center;
 }
 .sdm-remove-btn {
@@ -2002,13 +2103,13 @@ body::after {
 .sdm-validation {
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.2);
-  border-radius: var(--mk-r-xl);
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  margin-bottom: var(--mk-sp-4);
+  border-radius: var(--radius-md);
+  padding: var(--sp-2) var(--sp-3);
+  margin-bottom: var(--sp-4);
 }
 .sdm-validation-item {
-  font-size: var(--mk-text-xs);
-  color: var(--mk-danger);
+  font-size: var(--text-xs);
+  color: var(--color-danger);
   padding: 2px 0;
 }
 
@@ -2027,74 +2128,74 @@ body::after {
 .dc-header {
   display: flex;
   align-items: center;
-  gap: var(--mk-sp-3);
-  padding: var(--mk-sp-3) var(--mk-sp-4);
-  border-bottom: 1px solid var(--mk-line);
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
   flex-wrap: wrap;
 }
 .dc-header-left {
   display: flex;
   align-items: center;
-  gap: var(--mk-sp-3);
+  gap: var(--sp-3);
 }
 .dc-header-info {
   display: flex;
   align-items: center;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
 }
 .dc-header-id {
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
-  font-family: var(--mk-font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono, monospace);
 }
 
 /* ── Progress ── */
 .dc-progress {
   display: flex;
   align-items: center;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
   margin-left: auto;
 }
 .dc-progress-bar {
   width: 120px;
   height: 4px;
-  background: var(--mk-line);
-  border-radius: var(--mk-r-full);
+  background: var(--color-border);
+  border-radius: var(--radius-full);
   overflow: hidden;
 }
 .dc-progress-fill {
   height: 100%;
-  background: var(--mk-purple-500);
-  border-radius: var(--mk-r-full);
+  background: var(--purple-500);
+  border-radius: var(--radius-full);
   transition: width 0.4s ease;
 }
 .dc-progress-text {
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
   white-space: nowrap;
 }
 
 /* ── Participants bar ── */
 .dc-participants {
   display: flex;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
   flex-shrink: 0;
 }
 .dc-participant {
   display: flex;
   align-items: center;
   gap: 4px;
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
   padding: 2px 8px;
-  border-radius: var(--mk-r-full);
-  background: var(--mk-paper);
+  border-radius: var(--radius-full);
+  background: var(--color-surface);
   transition: opacity 0.15s;
 }
 .dc-participant--active {
   opacity: 1;
-  outline: 1px solid var(--mk-ink-700);
+  outline: 1px solid var(--color-text-secondary);
 }
 .dc-participant:not(.dc-participant--active) {
   opacity: 0.5;
@@ -2110,29 +2211,29 @@ body::after {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--mk-sp-10);
-  color: var(--mk-ink-500);
-  font-size: var(--mk-text-sm);
+  padding: var(--sp-10);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
 }
 
 /* ── Chat area ── */
 .dc-chat-area {
   flex: 1;
   overflow-y: auto;
-  padding: var(--mk-sp-4);
+  padding: var(--sp-4);
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-1);
+  gap: var(--sp-1);
 }
 
 /* ── Round divider ── */
 .dc-round-divider {
   display: flex;
   align-items: center;
-  gap: var(--mk-sp-3);
-  margin: var(--mk-sp-4) 0 var(--mk-sp-2);
-  color: var(--mk-ink-500);
-  font-size: var(--mk-text-xs);
+  gap: var(--sp-3);
+  margin: var(--sp-4) 0 var(--sp-2);
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -2142,19 +2243,19 @@ body::after {
   content: "";
   flex: 1;
   height: 1px;
-  background: var(--mk-line);
+  background: var(--color-border);
 }
 
 /* ── Message ── */
 .dc-message {
   display: flex;
-  gap: var(--mk-sp-3);
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  border-radius: var(--mk-r-md);
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--radius-sm);
   transition: background 0.15s;
 }
 .dc-message:hover {
-  background: var(--mk-paper);
+  background: var(--color-surface);
 }
 .dc-message--user {
   background: rgba(76, 141, 255, 0.06);
@@ -2177,7 +2278,7 @@ body::after {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   font-weight: 700;
   color: #fff;
   flex-shrink: 0;
@@ -2192,29 +2293,29 @@ body::after {
 .dc-message-meta {
   display: flex;
   align-items: baseline;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
   margin-bottom: 2px;
 }
 .dc-sender {
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
   font-weight: 600;
 }
 .dc-time {
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
 }
 .dc-content {
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
   line-height: 1.6;
-  color: var(--mk-ink-900);
+  color: var(--color-text);
   word-break: break-word;
 }
 .dc-content code {
   padding: 1px 4px;
-  background: var(--mk-paper);
+  background: var(--color-surface);
   border-radius: 3px;
   font-size: 0.9em;
-  font-family: var(--mk-font-mono);
+  font-family: var(--font-mono, monospace);
 }
 
 /* ── Typing dots ── */
@@ -2232,7 +2333,7 @@ body::after {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--mk-ink-500);
+  background: var(--color-text-muted);
   animation: dc-dot-bounce 1.4s ease-in-out infinite;
 }
 .dc-typing-dots span:nth-child(2) {
@@ -2249,95 +2350,95 @@ body::after {
 /* ── Input bar ── */
 .dc-input-bar {
   display: flex;
-  gap: var(--mk-sp-2);
-  padding: var(--mk-sp-3) var(--mk-sp-4);
-  border-top: 1px solid var(--mk-line);
+  gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-4);
+  border-top: 1px solid var(--color-border);
   flex-shrink: 0;
   align-items: flex-end;
 }
 .dc-input {
   flex: 1;
-  padding: var(--mk-sp-2) var(--mk-sp-3);
-  font-size: var(--mk-text-sm);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--text-sm);
   font-family: inherit;
-  background: var(--mk-bg);
-  color: var(--mk-ink-900);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   resize: none;
   min-height: 36px;
   max-height: 120px;
 }
 .dc-input:focus {
   outline: none;
-  border-color: var(--mk-primary);
+  border-color: var(--color-primary);
 }
 
 /* ── Consensus block ── */
 .dc-consensus {
-  margin-top: var(--mk-sp-4);
-  padding: var(--mk-sp-4);
+  margin-top: var(--sp-4);
+  padding: var(--sp-4);
   background: rgba(16, 185, 129, 0.06);
   border: 1px solid rgba(16, 185, 129, 0.2);
-  border-radius: var(--mk-r-xl);
+  border-radius: var(--radius-md);
 }
 .dc-consensus-header {
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
   font-weight: 700;
-  color: var(--mk-success);
+  color: var(--green-500);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: var(--mk-sp-2);
+  margin-bottom: var(--sp-2);
 }
 .dc-consensus-text {
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
   line-height: 1.6;
-  color: var(--mk-ink-900);
+  color: var(--color-text);
 }
 
 /* ── Dissenting ── */
 .dc-dissent {
-  margin-top: var(--mk-sp-3);
+  margin-top: var(--sp-3);
 }
 .dc-dissent-toggle {
   background: none;
   border: none;
-  color: var(--mk-ink-500);
+  color: var(--color-text-muted);
   cursor: pointer;
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   font-weight: 500;
   padding: 0;
 }
 .dc-dissent-toggle:hover {
-  color: var(--mk-ink-900);
+  color: var(--color-text);
 }
 .dc-dissent-list {
-  margin-top: var(--mk-sp-2);
+  margin-top: var(--sp-2);
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
 }
 .dc-dissent-item {
-  font-size: var(--mk-text-sm);
-  color: var(--mk-ink-700);
-  padding-left: var(--mk-sp-3);
-  border-left: 2px solid var(--mk-line);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  padding-left: var(--sp-3);
+  border-left: 2px solid var(--color-border);
   line-height: 1.5;
 }
 
 /* ── Cost summary ── */
 .dc-cost-summary {
-  margin-top: var(--mk-sp-4);
-  padding-top: var(--mk-sp-3);
+  margin-top: var(--sp-4);
+  padding-top: var(--sp-3);
   border-top: 1px solid rgba(16, 185, 129, 0.15);
 }
 .dc-cost-header {
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   font-weight: 600;
-  color: var(--mk-ink-500);
+  color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: var(--mk-sp-2);
+  margin-bottom: var(--sp-2);
 }
 .dc-cost-grid {
   display: flex;
@@ -2347,15 +2448,15 @@ body::after {
 .dc-cost-row {
   display: flex;
   justify-content: space-between;
-  font-size: var(--mk-text-sm);
-  color: var(--mk-ink-700);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
 }
 .dc-cost-total {
   margin-top: 4px;
   padding-top: 4px;
-  border-top: 1px solid var(--mk-line);
+  border-top: 1px solid var(--color-border);
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--color-text);
 }
 .dc-cost-value {
   font-variant-numeric: tabular-nums;
@@ -2363,52 +2464,52 @@ body::after {
 
 /* ── Error block ── */
 .dc-error-block {
-  margin-top: var(--mk-sp-4);
-  padding: var(--mk-sp-3) var(--mk-sp-4);
+  margin-top: var(--sp-4);
+  padding: var(--sp-3) var(--sp-4);
   background: rgba(239, 68, 68, 0.08);
   border: 1px solid rgba(239, 68, 68, 0.2);
-  border-radius: var(--mk-r-xl);
-  color: var(--mk-danger);
-  font-size: var(--mk-text-sm);
+  border-radius: var(--radius-md);
+  color: var(--color-danger);
+  font-size: var(--text-sm);
   font-weight: 500;
 }
 
 /* ── Responsive ── */
 /* ── ADR Preview ── */
 .dc-adr {
-  margin-top: var(--mk-sp-4);
-  padding: var(--mk-sp-4);
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-xl);
+  margin-top: var(--sp-4);
+  padding: var(--sp-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
 }
 .dc-adr-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--mk-sp-2);
-  margin-bottom: var(--mk-sp-3);
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-3);
 }
 .dc-adr-toggle {
   background: none;
   border: none;
-  color: var(--mk-ink-900);
+  color: var(--color-text);
   cursor: pointer;
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
   font-weight: 600;
   padding: 0;
 }
 .dc-adr-toggle:hover {
-  color: var(--mk-primary);
+  color: var(--color-primary);
 }
 .dc-adr-actions {
   display: flex;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
 }
 .dc-adr-content {
-  font-size: var(--mk-text-sm);
+  font-size: var(--text-sm);
   line-height: 1.7;
-  color: var(--mk-ink-900);
+  color: var(--color-text);
 }
 .dc-adr-content--collapsed {
   max-height: 140px;
@@ -2422,52 +2523,52 @@ body::after {
 .dc-adr-content h1,
 .dc-adr-content h2,
 .dc-adr-content h3 {
-  margin: var(--mk-sp-3) 0 var(--mk-sp-2);
-  color: var(--mk-ink-900);
+  margin: var(--sp-3) 0 var(--sp-2);
+  color: var(--color-text);
 }
 .dc-adr-content h1 { font-size: 1.1rem; }
 .dc-adr-content h2 { font-size: 1rem; }
-.dc-adr-content h3 { font-size: var(--mk-text-sm); }
+.dc-adr-content h3 { font-size: var(--text-sm); }
 .dc-adr-content p {
-  margin: 0 0 var(--mk-sp-2);
+  margin: 0 0 var(--sp-2);
 }
 .dc-adr-content ul,
 .dc-adr-content ol {
-  margin: 0 0 var(--mk-sp-2);
-  padding-left: var(--mk-sp-5);
+  margin: 0 0 var(--sp-2);
+  padding-left: var(--sp-5);
 }
 .dc-adr-content code {
   padding: 1px 4px;
-  background: var(--mk-bg);
+  background: var(--color-bg);
   border-radius: 3px;
   font-size: 0.9em;
-  font-family: var(--mk-font-mono);
+  font-family: var(--font-mono, monospace);
 }
 .dc-adr-content pre {
-  padding: var(--mk-sp-3);
-  background: var(--mk-bg);
-  border-radius: var(--mk-r-md);
+  padding: var(--sp-3);
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
   overflow-x: auto;
-  margin: 0 0 var(--mk-sp-2);
+  margin: 0 0 var(--sp-2);
 }
 .dc-adr-content pre code {
   background: none;
   padding: 0;
 }
 .dc-adr-content blockquote {
-  margin: 0 0 var(--mk-sp-2);
-  padding-left: var(--mk-sp-3);
-  border-left: 3px solid var(--mk-line);
-  color: var(--mk-ink-700);
+  margin: 0 0 var(--sp-2);
+  padding-left: var(--sp-3);
+  border-left: 3px solid var(--color-border);
+  color: var(--color-text-secondary);
 }
 .dc-adr-expand {
   display: block;
-  margin-top: var(--mk-sp-2);
+  margin-top: var(--sp-2);
   background: none;
   border: none;
-  color: var(--mk-primary);
+  color: var(--color-primary);
   cursor: pointer;
-  font-size: var(--mk-text-xs);
+  font-size: var(--text-xs);
   font-weight: 500;
   padding: 0;
 }
@@ -2479,23 +2580,23 @@ body::after {
 .debate-skeleton {
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-3);
-  padding: var(--mk-sp-4);
+  gap: var(--sp-3);
+  padding: var(--sp-4);
 }
 .debate-skeleton-row {
   display: flex;
-  gap: var(--mk-sp-3);
+  gap: var(--sp-3);
   align-items: center;
 }
 .debate-skeleton-bar {
   height: 14px;
-  border-radius: var(--mk-r-md);
-  background: var(--mk-paper);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
   animation: skeleton-shimmer 1.5s ease-in-out infinite;
 }
 .debate-skeleton-topic { width: 200px; }
 .debate-skeleton-short { width: 80px; }
-.debate-skeleton-badge { width: 60px; height: 22px; border-radius: var(--mk-r-full); }
+.debate-skeleton-badge { width: 60px; height: 22px; border-radius: var(--radius-full); }
 
 @keyframes skeleton-shimmer {
   0%, 100% { opacity: 0.4; }
@@ -2505,20 +2606,20 @@ body::after {
 /* ── Loading Skeletons (Chat) ── */
 .dc-skeleton {
   flex: 1;
-  padding: var(--mk-sp-4);
+  padding: var(--sp-4);
   display: flex;
   flex-direction: column;
-  gap: var(--mk-sp-4);
+  gap: var(--sp-4);
 }
 .dc-skeleton-msg {
   display: flex;
-  gap: var(--mk-sp-3);
+  gap: var(--sp-3);
 }
 .dc-skeleton-avatar {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: var(--mk-paper);
+  background: var(--color-surface);
   flex-shrink: 0;
   animation: skeleton-shimmer 1.5s ease-in-out infinite;
 }
@@ -2531,7 +2632,7 @@ body::after {
 .dc-skeleton-bar {
   height: 12px;
   border-radius: 4px;
-  background: var(--mk-paper);
+  background: var(--color-surface);
   animation: skeleton-shimmer 1.5s ease-in-out infinite;
 }
 .dc-skeleton-name { width: 120px; height: 14px; }
@@ -2557,8 +2658,8 @@ body::after {
   display: none;
 }
 .debate-card {
-  padding: var(--mk-sp-3);
-  border-bottom: 1px solid var(--mk-line);
+  padding: var(--sp-3);
+  border-bottom: 1px solid var(--color-border);
   cursor: pointer;
   transition: background 0.15s;
 }
@@ -2567,35 +2668,35 @@ body::after {
 }
 .debate-card:hover,
 .debate-card:focus-visible {
-  background: var(--mk-paper);
+  background: var(--color-surface-hover);
 }
 .debate-card:focus-visible {
-  outline: 2px solid var(--mk-primary);
+  outline: 2px solid var(--color-primary);
   outline-offset: -2px;
 }
 .debate-card-header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: var(--mk-sp-2);
-  margin-bottom: var(--mk-sp-2);
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-2);
 }
 .debate-card-topic {
   font-weight: 500;
-  font-size: var(--mk-text-sm);
-  color: var(--mk-ink-900);
+  font-size: var(--text-sm);
+  color: var(--color-text);
   line-height: 1.4;
 }
 .debate-card-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--mk-sp-2);
+  gap: var(--sp-2);
   align-items: center;
-  font-size: var(--mk-text-xs);
-  color: var(--mk-ink-500);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
 }
 .debate-card-project {
-  color: var(--mk-ink-700);
+  color: var(--color-text-secondary);
 }
 .debate-card-cost {
   font-variant-numeric: tabular-nums;
@@ -2603,7 +2704,7 @@ body::after {
 
 /* ── Keyboard focus for table rows ── */
 .debate-row:focus-visible {
-  outline: 2px solid var(--mk-primary);
+  outline: 2px solid var(--color-primary);
   outline-offset: -2px;
 }
 
@@ -2651,13 +2752,13 @@ body::after {
     flex: 1;
   }
   .dc-input-bar {
-    padding: var(--mk-sp-2) var(--mk-sp-3);
+    padding: var(--sp-2) var(--sp-3);
   }
   .sdm-panel {
     max-width: 100%;
     max-height: 95vh;
-    margin: var(--mk-sp-2);
-    border-radius: var(--mk-r-xl);
+    margin: var(--sp-2);
+    border-radius: var(--radius-md);
   }
   .sdm-participant-row {
     flex-wrap: wrap;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -505,7 +505,7 @@ function AppInner({ onFirstFetchDone }: AppInnerProps = {}) {
         <main className="v4-main">
           <div className="v4-content" style={{ paddingTop: 60 }}>
             <h1 style={{ fontSize: 28, marginBottom: 8 }}>MakeIT Dashboard</h1>
-            <p style={{ color: "var(--mk-ink-500)", marginBottom: 24 }}>
+            <p style={{ color: "var(--v4-ink-500)", marginBottom: 24 }}>
               Укажите GitHub Token для начала работы.
             </p>
             <TokenForm onTokenSet={handleRefresh} />

--- a/src/components/PipelineActiveTasksBlock/styles.css
+++ b/src/components/PipelineActiveTasksBlock/styles.css
@@ -21,9 +21,9 @@
 
 /* ── Panel container ─────────────────────────────────────────── */
 .pl2-panel {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   overflow: hidden;
 }
 
@@ -42,51 +42,51 @@
   align-items: center;
   gap: 12px;
   padding: 12px 18px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   flex-wrap: wrap;
   row-gap: 10px;
 }
 .pl2-panel-t {
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   display: flex;
   align-items: baseline;
   gap: 8px;
 }
 .pl2-panel-count {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 500;
 }
 .pl2-panel-sep {
   width: 1px;
   height: 14px;
-  background: var(--mk-line);
+  background: var(--v4-line);
 }
 .pl2-panel-proj {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
 .pl2-panel-proj b {
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   font-weight: 600;
 }
 .pl2-phase-summary {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10.5px;
   letter-spacing: 0.02em;
-  color: var(--mk-ink-500);
-  background: var(--mk-surface-2);
+  color: var(--v4-ink-500);
+  background: var(--v4-surface-2);
   padding: 4px 8px;
   border-radius: 99px;
 }
@@ -98,49 +98,49 @@
 }
 .pl2-phase-summary-it b {
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .pl2-phase-summary-it--zero { opacity: 0.55; }
-.pl2-phase-summary-it--zero b { color: var(--mk-ink-400); font-weight: 500; }
+.pl2-phase-summary-it--zero b { color: var(--v4-ink-400); font-weight: 500; }
 .pl2-phase-summary-sep {
-  color: var(--mk-ink-300);
+  color: var(--v4-ink-300);
   font-weight: 400;
 }
 .pl2-panel-cost {
   margin-left: auto;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
 }
 .pl2-panel-cost b {
-  color: var(--mk-success-strong);
+  color: var(--v4-success-700);
   font-weight: 700;
 }
 
 /* ── Banners ─────────────────────────────────────────────────── */
 .pl2-banner {
   padding: 10px 18px;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   font-size: 12.5px;
   display: flex;
   align-items: center;
   gap: 10px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
-.pl2-banner--stopping { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.pl2-banner--empty { background: var(--mk-surface-2); color: var(--mk-ink-600); }
+.pl2-banner--stopping { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.pl2-banner--empty { background: var(--v4-surface-2); color: var(--v4-ink-600); }
 .pl2-banner-dot {
   width: 8px; height: 8px; border-radius: 50%;
 }
 .pl2-banner--stopping .pl2-banner-dot {
-  background: var(--mk-warn);
+  background: var(--v4-warn-500);
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--mk-warn) 15%, transparent);
   animation: pl2-pulse 1.5s ease-in-out infinite;
 }
 .pl2-banner-spin {
   width: 12px; height: 12px;
-  border: 2px solid var(--mk-ink-300);
-  border-top-color: var(--mk-brand-500);
+  border: 2px solid var(--v4-ink-300);
+  border-top-color: var(--v4-accent-500);
   border-radius: 50%;
   animation: pl2-spin 0.9s linear infinite;
 }
@@ -149,39 +149,39 @@
 .pl2-skeleton-row {
   display: flex; gap: 14px; padding: 14px 18px;
   align-items: center;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .pl2-skeleton-row:last-child { border-bottom: 0; }
 .pl2-skeleton-bar {
   height: 12px;
   border-radius: 4px;
-  background: linear-gradient(90deg, var(--mk-surface-2), var(--mk-surface-3), var(--mk-surface-2));
+  background: linear-gradient(90deg, var(--v4-surface-2), var(--v4-surface-3), var(--v4-surface-2));
   background-size: 600px 100%;
   animation: pl2-shimmer 1.4s linear infinite;
 }
 
 /* ── Common chip / atom styles ──────────────────────────────── */
 .pl2-num {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11.5px;
   font-weight: 700;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   letter-spacing: 0.02em;
   text-decoration: none;
   flex-shrink: 0;
   cursor: pointer;
 }
-.pl2-num:hover { color: var(--mk-brand-600); }
+.pl2-num:hover { color: var(--v4-accent-600); }
 .pl2-risk-dot {
   width: 8px; height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
 }
-.pl2-risk-dot--low { background: var(--mk-success); }
-.pl2-risk-dot--medium { background: var(--mk-warn); }
-.pl2-risk-dot--high { background: var(--mk-danger); }
+.pl2-risk-dot--low { background: var(--v4-success-500); }
+.pl2-risk-dot--medium { background: var(--v4-warn-500); }
+.pl2-risk-dot--high { background: var(--v4-danger-500); }
 .pl2-pri {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9.5px;
   font-weight: 700;
   padding: 2px 6px;
@@ -189,43 +189,43 @@
   letter-spacing: 0.04em;
   flex-shrink: 0;
 }
-.pl2-pri--p1 { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
-.pl2-pri--p2 { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.pl2-pri--p3 { background: var(--mk-brand-50); color: var(--mk-brand-700); }
-.pl2-pri--p4 { background: var(--mk-surface-2); color: var(--mk-ink-600); }
+.pl2-pri--p1 { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.pl2-pri--p2 { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.pl2-pri--p3 { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.pl2-pri--p4 { background: var(--v4-surface-2); color: var(--v4-ink-600); }
 .pl2-title {
   flex: 1 1 240px;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   font-size: 12.5px;
   font-weight: 500;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
 }
 .pl2-title-placeholder {
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-style: italic;
 }
 .pl2-meta-mono {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-variant-numeric: tabular-nums;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
 }
-.pl2-cost { color: var(--mk-success-strong); font-weight: 600; }
-.pl2-cost--warn { color: var(--mk-warn-strong); }
-.pl2-cost--danger { color: var(--mk-danger-strong); }
-.pl2-attempt-warn { color: var(--mk-warn-strong); font-weight: 700; }
-.pl2-attempt-danger { color: var(--mk-danger-strong); font-weight: 700; }
+.pl2-cost { color: var(--v4-success-700); font-weight: 600; }
+.pl2-cost--warn { color: var(--v4-warn-700); }
+.pl2-cost--danger { color: var(--v4-danger-700); }
+.pl2-attempt-warn { color: var(--v4-warn-700); font-weight: 700; }
+.pl2-attempt-danger { color: var(--v4-danger-700); font-weight: 700; }
 
 /* Anomaly chip */
 .pl2-an {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 700;
   padding: 2px 7px;
@@ -234,28 +234,28 @@
   white-space: nowrap;
   flex-shrink: 0;
 }
-.pl2-an--stuck { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.pl2-an--budget { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.pl2-an--overbudget { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
-.pl2-an--retry { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
+.pl2-an--stuck { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.pl2-an--budget { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.pl2-an--overbudget { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.pl2-an--retry { background: var(--v4-danger-50); color: var(--v4-danger-700); }
 
 /* Phase color tokens */
-.pl2-ph-dev { --ph-c: var(--mk-brand-500); --ph-bg: var(--mk-brand-50); --ph-fg: var(--mk-brand-700); }
-.pl2-ph-review { --ph-c: var(--mk-purple-500); --ph-bg: var(--mk-purple-50); --ph-fg: var(--mk-purple-700); }
-.pl2-ph-qa_verify { --ph-c: var(--mk-sky-500); --ph-bg: var(--mk-sky-50); --ph-fg: var(--mk-sky-700); }
-.pl2-ph-merge { --ph-c: var(--mk-success); --ph-bg: var(--mk-success-soft); --ph-fg: var(--mk-success-strong); }
-.pl2-ph-ci_monitor { --ph-c: var(--mk-orange-bright-500); --ph-bg: #FFF6ED; --ph-fg: var(--mk-orange-bright-700); }
+.pl2-ph-dev { --ph-c: var(--v4-accent-500); --ph-bg: var(--v4-accent-50); --ph-fg: var(--v4-accent-700); }
+.pl2-ph-review { --ph-c: var(--v4-purple-500); --ph-bg: var(--v4-purple-50); --ph-fg: var(--v4-purple-700); }
+.pl2-ph-qa_verify { --ph-c: var(--v4-sky-500); --ph-bg: var(--v4-sky-50); --ph-fg: var(--v4-sky-700); }
+.pl2-ph-merge { --ph-c: var(--v4-success-500); --ph-bg: var(--v4-success-50); --ph-fg: var(--v4-success-700); }
+.pl2-ph-ci_monitor { --ph-c: var(--v4-orange-500); --ph-bg: var(--v4-orange-50); --ph-fg: var(--v4-orange-700); }
 
 /* ── Card chrome ─────────────────────────────────────────────── */
 .pl2-card-wrap { position: relative; }
 .pl2-card {
   position: relative;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   padding: 11px 40px 11px 21px;
   display: flex;
   flex-direction: column;
   gap: 6px;
-  background: var(--mk-paper);
+  background: var(--v4-paper);
   transition: background .15s;
 }
 .pl2-card-wrap:last-child .pl2-card { border-bottom: 0; }
@@ -266,10 +266,10 @@
   left: 0; top: 0; bottom: 0;
   width: 3px;
 }
-.pl2-card-strip--running { background: var(--mk-brand-500); }
-.pl2-card-strip--warn { background: var(--mk-warn); }
-.pl2-card-strip--danger { background: var(--mk-danger); }
-.pl2-card-strip--idle { background: var(--mk-ink-300); }
+.pl2-card-strip--running { background: var(--v4-accent-500); }
+.pl2-card-strip--warn { background: var(--v4-warn-500); }
+.pl2-card-strip--danger { background: var(--v4-danger-500); }
+.pl2-card-strip--idle { background: var(--v4-ink-300); }
 
 /* Expand button (top-right of card) */
 .pl2-card-toggle {
@@ -281,15 +281,15 @@
   border: 0;
   padding: 4px;
   cursor: pointer;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: 4px;
 }
-.pl2-card-toggle:hover { color: var(--mk-ink-900); background: var(--mk-surface-2); }
+.pl2-card-toggle:hover { color: var(--v4-ink-900); background: var(--v4-surface-2); }
 .pl2-card-toggle:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: 2px;
 }
 
@@ -311,23 +311,23 @@
 .pl2-dotchain-dot {
   width: 8px; height: 8px;
   border-radius: 50%;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   flex-shrink: 0;
   position: relative;
 }
 .pl2-dotchain-line {
   width: 8px;
   height: 2px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   flex-shrink: 0;
 }
-.pl2-dotchain-dot--success { background: var(--mk-success); }
-.pl2-dotchain-dot--partial { background: var(--mk-warn); }
+.pl2-dotchain-dot--success { background: var(--v4-success-500); }
+.pl2-dotchain-dot--partial { background: var(--v4-warn-500); }
 .pl2-dotchain-dot--failure,
-.pl2-dotchain-dot--terminal_failure { background: var(--mk-danger); }
+.pl2-dotchain-dot--terminal_failure { background: var(--v4-danger-500); }
 .pl2-dotchain-dot--pending {
-  background: var(--mk-surface-3);
-  border: 1px solid var(--mk-line-strong);
+  background: var(--v4-surface-3);
+  border: 1px solid var(--v4-line-strong);
   box-sizing: border-box;
 }
 .pl2-dotchain-dot--running {
@@ -342,10 +342,10 @@
   background: var(--ph-c);
   animation: pl2-pulse-strong 1.6s ease-out infinite;
 }
-.pl2-dotchain-line--success { background: var(--mk-success); }
-.pl2-dotchain-line--partial { background: var(--mk-warn); }
-.pl2-dotchain-line--failure { background: var(--mk-danger); }
-.pl2-dotchain-line--running { background: linear-gradient(90deg, var(--mk-success), var(--mk-surface-3)); }
+.pl2-dotchain-line--success { background: var(--v4-success-500); }
+.pl2-dotchain-line--partial { background: var(--v4-warn-500); }
+.pl2-dotchain-line--failure { background: var(--v4-danger-500); }
+.pl2-dotchain-line--running { background: linear-gradient(90deg, var(--v4-success-500), var(--v4-surface-3)); }
 
 /* Compact active phase pill */
 .pl2-c-phase {
@@ -356,7 +356,7 @@
   border-radius: 99px;
   background: var(--ph-bg);
   color: var(--ph-fg);
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10.5px;
   font-weight: 700;
   text-transform: uppercase;
@@ -379,31 +379,31 @@
   align-items: flex-end;
   gap: 1px;
   padding: 0 10px;
-  border-left: 1px solid var(--mk-line-soft);
+  border-left: 1px solid var(--v4-line-soft);
   min-width: 56px;
 }
 .pl2-c-stat:first-child { border-left: 0; padding-left: 8px; }
 .pl2-c-stat:last-child { padding-right: 0; }
 .pl2-c-stat-l {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 8.5px;
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .pl2-c-stat-v {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12.5px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-variant-numeric: tabular-nums;
   line-height: 1.1;
 }
 .pl2-c-stat--model .pl2-c-stat-v {
   font-size: 10.5px;
   font-weight: 600;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   text-transform: lowercase;
 }
 
@@ -415,11 +415,11 @@
   flex-wrap: wrap;
   /* Indent under title (skip strip + #NNNN + risk + pri area) */
   padding-left: calc(11.5px + 10px + 8px + 10px + 22px);
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
 }
 .pl2-c-substep {
   font-size: 10.5px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-style: italic;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -436,22 +436,22 @@
   height: 26px;
   padding: 0 10px;
   border-radius: 6px;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  color: var(--mk-ink-700);
-  font-family: var(--mk-font-sans);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  color: var(--v4-ink-700);
+  font-family: var(--v4-sans);
   font-size: 11.5px;
   font-weight: 500;
   cursor: pointer;
   text-decoration: none;
 }
-.pl2-btn:hover { border-color: var(--mk-line-strong); color: var(--mk-ink-900); }
+.pl2-btn:hover { border-color: var(--v4-line-strong); color: var(--v4-ink-900); }
 .pl2-btn--ghost { background: transparent; }
 
 /* ── Expanded view ──────────────────────────────────────────── */
 .pl2-exp {
-  background: var(--mk-surface-2);
-  border-top: 1px solid var(--mk-line-soft);
+  background: var(--v4-surface-2);
+  border-top: 1px solid var(--v4-line-soft);
   padding: 14px 18px 16px;
   display: flex;
   flex-direction: column;
@@ -477,18 +477,18 @@
   flex-wrap: wrap;
 }
 .pl2-exp-label {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9.5px;
   font-weight: 700;
   padding: 2px 7px;
   border-radius: 99px;
   letter-spacing: 0.04em;
-  background: var(--mk-paper);
-  color: var(--mk-ink-700);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  color: var(--v4-ink-700);
+  border: 1px solid var(--v4-line);
 }
 .pl2-cx {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9.5px;
   font-weight: 700;
   padding: 2px 7px;
@@ -496,9 +496,9 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
-.pl2-cx--auto { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.pl2-cx--assisted { background: var(--mk-brand-50); color: var(--mk-brand-700); }
-.pl2-cx--manual { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
+.pl2-cx--auto { background: var(--v4-success-50); color: var(--v4-success-700); }
+.pl2-cx--assisted { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.pl2-cx--manual { background: var(--v4-warn-50); color: var(--v4-warn-700); }
 
 .pl2-exp-tl {
   display: flex;
@@ -514,8 +514,8 @@
   padding: 8px 10px;
   border-radius: 8px;
   position: relative;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line-soft);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line-soft);
 }
 .pl2-exp-step.is-retry { margin-left: 24px; }
 .pl2-exp-step.is-current {
@@ -528,17 +528,17 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 700;
   color: #fff;
   flex-shrink: 0;
-  background: var(--mk-ink-400);
+  background: var(--v4-ink-400);
 }
-.pl2-exp-step.is-success .pl2-exp-step-bullet { background: var(--mk-success); }
-.pl2-exp-step.is-partial .pl2-exp-step-bullet { background: var(--mk-warn); }
+.pl2-exp-step.is-success .pl2-exp-step-bullet { background: var(--v4-success-500); }
+.pl2-exp-step.is-partial .pl2-exp-step-bullet { background: var(--v4-warn-500); }
 .pl2-exp-step.is-failure .pl2-exp-step-bullet,
-.pl2-exp-step.is-terminal_failure .pl2-exp-step-bullet { background: var(--mk-danger); }
+.pl2-exp-step.is-terminal_failure .pl2-exp-step-bullet { background: var(--v4-danger-500); }
 .pl2-exp-step.is-running .pl2-exp-step-bullet {
   background: var(--ph-c);
   position: relative;
@@ -558,30 +558,30 @@
   flex-wrap: wrap;
 }
 .pl2-exp-step-name {
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .pl2-exp-step-sum {
   margin-top: 4px;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   font-size: 12px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   line-height: 1.4;
 }
 .pl2-exp-step-sum.is-emphasized {
   font-size: 13px;
   font-weight: 500;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 
 /* ── Empty / no-tasks state ─────────────────────────────────── */
 .pl2-empty {
   padding: 20px 18px;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   font-size: 13px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   text-align: center;
 }
 

--- a/src/components/quality/AnnotationModal.tsx
+++ b/src/components/quality/AnnotationModal.tsx
@@ -42,7 +42,7 @@ const labelStyle: React.CSSProperties = {
 
 const labelTextStyle: React.CSSProperties = {
   fontSize: 11,
-  color: "var(--mk-ink-500)",
+  color: "#666",
   textTransform: "uppercase",
   letterSpacing: 0.4,
 };

--- a/src/components/quality/QualityChart.tsx
+++ b/src/components/quality/QualityChart.tsx
@@ -229,7 +229,7 @@ export function QualityChart({ buckets, labels, compact }: QualityChartProps) {
                 />
               </span>
               <span className="ct-seg">
-                <i className="sw" style={{ background: "var(--mk-quality-p1)" }} />
+                <i className="sw" style={{ background: "var(--v4-p1)" }} />
                 P1:
                 <b
                   ref={(el) => {
@@ -238,7 +238,7 @@ export function QualityChart({ buckets, labels, compact }: QualityChartProps) {
                 />
               </span>
               <span className="ct-seg">
-                <i className="sw" style={{ background: "var(--mk-quality-p2)" }} />
+                <i className="sw" style={{ background: "var(--v4-p2)" }} />
                 P2:
                 <b
                   ref={(el) => {
@@ -249,7 +249,7 @@ export function QualityChart({ buckets, labels, compact }: QualityChartProps) {
               <span className="ct-seg">
                 <i
                   className="sw"
-                  style={{ background: "var(--mk-quality-clean-soft)" }}
+                  style={{ background: "var(--v4-clean-soft)" }}
                 />
                 clean:
                 <b
@@ -281,7 +281,7 @@ export function QualityChart({ buckets, labels, compact }: QualityChartProps) {
               <span className="chart-tip-seg">
                 <i
                   className="sw"
-                  style={{ background: "var(--mk-quality-clean-soft)" }}
+                  style={{ background: "var(--v4-clean-soft)" }}
                 />{" "}
                 чистые
               </span>
@@ -294,7 +294,7 @@ export function QualityChart({ buckets, labels, compact }: QualityChartProps) {
             </div>
             <div className="chart-tip-foot chart-tip-foot--tight">
               <span className="chart-tip-seg">
-                <i className="sw" style={{ background: "var(--mk-quality-p2)" }} /> P2
+                <i className="sw" style={{ background: "var(--v4-p2)" }} /> P2
                 only
               </span>
               <span
@@ -302,24 +302,24 @@ export function QualityChart({ buckets, labels, compact }: QualityChartProps) {
                   if (el) tipRefsObj.current.p2 = el;
                 }}
                 className="chart-tip-tr"
-                style={{ color: "var(--mk-quality-p2-text)" }}
+                style={{ color: "var(--v4-p2-text)" }}
               />
             </div>
             <div className="chart-tip-foot chart-tip-foot--tight">
               <span className="chart-tip-seg">
-                <i className="sw" style={{ background: "var(--mk-quality-p1)" }} /> P1
+                <i className="sw" style={{ background: "var(--v4-p1)" }} /> P1
               </span>
               <span
                 ref={(el) => {
                   if (el) tipRefsObj.current.p1 = el;
                 }}
                 className="chart-tip-tr"
-                style={{ color: "var(--mk-quality-p1-text)" }}
+                style={{ color: "var(--v4-p1-text)" }}
               />
             </div>
             <div className="chart-tip-foot chart-tip-foot--tight">
               <span className="chart-tip-seg">
-                <i className="sw" style={{ background: "var(--mk-quality-p0)" }} /> P0
+                <i className="sw" style={{ background: "var(--v4-p0)" }} /> P0
                 (blockers)
               </span>
               <span
@@ -327,13 +327,13 @@ export function QualityChart({ buckets, labels, compact }: QualityChartProps) {
                   if (el) tipRefsObj.current.p0 = el;
                 }}
                 className="chart-tip-tr"
-                style={{ color: "var(--mk-quality-p0-text)" }}
+                style={{ color: "var(--v4-p0-text)" }}
               />
             </div>
             <div
               className="chart-tip-foot"
               style={{
-                borderTop: "1px solid var(--mk-line-soft)",
+                borderTop: "1px solid var(--v4-line-soft)",
                 paddingTop: 8,
                 marginTop: 4,
               }}

--- a/src/components/quality/QualityKPIs.tsx
+++ b/src/components/quality/QualityKPIs.tsx
@@ -40,11 +40,11 @@ export function QualityKPIs({ data, mode }: Props) {
       </div>
       <div className="kpi" style={kpiStyle(1)}>
         <div className="kpi-lbl">% P1 · {periodLabel}</div>
-        <div className="kpi-v" style={{ color: "var(--mk-quality-p1-text)" }}>{p1Pct}%</div>
+        <div className="kpi-v" style={{ color: "var(--v4-p1-text)" }}>{p1Pct}%</div>
       </div>
       <div className="kpi" style={kpiStyle(2)}>
         <div className="kpi-lbl">% P2 · {periodLabel}</div>
-        <div className="kpi-v" style={{ color: "var(--mk-quality-p2-text)" }}>{p2Pct}%</div>
+        <div className="kpi-v" style={{ color: "var(--v4-p2-text)" }}>{p2Pct}%</div>
       </div>
       <div className="kpi" style={kpiStyle(3)}>
         <div className="kpi-lbl">PR {periodLabel}</div>

--- a/src/components/quality/QualityProjectCard.tsx
+++ b/src/components/quality/QualityProjectCard.tsx
@@ -103,7 +103,7 @@ export function QualityProjectCard({ repo, client, data, mode, index }: Props) {
             <span className="num-p0" title="БЛОКЕР">
               <b
                 style={{
-                  color: "var(--mk-quality-p0-text)",
+                  color: "var(--v4-p0-text)",
                   background: "color-mix(in srgb, var(--mk-danger) 12%, transparent)",
                   padding: "1px 6px",
                   borderRadius: 3,

--- a/src/components/quality/QualityTab.tsx
+++ b/src/components/quality/QualityTab.tsx
@@ -62,7 +62,7 @@ export function QualityTab() {
             // (mini-API + sweep are independent, so this can be non-zero
             // even with no chart data).
             <p
-              style={{ fontSize: 11, opacity: 0.7, fontFamily: "var(--mk-font-mono)" }}
+              style={{ fontSize: 11, opacity: 0.7, fontFamily: "var(--v4-mono)" }}
               aria-live="polite"
             >
               сохранено событий: {annotations.length} — появятся на таймлайне после первой агрегации
@@ -111,9 +111,9 @@ export function QualityTab() {
             <button className={mode === "12w" ? "active" : ""} onClick={() => setMode("12w")}>12 недель · По неделям</button>
           </div>
           <button className="btn-add-event" onClick={() => setShowAddModal(true)}>+ событие</button>
-          <div style={{ fontFamily: "var(--mk-font-mono)", fontSize: 10, color: "var(--mk-ink-500)", textAlign: "right" }}>
+          <div style={{ fontFamily: "var(--v4-mono)", fontSize: 10, color: "var(--v4-ink-500)", textAlign: "right" }}>
             <div>Синхр. ежедневно · 03:00 Бали</div>
-            <div style={{ color: "var(--mk-ink-400)" }}>
+            <div style={{ color: "var(--v4-ink-400)" }}>
               последняя: {new Date(data.generated_at).toLocaleString("ru")}
             </div>
           </div>

--- a/src/components/v4/AIInsightsPanel.tsx
+++ b/src/components/v4/AIInsightsPanel.tsx
@@ -172,7 +172,7 @@ export function AIInsightsPanel({ reports, loading, lastUpdated, onOpenHealth, e
       <div className="v4-panel-h">
         <div className="v4-panel-t">
           <svg
-            style={{ width: 14, height: 14, color: "var(--mk-purple-500)" }}
+            style={{ width: 14, height: 14, color: "var(--v4-purple-500)" }}
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"

--- a/src/components/v4/ClosedChart30d.tsx
+++ b/src/components/v4/ClosedChart30d.tsx
@@ -137,7 +137,7 @@ export function ClosedChart30d({ projects }: Props) {
               x2={W - PAD_R}
               y1={y}
               y2={y}
-              stroke="var(--mk-line-soft)"
+              stroke="var(--v4-line-soft)"
               strokeWidth="1"
               strokeDasharray={i === grid.length - 1 ? "0" : "2 4"}
             />
@@ -150,7 +150,7 @@ export function ClosedChart30d({ projects }: Props) {
               y={PAD_T - 6}
               width={barW + 4}
               height={INNER_H + 12}
-              fill="var(--mk-brand-100)"
+              fill="var(--v4-accent-100)"
               opacity="0.45"
               rx="4"
             />
@@ -165,8 +165,8 @@ export function ClosedChart30d({ projects }: Props) {
             const isHover = hover === i;
             const fill =
               isHover || isPeak
-                ? "var(--mk-brand-700)"
-                : "var(--mk-brand-500)";
+                ? "var(--v4-accent-700)"
+                : "var(--v4-accent-500)";
             return (
               <g key={d.day}>
                 <rect
@@ -184,7 +184,7 @@ export function ClosedChart30d({ projects }: Props) {
                     cx={cxOf(i)}
                     cy={y - 7}
                     r="3"
-                    fill="var(--mk-brand-700)"
+                    fill="var(--v4-accent-700)"
                   />
                 )}
               </g>
@@ -198,7 +198,7 @@ export function ClosedChart30d({ projects }: Props) {
                 ref={pathRef}
                 d={trendD}
                 fill="none"
-                stroke="var(--mk-success)"
+                stroke="var(--v4-success-500)"
                 strokeWidth="2.5"
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -209,7 +209,7 @@ export function ClosedChart30d({ projects }: Props) {
               <path
                 d={trendD}
                 fill="none"
-                stroke="var(--mk-paper)"
+                stroke="var(--v4-paper)"
                 strokeWidth="2.5"
                 strokeDasharray="0 7 4 0"
                 opacity={t > 0.6 ? (t - 0.6) / 0.4 : 0}
@@ -226,9 +226,9 @@ export function ClosedChart30d({ projects }: Props) {
                 x={cxOf(i)}
                 y={H - 10}
                 textAnchor="middle"
-                fontFamily="var(--mk-font-mono)"
+                fontFamily="var(--v4-mono)"
                 fontSize="10"
-                fill="var(--mk-ink-400)"
+                fill="var(--v4-ink-400)"
               >
                 {new Date(d.day).getDate()}
               </text>
@@ -248,7 +248,7 @@ export function ClosedChart30d({ projects }: Props) {
                   x2={cx}
                   y1={y - 4}
                   y2={PAD_T + INNER_H}
-                  stroke="var(--mk-brand-700)"
+                  stroke="var(--v4-accent-700)"
                   strokeWidth="1"
                   strokeDasharray="2 2"
                   opacity="0.5"
@@ -259,13 +259,13 @@ export function ClosedChart30d({ projects }: Props) {
                   width="44"
                   height="20"
                   rx="4"
-                  fill="var(--mk-ink-900)"
+                  fill="var(--v4-ink-900)"
                 />
                 <text
                   x={cx}
                   y={y - 12}
                   textAnchor="middle"
-                  fontFamily="var(--mk-font-mono)"
+                  fontFamily="var(--v4-mono)"
                   fontSize="11"
                   fontWeight="700"
                   fill="#fff"
@@ -329,7 +329,7 @@ export function ClosedChart30d({ projects }: Props) {
         <span className="v4-cc-lg">
           <span
             className="v4-cc-sw"
-            style={{ background: "var(--mk-brand-500)" }}
+            style={{ background: "var(--v4-accent-500)" }}
           />
           Закрыто (шт.)
         </span>
@@ -340,7 +340,7 @@ export function ClosedChart30d({ projects }: Props) {
               y1="3"
               x2="22"
               y2="3"
-              stroke="var(--mk-success)"
+              stroke="var(--v4-success-500)"
               strokeWidth="2.5"
               strokeLinecap="round"
             />

--- a/src/components/v4/DashboardProjectCard.tsx
+++ b/src/components/v4/DashboardProjectCard.tsx
@@ -92,10 +92,10 @@ export function DashboardProjectCard({ project, monitor, index = 0 }: Props) {
   const pct = total > 0 ? Math.round((done / total) * 100) : 0;
   const fillColor =
     pct >= 75
-      ? "var(--mk-success)"
+      ? "var(--v4-success-500)"
       : pct >= 40
-      ? "var(--mk-brand-500)"
-      : "var(--mk-warn)";
+      ? "var(--v4-accent-500)"
+      : "var(--v4-warn-500)";
 
   const hasFinances = project.budget > 0;
   const paid = project.paid;

--- a/src/components/v4/KpiRow.tsx
+++ b/src/components/v4/KpiRow.tsx
@@ -111,7 +111,7 @@ function VelocitySpark({ values }: { values: number[] }) {
         <path
           d={geom.line}
           fill="none"
-          stroke="var(--mk-success)"
+          stroke="var(--v4-success-500)"
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -123,18 +123,18 @@ function VelocitySpark({ values }: { values: number[] }) {
               x2={hover.x}
               y1={SPARK_P}
               y2={SPARK_H}
-              stroke="var(--mk-success)"
+              stroke="var(--v4-success-500)"
               strokeWidth="1"
               strokeDasharray="2 2"
               opacity="0.5"
             />
-            <circle cx={hover.x} cy={hover.y} r="6" fill="var(--mk-success)" opacity="0.18" />
+            <circle cx={hover.x} cy={hover.y} r="6" fill="var(--v4-success-500)" opacity="0.18" />
             <circle
               cx={hover.x}
               cy={hover.y}
               r="3.5"
               fill="#fff"
-              stroke="var(--mk-success)"
+              stroke="var(--v4-success-500)"
               strokeWidth="2"
             />
           </g>
@@ -332,19 +332,19 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
               key: "P1",
               n: <TweenedNumber value={priorityTotals.P1} />,
               l: "P1",
-              color: "var(--mk-priority-p1)",
+              color: "var(--v4-p1)",
             },
             {
               key: "P2",
               n: <TweenedNumber value={priorityTotals.P2} />,
               l: "P2",
-              color: "var(--mk-priority-p2)",
+              color: "var(--v4-p2)",
             },
             {
               key: "P3",
               n: <TweenedNumber value={priorityTotals.P3} />,
               l: "P3",
-              color: "var(--mk-priority-p3)",
+              color: "var(--v4-p3)",
             },
           ]}
         />
@@ -444,7 +444,7 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
               >
                 <span
                   className="v4-fin-lg-sw"
-                  style={{ background: "var(--mk-success)" }}
+                  style={{ background: "var(--v4-success-500)" }}
                 />
                 Оплачено <b>{compactUSD(summary.totalPaid)}</b>
               </span>
@@ -465,7 +465,7 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
                 key: "paid",
                 n: compactUSD(summary.totalPaid),
                 l: "Оплачено",
-                color: "var(--mk-success-strong)",
+                color: "var(--v4-success-700)",
               },
               {
                 key: "rem",

--- a/src/components/v4/MakeItLoader.tsx
+++ b/src/components/v4/MakeItLoader.tsx
@@ -6,7 +6,7 @@ export interface MakeItLoaderProps {
   size?: number;
   /** Force dark scheme. If omitted, inherits `color` from parent. */
   dark?: boolean;
-  /** Override accent color. Default `var(--mk-brand-600)` → `#2563EB`. */
+  /** Override accent color. Default `var(--v4-accent-600)` → `#2563EB`. */
   accent?: string;
   /** Center self in parent via flex. */
   center?: boolean;

--- a/src/components/v4/MilestonesStrip.tsx
+++ b/src/components/v4/MilestonesStrip.tsx
@@ -112,12 +112,12 @@ export function MilestonesStrip({ milestones, lastUpdated }: Props) {
             const pct = total > 0 ? Math.round((m.closedIssues / total) * 100) : 0;
             const fillColor =
               cls === "done"
-                ? "var(--mk-success)"
+                ? "var(--v4-success-500)"
                 : cls === "over"
-                ? "var(--mk-warn)"
+                ? "var(--v4-warn-500)"
                 : cls === "warn"
-                ? "var(--mk-success)"
-                : "var(--mk-brand-500)";
+                ? "var(--v4-success-500)"
+                : "var(--v4-accent-500)";
             const priority = inferPriority(m);
             const dueLabel = !m.dueOn
               ? "—"

--- a/src/components/v4/OrphanIssuesPanel.tsx
+++ b/src/components/v4/OrphanIssuesPanel.tsx
@@ -229,7 +229,7 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated, error = null }:
       <div className="v4-panel-h">
         <div className="v4-panel-t">
           <svg
-            style={{ width: 14, height: 14, color: "var(--mk-warn-strong)" }}
+            style={{ width: 14, height: 14, color: "var(--v4-warn-700)" }}
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -287,7 +287,7 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated, error = null }:
                 x2={W - PAD_R}
                 y1={y}
                 y2={y}
-                stroke="var(--mk-line-soft)"
+                stroke="var(--v4-line-soft)"
                 strokeWidth="1"
                 strokeDasharray={i === grid.length - 1 ? "0" : "2 4"}
               />
@@ -300,7 +300,7 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated, error = null }:
                 x2={xOf(hover)}
                 y1={PAD_T - 4}
                 y2={PAD_T + INNER_H}
-                stroke="var(--mk-brand-700)"
+                stroke="var(--v4-accent-700)"
                 strokeWidth="1"
                 strokeDasharray="2 3"
                 opacity="0.55"
@@ -311,7 +311,7 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated, error = null }:
             {areaD && (
               <path
                 d={areaD}
-                fill="var(--mk-brand-100)"
+                fill="var(--v4-accent-100)"
                 opacity={t * 0.6}
               />
             )}
@@ -322,7 +322,7 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated, error = null }:
                 ref={pathRef}
                 d={lineD}
                 fill="none"
-                stroke="var(--mk-brand-500)"
+                stroke="var(--v4-accent-500)"
                 strokeWidth="2.5"
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -337,8 +337,8 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated, error = null }:
                 cx={xOf(hover)}
                 cy={yOf(buckets[hover].count)}
                 r="4"
-                fill="var(--mk-brand-700)"
-                stroke="var(--mk-paper)"
+                fill="var(--v4-accent-700)"
+                stroke="var(--v4-paper)"
                 strokeWidth="2"
               />
             )}
@@ -351,9 +351,9 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated, error = null }:
                   x={xOf(i)}
                   y={H - 10}
                   textAnchor="middle"
-                  fontFamily="var(--mk-font-mono)"
+                  fontFamily="var(--v4-mono)"
                   fontSize="10"
-                  fill="var(--mk-ink-400)"
+                  fill="var(--v4-ink-400)"
                 >
                   {new Date(b.iso).getUTCDate()}
                 </text>
@@ -418,7 +418,7 @@ export function OrphanIssuesPanel({ items, loading, lastUpdated, error = null }:
           <span className="v4-cc-lg">
             <span
               className="v4-cc-sw"
-              style={{ background: "var(--mk-brand-500)" }}
+              style={{ background: "var(--v4-accent-500)" }}
             />
             Orphan-issues (open, без milestone)
           </span>

--- a/src/components/v4/ProgressMatrix.tsx
+++ b/src/components/v4/ProgressMatrix.tsx
@@ -71,7 +71,7 @@ function Ring({ pct, anim }: { pct: number; anim: number }) {
   const len = pct * c * anim;
   return (
     <svg width="24" height="24" viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r={r} fill="none" stroke="var(--mk-line)" strokeWidth="3" />
+      <circle cx="12" cy="12" r={r} fill="none" stroke="var(--v4-line)" strokeWidth="3" />
       <circle
         cx="12"
         cy="12"
@@ -131,9 +131,9 @@ function SortHeader({
         border: 0,
         cursor: "pointer",
         background: active
-          ? "var(--mk-surface-2)"
+          ? "var(--v4-surface-2)"
           : hovered
-            ? "var(--mk-brand-50)"
+            ? "var(--v4-accent-50)"
             : "transparent",
         padding: "8px 10px",
         borderRadius: 6,
@@ -141,12 +141,12 @@ function SortHeader({
         alignItems: "center",
         justifyContent: align,
         gap: 6,
-        fontFamily: "var(--mk-font-mono)",
+        fontFamily: "var(--v4-mono)",
         fontSize: 10,
         fontWeight: 700,
         letterSpacing: ".08em",
         textTransform: "uppercase",
-        color: active ? "var(--mk-ink-900)" : "var(--mk-ink-500)",
+        color: active ? "var(--v4-ink-900)" : "var(--v4-ink-500)",
         transition: "background .15s, color .15s",
       }}
     >
@@ -190,13 +190,13 @@ function PriorityCell({ val, max, color, alpha, dimmed, focused }: CellProps) {
     boxShadow: focused ? "var(--mk-shadow-md)" : "none",
   };
   const labelColor =
-    val === 0 ? "var(--mk-ink-300)" : t > 0.55 ? "#fff" : "var(--mk-ink-800)";
+    val === 0 ? "var(--v4-ink-300)" : t > 0.55 ? "#fff" : "var(--v4-ink-800)";
   return (
     <div style={style}>
       <span
         className="num"
         style={{
-          fontFamily: "var(--mk-font-mono)",
+          fontFamily: "var(--v4-mono)",
           fontSize: 12,
           fontWeight: t > 0.4 ? 700 : 500,
           color: labelColor,
@@ -321,7 +321,7 @@ export function ProgressMatrix({ projects }: Props) {
         </div>
         <div
           className="v4-panel-meta"
-          style={{ color: "var(--mk-ink-500)" }}
+          style={{ color: "var(--v4-ink-500)" }}
         >
           плотность = доля от макс по столбцу
         </div>
@@ -334,19 +334,19 @@ export function ProgressMatrix({ projects }: Props) {
           gridTemplateColumns:
             "170px 100px 70px repeat(4, 1fr) 70px 70px",
           padding: "4px 14px",
-          borderBottom: "1px solid var(--mk-line-soft)",
+          borderBottom: "1px solid var(--v4-line-soft)",
           alignItems: "center",
         }}
       >
         <div
           style={{
             padding: "8px 10px",
-            fontFamily: "var(--mk-font-mono)",
+            fontFamily: "var(--v4-mono)",
             fontSize: 10,
             fontWeight: 700,
             letterSpacing: ".08em",
             textTransform: "uppercase",
-            color: "var(--mk-ink-500)",
+            color: "var(--v4-ink-500)",
           }}
         >
           проект
@@ -368,15 +368,15 @@ export function ProgressMatrix({ projects }: Props) {
           }
           style={{
             padding: "8px 10px",
-            fontFamily: "var(--mk-font-mono)",
+            fontFamily: "var(--v4-mono)",
             fontSize: 10,
             fontWeight: 700,
             letterSpacing: ".08em",
             textTransform: "uppercase",
-            color: "var(--mk-ink-500)",
+            color: "var(--v4-ink-500)",
             textAlign: "right",
             background:
-              hover?.col === "closed" ? "var(--mk-brand-50)" : "transparent",
+              hover?.col === "closed" ? "var(--v4-accent-50)" : "transparent",
             borderRadius: 6,
             transition: "background .15s",
           }}
@@ -470,7 +470,7 @@ export function ProgressMatrix({ projects }: Props) {
                 padding: "3px 0",
                 opacity: a,
                 transform: `translateX(${(1 - a) * -14}px)`,
-                background: isRowHover ? "var(--mk-surface-2)" : "transparent",
+                background: isRowHover ? "var(--v4-surface-2)" : "transparent",
                 borderRadius: 6,
                 transition: "background .15s",
               }}
@@ -479,8 +479,8 @@ export function ProgressMatrix({ projects }: Props) {
                 className="num"
                 style={{
                   padding: "0 10px",
-                  fontFamily: "var(--mk-font-mono)",
-                  color: isRowHover ? "var(--mk-ink-900)" : "var(--mk-ink-800)",
+                  fontFamily: "var(--v4-mono)",
+                  color: isRowHover ? "var(--v4-ink-900)" : "var(--v4-ink-800)",
                   fontSize: 13,
                   fontWeight: isRowHover ? 600 : 500,
                   opacity: dimRow ? 0.4 : 1,
@@ -508,10 +508,10 @@ export function ProgressMatrix({ projects }: Props) {
                 <span
                   className="num"
                   style={{
-                    fontFamily: "var(--mk-font-mono)",
+                    fontFamily: "var(--v4-mono)",
                     fontSize: 12,
                     fontWeight: 700,
-                    color: "var(--mk-ink-800)",
+                    color: "var(--v4-ink-800)",
                   }}
                 >
                   {Math.round(d.progress * 100)}%
@@ -521,10 +521,10 @@ export function ProgressMatrix({ projects }: Props) {
               <div
                 className="num"
                 style={{
-                  fontFamily: "var(--mk-font-mono)",
+                  fontFamily: "var(--v4-mono)",
                   textAlign: "right",
                   padding: "0 10px",
-                  color: "var(--mk-ink-600)",
+                  color: "var(--v4-ink-600)",
                   fontSize: 12,
                   opacity:
                     cellAlpha(rowI, colIdx("closed")) * (isCellDim("closed") ? 0.4 : 1),
@@ -570,7 +570,7 @@ export function ProgressMatrix({ projects }: Props) {
               <div
                 className="num"
                 style={{
-                  fontFamily: "var(--mk-font-mono)",
+                  fontFamily: "var(--v4-mono)",
                   textAlign: "right",
                   padding: "0 6px",
                   height: 30,
@@ -605,7 +605,7 @@ export function ProgressMatrix({ projects }: Props) {
               <div
                 className="num"
                 style={{
-                  fontFamily: "var(--mk-font-mono)",
+                  fontFamily: "var(--v4-mono)",
                   textAlign: "right",
                   padding: "0 6px",
                   height: 30,
@@ -620,8 +620,8 @@ export function ProgressMatrix({ projects }: Props) {
                     totalT > 0.55
                       ? "#fff"
                       : isRowHover
-                        ? "var(--mk-ink-900)"
-                        : "var(--mk-ink-800)",
+                        ? "var(--v4-ink-900)"
+                        : "var(--v4-ink-800)",
                   fontSize: 13,
                   fontWeight: 700,
                   opacity:

--- a/src/components/v4/ProjectsView.tsx
+++ b/src/components/v4/ProjectsView.tsx
@@ -544,13 +544,13 @@ export function ProjectsView({
             <div className="v4-projects-agg-l">открытых</div>
           </div>
           <div className="v4-projects-agg-cell">
-            <div className="v4-projects-agg-n num" style={{ color: agg.p1 > 0 ? "var(--mk-priority-p1)" : undefined }}>
+            <div className="v4-projects-agg-n num" style={{ color: agg.p1 > 0 ? "var(--v4-p1)" : undefined }}>
               {agg.p1}
             </div>
             <div className="v4-projects-agg-l">P1</div>
           </div>
           <div className="v4-projects-agg-cell">
-            <div className="v4-projects-agg-n num" style={{ color: agg.stale > 0 ? "var(--mk-warn-strong)" : undefined }}>
+            <div className="v4-projects-agg-n num" style={{ color: agg.stale > 0 ? "var(--v4-warn-700)" : undefined }}>
               {agg.stale}
             </div>
             <div className="v4-projects-agg-l">застой</div>

--- a/src/components/v4/SettingsBootstrap.tsx
+++ b/src/components/v4/SettingsBootstrap.tsx
@@ -95,7 +95,7 @@ export function SettingsBootstrap({ onSuccess }: Props) {
           <h1 style={{ fontSize: 28, marginBottom: 8 }}>MakeIT Dashboard</h1>
           <p
             style={{
-              color: "var(--mk-ink-500)",
+              color: "var(--v4-ink-500)",
               marginBottom: 24,
               fontSize: 14,
               lineHeight: 1.5,
@@ -112,7 +112,7 @@ export function SettingsBootstrap({ onSuccess }: Props) {
                 display: "block",
                 marginBottom: 6,
                 fontSize: 12,
-                color: "var(--mk-ink-500)",
+                color: "var(--v4-ink-500)",
               }}
             >
               Bootstrap-токен
@@ -162,7 +162,7 @@ export function SettingsBootstrap({ onSuccess }: Props) {
               style={{
                 marginTop: 18,
                 fontSize: 12,
-                color: "var(--mk-ink-500)",
+                color: "var(--v4-ink-500)",
                 lineHeight: 1.5,
               }}
             >

--- a/src/components/v4/SettingsBudgetPanel.tsx
+++ b/src/components/v4/SettingsBudgetPanel.tsx
@@ -124,10 +124,10 @@ export function SettingsBudgetPanel() {
         }}
       >
         <div style={{ fontWeight: 600, fontSize: 13 }}>Claude API budget</div>
-        <div style={{ fontSize: 12, color: "var(--mk-ink-500)" }}>{spend.month}</div>
+        <div style={{ fontSize: 12, color: "var(--v4-ink-500)" }}>{spend.month}</div>
       </div>
 
-      <div style={{ color: "var(--mk-ink-500)", fontSize: 12, marginBottom: 10 }}>
+      <div style={{ color: "var(--v4-ink-500)", fontSize: 12, marginBottom: 10 }}>
         Hard cap {fmtUsd(MONTHLY_CAP_USD)} в месяц на весь портфель. На {WARN_PCT}% — UI
         warning, на {FALLBACK_PCT}% — авто-fallback на Haiku, на {HARD_STOP_PCT}% — hard-stop.
       </div>
@@ -195,14 +195,14 @@ export function SettingsBudgetPanel() {
         <div
           style={{
             fontSize: 12,
-            color: "var(--mk-ink-500)",
+            color: "var(--v4-ink-500)",
             marginBottom: 6,
           }}
         >
           Разбивка по типу вызовов
         </div>
         {breakdownEntries.length === 0 ? (
-          <div style={{ fontSize: 12, color: "var(--mk-ink-500)" }}>
+          <div style={{ fontSize: 12, color: "var(--v4-ink-500)" }}>
             В этом месяце ещё не было Claude API вызовов.
           </div>
         ) : (
@@ -237,7 +237,7 @@ export function SettingsBudgetPanel() {
       <div style={{ marginTop: 12 }}>
         {confirmReset ? (
           <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-            <span style={{ fontSize: 12, color: "var(--mk-ink-700)" }}>
+            <span style={{ fontSize: 12, color: "var(--v4-ink-700)" }}>
               Сбросить расход за {spend.month}? История прошлых месяцев останется.
             </span>
             <button

--- a/src/components/v4/SettingsPanel.tsx
+++ b/src/components/v4/SettingsPanel.tsx
@@ -353,14 +353,14 @@ export function SettingsPanel({ onClose, onBootstrapCleared }: Props) {
                       <div style={{ fontWeight: 600, fontSize: 13 }}>{label}</div>
                       <div
                         className="v4-mono"
-                        style={{ color: "var(--mk-ink-500)", fontSize: 11 }}
+                        style={{ color: "var(--v4-ink-500)", fontSize: 11 }}
                       >
                         {key}
                       </div>
                       {hint && (
                         <div
                           style={{
-                            color: "var(--mk-ink-500)",
+                            color: "var(--v4-ink-500)",
                             fontSize: 11,
                             marginTop: 2,
                           }}
@@ -374,7 +374,7 @@ export function SettingsPanel({ onClose, onBootstrapCleared }: Props) {
                       style={{
                         whiteSpace: "nowrap",
                         fontSize: 12,
-                        color: row.value ? "var(--mk-ink-900)" : "var(--mk-ink-500)",
+                        color: row.value ? "var(--v4-ink-900)" : "var(--v4-ink-500)",
                       }}
                       aria-label={`Текущее значение ${label}: ${maskValue(row.value)}`}
                     >
@@ -432,7 +432,7 @@ export function SettingsPanel({ onClose, onBootstrapCleared }: Props) {
                         justifyContent: "flex-end",
                       }}
                     >
-                      <span style={{ fontSize: 12, color: "var(--mk-ink-700)" }}>
+                      <span style={{ fontSize: 12, color: "var(--v4-ink-700)" }}>
                         Подтвердите очистку:
                       </span>
                       <button
@@ -502,7 +502,7 @@ export function SettingsPanel({ onClose, onBootstrapCleared }: Props) {
             <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 4 }}>
               Подключение
             </div>
-            <div style={{ color: "var(--mk-ink-500)", fontSize: 12, marginBottom: 10 }}>
+            <div style={{ color: "var(--v4-ink-500)", fontSize: 12, marginBottom: 10 }}>
               Bootstrap-токен авторизует этот браузер для чтения секретов из Pipeline.
               Сменить — если подменили токен на сервере.
             </div>
@@ -537,14 +537,14 @@ export function SettingsPanel({ onClose, onBootstrapCleared }: Props) {
             >
               Опасная зона
             </div>
-            <div style={{ color: "var(--mk-ink-500)", fontSize: 12, marginBottom: 10 }}>
+            <div style={{ color: "var(--v4-ink-500)", fontSize: 12, marginBottom: 10 }}>
               Удалить все секреты из server-side store. Действие необратимо — после этого
               dashboard перестанет видеть GitHub / Claude / BetterStack пока вы не введёте
               их заново.
             </div>
             {confirmAllDelete ? (
               <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-                <span style={{ fontSize: 12, color: "var(--mk-ink-700)" }}>
+                <span style={{ fontSize: 12, color: "var(--v4-ink-700)" }}>
                   Точно очистить все {keys?.length ?? 0} ключей?
                 </span>
                 <button

--- a/src/components/v4/audit/AuditKpiStrip.tsx
+++ b/src/components/v4/audit/AuditKpiStrip.tsx
@@ -32,7 +32,7 @@ export function AuditKpiStrip({ projects }: Props) {
         <div className="v4-projects-agg-cell" title="Сумма critical-находок по портфелю">
           <div
             className="v4-projects-agg-n num"
-            style={{ color: totals.critical > 0 ? "var(--mk-danger-strong)" : undefined }}
+            style={{ color: totals.critical > 0 ? "var(--v4-danger-700)" : undefined }}
           >
             {totals.critical}
           </div>
@@ -41,7 +41,7 @@ export function AuditKpiStrip({ projects }: Props) {
         <div className="v4-projects-agg-cell" title="Сумма high-находок по портфелю">
           <div
             className="v4-projects-agg-n num"
-            style={{ color: totals.high > 0 ? "var(--mk-warn-strong)" : undefined }}
+            style={{ color: totals.high > 0 ? "var(--v4-warn-700)" : undefined }}
           >
             {totals.high}
           </div>

--- a/src/components/v4/audit/AuditProjectCardV4.tsx
+++ b/src/components/v4/audit/AuditProjectCardV4.tsx
@@ -167,13 +167,13 @@ export function AuditProjectCardV4({
           {isVerified && lr.verification && (
             <div className="v4-au-card-verify">
               <span className="v4-au-text-muted">Верификация</span>
-              <span className="v4-pl-mono" style={{ color: "var(--mk-danger-strong)" }} title="Подтверждено">
+              <span className="v4-pl-mono" style={{ color: "var(--v4-danger-700)" }} title="Подтверждено">
                 ✓ {lr.verification.confirmed}
               </span>
-              <span className="v4-pl-mono" style={{ color: "var(--mk-success-strong)" }} title="Ложное срабатывание">
+              <span className="v4-pl-mono" style={{ color: "var(--v4-success-700)" }} title="Ложное срабатывание">
                 ✗ {lr.verification.false_positive}
               </span>
-              <span className="v4-pl-mono" style={{ color: "var(--mk-warn-strong)" }} title="Неуверенно">
+              <span className="v4-pl-mono" style={{ color: "var(--v4-warn-700)" }} title="Неуверенно">
                 ? {lr.verification.uncertain}
               </span>
             </div>

--- a/src/components/v4/audit/UXProjectCardV4.tsx
+++ b/src/components/v4/audit/UXProjectCardV4.tsx
@@ -282,7 +282,7 @@ function UXFindingsList({
             <div className="v4-au-ux-finding-h">
               <span
                 className="v4-au-ux-finding-sev"
-                style={{ color: SEVERITY_COLOR[f.severity as Severity] ?? "var(--mk-ink-500)" }}
+                style={{ color: SEVERITY_COLOR[f.severity as Severity] ?? "var(--v4-ink-500)" }}
               >
                 {f.severity.toUpperCase()}
               </span>

--- a/src/components/v4/audit/utils.ts
+++ b/src/components/v4/audit/utils.ts
@@ -8,10 +8,10 @@ export type Severity = "critical" | "high" | "medium" | "low";
 export type AuditHealth = "ok" | "warn" | "danger" | "unknown";
 
 export const SEVERITY_COLOR: Record<Severity, string> = {
-  critical: "var(--mk-danger)",
-  high: "var(--mk-warn)",
-  medium: "var(--mk-brand-500)",
-  low: "var(--mk-ink-400)",
+  critical: "var(--v4-danger-500)",
+  high: "var(--v4-warn-500)",
+  medium: "var(--v4-accent-500)",
+  low: "var(--v4-ink-400)",
 };
 
 export const SEVERITY_LABEL: Record<Severity, string> = {

--- a/src/components/v4/debate/DebateKpiStrip.tsx
+++ b/src/components/v4/debate/DebateKpiStrip.tsx
@@ -23,7 +23,7 @@ export function DebateKpiStrip({ debates }: Props) {
         <div className="v4-projects-agg-cell" title="В работе или в очереди">
           <div
             className="v4-projects-agg-n num"
-            style={{ color: running > 0 ? "var(--mk-warn-strong)" : undefined }}
+            style={{ color: running > 0 ? "var(--v4-warn-700)" : undefined }}
           >
             {running}
           </div>
@@ -32,7 +32,7 @@ export function DebateKpiStrip({ debates }: Props) {
         <div className="v4-projects-agg-cell" title="Успешно завершены">
           <div
             className="v4-projects-agg-n num"
-            style={{ color: done > 0 ? "var(--mk-success-strong)" : undefined }}
+            style={{ color: done > 0 ? "var(--v4-success-700)" : undefined }}
           >
             {done}
           </div>
@@ -40,7 +40,7 @@ export function DebateKpiStrip({ debates }: Props) {
         </div>
         {error > 0 && (
           <div className="v4-projects-agg-cell" title="Завершились с ошибкой">
-            <div className="v4-projects-agg-n num" style={{ color: "var(--mk-danger-strong)" }}>
+            <div className="v4-projects-agg-n num" style={{ color: "var(--v4-danger-700)" }}>
               {error}
             </div>
             <div className="v4-projects-agg-l">ошибки</div>

--- a/src/components/v4/health/FancySpark.tsx
+++ b/src/components/v4/health/FancySpark.tsx
@@ -27,10 +27,10 @@ export function FancySpark({ trend }: Props) {
   const area = `${path} L ${W} ${H} L 0 ${H} Z`;
   const stroke =
     trend.direction === "up"
-      ? "var(--mk-success)"
+      ? "var(--v4-success-500)"
       : trend.direction === "down"
-        ? "var(--mk-danger)"
-        : "var(--mk-ink-400)";
+        ? "var(--v4-danger-500)"
+        : "var(--v4-ink-400)";
   const fill =
     trend.direction === "up"
       ? "color-mix(in srgb, var(--mk-success) 12%, transparent)"
@@ -95,7 +95,7 @@ export function FancySpark({ trend }: Props) {
               x2={coords[hover][0]}
               y1="0"
               y2={H}
-              stroke="var(--mk-ink-300)"
+              stroke="var(--v4-ink-300)"
               strokeWidth="1"
               strokeDasharray="2 2"
             />

--- a/src/components/v4/hub/CommitmentsTable.tsx
+++ b/src/components/v4/hub/CommitmentsTable.tsx
@@ -120,8 +120,8 @@ const inputStyle: React.CSSProperties = {
   fontSize: 13,
   border: "1px solid var(--mk-line)",
   borderRadius: 6,
-  background: "transparent",
-  color: "var(--mk-ink-900)",
+  background: "var(--v4-surface, transparent)",
+  color: "var(--v4-ink-900, inherit)",
 };
 
 const cellStyle: React.CSSProperties = {
@@ -136,8 +136,8 @@ const btnStyle: React.CSSProperties = {
   padding: "4px 10px",
   borderRadius: 6,
   border: "1px solid var(--mk-line)",
-  background: "transparent",
-  color: "var(--mk-ink-700)",
+  background: "var(--v4-surface, transparent)",
+  color: "var(--v4-ink-700, inherit)",
   cursor: "pointer",
 };
 
@@ -421,7 +421,7 @@ export function CommitmentsTable({ repo, onCount }: Props) {
       <div
         style={{
           padding: 16,
-          color: "var(--mk-ink-500)",
+          color: "var(--v4-ink-500)",
           fontSize: 13,
         }}
       >
@@ -466,7 +466,7 @@ export function CommitmentsTable({ repo, onCount }: Props) {
           padding: 20,
           border: "1px dashed var(--mk-line)",
           borderRadius: 10,
-          color: "var(--mk-ink-500)",
+          color: "var(--v4-ink-500)",
           fontSize: 13,
           display: "flex",
           flexDirection: "column",
@@ -563,7 +563,7 @@ export function CommitmentsTable({ repo, onCount }: Props) {
                     padding: "8px 10px",
                     fontSize: 12,
                     fontWeight: 600,
-                    color: "var(--mk-ink-500)",
+                    color: "var(--v4-ink-500)",
                     borderBottom:
                       "1px solid var(--mk-line)",
                     whiteSpace: "nowrap",
@@ -615,7 +615,7 @@ export function CommitmentsTable({ repo, onCount }: Props) {
                         color:
                           r.status === "overdue"
                             ? "var(--mk-danger-strong)"
-                            : "var(--mk-ink-700)",
+                            : "var(--v4-ink-700)",
                       }}
                     >
                       {statusLabel(r.status)}
@@ -723,7 +723,7 @@ export function CommitmentsTable({ repo, onCount }: Props) {
           {saving ? "Сохранение…" : "Сохранить изменения"}
         </button>
         {dirty && !saving && (
-          <span style={{ fontSize: 12, color: "var(--mk-ink-500)" }}>
+          <span style={{ fontSize: 12, color: "var(--v4-ink-500)" }}>
             Несохранённые изменения
           </span>
         )}

--- a/src/components/v4/hub/CustomerHealthGauge.tsx
+++ b/src/components/v4/hub/CustomerHealthGauge.tsx
@@ -209,7 +209,7 @@ export function CustomerHealthGauge({
         padding: 14,
         borderRadius: 10,
         background: "var(--mk-paper)",
-        border: "1px solid var(--mk-line)",
+        border: "1px solid var(--v4-line)",
       }}
     >
       <div
@@ -226,7 +226,7 @@ export function CustomerHealthGauge({
             fontWeight: 600,
             textTransform: "uppercase",
             letterSpacing: 0.4,
-            color: "var(--mk-ink-500)",
+            color: "var(--v4-ink-500)",
           }}
         >
           Здоровье клиента
@@ -249,7 +249,7 @@ export function CustomerHealthGauge({
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            color: "var(--mk-ink-500)",
+            color: "var(--v4-ink-500)",
             fontSize: 13,
           }}
         >
@@ -282,7 +282,7 @@ export function CustomerHealthGauge({
             alignItems: "center",
             justifyContent: "center",
             gap: 6,
-            color: "var(--mk-ink-500)",
+            color: "var(--v4-ink-500)",
             fontSize: 13,
             textAlign: "center",
           }}
@@ -355,7 +355,7 @@ export function CustomerHealthGauge({
                     style={{
                       fontSize: 11,
                       fontWeight: 600,
-                      fill: "var(--mk-ink-500)",
+                      fill: "var(--v4-ink-500)",
                     }}
                   >
                     {zone.label}
@@ -414,7 +414,7 @@ export function CustomerHealthGauge({
                         fontWeight: 600,
                         textTransform: "uppercase",
                         letterSpacing: 0.3,
-                        color: "var(--mk-ink-500)",
+                        color: "var(--v4-ink-500)",
                       }}
                     >
                       {label}

--- a/src/components/v4/hub/DecisionLog.tsx
+++ b/src/components/v4/hub/DecisionLog.tsx
@@ -73,7 +73,7 @@ export function DecisionLog({ decisions }: Props) {
           padding: 16,
           border: "1px dashed var(--mk-line)",
           borderRadius: 10,
-          color: "var(--mk-ink-500)",
+          color: "var(--v4-ink-500)",
           fontSize: 13,
         }}
       >
@@ -120,7 +120,7 @@ export function DecisionLog({ decisions }: Props) {
               <div
                 style={{
                   fontSize: 12,
-                  color: "var(--mk-ink-500)",
+                  color: "var(--v4-ink-500)",
                   fontVariantNumeric: "tabular-nums",
                 }}
               >
@@ -136,7 +136,7 @@ export function DecisionLog({ decisions }: Props) {
                     padding: "2px 8px",
                     borderRadius: 999,
                     background: "var(--mk-line-soft)",
-                    color: "var(--mk-ink-700)",
+                    color: "var(--v4-ink-700)",
                     textDecoration: "none",
                   }}
                   title={link}
@@ -150,7 +150,7 @@ export function DecisionLog({ decisions }: Props) {
                     padding: "2px 8px",
                     borderRadius: 999,
                     background: "var(--mk-line-soft)",
-                    color: "var(--mk-ink-700)",
+                    color: "var(--v4-ink-700)",
                   }}
                 >
                   {sourceLabel(tag)}
@@ -159,7 +159,7 @@ export function DecisionLog({ decisions }: Props) {
             </div>
             <div style={{ fontWeight: 600, fontSize: 14 }}>{d.title}</div>
             {d.description && (
-              <div style={{ fontSize: 13, color: "var(--mk-ink-700)" }}>
+              <div style={{ fontSize: 13, color: "var(--v4-ink-700)" }}>
                 {d.description}
               </div>
             )}

--- a/src/components/v4/hub/DigestViewer.tsx
+++ b/src/components/v4/hub/DigestViewer.tsx
@@ -75,8 +75,8 @@ const btnStyle: React.CSSProperties = {
   padding: "6px 12px",
   borderRadius: 8,
   border: "1px solid var(--mk-line)",
-  background: "var(--mk-paper)",
-  color: "var(--mk-ink-900)",
+  background: "var(--v4-card, #fff)",
+  color: "var(--v4-ink-900)",
   cursor: "pointer",
 };
 
@@ -85,8 +85,8 @@ const selectStyle: React.CSSProperties = {
   padding: "6px 8px",
   borderRadius: 8,
   border: "1px solid var(--mk-line)",
-  background: "var(--mk-paper)",
-  color: "var(--mk-ink-900)",
+  background: "var(--v4-card, #fff)",
+  color: "var(--v4-ink-900)",
 };
 
 export function DigestViewer({ repo, input }: Props) {
@@ -202,7 +202,7 @@ export function DigestViewer({ repo, input }: Props) {
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <label
             htmlFor="v4-hub-digest-week"
-            style={{ fontSize: 12, color: "var(--mk-ink-500)" }}
+            style={{ fontSize: 12, color: "var(--v4-ink-500)" }}
           >
             История
           </label>
@@ -252,7 +252,7 @@ export function DigestViewer({ repo, input }: Props) {
             gap: 8,
           }}
         >
-          <p style={{ margin: 0, fontSize: 13, color: "var(--mk-ink-900)" }}>
+          <p style={{ margin: 0, fontSize: 13, color: "var(--v4-ink-900)" }}>
             Регенерация запросит Claude ({costPreview.model}). Оценочная
             стоимость:{" "}
             <strong>${costPreview.usd.toFixed(4)}</strong>
@@ -288,7 +288,7 @@ export function DigestViewer({ repo, input }: Props) {
         <div
           style={{
             padding: 16,
-            color: "var(--mk-ink-500)",
+            color: "var(--v4-ink-500)",
             fontSize: 13,
           }}
         >
@@ -317,7 +317,7 @@ export function DigestViewer({ repo, input }: Props) {
           style={{
             fontSize: 13,
             lineHeight: 1.55,
-            color: "var(--mk-ink-900)",
+            color: "var(--v4-ink-900)",
           }}
         />
       ) : (
@@ -326,7 +326,7 @@ export function DigestViewer({ repo, input }: Props) {
             padding: 16,
             border: "1px dashed var(--mk-line)",
             borderRadius: 10,
-            color: "var(--mk-ink-500)",
+            color: "var(--v4-ink-500)",
             fontSize: 13,
           }}
         >

--- a/src/components/v4/hub/DoraCards.tsx
+++ b/src/components/v4/hub/DoraCards.tsx
@@ -31,7 +31,7 @@ function tierStyle(tier: DoraTier): { background: string; accent: string; label:
       return { background: "color-mix(in srgb, var(--mk-danger) 12%, transparent)", accent: "var(--mk-danger)", label: "Низкий" };
     case "na":
     default:
-      return { background: "var(--mk-line-soft)", accent: "var(--mk-ink-500)", label: "н/д" };
+      return { background: "var(--mk-line-soft)", accent: "var(--v4-ink-500)", label: "н/д" };
   }
 }
 
@@ -90,7 +90,7 @@ function Card({ title, value, tier, tooltip }: CardProps) {
           fontWeight: 600,
           textTransform: "uppercase",
           letterSpacing: 0.4,
-          color: "var(--mk-ink-500)",
+          color: "var(--v4-ink-500)",
         }}
       >
         {title}

--- a/src/components/v4/hub/OnboardingChecklist.tsx
+++ b/src/components/v4/hub/OnboardingChecklist.tsx
@@ -57,7 +57,7 @@ export function OnboardingChecklist({ findings }: Props) {
           padding: 16,
           border: "1px dashed var(--mk-line)",
           borderRadius: 10,
-          color: "var(--mk-ink-500)",
+          color: "var(--v4-ink-500)",
           fontSize: 13,
         }}
       >
@@ -91,7 +91,7 @@ export function OnboardingChecklist({ findings }: Props) {
         <span
           style={{
             fontSize: 12,
-            color: "var(--mk-ink-500)",
+            color: "var(--v4-ink-500)",
             fontVariantNumeric: "tabular-nums",
           }}
           aria-label={`${passed} из ${total} правил выполнены`}
@@ -150,7 +150,7 @@ export function OnboardingChecklist({ findings }: Props) {
                       ? "var(--mk-success)"
                       : kind === "fail"
                         ? "var(--mk-danger)"
-                        : "var(--mk-ink-500)",
+                        : "var(--v4-ink-500)",
                   fontWeight: 600,
                 }}
               >
@@ -161,8 +161,8 @@ export function OnboardingChecklist({ findings }: Props) {
                   flex: 1,
                   color:
                     kind === "fail"
-                      ? "var(--mk-ink-900)"
-                      : "var(--mk-ink-700)",
+                      ? "var(--v4-ink-900)"
+                      : "var(--v4-ink-700)",
                 }}
               >
                 {f.title}
@@ -172,7 +172,7 @@ export function OnboardingChecklist({ findings }: Props) {
                   aria-hidden="true"
                   style={{
                     fontSize: 11,
-                    color: "var(--mk-ink-500)",
+                    color: "var(--v4-ink-500)",
                     cursor: "help",
                   }}
                 >

--- a/src/components/v4/hub/PulseTimeline.tsx
+++ b/src/components/v4/hub/PulseTimeline.tsx
@@ -98,7 +98,7 @@ export function PulseTimeline({ events }: Props) {
           padding: 16,
           border: "1px dashed var(--mk-line)",
           borderRadius: 10,
-          color: "var(--mk-ink-500)",
+          color: "var(--v4-ink-500)",
           fontSize: 13,
         }}
       >
@@ -118,7 +118,7 @@ export function PulseTimeline({ events }: Props) {
               fontWeight: 600,
               textTransform: "uppercase",
               letterSpacing: "0.04em",
-              color: "var(--mk-ink-500)",
+              color: "var(--v4-ink-500)",
               margin: "0 0 8px",
             }}
           >
@@ -173,7 +173,7 @@ export function PulseTimeline({ events }: Props) {
                     style={{
                       fontSize: 16,
                       lineHeight: "20px",
-                      color: "var(--mk-ink-500)",
+                      color: "var(--v4-ink-500)",
                       flexShrink: 0,
                     }}
                   >
@@ -191,7 +191,7 @@ export function PulseTimeline({ events }: Props) {
                     <div
                       style={{
                         fontSize: 13,
-                        color: "var(--mk-ink-900)",
+                        color: "var(--v4-ink-900)",
                         overflow: "hidden",
                         textOverflow: "ellipsis",
                       }}
@@ -204,7 +204,7 @@ export function PulseTimeline({ events }: Props) {
                         alignItems: "center",
                         gap: 8,
                         fontSize: 11,
-                        color: "var(--mk-ink-500)",
+                        color: "var(--v4-ink-500)",
                       }}
                     >
                       <span
@@ -212,7 +212,7 @@ export function PulseTimeline({ events }: Props) {
                           padding: "1px 7px",
                           borderRadius: 999,
                           background: "var(--mk-line-soft)",
-                          color: "var(--mk-ink-700)",
+                          color: "var(--v4-ink-700)",
                         }}
                       >
                         {SOURCE_LABEL[ev.source]}

--- a/src/components/v4/hub/RenewalsTable.tsx
+++ b/src/components/v4/hub/RenewalsTable.tsx
@@ -149,8 +149,8 @@ const inputStyle: React.CSSProperties = {
   fontSize: 13,
   border: "1px solid var(--mk-line)",
   borderRadius: 6,
-  background: "transparent",
-  color: "var(--mk-ink-900)",
+  background: "var(--v4-surface, transparent)",
+  color: "var(--v4-ink-900, inherit)",
 };
 
 const pillStyle: React.CSSProperties = {
@@ -158,7 +158,7 @@ const pillStyle: React.CSSProperties = {
   padding: "2px 8px",
   borderRadius: 999,
   background: "var(--mk-line-soft)",
-  color: "var(--mk-ink-700)",
+  color: "var(--v4-ink-700)",
   whiteSpace: "nowrap",
 };
 
@@ -167,8 +167,8 @@ const btn: React.CSSProperties = {
   padding: "6px 12px",
   borderRadius: 8,
   border: "1px solid var(--mk-line)",
-  background: "transparent",
-  color: "var(--mk-ink-900)",
+  background: "var(--v4-surface, transparent)",
+  color: "var(--v4-ink-900, inherit)",
   cursor: "pointer",
 };
 
@@ -544,7 +544,7 @@ export function RenewalsTable({ repo, onCount }: Props) {
           padding: 16,
           border: "1px dashed var(--mk-line)",
           borderRadius: 10,
-          color: "var(--mk-ink-500)",
+          color: "var(--v4-ink-500)",
           fontSize: 13,
           display: "flex",
           flexDirection: "column",
@@ -589,7 +589,7 @@ export function RenewalsTable({ repo, onCount }: Props) {
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <label
             htmlFor="renewals-type-filter"
-            style={{ fontSize: 12, color: "var(--mk-ink-500)" }}
+            style={{ fontSize: 12, color: "var(--v4-ink-500)" }}
           >
             Тип:
           </label>
@@ -606,7 +606,7 @@ export function RenewalsTable({ repo, onCount }: Props) {
               </option>
             ))}
           </select>
-          <span style={{ fontSize: 12, color: "var(--mk-ink-500)" }}>
+          <span style={{ fontSize: 12, color: "var(--v4-ink-500)" }}>
             {visible.length} · сортировка по сроку
           </span>
         </div>
@@ -656,7 +656,7 @@ export function RenewalsTable({ repo, onCount }: Props) {
             padding: 16,
             border: "1px dashed var(--mk-line)",
             borderRadius: 10,
-            color: "var(--mk-ink-500)",
+            color: "var(--v4-ink-500)",
             fontSize: 13,
           }}
         >
@@ -674,7 +674,7 @@ export function RenewalsTable({ repo, onCount }: Props) {
             }}
           >
             <thead>
-              <tr style={{ textAlign: "left", color: "var(--mk-ink-500)" }}>
+              <tr style={{ textAlign: "left", color: "var(--v4-ink-500)" }}>
                 <th style={{ ...cellStyle, fontWeight: 600 }}>Тип</th>
                 <th style={{ ...cellStyle, fontWeight: 600 }}>Название</th>
                 <th style={{ ...cellStyle, fontWeight: 600 }}>Истекает</th>
@@ -755,7 +755,7 @@ export function RenewalsTable({ repo, onCount }: Props) {
                     <td style={cellStyle}>
                       {isAuto ? (
                         <span
-                          style={{ fontSize: 12, color: "var(--mk-ink-500)" }}
+                          style={{ fontSize: 12, color: "var(--v4-ink-500)" }}
                           title="Определено автоматически, правьте в package.json"
                         >
                           только чтение
@@ -938,7 +938,7 @@ function RenewalFormModal({
     flexDirection: "column",
     gap: 4,
     fontSize: 12,
-    color: "var(--mk-ink-500)",
+    color: "var(--v4-ink-500)",
   };
   return (
     <div
@@ -958,8 +958,8 @@ function RenewalFormModal({
     >
       <div
         style={{
-          background: "var(--mk-paper)",
-          color: "var(--mk-ink-900)",
+          background: "var(--v4-surface, #fff)",
+          color: "var(--v4-ink-900, inherit)",
           borderRadius: 12,
           padding: 20,
           width: "min(520px, 100%)",
@@ -1075,8 +1075,8 @@ function ConflictDialog({
     >
       <div
         style={{
-          background: "var(--mk-paper)",
-          color: "var(--mk-ink-900)",
+          background: "var(--v4-surface, #fff)",
+          color: "var(--v4-ink-900, inherit)",
           borderRadius: 12,
           padding: 20,
           width: "min(440px, 100%)",
@@ -1086,7 +1086,7 @@ function ConflictDialog({
         }}
       >
         <h3 style={{ margin: 0, fontSize: 16 }}>Конфликт версий</h3>
-        <p style={{ margin: 0, fontSize: 13, color: "var(--mk-ink-700)" }}>
+        <p style={{ margin: 0, fontSize: 13, color: "var(--v4-ink-700)" }}>
           Кто-то изменил <code>renewals.yaml</code> после того, как вы открыли
           список. Перезагрузите свежую версию (ваши правки наложатся поверх)
           или перезапишите её своими данными.

--- a/src/components/v4/hub/RiskRegisterTable.tsx
+++ b/src/components/v4/hub/RiskRegisterTable.tsx
@@ -129,8 +129,8 @@ const inputStyle: React.CSSProperties = {
   fontSize: 13,
   border: "1px solid var(--mk-line)",
   borderRadius: 6,
-  background: "transparent",
-  color: "var(--mk-ink-900)",
+  background: "var(--v4-surface, transparent)",
+  color: "var(--v4-ink-900, inherit)",
 };
 
 const pillStyle: React.CSSProperties = {
@@ -138,7 +138,7 @@ const pillStyle: React.CSSProperties = {
   padding: "2px 8px",
   borderRadius: 999,
   background: "var(--mk-line-soft)",
-  color: "var(--mk-ink-700)",
+  color: "var(--v4-ink-700)",
   whiteSpace: "nowrap",
 };
 
@@ -147,8 +147,8 @@ const btn: React.CSSProperties = {
   padding: "6px 12px",
   borderRadius: 8,
   border: "1px solid var(--mk-line)",
-  background: "transparent",
-  color: "var(--mk-ink-900)",
+  background: "var(--v4-surface, transparent)",
+  color: "var(--v4-ink-900, inherit)",
   cursor: "pointer",
 };
 
@@ -539,7 +539,7 @@ export function RiskRegisterTable({ repo, onCount }: Props) {
           padding: 16,
           border: "1px dashed var(--mk-line)",
           borderRadius: 10,
-          color: "var(--mk-ink-500)",
+          color: "var(--v4-ink-500)",
           fontSize: 13,
           display: "flex",
           flexDirection: "column",
@@ -578,7 +578,7 @@ export function RiskRegisterTable({ repo, onCount }: Props) {
           gap: 8,
         }}
       >
-        <span style={{ fontSize: 12, color: "var(--mk-ink-500)" }}>
+        <span style={{ fontSize: 12, color: "var(--v4-ink-500)" }}>
           {risks.length}{" "}
           {risks.length === 1 ? "риск" : "рисков"} · сортировка по severity
         </span>
@@ -660,7 +660,7 @@ export function RiskRegisterTable({ repo, onCount }: Props) {
             padding: 16,
             border: "1px dashed var(--mk-line)",
             borderRadius: 10,
-            color: "var(--mk-ink-500)",
+            color: "var(--v4-ink-500)",
             fontSize: 13,
           }}
         >
@@ -676,7 +676,7 @@ export function RiskRegisterTable({ repo, onCount }: Props) {
             }}
           >
             <thead>
-              <tr style={{ textAlign: "left", color: "var(--mk-ink-500)" }}>
+              <tr style={{ textAlign: "left", color: "var(--v4-ink-500)" }}>
                 <th style={{ ...cellStyle, fontWeight: 600 }}>Серьёзность</th>
                 <th style={{ ...cellStyle, fontWeight: 600 }}>Риск</th>
                 <th style={{ ...cellStyle, fontWeight: 600 }}>Вероятность</th>
@@ -882,8 +882,8 @@ function ExtractReviewModal({
         ref={modalRef}
         tabIndex={-1}
         style={{
-          background: "var(--mk-paper)",
-          color: "var(--mk-ink-900)",
+          background: "var(--v4-surface, #fff)",
+          color: "var(--v4-ink-900, inherit)",
           borderRadius: 12,
           padding: 20,
           width: "min(640px, 100%)",
@@ -915,7 +915,7 @@ function ExtractReviewModal({
               padding: 16,
               border: "1px dashed var(--mk-line)",
               borderRadius: 10,
-              color: "var(--mk-ink-500)",
+              color: "var(--v4-ink-500)",
               fontSize: 13,
             }}
           >
@@ -928,7 +928,7 @@ function ExtractReviewModal({
               style={{
                 margin: 0,
                 fontSize: 12,
-                color: "var(--mk-ink-500)",
+                color: "var(--v4-ink-500)",
               }}
             >
               {proposals.length}{" "}
@@ -991,7 +991,7 @@ function ExtractReviewModal({
                           <div
                             style={{
                               fontSize: 13,
-                              color: "var(--mk-ink-700)",
+                              color: "var(--v4-ink-700)",
                             }}
                           >
                             Митигация: {p.mitigation}
@@ -1065,7 +1065,7 @@ function ProposalEditForm({ value, onChange }: ProposalEditFormProps) {
     flexDirection: "column",
     gap: 4,
     fontSize: 12,
-    color: "var(--mk-ink-500)",
+    color: "var(--v4-ink-500)",
   };
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
@@ -1308,7 +1308,7 @@ function RiskFormModal({ draft, busy, onChange, onSave, onCancel }: EditProps) {
     flexDirection: "column",
     gap: 4,
     fontSize: 12,
-    color: "var(--mk-ink-500)",
+    color: "var(--v4-ink-500)",
   };
   // a11y: focus-trap + Escape→cancel + focus-restore (this dialog
   // promises aria-modal="true"). Escape maps to onCancel.
@@ -1333,8 +1333,8 @@ function RiskFormModal({ draft, busy, onChange, onSave, onCancel }: EditProps) {
         ref={modalRef}
         tabIndex={-1}
         style={{
-          background: "var(--mk-paper)",
-          color: "var(--mk-ink-900)",
+          background: "var(--v4-surface, #fff)",
+          color: "var(--v4-ink-900, inherit)",
           borderRadius: 12,
           padding: 20,
           width: "min(520px, 100%)",
@@ -1529,8 +1529,8 @@ function ConflictDialog({
         ref={modalRef}
         tabIndex={-1}
         style={{
-          background: "var(--mk-paper)",
-          color: "var(--mk-ink-900)",
+          background: "var(--v4-surface, #fff)",
+          color: "var(--v4-ink-900, inherit)",
           borderRadius: 12,
           padding: 20,
           width: "min(440px, 100%)",
@@ -1541,7 +1541,7 @@ function ConflictDialog({
         }}
       >
         <h3 style={{ margin: 0, fontSize: 16 }}>Конфликт версий</h3>
-        <p style={{ margin: 0, fontSize: 13, color: "var(--mk-ink-700)" }}>
+        <p style={{ margin: 0, fontSize: 13, color: "var(--v4-ink-700)" }}>
           Кто-то изменил <code>risks.yaml</code> после того, как вы открыли
           реестр. Перезагрузите свежую версию (ваши правки наложатся поверх) или
           перезапишите её своими данными.

--- a/src/components/v4/hub/TaskMatrix.tsx
+++ b/src/components/v4/hub/TaskMatrix.tsx
@@ -105,20 +105,20 @@ function cellStyle(val: number, max: number, color: string): CSSProperties {
 
 function cellLabelColor(val: number, max: number): string {
   const t = max > 0 ? val / max : 0;
-  if (val === 0) return "var(--mk-ink-300)";
-  return t > 0.55 ? "#fff" : "var(--mk-ink-800)";
+  if (val === 0) return "var(--v4-ink-300)";
+  return t > 0.55 ? "#fff" : "var(--v4-ink-800)";
 }
 
 const GRID_COLUMNS = "70px repeat(4, 1fr) 70px";
 
 const HEADER_CELL: CSSProperties = {
   padding: "8px 10px",
-  fontFamily: "var(--mk-font-mono)",
+  fontFamily: "var(--v4-mono)",
   fontSize: 10,
   fontWeight: 700,
   letterSpacing: ".08em",
   textTransform: "uppercase",
-  color: "var(--mk-ink-500)",
+  color: "var(--v4-ink-500)",
   textAlign: "right",
 };
 
@@ -139,7 +139,7 @@ export function TaskMatrix({ issues }: Props) {
         <div className="v4-panel-t">
           Открытые задачи <span className="v4-tag">приоритет × сложность</span>
         </div>
-        <div className="v4-panel-meta" style={{ color: "var(--mk-ink-500)" }}>
+        <div className="v4-panel-meta" style={{ color: "var(--v4-ink-500)" }}>
           плотность = доля от самой загруженной ячейки
         </div>
       </div>
@@ -152,7 +152,7 @@ export function TaskMatrix({ issues }: Props) {
             gridTemplateColumns: GRID_COLUMNS,
             gap: 6,
             alignItems: "center",
-            borderBottom: "1px solid var(--mk-line-soft)",
+            borderBottom: "1px solid var(--v4-line-soft)",
             paddingBottom: 4,
             marginBottom: 4,
           }}
@@ -185,10 +185,10 @@ export function TaskMatrix({ issues }: Props) {
                 alignItems: "center",
                 gap: 6,
                 padding: "0 10px",
-                fontFamily: "var(--mk-font-mono)",
+                fontFamily: "var(--v4-mono)",
                 fontSize: 13,
                 fontWeight: 600,
-                color: "var(--mk-ink-800)",
+                color: "var(--v4-ink-800)",
               }}
             >
               <i
@@ -210,7 +210,7 @@ export function TaskMatrix({ issues }: Props) {
                   <span
                     className="num"
                     style={{
-                      fontFamily: "var(--mk-font-mono)",
+                      fontFamily: "var(--v4-mono)",
                       fontSize: 12,
                       fontWeight: model.cellMax > 0 && val / model.cellMax > 0.4 ? 700 : 500,
                       color: cellLabelColor(val, model.cellMax),
@@ -225,12 +225,12 @@ export function TaskMatrix({ issues }: Props) {
             <div
               className="num"
               style={{
-                fontFamily: "var(--mk-font-mono)",
+                fontFamily: "var(--v4-mono)",
                 textAlign: "right",
                 padding: "0 10px",
                 fontSize: 12,
                 fontWeight: 700,
-                color: "var(--mk-ink-700)",
+                color: "var(--v4-ink-700)",
               }}
             >
               {model.rowTotals[r]}
@@ -245,7 +245,7 @@ export function TaskMatrix({ issues }: Props) {
             gridTemplateColumns: GRID_COLUMNS,
             gap: 6,
             alignItems: "center",
-            borderTop: "1px solid var(--mk-line-soft)",
+            borderTop: "1px solid var(--v4-line-soft)",
             paddingTop: 6,
             marginTop: 4,
           }}
@@ -263,12 +263,12 @@ export function TaskMatrix({ issues }: Props) {
               key={c}
               className="num"
               style={{
-                fontFamily: "var(--mk-font-mono)",
+                fontFamily: "var(--v4-mono)",
                 textAlign: "right",
                 paddingRight: 10,
                 fontSize: 12,
                 fontWeight: 700,
-                color: "var(--mk-ink-700)",
+                color: "var(--v4-ink-700)",
               }}
             >
               {model.colTotals[c]}
@@ -277,12 +277,12 @@ export function TaskMatrix({ issues }: Props) {
           <div
             className="num"
             style={{
-              fontFamily: "var(--mk-font-mono)",
+              fontFamily: "var(--v4-mono)",
               textAlign: "right",
               padding: "0 10px",
               fontSize: 13,
               fontWeight: 700,
-              color: "var(--mk-ink-900)",
+              color: "var(--v4-ink-900)",
             }}
           >
             {model.grandTotal}

--- a/src/components/v4/milestones/MilestonesGantt.tsx
+++ b/src/components/v4/milestones/MilestonesGantt.tsx
@@ -347,28 +347,28 @@ export function MilestonesGantt({
             <span className="v4-msgantt-lg">
               <span
                 className="v4-msgantt-dot"
-                style={{ background: "var(--mk-danger)" }}
+                style={{ background: "var(--v4-danger-500)" }}
               />
               просрочено
             </span>
             <span className="v4-msgantt-lg">
               <span
                 className="v4-msgantt-dot"
-                style={{ background: "var(--mk-warn)" }}
+                style={{ background: "var(--v4-warn-500)" }}
               />
               ≤ 3 дн
             </span>
             <span className="v4-msgantt-lg">
               <span
                 className="v4-msgantt-dot"
-                style={{ background: "var(--mk-brand-500)" }}
+                style={{ background: "var(--v4-accent-500)" }}
               />
               ≤ 14 дн
             </span>
             <span className="v4-msgantt-lg">
               <span
                 className="v4-msgantt-dot"
-                style={{ background: "var(--mk-success)" }}
+                style={{ background: "var(--v4-success-500)" }}
               />
               готов
             </span>

--- a/src/components/v4/milestones/MilestonesHero.tsx
+++ b/src/components/v4/milestones/MilestonesHero.tsx
@@ -116,18 +116,18 @@ function VelocitySpark({ values }: { values: number[] }) {
               x2={hover.x}
               y1={SPARK_P}
               y2={SPARK_H}
-              stroke="var(--mk-success)"
+              stroke="var(--v4-success-500)"
               strokeWidth="1"
               strokeDasharray="2 2"
               opacity="0.5"
             />
-            <circle cx={hover.x} cy={hover.y} r="6" fill="var(--mk-success)" opacity="0.18" />
+            <circle cx={hover.x} cy={hover.y} r="6" fill="var(--v4-success-500)" opacity="0.18" />
             <circle
               cx={hover.x}
               cy={hover.y}
               r="3.5"
               fill="#fff"
-              stroke="var(--mk-success)"
+              stroke="var(--v4-success-500)"
               strokeWidth="2"
             />
           </g>

--- a/src/components/v4/milestones/MilestonesStatusBar.tsx
+++ b/src/components/v4/milestones/MilestonesStatusBar.tsx
@@ -13,12 +13,12 @@ const ORDER: {
   l: string;
   c: string;
 }[] = [
-  { k: "overdue", l: "Просрочено", c: "var(--mk-danger)" },
-  { k: "warn", l: "≤ 3 дн", c: "var(--mk-warn)" },
-  { k: "soon", l: "≤ 14 дн", c: "var(--mk-brand-500)" },
-  { k: "norm", l: "Дальше", c: "var(--mk-ink-400)" },
-  { k: "noeta", l: "Без даты", c: "var(--mk-ink-300)" },
-  { k: "done", l: "Завершено", c: "var(--mk-success)" },
+  { k: "overdue", l: "Просрочено", c: "var(--v4-danger-500)" },
+  { k: "warn", l: "≤ 3 дн", c: "var(--v4-warn-500)" },
+  { k: "soon", l: "≤ 14 дн", c: "var(--v4-accent-500)" },
+  { k: "norm", l: "Дальше", c: "var(--v4-ink-400)" },
+  { k: "noeta", l: "Без даты", c: "var(--v4-ink-300)" },
+  { k: "done", l: "Завершено", c: "var(--v4-success-500)" },
 ];
 
 export function MilestonesStatusBar({ milestones, now }: Props) {

--- a/src/components/v4/milestones/MilestonesView.tsx
+++ b/src/components/v4/milestones/MilestonesView.tsx
@@ -167,7 +167,7 @@ export function MilestonesView({ milestones: rawMilestones, projects, lastUpdate
         .sort((a, b) => a[0].localeCompare(b[0], "ru"))
         .map(([repo, items]) => ({
           // "repo" key falls through to the default `.v4-msgroup-dot`
-          // background (var(--mk-ink-400)) — handoff: repo grouping
+          // background (var(--v4-ink-400)) — handoff: repo grouping
           // intentionally has no per-bucket colour.
           key: "repo",
           title: repo,

--- a/src/components/v4/milestones/utils.ts
+++ b/src/components/v4/milestones/utils.ts
@@ -18,7 +18,7 @@ export const REPO_GLYPH: Record<string, string> = {
 };
 
 export function repoGlyphColor(repo: string): string {
-  return REPO_GLYPH[repo] ?? "var(--mk-ink-400)";
+  return REPO_GLYPH[repo] ?? "var(--v4-ink-400)";
 }
 
 const RU_MONTHS_SHORT = [

--- a/src/components/v4/monitoring/MonitoringKpiStrip.tsx
+++ b/src/components/v4/monitoring/MonitoringKpiStrip.tsx
@@ -28,7 +28,7 @@ export function MonitoringKpiStrip({ monitors }: Props) {
         <div className="v4-projects-agg-cell" title="Сервисы со статусом up">
           <div
             className="v4-projects-agg-n num"
-            style={{ color: up > 0 ? "var(--mk-success-strong)" : undefined }}
+            style={{ color: up > 0 ? "var(--v4-success-700)" : undefined }}
           >
             {up}
           </div>
@@ -37,7 +37,7 @@ export function MonitoringKpiStrip({ monitors }: Props) {
         <div className="v4-projects-agg-cell" title="Сервисы со статусом down">
           <div
             className="v4-projects-agg-n num"
-            style={{ color: down > 0 ? "var(--mk-danger-strong)" : undefined }}
+            style={{ color: down > 0 ? "var(--v4-danger-700)" : undefined }}
           >
             {down}
           </div>
@@ -62,10 +62,10 @@ export function MonitoringKpiStrip({ monitors }: Props) {
               color: avgUptime === null
                 ? undefined
                 : avgUptime >= 99.9
-                  ? "var(--mk-success-strong)"
+                  ? "var(--v4-success-700)"
                   : avgUptime >= 99
                     ? undefined
-                    : "var(--mk-warn-strong)",
+                    : "var(--v4-warn-700)",
             }}
           >
             {avgUptime !== null ? `${avgUptime.toFixed(2)}%` : "—"}

--- a/src/components/v4/monitoring/utils.ts
+++ b/src/components/v4/monitoring/utils.ts
@@ -39,11 +39,11 @@ export function poolHealth(monitors: Monitor[]): MonitorHealth {
 }
 
 export function uptimeColor(pct: number | null): string {
-  if (pct === null) return "var(--mk-ink-400)";
-  if (pct >= 99.9) return "var(--mk-success-strong)";
-  if (pct >= 99) return "var(--mk-success)";
-  if (pct >= 95) return "var(--mk-warn-strong)";
-  return "var(--mk-danger-strong)";
+  if (pct === null) return "var(--v4-ink-400)";
+  if (pct >= 99.9) return "var(--v4-success-700)";
+  if (pct >= 99) return "var(--v4-success-500)";
+  if (pct >= 95) return "var(--v4-warn-700)";
+  return "var(--v4-danger-700)";
 }
 
 /** Reverse-lookup project repo for a monitor via MONITOR_MATCH keywords. */

--- a/src/components/v4/pipeline/ClassifyDialog.tsx
+++ b/src/components/v4/pipeline/ClassifyDialog.tsx
@@ -68,22 +68,22 @@ export function ClassifyDialog({
                   <div className="v4-ptrack" style={{ height: 8 }}>
                     <div
                       className="v4-pfill"
-                      style={{ width: `${pct}%`, background: "var(--mk-brand-500)" }}
+                      style={{ width: `${pct}%`, background: "var(--v4-accent-500)" }}
                     />
                   </div>
                   <div className="v4-pl-classify-meta v4-pl-mono">
                     {done} / {total} ({pct}%)
                   </div>
                   <div className="v4-pl-classify-breakdown">
-                    <span style={{ color: "var(--mk-success-strong)" }}>
+                    <span style={{ color: "var(--v4-success-700)" }}>
                       auto: {progress.breakdown.auto}
                     </span>
                     <span className="v4-pl-sep">·</span>
-                    <span style={{ color: "var(--mk-warn-strong)" }}>
+                    <span style={{ color: "var(--v4-warn-700)" }}>
                       assisted: {progress.breakdown.assisted}
                     </span>
                     <span className="v4-pl-sep">·</span>
-                    <span style={{ color: "var(--mk-danger-strong)" }}>
+                    <span style={{ color: "var(--v4-danger-700)" }}>
                       manual: {progress.breakdown.manual}
                     </span>
                     {progress.breakdown.errors > 0 && (
@@ -106,19 +106,19 @@ export function ClassifyDialog({
             <div className="v4-pl-classify-done">
               <div className="v4-pl-classify-grid">
                 <div>
-                  <div className="num" style={{ fontSize: 28, fontWeight: 700, color: "var(--mk-success-strong)" }}>
+                  <div className="num" style={{ fontSize: 28, fontWeight: 700, color: "var(--v4-success-700)" }}>
                     {progress.breakdown.auto}
                   </div>
                   <div className="v4-pl-classify-cell-l">Auto</div>
                 </div>
                 <div>
-                  <div className="num" style={{ fontSize: 28, fontWeight: 700, color: "var(--mk-warn-strong)" }}>
+                  <div className="num" style={{ fontSize: 28, fontWeight: 700, color: "var(--v4-warn-700)" }}>
                     {progress.breakdown.assisted}
                   </div>
                   <div className="v4-pl-classify-cell-l">Assisted</div>
                 </div>
                 <div>
-                  <div className="num" style={{ fontSize: 28, fontWeight: 700, color: "var(--mk-danger-strong)" }}>
+                  <div className="num" style={{ fontSize: 28, fontWeight: 700, color: "var(--v4-danger-700)" }}>
                     {progress.breakdown.manual}
                   </div>
                   <div className="v4-pl-classify-cell-l">Manual</div>

--- a/src/components/v4/pipeline/ConfigPanel.tsx
+++ b/src/components/v4/pipeline/ConfigPanel.tsx
@@ -6,9 +6,9 @@ const LABEL_OPTIONS = ["P1-critical", "P2-high", "P3-medium"] as const;
 export type LabelOption = (typeof LABEL_OPTIONS)[number];
 
 const LABEL_COLOR: Record<LabelOption, string> = {
-  "P1-critical": "var(--mk-priority-p1)",
-  "P2-high": "var(--mk-priority-p2)",
-  "P3-medium": "var(--mk-priority-p3)",
+  "P1-critical": "var(--v4-p1)",
+  "P2-high": "var(--v4-p2)",
+  "P3-medium": "var(--v4-p3)",
 };
 
 const COMPLEXITY_OPTIONS: { value: ComplexityFilter; label: string; hint: string }[] = [

--- a/src/components/v4/pipeline/PipelineComplexityPanel.tsx
+++ b/src/components/v4/pipeline/PipelineComplexityPanel.tsx
@@ -11,9 +11,9 @@ export function PipelineComplexityPanel({ stats }: Props) {
   if (total === 0 && (!stats.model_usage || stats.model_usage.length === 0)) return null;
 
   const items = [
-    { key: "auto" as const, label: "Auto", count: b.auto, color: "var(--mk-success-strong)" },
-    { key: "assisted" as const, label: "Assisted", count: b.assisted, color: "var(--mk-warn-strong)" },
-    { key: "manual" as const, label: "Manual", count: b.manual, color: "var(--mk-danger-strong)" },
+    { key: "auto" as const, label: "Auto", count: b.auto, color: "var(--v4-success-700)" },
+    { key: "assisted" as const, label: "Assisted", count: b.assisted, color: "var(--v4-warn-700)" },
+    { key: "manual" as const, label: "Manual", count: b.manual, color: "var(--v4-danger-700)" },
   ];
 
   return (

--- a/src/components/v4/pipeline/PipelineKpiStrip.tsx
+++ b/src/components/v4/pipeline/PipelineKpiStrip.tsx
@@ -17,10 +17,10 @@ export function PipelineKpiStrip({ stats, sessionCost, sessionRuns }: Props) {
     firstPass === null
       ? undefined
       : firstPass >= 80
-      ? "var(--mk-success-strong)"
+      ? "var(--v4-success-700)"
       : firstPass >= 60
-      ? "var(--mk-warn-strong)"
-      : "var(--mk-danger-strong)";
+      ? "var(--v4-warn-700)"
+      : "var(--v4-danger-700)";
 
   return (
     <div className="v4-projects-toolbar v4-pl-kpi-strip">
@@ -38,7 +38,7 @@ export function PipelineKpiStrip({ stats, sessionCost, sessionRuns }: Props) {
         >
           <div
             className="v4-projects-agg-n num"
-            style={{ color: sessionCost > 0 ? "var(--mk-success-strong)" : undefined }}
+            style={{ color: sessionCost > 0 ? "var(--v4-success-700)" : undefined }}
           >
             {compactUSD(sessionCost)}
           </div>

--- a/src/components/v4/portfolio/PortfolioDigestPanel.tsx
+++ b/src/components/v4/portfolio/PortfolioDigestPanel.tsx
@@ -252,7 +252,7 @@ export function PortfolioDigestPanel({ week }: Props) {
       <div className="v4-panel-h">
         <div className="v4-panel-t">
           <svg
-            style={{ width: 14, height: 14, color: "var(--mk-brand-600)" }}
+            style={{ width: 14, height: 14, color: "var(--v4-accent-600)" }}
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"

--- a/src/components/v4/portfolio/PortfolioNextActions.tsx
+++ b/src/components/v4/portfolio/PortfolioNextActions.tsx
@@ -181,7 +181,7 @@ export function PortfolioNextActions({
       <div className="v4-panel-h">
         <div className="v4-panel-t">
           <svg
-            style={{ width: 14, height: 14, color: "var(--mk-brand-600)" }}
+            style={{ width: 14, height: 14, color: "var(--v4-accent-600)" }}
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"

--- a/src/components/v4/portfolio/PortfolioPromiseTracker.tsx
+++ b/src/components/v4/portfolio/PortfolioPromiseTracker.tsx
@@ -222,7 +222,7 @@ export function PortfolioPromiseTracker({ onOpenProject }: Props) {
       <div className="v4-panel-h">
         <div className="v4-panel-t">
           <svg
-            style={{ width: 14, height: 14, color: "var(--mk-brand-600)" }}
+            style={{ width: 14, height: 14, color: "var(--v4-accent-600)" }}
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"

--- a/src/components/v4/portfolio/PortfolioRenewals.tsx
+++ b/src/components/v4/portfolio/PortfolioRenewals.tsx
@@ -214,7 +214,7 @@ export function PortfolioRenewals({ onOpenProject }: Props) {
       <div className="v4-panel-h">
         <div className="v4-panel-t">
           <svg
-            style={{ width: 14, height: 14, color: "var(--mk-brand-600)" }}
+            style={{ width: 14, height: 14, color: "var(--v4-accent-600)" }}
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"

--- a/src/components/v4/quality/PendingChangesPanel.tsx
+++ b/src/components/v4/quality/PendingChangesPanel.tsx
@@ -275,7 +275,7 @@ export function PendingChangesPanel({
 }
 
 function confColor(c: number): string {
-  if (c >= 0.85) return "var(--mk-success-strong)";
-  if (c >= 0.7) return "var(--mk-warn-strong)";
-  return "var(--mk-danger-strong)";
+  if (c >= 0.85) return "var(--v4-success-700)";
+  if (c >= 0.7) return "var(--v4-warn-700)";
+  return "var(--v4-danger-700)";
 }

--- a/src/components/v4/quality/QualityBarCharts.tsx
+++ b/src/components/v4/quality/QualityBarCharts.tsx
@@ -1,12 +1,12 @@
 import type { QualityFindingsDistribution, QualityErrorsDistribution } from "../../../types";
 
 const PALETTE = [
-  "var(--mk-brand-500)",
-  "var(--mk-purple-500)",
+  "var(--v4-accent-500)",
+  "var(--v4-purple-500)",
   "var(--mk-sky-500)",
-  "var(--mk-success)",
-  "var(--mk-warn)",
-  "var(--mk-danger)",
+  "var(--v4-success-500)",
+  "var(--v4-warn-500)",
+  "var(--v4-danger-500)",
 ];
 
 function sortedEntries(record: Record<string, number>): [string, number][] {

--- a/src/components/v4/quality/QualityKpiGrid.tsx
+++ b/src/components/v4/quality/QualityKpiGrid.tsx
@@ -61,10 +61,10 @@ export function QualityKpiGrid({ snapshot, trends }: Props) {
             : (trend === "up") === def.higherIsBetter;
         const trendColor =
           trendBetter === null
-            ? "var(--mk-ink-400)"
+            ? "var(--v4-ink-400)"
             : trendBetter
-              ? "var(--mk-success-strong)"
-              : "var(--mk-danger-strong)";
+              ? "var(--v4-success-700)"
+              : "var(--v4-danger-700)";
         const sparkD = series.length > 1 ? sparklinePath(series, SPARK_W, SPARK_H) : "";
 
         return (
@@ -133,6 +133,6 @@ export function QualityKpiGrid({ snapshot, trends }: Props) {
 
 function deltaColor(abs: number, higherIsBetter: boolean): string {
   const better = higherIsBetter ? abs > 0 : abs < 0;
-  if (Math.abs(abs) < 0.005) return "var(--mk-ink-400)";
-  return better ? "var(--mk-success-strong)" : "var(--mk-danger-strong)";
+  if (Math.abs(abs) < 0.005) return "var(--v4-ink-400)";
+  return better ? "var(--v4-success-700)" : "var(--v4-danger-700)";
 }

--- a/src/components/v4/quality/QualityKpiStrip.tsx
+++ b/src/components/v4/quality/QualityKpiStrip.tsx
@@ -37,7 +37,7 @@ export function QualityKpiStrip({ snapshot, pendingChanges, retros }: Props) {
         >
           <div
             className="v4-projects-agg-n num"
-            style={{ color: pendingCount > 0 ? "var(--mk-warn-strong)" : undefined }}
+            style={{ color: pendingCount > 0 ? "var(--v4-warn-700)" : undefined }}
           >
             {pendingCount}
           </div>

--- a/src/components/v4/quality/QualityTrends.tsx
+++ b/src/components/v4/quality/QualityTrends.tsx
@@ -140,7 +140,7 @@ export function QualityTrendsV4({ trends }: Props) {
               >
                 <span
                   className="v4-qa-metric-dot"
-                  style={{ background: on ? m.color : "var(--mk-line-strong)" }}
+                  style={{ background: on ? m.color : "var(--v4-line-strong)" }}
                 />
                 {m.label}
               </button>

--- a/src/components/v4/quality/utils.ts
+++ b/src/components/v4/quality/utils.ts
@@ -101,10 +101,10 @@ export function healthOf(
 }
 
 export function healthColor(h: Health): string {
-  if (h === "ok") return "var(--mk-success-strong)";
-  if (h === "warn") return "var(--mk-warn-strong)";
-  if (h === "danger") return "var(--mk-danger-strong)";
-  return "var(--mk-ink-500)";
+  if (h === "ok") return "var(--v4-success-700)";
+  if (h === "warn") return "var(--v4-warn-700)";
+  if (h === "danger") return "var(--v4-danger-700)";
+  return "var(--v4-ink-500)";
 }
 
 /** Compose an SVG polyline path scaled to the given viewBox. */

--- a/src/components/v4/research/ResearchKpiStrip.tsx
+++ b/src/components/v4/research/ResearchKpiStrip.tsx
@@ -18,7 +18,7 @@ export function ResearchKpiStrip({ projects }: Props) {
         <div className="v4-projects-agg-cell" title="Проекты с RESEARCH.md">
           <div
             className="v4-projects-agg-n num"
-            style={{ color: t.withResearch > 0 ? "var(--mk-success-strong)" : undefined }}
+            style={{ color: t.withResearch > 0 ? "var(--v4-success-700)" : undefined }}
           >
             {t.withResearch}
           </div>
@@ -27,7 +27,7 @@ export function ResearchKpiStrip({ projects }: Props) {
         <div className="v4-projects-agg-cell" title="Проекты с DISCOVERY.md">
           <div
             className="v4-projects-agg-n num"
-            style={{ color: t.withDiscovery > 0 ? "var(--mk-success-strong)" : undefined }}
+            style={{ color: t.withDiscovery > 0 ? "var(--v4-success-700)" : undefined }}
           >
             {t.withDiscovery}
           </div>
@@ -44,7 +44,7 @@ export function ResearchKpiStrip({ projects }: Props) {
         <div className="v4-projects-agg-cell" title="Quick Wins — быстрые победы из DISCOVERY.md">
           <div
             className="v4-projects-agg-n num"
-            style={{ color: t.quickWins > 0 ? "var(--mk-success-strong)" : undefined }}
+            style={{ color: t.quickWins > 0 ? "var(--v4-success-700)" : undefined }}
           >
             {t.quickWins}
           </div>

--- a/src/components/v4/research/utils.ts
+++ b/src/components/v4/research/utils.ts
@@ -11,10 +11,10 @@ export const EFFORT_LABEL: Record<string, string> = {
 };
 
 export const IMPACT_COLOR: Record<string, string> = {
-  critical: "var(--mk-danger)",
-  high: "var(--mk-warn)",
-  medium: "var(--mk-brand-500)",
-  low: "var(--mk-ink-400)",
+  critical: "var(--v4-danger-500)",
+  high: "var(--v4-warn-500)",
+  medium: "var(--v4-accent-500)",
+  low: "var(--v4-ink-400)",
 };
 
 export const IMPACT_LABEL: Record<string, string> = {

--- a/src/components/v4/specs/SpecsKpiStrip.tsx
+++ b/src/components/v4/specs/SpecsKpiStrip.tsx
@@ -18,7 +18,7 @@ export function SpecsKpiStrip({ projects }: Props) {
         <div className="v4-projects-agg-cell" title="PRD в активной разработке">
           <div
             className="v4-projects-agg-n num"
-            style={{ color: t.inDevelopment > 0 ? "var(--mk-success-strong)" : undefined }}
+            style={{ color: t.inDevelopment > 0 ? "var(--v4-success-700)" : undefined }}
           >
             {t.inDevelopment}
           </div>
@@ -27,7 +27,7 @@ export function SpecsKpiStrip({ projects }: Props) {
         <div className="v4-projects-agg-cell" title="Спека готова, можно запускать">
           <div
             className="v4-projects-agg-n num"
-            style={{ color: t.specReady > 0 ? "var(--mk-warn-strong)" : undefined }}
+            style={{ color: t.specReady > 0 ? "var(--v4-warn-600)" : undefined }}
           >
             {t.specReady}
           </div>
@@ -40,7 +40,7 @@ export function SpecsKpiStrip({ projects }: Props) {
         <div className="v4-projects-agg-cell" title="Завершённые проекты">
           <div
             className="v4-projects-agg-n num"
-            style={{ color: t.completed > 0 ? "var(--mk-success-strong)" : undefined }}
+            style={{ color: t.completed > 0 ? "var(--v4-success-700)" : undefined }}
           >
             {t.completed}
           </div>

--- a/src/components/v4/transcripts/BatchProgressV4.tsx
+++ b/src/components/v4/transcripts/BatchProgressV4.tsx
@@ -69,7 +69,7 @@ export function BatchProgressV4({ files, active, onCancel, onClose }: Props) {
             className="v4-pfill"
             style={{
               width: `${pct}%`,
-              background: errors > 0 ? "var(--mk-warn)" : "var(--mk-brand-500)",
+              background: errors > 0 ? "var(--v4-warn-500)" : "var(--v4-accent-500)",
             }}
           />
         </div>

--- a/src/components/v4/transcripts/TranscriptProgressV4.tsx
+++ b/src/components/v4/transcripts/TranscriptProgressV4.tsx
@@ -165,7 +165,7 @@ export function TranscriptProgressV4({ taskId, onDone, onRetry }: Props) {
               className="v4-pfill"
               style={{
                 width: `${pct}%`,
-                background: isDone ? "var(--mk-success)" : "var(--mk-brand-500)",
+                background: isDone ? "var(--v4-success-500)" : "var(--v4-accent-500)",
               }}
             />
           </div>

--- a/src/components/v4/transcripts/TranscriptsView.tsx
+++ b/src/components/v4/transcripts/TranscriptsView.tsx
@@ -279,7 +279,7 @@ export function TranscriptsView({ projects }: Props) {
           <div className="v4-projects-agg-cell">
             <div
               className="v4-projects-agg-n num"
-              style={{ color: agg.active > 0 ? "var(--mk-brand-700)" : undefined }}
+              style={{ color: agg.active > 0 ? "var(--v4-accent-700)" : undefined }}
             >
               {agg.active}
             </div>
@@ -288,7 +288,7 @@ export function TranscriptsView({ projects }: Props) {
           <div className="v4-projects-agg-cell">
             <div
               className="v4-projects-agg-n num"
-              style={{ color: agg.done > 0 ? "var(--mk-success-strong)" : undefined }}
+              style={{ color: agg.done > 0 ? "var(--v4-success-700)" : undefined }}
             >
               {agg.done}
             </div>
@@ -297,7 +297,7 @@ export function TranscriptsView({ projects }: Props) {
           <div className="v4-projects-agg-cell">
             <div
               className="v4-projects-agg-n num"
-              style={{ color: agg.error > 0 ? "var(--mk-danger-strong)" : undefined }}
+              style={{ color: agg.error > 0 ? "var(--v4-danger-700)" : undefined }}
             >
               {agg.error}
             </div>

--- a/src/styles/v4-bizproc.css
+++ b/src/styles/v4-bizproc.css
@@ -16,25 +16,25 @@
 .v4-bp-head-ic {
   display: inline-flex;
   font-size: 18px;
-  color: var(--mk-brand-500);
+  color: var(--v4-accent-500);
 }
 .v4-bp-title {
-  font: 800 16px/1.2 var(--mk-font-sans);
-  color: var(--mk-ink-900);
+  font: 800 16px/1.2 var(--v4-sans);
+  color: var(--v4-ink-900);
 }
 .v4-bp-src {
   margin-left: auto;
-  font: 600 11px/1 var(--mk-font-mono);
-  color: var(--mk-ink-500);
+  font: 600 11px/1 var(--v4-mono);
+  color: var(--v4-ink-500);
 }
 .v4-bp-src code,
 .v4-bp-empty-text code,
 .v4-bp-empty-sub code,
 .v4-bp-example-note code {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 0.92em;
-  background: var(--mk-surface-3);
-  color: var(--mk-ink-700);
+  background: var(--v4-surface-3);
+  color: var(--v4-ink-700);
   padding: 1px 5px;
   border-radius: 5px;
 }
@@ -52,34 +52,34 @@
   flex-wrap: wrap;
 }
 .v4-bp-chip {
-  font: 600 12px/1 var(--mk-font-sans);
+  font: 600 12px/1 var(--v4-sans);
   padding: 8px 14px;
-  border-radius: var(--mk-r-md);
-  border: 1px solid var(--mk-line);
-  background: var(--mk-paper);
-  color: var(--mk-ink-600);
+  border-radius: var(--v4-r-md, 8px);
+  border: 1px solid var(--v4-line);
+  background: var(--v4-paper);
+  color: var(--v4-ink-600);
   cursor: pointer;
   transition: border-color 0.15s, color 0.15s, background 0.15s;
 }
 .v4-bp-chip:hover {
-  border-color: var(--mk-brand-500);
-  color: var(--mk-ink-900);
+  border-color: var(--v4-accent-500);
+  color: var(--v4-ink-900);
 }
 .v4-bp-chip--on {
-  background: var(--mk-brand-500);
-  border-color: var(--mk-brand-500);
+  background: var(--v4-accent-500);
+  border-color: var(--v4-accent-500);
   color: #fff;
 }
 .v4-bp-meta {
   margin-left: auto;
   display: flex;
   gap: 16px;
-  font: 500 11px/1 var(--mk-font-sans);
-  color: var(--mk-ink-500);
+  font: 500 11px/1 var(--v4-sans);
+  color: var(--v4-ink-500);
 }
 .v4-bp-meta b {
-  color: var(--mk-ink-700);
-  font: 700 11px/1 var(--mk-font-mono);
+  color: var(--v4-ink-700);
+  font: 700 11px/1 var(--v4-mono);
 }
 
 /* ── legend ── */
@@ -87,8 +87,8 @@
   display: flex;
   gap: 18px;
   flex-wrap: wrap;
-  font: 500 11px/1 var(--mk-font-sans);
-  color: var(--mk-ink-600);
+  font: 500 11px/1 var(--v4-sans);
+  color: var(--v4-ink-600);
 }
 .v4-bp-lg {
   display: flex;
@@ -103,9 +103,9 @@
 /* ── canvas ── */
 .v4-bp-canvas {
   overflow-x: auto;
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
-  background: var(--mk-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg, 12px);
+  background: var(--v4-paper);
 }
 .v4-bp-svg {
   display: block;
@@ -113,49 +113,49 @@
 
 /* swimlanes */
 .v4-bp-lane {
-  fill: var(--mk-paper);
-  stroke: var(--mk-line-soft);
+  fill: var(--v4-paper);
+  stroke: var(--v4-line-soft);
   stroke-width: 1;
 }
 .v4-bp-lane--alt {
-  fill: var(--mk-surface-2);
+  fill: var(--v4-surface-2);
 }
 .v4-bp-lane-gutter {
-  fill: var(--mk-surface-3);
-  stroke: var(--mk-line);
+  fill: var(--v4-surface-3);
+  stroke: var(--v4-line);
   stroke-width: 1;
 }
 .v4-bp-lane-label {
-  font: 800 12px var(--mk-font-sans);
-  fill: var(--mk-ink-700);
+  font: 800 12px var(--v4-sans);
+  fill: var(--v4-ink-700);
 }
 
 /* flows */
 .v4-bp-flow {
   fill: none;
-  stroke: var(--mk-ink-400);
+  stroke: var(--v4-ink-400);
   stroke-width: 1.6;
 }
 .v4-bp-flow--warn {
-  stroke: var(--mk-warn);
+  stroke: var(--v4-warn-500);
   stroke-dasharray: 5 4;
 }
 .v4-bp-arrhead {
-  fill: var(--mk-ink-400);
+  fill: var(--v4-ink-400);
 }
 .v4-bp-arrhead--warn {
-  fill: var(--mk-warn);
+  fill: var(--v4-warn-500);
 }
 .v4-bp-flbl-bg {
-  fill: var(--mk-paper);
-  stroke: var(--mk-line);
+  fill: var(--v4-paper);
+  stroke: var(--v4-line);
 }
 .v4-bp-flbl {
-  font: 700 10px var(--mk-font-mono);
-  fill: var(--mk-ink-600);
+  font: 700 10px var(--v4-mono);
+  fill: var(--v4-ink-600);
 }
 .v4-bp-flbl--warn {
-  fill: var(--mk-warn-strong);
+  fill: var(--v4-warn-700);
 }
 
 /* nodes */
@@ -163,44 +163,44 @@
   stroke-width: 2.5;
 }
 .v4-bp-ev--start {
-  fill: var(--mk-success-soft);
-  stroke: var(--mk-success);
+  fill: var(--v4-success-50);
+  stroke: var(--v4-success-500);
 }
 .v4-bp-ev--end {
-  fill: var(--mk-danger-soft);
-  stroke: var(--mk-danger);
+  fill: var(--v4-danger-50);
+  stroke: var(--v4-danger-500);
   stroke-width: 4;
 }
 .v4-bp-gw {
-  fill: var(--mk-warn-soft);
-  stroke: var(--mk-warn);
+  fill: var(--v4-warn-50);
+  stroke: var(--v4-warn-500);
   stroke-width: 1.6;
 }
 .v4-bp-gw-x {
-  font: 800 15px var(--mk-font-mono);
-  fill: var(--mk-warn-strong);
+  font: 800 15px var(--v4-mono);
+  fill: var(--v4-warn-700);
 }
 .v4-bp-task {
-  fill: var(--mk-brand-50);
-  stroke: var(--mk-brand-500);
+  fill: var(--v4-accent-50);
+  stroke: var(--v4-accent-500);
   stroke-width: 1.4;
 }
 .v4-bp-task--sys {
-  fill: var(--mk-purple-50);
-  stroke: var(--mk-purple-500);
+  fill: var(--v4-purple-50);
+  stroke: var(--v4-purple-500);
   stroke-dasharray: 5 3;
 }
 .v4-bp-ntext {
-  font: 600 12px var(--mk-font-sans);
-  fill: var(--mk-ink-900);
+  font: 600 12px var(--v4-sans);
+  fill: var(--v4-ink-900);
 }
 .v4-bp-nsub {
-  font: 600 9.5px var(--mk-font-mono);
-  fill: var(--mk-ink-500);
+  font: 600 9.5px var(--v4-mono);
+  fill: var(--v4-ink-500);
 }
 .v4-bp-ncap {
-  font: 600 10.5px var(--mk-font-mono);
-  fill: var(--mk-ink-500);
+  font: 600 10.5px var(--v4-mono);
+  fill: var(--v4-ink-500);
 }
 .v4-bp-node {
   cursor: default;
@@ -219,54 +219,54 @@
   gap: 8px;
   padding: 44px 24px;
   text-align: center;
-  border: 1px dashed var(--mk-line-strong);
-  border-radius: var(--mk-r-lg);
-  background: var(--mk-surface-2);
+  border: 1px dashed var(--v4-line-strong);
+  border-radius: var(--v4-r-lg, 12px);
+  background: var(--v4-surface-2);
 }
 .v4-bp-empty--cta {
   gap: 10px;
 }
 .v4-bp-empty-ic {
   font-size: 26px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .v4-bp-empty-text {
-  font: 600 13px/1.5 var(--mk-font-sans);
-  color: var(--mk-ink-700);
+  font: 600 13px/1.5 var(--v4-sans);
+  color: var(--v4-ink-700);
 }
 .v4-bp-empty-sub {
   max-width: 520px;
-  font: 500 12px/1.6 var(--mk-font-sans);
-  color: var(--mk-ink-500);
+  font: 500 12px/1.6 var(--v4-sans);
+  color: var(--v4-ink-500);
 }
 .v4-bp-btn {
   margin-top: 4px;
-  font: 600 12px/1 var(--mk-font-sans);
+  font: 600 12px/1 var(--v4-sans);
   padding: 9px 16px;
-  border-radius: var(--mk-r-md);
-  border: 1px solid var(--mk-brand-500);
-  background: var(--mk-brand-500);
+  border-radius: var(--v4-r-md, 8px);
+  border: 1px solid var(--v4-accent-500);
+  background: var(--v4-accent-500);
   color: #fff;
   cursor: pointer;
   transition: background 0.15s;
 }
 .v4-bp-btn:hover {
-  background: var(--mk-brand-600);
+  background: var(--v4-accent-600);
 }
 .v4-bp-example-note {
-  font: 500 12px/1.5 var(--mk-font-sans);
-  color: var(--mk-ink-500);
+  font: 500 12px/1.5 var(--v4-sans);
+  color: var(--v4-ink-500);
   padding: 10px 14px;
-  background: var(--mk-warn-soft);
-  border: 1px solid var(--mk-warn-100);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-warn-50);
+  border: 1px solid var(--v4-warn-100);
+  border-radius: var(--v4-r-md, 8px);
 }
 .v4-bp-linkbtn {
   background: none;
   border: none;
   padding: 0;
-  font: 600 12px/1 var(--mk-font-sans);
-  color: var(--mk-brand-600);
+  font: 600 12px/1 var(--v4-sans);
+  color: var(--v4-accent-600);
   cursor: pointer;
   text-decoration: underline;
 }

--- a/src/styles/v4-health.css
+++ b/src/styles/v4-health.css
@@ -47,7 +47,7 @@
   margin: 0;
   font-size: 26px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   letter-spacing: -0.025em;
   line-height: 1.05;
 }
@@ -61,7 +61,7 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 700;
   padding: 3px 8px;
@@ -70,16 +70,16 @@
   text-transform: uppercase;
 }
 .ph-tag svg { width: 11px; height: 11px; }
-.ph-tag--tier1 { background: var(--mk-purple-50); color: var(--mk-purple-700); }
-.ph-tag--tier2 { background: var(--mk-brand-50); color: var(--mk-brand-700); }
-.ph-tag--tier3 { background: var(--mk-surface-2); color: var(--mk-ink-600); }
-.ph-tag--complex { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
+.ph-tag--tier1 { background: var(--v4-purple-50); color: var(--v4-purple-700); }
+.ph-tag--tier2 { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.ph-tag--tier3 { background: var(--v4-surface-2); color: var(--v4-ink-600); }
+.ph-tag--complex { background: var(--v4-warn-50); color: var(--v4-warn-700); }
 .ph-tag--client { background: #FDF2F8; color: #9D174D; }
-.ph-tag--internal { background: var(--mk-surface-2); color: var(--mk-ink-600); }
-.ph-tag--grace { background: var(--mk-success-soft); color: var(--mk-success-strong); }
+.ph-tag--internal { background: var(--v4-surface-2); color: var(--v4-ink-600); }
+.ph-tag--grace { background: var(--v4-success-50); color: var(--v4-success-700); }
 .ph-hero-sub {
   font-size: 12px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -90,9 +90,9 @@
   align-items: center;
   gap: 5px;
 }
-.ph-hero-sub svg { width: 12px; height: 12px; color: var(--mk-ink-400); }
-.ph-hero-sub .v4-sep { color: var(--mk-ink-300); }
-.ph-hero-link { color: var(--mk-brand-600); text-decoration: none; font-weight: 500; }
+.ph-hero-sub svg { width: 12px; height: 12px; color: var(--v4-ink-400); }
+.ph-hero-sub .v4-sep { color: var(--v4-ink-300); }
+.ph-hero-link { color: var(--v4-accent-600); text-decoration: none; font-weight: 500; }
 .ph-hero-link:hover { text-decoration: underline; }
 .ph-hero-actions {
   display: flex;
@@ -109,8 +109,8 @@
   gap: 14px;
 }
 .ph-tile {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 14px;
   padding: 18px 20px;
   display: flex;
@@ -125,7 +125,7 @@
 .ph-tile:not(.ph-tile--main):hover {
   transform: translateY(-2px);
   box-shadow: 0 8px 24px rgba(13,18,28,0.07);
-  border-color: var(--mk-line-strong);
+  border-color: var(--v4-line-strong, #d8dde6);
 }
 .ph-tile:nth-child(1) { animation-delay: 0ms; }
 .ph-tile:nth-child(2) { animation-delay: 90ms; }
@@ -155,10 +155,10 @@
 
 .ph-tile-lbl {
   display: flex; align-items: center; gap: 8px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.08em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   height: 18px;
   z-index: 1;
 }
@@ -166,8 +166,8 @@
   display: inline-flex; align-items: center; justify-content: center;
   width: 18px; height: 18px;
   border-radius: 5px;
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-600);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-600);
 }
 .ph-tile-lbl-ic svg { width: 11px; height: 11px; }
 .ph-tile--main .ph-tile-lbl { color: rgba(255,255,255,0.85); }
@@ -190,7 +190,7 @@
   align-items: center; justify-content: center;
 }
 .ph-ring-grade {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 44px; font-weight: 800; line-height: 1;
   letter-spacing: -0.04em;
   color: #fff;
@@ -219,7 +219,7 @@
 .ph-sw--unknown { background: #FCD34D; }
 .ph-tile-row-l { font-size: 13px; flex: 1; color: rgba(255,255,255,0.85); }
 .ph-tile-row b {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-weight: 700; color: #fff;
   font-size: 18px; min-width: 32px; text-align: right;
   letter-spacing: -0.02em;
@@ -232,32 +232,32 @@
   margin-top: 2px;
 }
 .ph-tile-num {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 48px; font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   line-height: 1; letter-spacing: -0.025em;
 }
 .ph-tile-num-u {
   font-size: 13px; font-weight: 600;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-left: 6px;
 }
 .ph-tile-chip {
   margin-left: auto; align-self: center;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px; font-weight: 700;
   padding: 4px 8px; border-radius: 6px;
   white-space: nowrap;
 }
-.ph-tile-chip--pos { background: var(--mk-success-soft); color: var(--mk-success-strong); }
+.ph-tile-chip--pos { background: var(--v4-success-50); color: var(--v4-success-700); }
 .ph-tile-chip--neg { background: #FEE4E2; color: #B42318; }
-.ph-tile-chip--neu { background: var(--mk-surface-2); color: var(--mk-ink-600); }
+.ph-tile-chip--neu { background: var(--v4-surface-2); color: var(--v4-ink-600); }
 .ph-tile-meta {
   display: flex; justify-content: space-between;
-  font-size: 11px; color: var(--mk-ink-500);
+  font-size: 11px; color: var(--v4-ink-500);
   margin-top: auto;
 }
-.ph-tile-meta b { color: var(--mk-ink-900); font-size: 13px; }
+.ph-tile-meta b { color: var(--v4-ink-900); font-size: 13px; }
 
 /* severity bars in tile */
 .ph-sev-bars {
@@ -269,17 +269,17 @@
   gap: 8px; align-items: center;
 }
 .ph-sev-bar-l {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9.5px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.04em;
 }
-.ph-sev-bar-l--critical { color: var(--mk-danger-strong); }
-.ph-sev-bar-l--high { color: var(--mk-danger); }
-.ph-sev-bar-l--medium { color: var(--mk-warn-strong); }
-.ph-sev-bar-l--low { color: var(--mk-ink-500); }
+.ph-sev-bar-l--critical { color: var(--v4-danger-700); }
+.ph-sev-bar-l--high { color: var(--v4-danger-500); }
+.ph-sev-bar-l--medium { color: var(--v4-warn-700); }
+.ph-sev-bar-l--low { color: var(--v4-ink-500); }
 .ph-sev-bar-track {
   height: 8px;
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
   border-radius: 99px;
   overflow: hidden;
 }
@@ -293,14 +293,14 @@
   from { transform: scaleX(0); }
   to { transform: scaleX(1); }
 }
-.ph-sev-bar-fill--critical { background: var(--mk-danger-strong); }
-.ph-sev-bar-fill--high { background: var(--mk-danger); }
-.ph-sev-bar-fill--medium { background: var(--mk-warn); }
-.ph-sev-bar-fill--low { background: var(--mk-ink-400); }
+.ph-sev-bar-fill--critical { background: var(--v4-danger-700); }
+.ph-sev-bar-fill--high { background: var(--v4-danger-500); }
+.ph-sev-bar-fill--medium { background: var(--v4-warn-500); }
+.ph-sev-bar-fill--low { background: var(--v4-ink-400); }
 .ph-sev-bar-n {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12px; font-weight: 700;
-  text-align: right; color: var(--mk-ink-700);
+  text-align: right; color: var(--v4-ink-700);
 }
 
 /* sparkline */
@@ -350,7 +350,7 @@
   position: absolute;
   top: -6px;
   transform: translate(-50%, -100%);
-  background: var(--mk-ink-900);
+  background: var(--v4-ink-900);
   color: #fff;
   padding: 5px 8px;
   border-radius: 6px;
@@ -371,7 +371,7 @@
   left: 50%;
   transform: translateX(-50%);
   border: 4px solid transparent;
-  border-top-color: var(--mk-ink-900);
+  border-top-color: var(--v4-ink-900);
 }
 .ph-spark-tip-day {
   color: rgba(255,255,255,0.65);
@@ -383,8 +383,8 @@
 
 /* ══════════ LAYER STRIP ══════════ */
 .ph-layer-strip {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 14px;
   padding: 16px 20px 18px;
   margin-bottom: 18px;
@@ -396,13 +396,13 @@
 .ph-layer-strip-t {
   display: flex; align-items: center; gap: 8px;
   font-size: 12px; font-weight: 700;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   text-transform: uppercase; letter-spacing: 0.06em;
 }
-.ph-layer-strip-t svg { width: 14px; height: 14px; color: var(--mk-brand-600); }
+.ph-layer-strip-t svg { width: 14px; height: 14px; color: var(--v4-accent-600); }
 .ph-layer-legend {
   display: flex; gap: 14px;
-  font-size: 11px; color: var(--mk-ink-500);
+  font-size: 11px; color: var(--v4-ink-500);
 }
 .ph-layer-legend span {
   display: inline-flex; align-items: center; gap: 5px;
@@ -412,10 +412,10 @@
   border-radius: 2px;
   display: inline-block;
 }
-.ph-dot--pass { background: var(--mk-success); }
-.ph-dot--fail { background: var(--mk-danger); }
-.ph-dot--unknown { background: var(--mk-warn); }
-.ph-dot--skipped { background: var(--mk-ink-300); }
+.ph-dot--pass { background: var(--v4-success-500); }
+.ph-dot--fail { background: var(--v4-danger-500); }
+.ph-dot--unknown { background: var(--v4-warn-500); }
+.ph-dot--skipped { background: var(--v4-ink-300); }
 
 .ph-layer-rows {
   display: flex; flex-direction: column; gap: 10px;
@@ -431,7 +431,7 @@
   border-radius: 8px;
   transition: background .18s ease;
 }
-.ph-layer-row:hover { background: var(--mk-paper); }
+.ph-layer-row:hover { background: var(--v4-surface-1, #f7f8fb); }
 .ph-layer-row:hover .ph-layer-row-track { box-shadow: inset 0 1px 2px rgba(0,0,0,0.06); }
 @keyframes ph-layer-row-in {
   from { opacity: 0; transform: translateY(4px); }
@@ -442,18 +442,18 @@
   font-size: 13px;
 }
 .ph-layer-row-num {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px; font-weight: 700;
-  color: var(--mk-brand-700);
-  background: var(--mk-brand-50);
+  color: var(--v4-accent-700);
+  background: var(--v4-accent-50);
   padding: 3px 7px; border-radius: 5px;
   letter-spacing: 0.03em;
 }
-.ph-layer-row-name { color: var(--mk-ink-800); font-weight: 600; }
+.ph-layer-row-name { color: var(--v4-ink-800); font-weight: 600; }
 .ph-layer-row-track {
   height: 16px;
   border-radius: 99px;
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
   overflow: hidden;
   display: flex;
   box-shadow: inset 0 1px 2px rgba(0,0,0,0.04);
@@ -467,42 +467,42 @@
   from { transform: scaleX(0); }
   to { transform: scaleX(1); }
 }
-.ph-layer-row-seg--pass { background: var(--mk-success); }
-.ph-layer-row-seg--fail { background: var(--mk-danger); }
-.ph-layer-row-seg--unknown { background: var(--mk-warn); }
-.ph-layer-row-seg--skipped { background: var(--mk-ink-300); }
+.ph-layer-row-seg--pass { background: var(--v4-success-500); }
+.ph-layer-row-seg--fail { background: var(--v4-danger-500); }
+.ph-layer-row-seg--unknown { background: var(--v4-warn-500); }
+.ph-layer-row-seg--skipped { background: var(--v4-ink-300); }
 .ph-layer-row-counts {
   display: flex; gap: 4px; align-items: baseline;
   font-size: 13px; font-weight: 700;
   justify-content: flex-end;
 }
-.ph-layer-row-counts .ph-c-pass { color: var(--mk-success-strong); }
-.ph-layer-row-counts .ph-c-fail { color: var(--mk-danger-strong); }
-.ph-layer-row-counts .ph-c-unknown { color: var(--mk-warn-strong); }
-.ph-layer-row-counts .ph-c-muted { color: var(--mk-ink-300); }
-.ph-layer-row-counts .ph-c-sep { color: var(--mk-ink-300); }
+.ph-layer-row-counts .ph-c-pass { color: var(--v4-success-700); }
+.ph-layer-row-counts .ph-c-fail { color: var(--v4-danger-700); }
+.ph-layer-row-counts .ph-c-unknown { color: var(--v4-warn-700); }
+.ph-layer-row-counts .ph-c-muted { color: var(--v4-ink-300); }
+.ph-layer-row-counts .ph-c-sep { color: var(--v4-ink-300); }
 
 /* ══════════ BOARD / GROUPS ══════════ */
 .ph-board {
   display: flex; flex-direction: column; gap: 14px;
 }
 .ph-group {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 14px;
   overflow: hidden;
 }
-.ph-group--danger { border-color: var(--mk-danger-100); }
+.ph-group--danger { border-color: var(--v4-danger-100); }
 .ph-group-h {
   display: flex; align-items: center; gap: 12px;
   padding: 14px 18px;
   cursor: pointer; user-select: none;
 }
 .ph-group--danger > .ph-group-h {
-  background: linear-gradient(90deg, var(--mk-danger-soft), transparent 60%);
+  background: linear-gradient(90deg, var(--v4-danger-50), transparent 60%);
 }
 .ph-group--warn > .ph-group-h {
-  background: linear-gradient(90deg, var(--mk-warn-soft), transparent 60%);
+  background: linear-gradient(90deg, var(--v4-warn-50), transparent 60%);
 }
 .ph-group-icon {
   width: 32px; height: 32px;
@@ -511,26 +511,26 @@
   flex-shrink: 0;
 }
 .ph-group-icon svg { width: 15px; height: 15px; }
-.ph-group-icon--danger { background: var(--mk-danger); color: #fff; }
-.ph-group-icon--warn { background: var(--mk-warn); color: #fff; }
-.ph-group-icon--good { background: var(--mk-success); color: #fff; }
-.ph-group-icon--muted { background: var(--mk-surface-2); color: var(--mk-ink-500); }
+.ph-group-icon--danger { background: var(--v4-danger-500); color: #fff; }
+.ph-group-icon--warn { background: var(--v4-warn-500); color: #fff; }
+.ph-group-icon--good { background: var(--v4-success-500); color: #fff; }
+.ph-group-icon--muted { background: var(--v4-surface-2); color: var(--v4-ink-500); }
 .ph-group-titles { flex: 1; min-width: 0; }
 .ph-group-titles h3 {
   margin: 0;
   font-size: 15px; font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   letter-spacing: -0.01em;
 }
 .ph-group-titles p {
   margin: 1px 0 0;
-  font-size: 12px; color: var(--mk-ink-500);
+  font-size: 12px; color: var(--v4-ink-500);
 }
-.ph-chevron { color: var(--mk-ink-400); transition: transform 220ms cubic-bezier(.2,.8,.2,1), color .2s; }
+.ph-chevron { color: var(--v4-ink-400); transition: transform 220ms cubic-bezier(.2,.8,.2,1), color .2s; }
 .ph-chevron svg { width: 16px; height: 16px; }
-.ph-chevron.is-open { transform: rotate(180deg); color: var(--mk-ink-700); }
+.ph-chevron.is-open { transform: rotate(180deg); color: var(--v4-ink-700); }
 .ph-group-body {
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   animation: ph-group-body-in .28s cubic-bezier(.2,.8,.2,1) both;
   overflow: hidden;
 }
@@ -538,31 +538,31 @@
   from { opacity: 0; transform: translateY(-4px); }
   to { opacity: 1; transform: translateY(0); }
 }
-.ph-group-body--soft { background: var(--mk-surface-2); }
+.ph-group-body--soft { background: var(--v4-surface-2); }
 
 /* ── LAYER BLOCK ── */
-.ph-layerblock + .ph-layerblock { border-top: 1px solid var(--mk-line-soft); }
+.ph-layerblock + .ph-layerblock { border-top: 1px solid var(--v4-line-soft); }
 .ph-layerblock-h {
   display: flex; align-items: baseline; gap: 8px;
   padding: 10px 18px 6px;
-  background: var(--mk-surface-2);
-  border-bottom: 1px solid var(--mk-line-soft);
+  background: var(--v4-surface-2);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .ph-layerblock-num {
   font-size: 10px; font-weight: 700;
-  color: var(--mk-brand-700);
-  background: var(--mk-brand-50);
+  color: var(--v4-accent-700);
+  background: var(--v4-accent-50);
   padding: 2px 6px; border-radius: 4px;
   letter-spacing: 0.04em;
 }
-.ph-layerblock-name { font-size: 12px; font-weight: 600; color: var(--mk-ink-800); }
-.ph-layerblock-count { margin-left: auto; font-size: 11px; color: var(--mk-ink-400); }
+.ph-layerblock-name { font-size: 12px; font-weight: 600; color: var(--v4-ink-800); }
+.ph-layerblock-count { margin-left: auto; font-size: 11px; color: var(--v4-ink-400); }
 
 .ph-finding-list { list-style: none; margin: 0; padding: 0; }
 
 /* ── FINDING ITEM ── */
 .ph-fi {
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   border-left: 3px solid transparent;
   padding: 14px 18px 14px 15px;
   transition: background .18s ease, border-left-color .18s ease, transform .15s ease;
@@ -579,12 +579,12 @@
   }
 }
 .ph-fi:last-child { border-bottom: 0; }
-.ph-fi:hover { background: var(--mk-paper); }
-.ph-fi--fail.ph-fi--sev-critical { border-left-color: var(--mk-danger-strong); }
-.ph-fi--fail.ph-fi--sev-high { border-left-color: var(--mk-danger); }
-.ph-fi--fail.ph-fi--sev-medium { border-left-color: var(--mk-warn); }
-.ph-fi--fail.ph-fi--sev-low { border-left-color: var(--mk-ink-300); }
-.ph-fi--unknown { border-left-color: var(--mk-warn); border-left-style: dashed; }
+.ph-fi:hover { background: var(--v4-surface-1, #f7f8fb); }
+.ph-fi--fail.ph-fi--sev-critical { border-left-color: var(--v4-danger-700); }
+.ph-fi--fail.ph-fi--sev-high { border-left-color: var(--v4-danger-500); }
+.ph-fi--fail.ph-fi--sev-medium { border-left-color: var(--v4-warn-500); }
+.ph-fi--fail.ph-fi--sev-low { border-left-color: var(--v4-ink-300); }
+.ph-fi--unknown { border-left-color: var(--v4-warn-500); border-left-style: dashed; }
 .ph-fi-top {
   display: grid;
   grid-template-columns: 100px 1fr auto;
@@ -595,23 +595,23 @@
 .ph-fi-title {
   display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
   font-size: 13.5px; font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   line-height: 1.35;
 }
 .ph-fi-rule {
   font-size: 10.5px; font-weight: 500;
-  color: var(--mk-ink-500);
-  background: var(--mk-surface-2);
+  color: var(--v4-ink-500);
+  background: var(--v4-surface-2);
   padding: 1px 6px; border-radius: 4px;
 }
 .ph-fi-detail {
   margin-top: 4px;
-  font-size: 12.5px; color: var(--mk-ink-600);
+  font-size: 12.5px; color: var(--v4-ink-600);
   line-height: 1.5;
 }
 .ph-fi-source {
   margin-top: 6px;
-  font-size: 10.5px; color: var(--mk-ink-400);
+  font-size: 10.5px; color: var(--v4-ink-400);
   font-weight: 500;
   display: inline-flex; align-items: center; gap: 4px;
 }
@@ -625,16 +625,16 @@
 /* «→ issue» button states */
 .ph-fi-issue.is-linked {
   text-decoration: none;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
 }
 .ph-fi-issue.is-error {
-  border-color: var(--mk-danger);
-  color: var(--mk-danger-strong);
-  background: var(--mk-danger-soft);
+  border-color: var(--v4-danger-500);
+  color: var(--v4-danger-700);
+  background: var(--v4-danger-50);
 }
 .ph-fi-issue.is-error:hover {
-  border-color: var(--mk-danger-strong);
-  color: var(--mk-danger-strong);
+  border-color: var(--v4-danger-700);
+  color: var(--v4-danger-700);
 }
 .ph-fi-issue.is-loading { cursor: progress; opacity: 0.85; }
 .ph-fi-issue-spin {
@@ -647,21 +647,21 @@
 }
 .ph-fi-rem {
   margin: 12px 0 2px 114px;
-  background: var(--mk-brand-50);
-  border: 1px solid var(--mk-brand-100);
+  background: var(--v4-accent-50);
+  border: 1px solid var(--v4-accent-100);
   border-radius: 8px;
   padding: 12px 14px;
 }
 .ph-fi-rem-h {
   display: flex; align-items: center; gap: 6px;
   font-size: 11px; font-weight: 700;
-  color: var(--mk-brand-700);
+  color: var(--v4-accent-700);
   text-transform: uppercase; letter-spacing: 0.06em;
   margin-bottom: 6px;
 }
 .ph-fi-rem-h svg { width: 12px; height: 12px; }
 .ph-fi-rem-body {
-  font-size: 12.5px; color: var(--mk-ink-800);
+  font-size: 12.5px; color: var(--v4-ink-800);
   line-height: 1.55;
   white-space: pre-wrap;
 }
@@ -669,7 +669,7 @@
 /* ── SEVERITY TAG ── */
 .ph-sev {
   display: inline-flex; align-items: center; gap: 5px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10.5px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.04em;
   padding: 3px 8px; border-radius: 99px;
@@ -680,23 +680,23 @@
   width: 6px; height: 6px; border-radius: 50%;
   display: inline-block;
 }
-.ph-sev--critical { background: var(--mk-danger-strong); color: #fff; }
+.ph-sev--critical { background: var(--v4-danger-700); color: #fff; }
 .ph-sev--critical .ph-sev-dot { background: #fff; }
 .ph-sev--high {
-  background: var(--mk-danger-soft); color: var(--mk-danger-strong);
-  border: 1px solid var(--mk-danger-100);
+  background: var(--v4-danger-50); color: var(--v4-danger-700);
+  border: 1px solid var(--v4-danger-100);
 }
-.ph-sev--high .ph-sev-dot { background: var(--mk-danger); }
+.ph-sev--high .ph-sev-dot { background: var(--v4-danger-500); }
 .ph-sev--medium {
-  background: var(--mk-warn-soft); color: var(--mk-warn-strong);
-  border: 1px solid var(--mk-warn-100);
+  background: var(--v4-warn-50); color: var(--v4-warn-700);
+  border: 1px solid var(--v4-warn-100);
 }
-.ph-sev--medium .ph-sev-dot { background: var(--mk-warn); }
-.ph-sev--low { background: var(--mk-surface-2); color: var(--mk-ink-600); }
-.ph-sev--low .ph-sev-dot { background: var(--mk-ink-400); }
+.ph-sev--medium .ph-sev-dot { background: var(--v4-warn-500); }
+.ph-sev--low { background: var(--v4-surface-2); color: var(--v4-ink-600); }
+.ph-sev--low .ph-sev-dot { background: var(--v4-ink-400); }
 .ph-sev--unknown {
-  background: var(--mk-surface-2); color: var(--mk-ink-600);
-  border: 1px dashed var(--mk-ink-300);
+  background: var(--v4-surface-2); color: var(--v4-ink-600);
+  border: 1px dashed var(--v4-ink-300);
 }
 
 /* ── PASS GRID ── */
@@ -705,36 +705,36 @@
 }
 .ph-pass-col {
   padding: 14px 18px;
-  border-right: 1px solid var(--mk-line-soft);
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-right: 1px solid var(--v4-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .ph-pass-col-h {
   font-size: 11px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.06em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-bottom: 8px;
 }
 .ph-pass-col-h .v4-mono {
-  color: var(--mk-success-strong);
-  background: var(--mk-success-soft);
+  color: var(--v4-success-700);
+  background: var(--v4-success-50);
   padding: 2px 6px; border-radius: 4px;
   margin-right: 4px;
 }
 .ph-pass-col ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 5px; }
 .ph-pass-col li {
   display: flex; align-items: center; gap: 8px;
-  font-size: 12px; color: var(--mk-ink-700);
+  font-size: 12px; color: var(--v4-ink-700);
 }
 .ph-pass-col li svg {
   width: 13px; height: 13px;
-  color: var(--mk-success);
+  color: var(--v4-success-500);
   flex-shrink: 0;
 }
 .ph-pass-col li > span:nth-child(2) {
   flex: 1; min-width: 0;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.ph-pass-rule { font-size: 9.5px; color: var(--mk-ink-400); flex-shrink: 0; }
+.ph-pass-rule { font-size: 9.5px; color: var(--v4-ink-400); flex-shrink: 0; }
 
 /* ── SKIPPED LIST ── */
 .ph-skip-list { list-style: none; margin: 0; padding: 4px 0; }
@@ -742,16 +742,16 @@
   display: grid; grid-template-columns: 1fr auto;
   gap: 10px;
   padding: 9px 18px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   font-size: 12px;
   align-items: baseline;
 }
 .ph-skip-list li:last-child { border-bottom: 0; }
-.ph-skip-title { color: var(--mk-ink-700); font-weight: 500; }
-.ph-skip-rule { font-size: 10px; color: var(--mk-ink-400); text-align: right; }
+.ph-skip-title { color: var(--v4-ink-700); font-weight: 500; }
+.ph-skip-rule { font-size: 10px; color: var(--v4-ink-400); text-align: right; }
 .ph-skip-detail {
   grid-column: 1 / -1;
-  font-size: 11px; color: var(--mk-ink-500);
+  font-size: 11px; color: var(--v4-ink-500);
   margin-top: 1px;
 }
 
@@ -761,41 +761,41 @@
   position: sticky; top: 72px;
 }
 .ph-side-card {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 14px;
   overflow: hidden;
 }
 .ph-side-card--accent {
-  background: linear-gradient(180deg, var(--mk-brand-50), var(--mk-paper) 60%);
+  background: linear-gradient(180deg, var(--v4-accent-50), var(--v4-paper) 60%);
 }
 .ph-side-h {
   padding: 12px 16px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   font-size: 11px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.06em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   display: flex; align-items: center; gap: 6px;
 }
-.ph-side-h svg { width: 14px; height: 14px; color: var(--mk-brand-600); }
+.ph-side-h svg { width: 14px; height: 14px; color: var(--v4-accent-600); }
 .ph-side-body { padding: 14px 16px; }
 .ph-side-spark-meta {
   display: flex; justify-content: space-between; align-items: baseline;
   margin-top: 8px;
-  font-size: 11px; color: var(--mk-ink-500);
+  font-size: 11px; color: var(--v4-ink-500);
 }
 .ph-side-spark-meta > div { display: flex; flex-direction: column; gap: 2px; }
 .ph-side-meta-l {
   font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .ph-side-meta-now {
-  color: var(--mk-ink-900); font-weight: 700; font-size: 16px;
+  color: var(--v4-ink-900); font-weight: 700; font-size: 16px;
 }
 .ph-side-future {
   margin-top: 12px; padding-top: 10px;
-  border-top: 1px dashed var(--mk-line);
-  font-size: 10px; color: var(--mk-ink-400);
+  border-top: 1px dashed var(--v4-line);
+  font-size: 10px; color: var(--v4-ink-400);
 }
 .ph-side-meta {
   padding: 12px 16px;
@@ -803,40 +803,40 @@
 }
 .ph-side-meta > div {
   display: flex; justify-content: space-between; align-items: baseline;
-  gap: 12px; font-size: 12px; color: var(--mk-ink-700);
+  gap: 12px; font-size: 12px; color: var(--v4-ink-700);
 }
 .ph-side-foot {
   padding: 10px 16px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   display: flex; align-items: center;
 }
 .ph-side-foot .v4-linkbtn { display: inline-flex; align-items: center; gap: 6px; }
 .ph-side-foot svg { width: 12px; height: 12px; }
 .ph-side-body--rules p {
   margin: 0 0 8px;
-  font-size: 12px; color: var(--mk-ink-600);
+  font-size: 12px; color: var(--v4-ink-600);
   line-height: 1.5;
 }
-.ph-link { color: var(--mk-brand-600); text-decoration: none; font-weight: 500; }
+.ph-link { color: var(--v4-accent-600); text-decoration: none; font-weight: 500; }
 .ph-link:hover { text-decoration: underline; }
 .ph-rule-tree {
   list-style: none; margin: 0; padding: 0;
   display: flex; flex-direction: column; gap: 4px;
-  font-size: 11.5px; color: var(--mk-ink-700);
+  font-size: 11.5px; color: var(--v4-ink-700);
 }
 .ph-rule-tree .v4-mono {
-  color: var(--mk-brand-700);
-  background: var(--mk-brand-50);
+  color: var(--v4-accent-700);
+  background: var(--v4-accent-50);
   padding: 1px 5px; border-radius: 3px;
   font-size: 10px; margin-right: 4px;
 }
-.ph-rule-tree a { color: var(--mk-brand-600); text-decoration: none; }
+.ph-rule-tree a { color: var(--v4-accent-600); text-decoration: none; }
 .ph-rule-tree a:hover { text-decoration: underline; }
 
 /* ══════════ STATES ══════════ */
 .ph-clean {
-  background: linear-gradient(180deg, var(--mk-success-soft) 0%, var(--mk-paper) 60%);
-  border: 1px solid var(--mk-success-100);
+  background: linear-gradient(180deg, var(--v4-success-50) 0%, var(--v4-paper) 60%);
+  border: 1px solid var(--v4-success-100);
   border-radius: 14px;
   padding: 36px 28px;
   display: flex; flex-direction: column; align-items: center;
@@ -845,7 +845,7 @@
 .ph-clean-glyph {
   width: 64px; height: 64px;
   border-radius: 50%;
-  background: var(--mk-success); color: #fff;
+  background: var(--v4-success-500); color: #fff;
   display: flex; align-items: center; justify-content: center;
   margin-bottom: 4px;
   box-shadow: 0 0 0 6px rgba(18, 183, 106, 0.18);
@@ -854,12 +854,12 @@
 .ph-clean h3 {
   margin: 0;
   font-size: 18px; font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   letter-spacing: -0.01em;
 }
 .ph-clean p {
   margin: 0;
-  font-size: 13px; color: var(--mk-ink-600);
+  font-size: 13px; color: var(--v4-ink-600);
   max-width: 420px; line-height: 1.5;
 }
 
@@ -867,20 +867,20 @@
   padding: 28px 24px;
   display: flex; flex-direction: column; align-items: flex-start;
   gap: 8px;
-  border: 1px solid var(--mk-danger-100);
+  border: 1px solid var(--v4-danger-100);
   border-radius: 14px;
-  background: linear-gradient(180deg, var(--mk-danger-soft), var(--mk-paper) 60%);
+  background: linear-gradient(180deg, var(--v4-danger-50), var(--v4-paper) 60%);
 }
 .ph-error-icon {
   width: 36px; height: 36px;
   border-radius: 8px;
-  background: var(--mk-danger); color: #fff;
+  background: var(--v4-danger-500); color: #fff;
   display: flex; align-items: center; justify-content: center;
   margin-bottom: 6px;
 }
 .ph-error-icon svg { width: 18px; height: 18px; }
-.ph-error h3 { margin: 0; font-size: 16px; font-weight: 700; color: var(--mk-ink-900); }
-.ph-error p { margin: 0; font-size: 13px; color: var(--mk-ink-600); line-height: 1.5; }
+.ph-error h3 { margin: 0; font-size: 16px; font-weight: 700; color: var(--v4-ink-900); }
+.ph-error p { margin: 0; font-size: 13px; color: var(--v4-ink-600); line-height: 1.5; }
 .ph-error-actions {
   margin-top: 6px;
   display: flex; gap: 12px; align-items: center;
@@ -889,18 +889,18 @@
 /* loading */
 .ph-loading { display: flex; flex-direction: column; gap: 14px; }
 .ph-skel-hero {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 14px;
   padding: 22px;
   display: flex; flex-direction: column; gap: 12px;
 }
 .ph-skel-tags { display: flex; gap: 6px; }
 .ph-skel-row { display: grid; grid-template-columns: 220px 1fr; gap: 22px; margin-top: 10px; }
-.ph-skel-grade { background: var(--mk-surface-3); border-radius: 12px; height: 160px; }
+.ph-skel-grade { background: var(--v4-surface-3); border-radius: 12px; height: 160px; }
 .ph-skel-meta { display: flex; flex-direction: column; gap: 10px; }
 .ph-skel-block {
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   border-radius: 6px;
   position: relative; overflow: hidden;
 }
@@ -918,28 +918,28 @@
 .ph-skel-msg {
   display: flex; align-items: center; gap: 10px;
   padding: 12px 18px;
-  background: var(--mk-brand-50);
-  border: 1px solid var(--mk-brand-100);
+  background: var(--v4-accent-50);
+  border: 1px solid var(--v4-accent-100);
   border-radius: 10px;
-  font-size: 13px; color: var(--mk-brand-700); font-weight: 500;
+  font-size: 13px; color: var(--v4-accent-700); font-weight: 500;
 }
 .ph-skel-spin {
   width: 14px; height: 14px;
-  border: 2px solid var(--mk-brand-100);
-  border-top-color: var(--mk-brand-500);
+  border: 2px solid var(--v4-accent-100);
+  border-top-color: var(--v4-accent-500);
   border-radius: 50%;
   animation: v4-spin 0.9s linear infinite;
 }
 .ph-skel-rows {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 14px;
   overflow: hidden;
 }
 .ph-skel-finding {
   display: grid; grid-template-columns: 90px 1fr 100px;
   gap: 14px; padding: 14px 18px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   align-items: center;
 }
 .ph-skel-finding:last-child { border-bottom: 0; }
@@ -949,16 +949,16 @@
 .ph-refresh-banner {
   display: flex; align-items: center; gap: 10px;
   padding: 10px 16px;
-  background: var(--mk-brand-50);
-  border: 1px solid var(--mk-brand-100);
+  background: var(--v4-accent-50);
+  border: 1px solid var(--v4-accent-100);
   border-radius: 10px;
   margin-bottom: 14px;
-  font-size: 12.5px; color: var(--mk-brand-700); font-weight: 500;
+  font-size: 12.5px; color: var(--v4-accent-700); font-weight: 500;
 }
 .ph-refresh-spin {
   width: 12px; height: 12px;
-  border: 2px solid var(--mk-brand-100);
-  border-top-color: var(--mk-brand-500);
+  border: 2px solid var(--v4-accent-100);
+  border-top-color: var(--v4-accent-500);
   border-radius: 50%;
   animation: v4-spin 0.9s linear infinite;
 }
@@ -966,58 +966,58 @@
 .ph-grace-banner {
   display: flex; align-items: center; gap: 12px;
   padding: 12px 16px;
-  background: var(--mk-success-soft);
-  border: 1px solid var(--mk-success-100);
+  background: var(--v4-success-50);
+  border: 1px solid var(--v4-success-100);
   border-radius: 10px;
   margin-bottom: 14px;
-  font-size: 13px; color: var(--mk-success-strong);
+  font-size: 13px; color: var(--v4-success-700);
 }
-.ph-grace-banner b { color: var(--mk-success-strong); }
+.ph-grace-banner b { color: var(--v4-success-700); }
 
 /* classification missing */
 .ph-classmissing {
   padding: 36px 30px;
   display: flex; flex-direction: column; align-items: flex-start; gap: 8px;
-  background: linear-gradient(180deg, var(--mk-brand-50), var(--mk-paper) 50%);
-  border: 1px solid var(--mk-brand-100);
+  background: linear-gradient(180deg, var(--v4-accent-50), var(--v4-paper) 50%);
+  border: 1px solid var(--v4-accent-100);
   border-radius: 14px;
 }
 .ph-classmissing-art {
   width: 44px; height: 44px;
   border-radius: 10px;
-  background: var(--mk-brand-500); color: #fff;
+  background: var(--v4-accent-500); color: #fff;
   display: flex; align-items: center; justify-content: center;
   margin-bottom: 6px;
 }
 .ph-classmissing-art svg { width: 22px; height: 22px; }
 .ph-classmissing h3 {
   margin: 0; font-size: 18px; font-weight: 700;
-  color: var(--mk-ink-900); letter-spacing: -0.01em;
+  color: var(--v4-ink-900); letter-spacing: -0.01em;
 }
 .ph-classmissing p {
-  margin: 0; font-size: 13px; color: var(--mk-ink-600);
+  margin: 0; font-size: 13px; color: var(--v4-ink-600);
   line-height: 1.55; max-width: 540px;
 }
 .ph-classmissing-steps {
   margin: 12px 0 4px 0; padding-left: 22px;
   display: flex; flex-direction: column; gap: 6px;
-  font-size: 12.5px; color: var(--mk-ink-700); line-height: 1.5;
+  font-size: 12.5px; color: var(--v4-ink-700); line-height: 1.5;
 }
-.ph-classmissing-steps li::marker { color: var(--mk-brand-600); font-weight: 700; }
+.ph-classmissing-steps li::marker { color: var(--v4-accent-600); font-weight: 700; }
 .ph-classmissing-actions { margin-top: 14px; display: flex; gap: 10px; }
 
 /* state-banner for tweak demo */
 .ph-state-banner {
   display: flex; align-items: center; gap: 10px;
   padding: 8px 16px;
-  background: var(--mk-ink-900);
+  background: var(--v4-ink-900);
   color: rgba(255,255,255,0.92);
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px; letter-spacing: 0.04em;
   text-transform: uppercase; font-weight: 600;
 }
 .ph-state-banner b { color: #fff; font-weight: 700; }
-.ph-state-banner span { color: rgba(255,255,255,0.55); font-weight: 400; text-transform: none; letter-spacing: 0; font-family: var(--mk-font-sans); }
+.ph-state-banner span { color: rgba(255,255,255,0.55); font-weight: 400; text-transform: none; letter-spacing: 0; font-family: var(--v4-sans); }
 
 /* responsive */
 /* Breakpoint contract exception (issue #490): 1180 is >1100;
@@ -1044,52 +1044,52 @@
 .ph-bulk-filters {
   display: flex; gap: 6px; flex-wrap: wrap;
   padding: 12px 20px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .ph-bulk-chip {
   appearance: none;
   display: inline-flex; align-items: center; gap: 6px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.04em;
   padding: 5px 10px;
   border-radius: 99px;
-  border: 1px solid var(--mk-line);
-  background: var(--mk-paper);
-  color: var(--mk-ink-700);
+  border: 1px solid var(--v4-line);
+  background: var(--v4-paper);
+  color: var(--v4-ink-700);
   cursor: pointer;
   transition: background .15s, border-color .15s, color .15s, opacity .15s;
 }
 .ph-bulk-chip:hover:not(:disabled) {
-  border-color: var(--mk-line-strong);
+  border-color: var(--v4-line-strong);
 }
 .ph-bulk-chip:disabled { opacity: .45; cursor: not-allowed; }
 .ph-bulk-chip.is-dim { opacity: .4; }
 .ph-bulk-chip-dot {
   width: 8px; height: 8px; border-radius: 50%;
-  background: var(--mk-ink-400);
+  background: var(--v4-ink-400);
   display: inline-block;
 }
 .ph-bulk-chip-count {
   font-size: 10.5px; font-weight: 600;
   padding: 1px 6px; border-radius: 99px;
-  background: var(--mk-surface-2); color: var(--mk-ink-600);
+  background: var(--v4-surface-2); color: var(--v4-ink-600);
 }
 
-.ph-bulk-chip--critical .ph-bulk-chip-dot { background: var(--mk-danger-strong); }
-.ph-bulk-chip--high     .ph-bulk-chip-dot { background: var(--mk-danger); }
-.ph-bulk-chip--medium   .ph-bulk-chip-dot { background: var(--mk-warn); }
-.ph-bulk-chip--low      .ph-bulk-chip-dot { background: var(--mk-ink-400); }
+.ph-bulk-chip--critical .ph-bulk-chip-dot { background: var(--v4-danger-700); }
+.ph-bulk-chip--high     .ph-bulk-chip-dot { background: var(--v4-danger-500); }
+.ph-bulk-chip--medium   .ph-bulk-chip-dot { background: var(--v4-warn-500); }
+.ph-bulk-chip--low      .ph-bulk-chip-dot { background: var(--v4-ink-400); }
 
 .ph-bulk-chip.is-all {
-  border-color: var(--mk-brand-500);
-  background: var(--mk-brand-50);
-  color: var(--mk-brand-700);
+  border-color: var(--v4-accent-500);
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
 }
 .ph-bulk-chip.is-some {
-  border-color: var(--mk-brand-500);
-  background: var(--mk-paper);
-  color: var(--mk-brand-700);
+  border-color: var(--v4-accent-500);
+  background: var(--v4-paper);
+  color: var(--v4-accent-700);
   border-style: dashed;
 }
 
@@ -1104,14 +1104,14 @@
   display: flex; flex-direction: column; gap: 4px;
 }
 .ph-bulk-row {
-  border: 1px solid var(--mk-line-soft);
+  border: 1px solid var(--v4-line-soft);
   border-radius: 10px;
-  background: var(--mk-paper);
+  background: var(--v4-paper);
   transition: border-color .15s, background .15s;
 }
 .ph-bulk-row.is-selected {
-  border-color: var(--mk-brand-500);
-  background: var(--mk-brand-50);
+  border-color: var(--v4-accent-300, var(--v4-accent-500));
+  background: var(--v4-accent-50);
 }
 .ph-bulk-row-main {
   display: grid;
@@ -1124,7 +1124,7 @@
 .ph-bulk-row-cb {
   width: 16px; height: 16px;
   cursor: pointer;
-  accent-color: var(--mk-brand-600);
+  accent-color: var(--v4-accent-600);
 }
 .ph-bulk-row-cb:disabled { cursor: not-allowed; }
 .ph-bulk-row-text {
@@ -1133,70 +1133,70 @@
 }
 .ph-bulk-row-title {
   display: inline-flex; align-items: baseline; gap: 8px;
-  font-size: 13px; color: var(--mk-ink-900); font-weight: 500;
+  font-size: 13px; color: var(--v4-ink-900); font-weight: 500;
   flex-wrap: wrap;
 }
 .ph-bulk-row-rule {
-  font-size: 10.5px; color: var(--mk-ink-500);
+  font-size: 10.5px; color: var(--v4-ink-500);
   font-weight: 600;
 }
 .ph-bulk-row-detail {
-  font-size: 11.5px; color: var(--mk-ink-500);
+  font-size: 11.5px; color: var(--v4-ink-500);
   line-height: 1.4;
 }
 .ph-bulk-row-status {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px; font-weight: 600;
   display: inline-flex; align-items: center; gap: 4px;
   white-space: nowrap;
 }
 .ph-bulk-row-status svg { width: 12px; height: 12px; }
 .ph-bulk-row-status a {
-  color: var(--mk-brand-600);
+  color: var(--v4-accent-600);
   text-decoration: none;
   display: inline-flex; align-items: center; gap: 4px;
 }
 .ph-bulk-row-status a:hover { text-decoration: underline; }
 .ph-bulk-row-status--created a,
-.ph-bulk-row-status--duplicate a { color: var(--mk-success-strong); }
-.ph-bulk-row-status--error { color: var(--mk-danger-strong); }
+.ph-bulk-row-status--duplicate a { color: var(--v4-success-700, var(--v4-accent-600)); }
+.ph-bulk-row-status--error { color: var(--v4-danger-700); }
 .ph-bulk-row-toggle {
   appearance: none;
   border: 0; background: transparent;
   width: 28px; height: 28px;
   border-radius: 6px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   cursor: pointer;
   display: inline-flex; align-items: center; justify-content: center;
   transition: background .15s, color .15s;
 }
 .ph-bulk-row-toggle:hover:not(:disabled) {
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-900);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
 }
 .ph-bulk-row-toggle svg { width: 14px; height: 14px; }
 .ph-bulk-row-preview {
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   padding: 10px 14px 12px;
-  background: var(--mk-paper);
+  background: var(--v4-surface-1, var(--v4-surface-2));
   border-radius: 0 0 10px 10px;
 }
 .ph-bulk-row-preview-h {
   display: inline-flex; align-items: center; gap: 6px;
   font-size: 10.5px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.06em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-bottom: 6px;
 }
 .ph-bulk-row-preview-h svg { width: 12px; height: 12px; }
 .ph-bulk-row-preview pre {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   line-height: 1.5;
   margin: 0;
   padding: 8px 10px;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line-soft);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line-soft);
   border-radius: 6px;
   white-space: pre-wrap;
   word-break: break-word;
@@ -1207,52 +1207,52 @@
 .ph-bulk-progress {
   display: flex; align-items: center; gap: 12px;
   padding: 10px 20px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
 }
 .ph-bulk-progress-bar {
   flex: 1;
   height: 6px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3, var(--v4-surface-2));
   border-radius: 99px;
   overflow: hidden;
 }
 .ph-bulk-progress-fill {
   height: 100%;
-  background: var(--mk-brand-500);
+  background: var(--v4-accent-500);
   border-radius: 99px;
   transition: width .3s ease-out;
 }
 .ph-bulk-progress .num {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12px; font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 
 .ph-bulk-warning {
   display: flex; align-items: center; gap: 8px;
   padding: 10px 20px;
   font-size: 12px;
-  color: var(--mk-warn-strong);
-  background: var(--mk-warn-soft);
-  border-top: 1px solid var(--mk-warn-100);
+  color: var(--v4-warn-700);
+  background: var(--v4-warn-50);
+  border-top: 1px solid var(--v4-warn-100);
 }
 .ph-bulk-warning svg { width: 14px; height: 14px; flex-shrink: 0; }
 .ph-bulk-warning--err {
-  color: var(--mk-danger-strong);
-  background: var(--mk-danger-soft);
-  border-top-color: var(--mk-danger-100);
+  color: var(--v4-danger-700);
+  background: var(--v4-danger-50);
+  border-top-color: var(--v4-danger-100);
 }
 
 .ph-bulk-footer {
   display: flex; align-items: center; gap: 12px;
   padding: 12px 20px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
 }
 .ph-bulk-count {
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
-.ph-bulk-count b { color: var(--mk-ink-900); }
+.ph-bulk-count b { color: var(--v4-ink-900); }
 .ph-bulk-footer-btns {
   margin-left: auto;
   display: flex; gap: 8px;

--- a/src/styles/v4-quality.css
+++ b/src/styles/v4-quality.css
@@ -17,30 +17,16 @@
  * ============================================================ */
 
 .v4-quality-tab {
-  /* Codex severity palette — align с shields.io бейджами в PR-коммитах.
-   * Scoped к `.v4-quality-tab` намеренно: в Quality «P0/P1/P2» — это
-   * severity (БЛОКЕР/высокое/среднее), а не project priority (см.
-   * --mk-priority-p* в tokens.css). --mk-quality-* — новые имена для
-   * TSX (Session J); --v4-* остаются для совместимости с селекторами
-   * v4-quality.css до Session K. */
-  --mk-quality-p0: #EF4444;
-  --mk-quality-p1: #F59E0B;
-  --mk-quality-p2: #EAB308;
-  --mk-quality-clean: #2563EB;
-  --mk-quality-clean-soft: #93C5FD;
-  --mk-quality-p0-text: #991B1B;
-  --mk-quality-p1-text: #B45309;
-  --mk-quality-p2-text: #854D0E;
-  --mk-quality-clean-text: #1D4ED8;
-  --v4-p0: var(--mk-quality-p0);
-  --v4-p1: var(--mk-quality-p1);
-  --v4-p2: var(--mk-quality-p2);
-  --v4-clean: var(--mk-quality-clean);
-  --v4-clean-soft: var(--mk-quality-clean-soft);
-  --v4-p0-text: var(--mk-quality-p0-text);
-  --v4-p1-text: var(--mk-quality-p1-text);
-  --v4-p2-text: var(--mk-quality-p2-text);
-  --v4-clean-text: var(--mk-quality-clean-text);
+  /* Codex severity palette — align с shields.io бейджами в PR-коммитах */
+  --v4-p0: #EF4444;             /* red — БЛОКЕР */
+  --v4-p1: #F59E0B;             /* orange — высокое */
+  --v4-p2: #EAB308;             /* yellow — среднее */
+  --v4-clean: #2563EB;          /* синий — чистые PR */
+  --v4-clean-soft: #93C5FD;     /* голубой для светлого фона */
+  --v4-p0-text: #991B1B;        /* dark red для текста на белом */
+  --v4-p1-text: #B45309;        /* dark amber */
+  --v4-p2-text: #854D0E;        /* dark yellow-amber */
+  --v4-clean-text: #1D4ED8;
 }
 
 /* ──── KPI · P0 alert pill ──── */

--- a/src/styles/v4-quality.css
+++ b/src/styles/v4-quality.css
@@ -19,8 +19,10 @@
 .v4-quality-tab {
   /* Codex severity palette — align с shields.io бейджами в PR-коммитах.
    * Scoped к `.v4-quality-tab` намеренно: в Quality «P0/P1/P2» — это
-   * severity (БЛОКЕР/высокое/среднее), а не project priority
-   * (см. --mk-priority-p* в tokens.css). */
+   * severity (БЛОКЕР/высокое/среднее), а не project priority (см.
+   * --mk-priority-p* в tokens.css). --mk-quality-* — новые имена для
+   * TSX (Session J); --v4-* остаются для совместимости с селекторами
+   * v4-quality.css до Session K. */
   --mk-quality-p0: #EF4444;
   --mk-quality-p1: #F59E0B;
   --mk-quality-p2: #EAB308;
@@ -30,13 +32,22 @@
   --mk-quality-p1-text: #B45309;
   --mk-quality-p2-text: #854D0E;
   --mk-quality-clean-text: #1D4ED8;
+  --v4-p0: var(--mk-quality-p0);
+  --v4-p1: var(--mk-quality-p1);
+  --v4-p2: var(--mk-quality-p2);
+  --v4-clean: var(--mk-quality-clean);
+  --v4-clean-soft: var(--mk-quality-clean-soft);
+  --v4-p0-text: var(--mk-quality-p0-text);
+  --v4-p1-text: var(--mk-quality-p1-text);
+  --v4-p2-text: var(--mk-quality-p2-text);
+  --v4-clean-text: var(--mk-quality-clean-text);
 }
 
 /* ──── KPI · P0 alert pill ──── */
 .v4-quality-tab .kpi-p0-alert {
-  background: var(--mk-quality-p0);
+  background: var(--v4-p0);
   color: #fff;
-  border-radius: var(--mk-r-md);
+  border-radius: var(--v4-r-md);
   padding: 14px 16px;
   display: flex;
   align-items: center;
@@ -50,14 +61,14 @@
 }
 .v4-quality-tab .kpi-p0-icon { font-size: 22px; line-height: 1; }
 .v4-quality-tab .kpi-p0-text { display: flex; flex-direction: column; }
-.v4-quality-tab .kpi-p0-text b { font-family: var(--mk-font-mono); font-size: 18px; line-height: 1.1; }
+.v4-quality-tab .kpi-p0-text b { font-family: var(--v4-mono); font-size: 18px; line-height: 1.1; }
 .v4-quality-tab .kpi-p0-text span { font-size: 11px; opacity: 0.9; margin-top: 2px; }
 
 /* ──── KPI cards ──── */
 .v4-quality-tab .kpi {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   padding: 12px 14px;
   animation: q-kpi-in 520ms cubic-bezier(0.16, 1, 0.3, 1) both;
   animation-delay: calc(var(--i, 0) * 60ms + 200ms);
@@ -67,7 +78,7 @@
 }
 .v4-quality-tab .kpi:hover {
   transform: translateY(-2px);
-  border-color: var(--mk-line-strong);
+  border-color: var(--v4-line-strong);
   box-shadow: 0 10px 28px rgba(11, 16, 32, 0.07);
 }
 @keyframes q-kpi-in {
@@ -78,21 +89,21 @@
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--mk-ink-500);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
   font-weight: 600;
   margin-bottom: 6px;
 }
 .v4-quality-tab .kpi-v {
   font-size: 26px;
   font-weight: 700;
-  color: var(--mk-ink-900);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-ink-900);
+  font-family: var(--v4-mono);
   line-height: 1;
   letter-spacing: -0.02em;
 }
-.v4-quality-tab .kpi-v.dirty { color: var(--mk-ink-900); }
-.v4-quality-tab .kpi-sub { font-size: 11px; color: var(--mk-ink-500); margin-top: 4px; }
+.v4-quality-tab .kpi-v.dirty { color: var(--v4-ink-900); }
+.v4-quality-tab .kpi-sub { font-size: 11px; color: var(--v4-ink-500); margin-top: 4px; }
 
 /* ──── Chart — vertical bars (main) ──── */
 .v4-quality-tab .chart {
@@ -101,7 +112,7 @@
   gap: 2px;
   flex: 1;
   min-height: 220px;
-  border-bottom: 1px dashed var(--mk-line);
+  border-bottom: 1px dashed var(--v4-line);
   position: relative;
   /* Coordinated reveal — opacity + translateY (GPU). НЕ clip-path
      (репейнтит N детей каждый кадр). */
@@ -128,17 +139,17 @@
   position: absolute;
   left: 0;
   right: 0;
-  border-top: 1px dashed var(--mk-line-soft);
+  border-top: 1px dashed var(--v4-line-soft);
 }
 .v4-quality-tab .chart-axis::before { top: 50%; }
 .v4-quality-tab .chart-axis::after  { top: 0; }
 .v4-quality-tab .chart-axis-label {
   position: absolute;
   right: 4px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9px;
-  color: var(--mk-ink-400);
-  background: var(--mk-paper);
+  color: var(--v4-ink-400);
+  background: var(--v4-paper);
   padding: 0 3px;
 }
 
@@ -158,7 +169,7 @@
   content: '';
   position: absolute;
   inset: -6px -4px -4px -4px;
-  background: var(--mk-brand-100);
+  background: var(--v4-accent-100);
   border-radius: 4px;
   opacity: 0;
   transition: opacity .15s ease;
@@ -177,7 +188,7 @@
 }
 /* В mini-чарте дополнительно border-top — gradient слабо читается на 80px. */
 .v4-quality-tab .card-chart .bar.has-p0 .bar-stack {
-  border-top: 2px solid var(--mk-quality-p0);
+  border-top: 2px solid var(--v4-p0);
 }
 
 /* Mini-pill "P0:N" сверху столбца, ВСЕГДА видна (только main chart). */
@@ -186,9 +197,9 @@
   top: -22px;
   left: 50%;
   transform: translateX(-50%);
-  background: var(--mk-quality-p0);
+  background: var(--v4-p0);
   color: #fff;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9px;
   font-weight: 700;
   padding: 2px 6px;
@@ -225,7 +236,7 @@
   top: 0;
   bottom: 0;
   width: 1px;
-  background-image: linear-gradient(to bottom, var(--mk-brand-700) 50%, transparent 50%);
+  background-image: linear-gradient(to bottom, var(--v4-accent-700) 50%, transparent 50%);
   background-size: 1px 4px;
   opacity: 0.5;
   pointer-events: none;
@@ -237,9 +248,9 @@
   bottom: 100%;
   left: 50%;
   transform: translateX(-50%) translateY(2px);
-  background: var(--mk-ink-900);
+  background: var(--v4-ink-900);
   color: #fff;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 700;
   padding: 3px 8px;
@@ -259,20 +270,20 @@
 /* Red сегмент = P0+P1 worst-wins (одна красная категория для читабельности).
    Tooltip разбивает их отдельно. P0-alert pulse — в KPI выше. */
 .v4-quality-tab .bar-crit {
-  background: var(--mk-quality-p0);
+  background: var(--v4-p0);
   width: 100%;
 }
 .v4-quality-tab .bar-p2 {
-  background: var(--mk-quality-p2);
+  background: var(--v4-p2);
   width: 100%;
 }
 .v4-quality-tab .bar-clean {
-  background: var(--mk-quality-clean-soft);
+  background: var(--v4-clean-soft);
   width: 100%;
   border-radius: 3px 3px 0 0;
 }
 .v4-quality-tab .bar-empty {
-  background: var(--mk-line-soft);
+  background: var(--v4-line-soft);
   width: 100%;
   height: 1px;
   margin-top: auto;
@@ -287,7 +298,7 @@
   display: flex;
   align-items: flex-end;
   gap: 2px;
-  border-bottom: 1px dashed var(--mk-line-soft);
+  border-bottom: 1px dashed var(--v4-line-soft);
   position: relative;
 }
 
@@ -295,8 +306,8 @@
 .v4-quality-tab .chart-tip {
   position: absolute;
   top: 8px;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line-strong);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line-strong);
   box-shadow: 0 8px 24px rgba(11, 16, 32, 0.12), 0 2px 6px rgba(11, 16, 32, 0.06);
   border-radius: 8px;
   padding: 10px 12px;
@@ -310,11 +321,11 @@
 }
 .v4-quality-tab .chart-tip.show { opacity: 1; transform: translateY(0); }
 .v4-quality-tab .chart-tip-l {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-bottom: 6px;
 }
 .v4-quality-tab .chart-tip-row {
@@ -324,35 +335,35 @@
   margin-bottom: 8px;
 }
 .v4-quality-tab .chart-tip-v {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 24px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-variant-numeric: tabular-nums;
   line-height: 1;
 }
-.v4-quality-tab .chart-tip-u { color: var(--mk-ink-500); font-size: 12px; }
+.v4-quality-tab .chart-tip-u { color: var(--v4-ink-500); font-size: 12px; }
 .v4-quality-tab .chart-tip-foot {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 10px;
   padding-top: 8px;
-  border-top: 1px solid var(--mk-line-soft);
-  color: var(--mk-ink-500);
+  border-top: 1px solid var(--v4-line-soft);
+  color: var(--v4-ink-500);
   font-size: 11px;
 }
 .v4-quality-tab .chart-tip-foot--tight { padding-top: 4px; border-top: 0; }
 .v4-quality-tab .chart-tip-tr {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 .v4-quality-tab .chart-tip-seg {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-weight: 600;
 }
 .v4-quality-tab .chart-tip-seg .sw { width: 8px; height: 8px; border-radius: 2px; }
@@ -362,7 +373,7 @@
   min-width: 160px;
   padding: 8px 10px;
   font-size: 11px;
-  background: var(--mk-ink-900);
+  background: var(--v4-ink-900);
   color: #fff;
   border: 0;
   box-shadow: 0 8px 20px rgba(11, 16, 32, 0.32);
@@ -370,7 +381,7 @@
   bottom: calc(100% + 8px);
   white-space: nowrap;
   line-height: 1.45;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
 }
 .v4-quality-tab .chart-tip--compact .ct-line1 {
   display: flex; align-items: baseline; gap: 6px; margin-bottom: 4px;
@@ -400,9 +411,9 @@
 .v4-quality-tab .chart-label {
   flex: 1;
   text-align: center;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   min-width: 4px;
   overflow: hidden;
 }
@@ -411,8 +422,8 @@
   gap: 14px;
   margin-top: 14px;
   font-size: 11px;
-  color: var(--mk-ink-500);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
   font-weight: 500;
 }
 .v4-quality-tab .chart-legend span { display: inline-flex; align-items: center; gap: 6px; }
@@ -430,7 +441,7 @@
   bottom: 0;
   width: 1px;
   background-image: linear-gradient(to bottom,
-    var(--mk-purple-500) 50%,
+    var(--v4-purple-500, #7C3AED) 50%,
     transparent 50%);
   background-size: 1px 6px;
   pointer-events: auto;
@@ -444,14 +455,14 @@
   width: 11px;
   height: 11px;
   border-radius: 50%;
-  background: var(--mk-purple-500);
-  border: 2px solid var(--mk-paper);
-  box-shadow: 0 0 0 1px var(--mk-purple-500);
+  background: var(--v4-purple-500, #7C3AED);
+  border: 2px solid var(--v4-paper);
+  box-shadow: 0 0 0 1px var(--v4-purple-500, #7C3AED);
 }
-.v4-quality-tab .annot.is-skill  .annot-dot { background: var(--mk-brand-600);  box-shadow: 0 0 0 1px var(--mk-brand-600); }
-.v4-quality-tab .annot.is-deploy .annot-dot { background: var(--mk-success); box-shadow: 0 0 0 1px var(--mk-success); }
-.v4-quality-tab .annot.is-manual .annot-dot { background: var(--mk-purple-500); }
-.v4-quality-tab .annot:hover { background-image: linear-gradient(to bottom, var(--mk-ink-900) 50%, transparent 50%); }
+.v4-quality-tab .annot.is-skill  .annot-dot { background: var(--v4-accent-600);  box-shadow: 0 0 0 1px var(--v4-accent-600); }
+.v4-quality-tab .annot.is-deploy .annot-dot { background: var(--v4-success-500); box-shadow: 0 0 0 1px var(--v4-success-500); }
+.v4-quality-tab .annot.is-manual .annot-dot { background: var(--v4-purple-500, #7C3AED); }
+.v4-quality-tab .annot:hover { background-image: linear-gradient(to bottom, var(--v4-ink-900) 50%, transparent 50%); }
 .v4-quality-tab .annot:hover .annot-dot { transform: scale(1.2); transition: transform .12s; }
 
 .v4-quality-tab .annot-tip {
@@ -459,7 +470,7 @@
   top: 22px;
   left: 0;
   transform: translateX(-50%) translateY(2px);
-  background: var(--mk-ink-900);
+  background: var(--v4-ink-900);
   color: #fff;
   font-size: 11px;
   line-height: 1.4;
@@ -475,7 +486,7 @@
 }
 .v4-quality-tab .annot-tip-cat {
   display: inline-block;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -484,19 +495,19 @@
   border-radius: 3px;
   margin-bottom: 4px;
 }
-.v4-quality-tab .annot-tip-date { font-family: var(--mk-font-mono); font-size: 10px; color: rgba(255,255,255,0.65); margin-top: 4px; }
+.v4-quality-tab .annot-tip-date { font-family: var(--v4-mono); font-size: 10px; color: rgba(255,255,255,0.65); margin-top: 4px; }
 .v4-quality-tab .annot-tip-device { color: rgba(255,255,255,0.55); font-style: italic; }
 .v4-quality-tab .annot:hover .annot-tip { opacity: 1; transform: translateX(-50%) translateY(0); }
 
 /* ──── Add-event button ──── */
 .v4-quality-tab .btn-add-event {
-  border: 1px dashed var(--mk-line-strong);
+  border: 1px dashed var(--v4-line-strong);
   background: transparent;
-  border-radius: var(--mk-r-md);
+  border-radius: var(--v4-r-md);
   padding: 6px 10px;
   font: inherit;
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -504,16 +515,16 @@
   transition: all .15s ease;
 }
 .v4-quality-tab .btn-add-event:hover {
-  color: var(--mk-purple-500);
-  border-color: var(--mk-purple-500);
-  background: var(--mk-purple-50);
+  color: var(--v4-purple-500, #7C3AED);
+  border-color: var(--v4-purple-500, #7C3AED);
+  background: var(--v4-purple-50, #F5F0FF);
 }
 
 /* ──── Project card (grid) ──── */
 .v4-quality-tab .card {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   padding: 14px 16px;
   display: flex;
   flex-direction: column;
@@ -528,7 +539,7 @@
 }
 .v4-quality-tab .card:hover {
   transform: translateY(-3px);
-  border-color: var(--mk-line-strong);
+  border-color: var(--v4-line-strong);
   box-shadow: 0 14px 32px -14px rgba(11, 16, 32, 0.18),
               0 4px 12px -4px rgba(11, 16, 32, 0.08);
 }
@@ -566,17 +577,17 @@
   font-size: 24px;
   margin: 0 0 4px 0;
   letter-spacing: -0.02em;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-weight: 700;
 }
-.v4-quality-tab .pageH .sub { color: var(--mk-ink-500); font-size: 13px; }
-.v4-quality-tab .pageH .sub b { color: var(--mk-ink-700); font-weight: 600; }
+.v4-quality-tab .pageH .sub { color: var(--v4-ink-500); font-size: 13px; }
+.v4-quality-tab .pageH .sub b { color: var(--v4-ink-700); font-weight: 600; }
 .v4-quality-tab .ctrls { display: flex; gap: 10px; align-items: center; }
 .v4-quality-tab .seg {
   display: inline-flex;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   padding: 3px;
 }
 .v4-quality-tab .seg button {
@@ -585,39 +596,39 @@
   padding: 6px 12px;
   font: inherit;
   font-size: 12px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   border-radius: 5px;
   cursor: pointer;
   font-weight: 500;
   transition: background .18s ease, color .18s ease;
 }
 .v4-quality-tab .seg button.active {
-  background: var(--mk-ink-900);
+  background: var(--v4-ink-900);
   color: #fff;
   font-weight: 600;
 }
 .v4-quality-tab .btn-refresh {
-  border: 1px solid var(--mk-line);
-  background: var(--mk-paper);
-  border-radius: var(--mk-r-md);
+  border: 1px solid var(--v4-line);
+  background: var(--v4-paper);
+  border-radius: var(--v4-r-md);
   padding: 7px 12px;
   font: inherit;
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   gap: 6px;
   font-weight: 500;
 }
-.v4-quality-tab .btn-refresh:hover { background: var(--mk-surface-2); }
+.v4-quality-tab .btn-refresh:hover { background: var(--v4-surface-2); }
 .v4-quality-tab .btn-refresh:disabled { opacity: 0.55; cursor: progress; }
 
 /* ──── PANEL containers ──── */
 .v4-quality-tab .panel {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -625,7 +636,7 @@
 .v4-quality-tab .panel-t {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -641,7 +652,7 @@
 }
 .v4-quality-tab .summary .chartwrap {
   padding: 18px;
-  border-right: 1px solid var(--mk-line-soft);
+  border-right: 1px solid var(--v4-line-soft);
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -663,30 +674,30 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
 }
 
 /* На узких экранах summary сваливается в один столбец, чтобы карты не сжимались */
 @media (max-width: 900px) {
   .v4-quality-tab .summary { grid-template-columns: 1fr; }
-  .v4-quality-tab .summary .chartwrap { border-right: 0; border-bottom: 1px solid var(--mk-line-soft); }
+  .v4-quality-tab .summary .chartwrap { border-right: 0; border-bottom: 1px solid var(--v4-line-soft); }
 }
 
 /* ──── TAGS ──── */
 .v4-quality-tab .tag {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9px;
   font-weight: 600;
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-500);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-500);
   padding: 2px 7px;
   border-radius: 99px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
-.v4-quality-tab .tag-warn { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.v4-quality-tab .tag-good { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-quality-tab .tag-bad  { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
+.v4-quality-tab .tag-warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-quality-tab .tag-good { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-quality-tab .tag-bad  { background: var(--v4-danger-50); color: var(--v4-danger-700); }
 
 /* ──── SECTION heading + sort toggle (project grid header) ──── */
 .v4-quality-tab .sect {
@@ -702,18 +713,18 @@
   font-size: 13px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--mk-ink-500);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
   font-weight: 600;
 }
-.v4-quality-tab .sect .meta { font-size: 11px; color: var(--mk-ink-400); font-family: var(--mk-font-mono); }
+.v4-quality-tab .sect .meta { font-size: 11px; color: var(--v4-ink-400); font-family: var(--v4-mono); }
 .v4-quality-tab .sort {
   display: inline-flex;
   gap: 4px;
   align-items: center;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   padding: 3px;
 }
 .v4-quality-tab .sort button {
@@ -722,13 +733,13 @@
   padding: 5px 10px;
   font: inherit;
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   border-radius: 4px;
   cursor: pointer;
 }
 .v4-quality-tab .sort button.active {
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-900);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
   font-weight: 600;
 }
 
@@ -749,64 +760,64 @@
 .v4-quality-tab .card-name {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-ink-900);
+  font-family: var(--v4-mono);
 }
 .v4-quality-tab .card-client {
   font-size: 10px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 500;
   margin-top: 1px;
 }
 .v4-quality-tab .card-now {
   font-size: 22px;
   font-weight: 700;
-  font-family: var(--mk-font-mono);
-  color: var(--mk-ink-900);
+  font-family: var(--v4-mono);
+  color: var(--v4-ink-900);
   letter-spacing: -0.02em;
   line-height: 1;
   text-align: right;
 }
 .v4-quality-tab .card-now-sub {
   font-size: 10px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   margin-top: 2px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   text-align: right;
 }
 .v4-quality-tab .card-foot {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   padding-top: 8px;
   font-size: 11px;
-  font-family: var(--mk-font-mono);
-  color: var(--mk-ink-500);
+  font-family: var(--v4-mono);
+  color: var(--v4-ink-500);
   gap: 8px;
   flex-wrap: wrap;
 }
 .v4-quality-tab .card-foot .nums { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
-.v4-quality-tab .card-foot .nums b { color: var(--mk-ink-800); font-weight: 600; }
-.v4-quality-tab .card-foot .num-p1 b { color: var(--mk-quality-p1-text); }
-.v4-quality-tab .card-foot .num-p2 b { color: var(--mk-quality-p2-text); }
+.v4-quality-tab .card-foot .nums b { color: var(--v4-ink-800); font-weight: 600; }
+.v4-quality-tab .card-foot .num-p1 b { color: var(--v4-p1-text); }
+.v4-quality-tab .card-foot .num-p2 b { color: var(--v4-p2-text); }
 .v4-quality-tab .card-empty {
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   text-align: center;
   padding: 24px 8px;
   font-size: 11px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
 }
-.v4-quality-tab .card-empty b { display: block; font-size: 14px; color: var(--mk-ink-500); margin-bottom: 4px; }
+.v4-quality-tab .card-empty b { display: block; font-size: 14px; color: var(--v4-ink-500); margin-bottom: 4px; }
 
 /* ──── BANNERS (stale data / fetch error) ──── */
 .v4-quality-tab .quality-stale-banner {
   margin-bottom: 14px;
   padding: 10px 14px;
-  background: var(--mk-warn-soft);
-  border: 1px solid var(--mk-warn-100);
-  border-radius: var(--mk-r-md);
-  color: var(--mk-warn-strong);
+  background: var(--v4-warn-50);
+  border: 1px solid var(--v4-warn-200, #fde68a);
+  border-radius: var(--v4-r-md);
+  color: var(--v4-warn-700);
   font-size: 12px;
   display: flex;
   justify-content: space-between;
@@ -816,28 +827,28 @@
 }
 .v4-quality-tab .quality-error-panel {
   padding: 24px;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   display: flex;
   flex-direction: column;
   gap: 12px;
   align-items: flex-start;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   font-size: 14px;
 }
 .v4-quality-tab .quality-error-panel button {
-  border: 1px solid var(--mk-line);
-  background: var(--mk-paper);
-  border-radius: var(--mk-r-md);
+  border: 1px solid var(--v4-line);
+  background: var(--v4-paper);
+  border-radius: var(--v4-r-md);
   padding: 7px 14px;
   font: inherit;
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   cursor: pointer;
   font-weight: 500;
 }
-.v4-quality-tab .quality-error-panel button:hover { background: var(--mk-surface-2); }
+.v4-quality-tab .quality-error-panel button:hover { background: var(--v4-surface-2); }
 
 /* Soft empty state when backend (sweep cron / JSON publisher) isn't deployed yet.
    Distinct from .quality-error-panel — this is not an error, just an awaiting state. */
@@ -845,11 +856,11 @@
   margin: 40px auto 0;
   max-width: 520px;
   padding: 40px 32px;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   text-align: center;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 .v4-quality-tab .quality-empty-icon {
   font-size: 40px;
@@ -860,21 +871,21 @@
   margin: 0 0 10px;
   font-size: 18px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-quality-tab .quality-empty-panel p {
   margin: 0 0 20px;
   font-size: 13px;
   line-height: 1.5;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-quality-tab .quality-empty-panel code {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12px;
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
   padding: 1px 5px;
   border-radius: 3px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 .v4-quality-tab .quality-empty-panel .btn-refresh {
   margin: 0 auto;

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -30,11 +30,85 @@
      • v4-health.css @media (max-width: 1180px) Hub page
    ══════════════════════════════════════════ */
 
+/* All --v4-* names are bridge aliases over src/styles/tokens.css.
+   Visual output unchanged; values come from --mk-* tokens.
+   Migration plan: remove this block once consumers are
+   migrated to --mk-* directly. */
+:root {
+  /* Surfaces / ink */
+  --v4-bg: var(--mk-bg);
+  --v4-paper: var(--mk-paper);
+  --v4-surface-2: var(--mk-surface-2);
+  --v4-surface-3: var(--mk-surface-3);
+  --v4-ink-900: var(--mk-ink-900);
+  --v4-ink-800: var(--mk-ink-800);
+  --v4-ink-700: var(--mk-ink-700);
+  --v4-ink-600: var(--mk-ink-600);
+  --v4-ink-500: var(--mk-ink-500);
+  --v4-ink-400: var(--mk-ink-400);
+  --v4-ink-300: var(--mk-ink-300);
+  --v4-line: var(--mk-line);
+  --v4-line-soft: var(--mk-line-soft);
+  --v4-line-strong: var(--mk-line-strong);
+
+  /* Accent (brand blue) */
+  --v4-accent-50: var(--mk-brand-50);
+  --v4-accent-100: var(--mk-brand-100);
+  --v4-accent-500: var(--mk-brand-500);
+  --v4-accent-600: var(--mk-brand-600);
+  --v4-accent-700: var(--mk-brand-700);
+
+  /* Semantic */
+  --v4-success-50: var(--mk-success-soft);
+  --v4-success-100: var(--mk-success-100);
+  --v4-success-500: var(--mk-success);
+  --v4-success-700: var(--mk-success-strong);
+  --v4-warn-50: var(--mk-warn-soft);
+  --v4-warn-100: var(--mk-warn-100);
+  --v4-warn-500: var(--mk-warn);
+  --v4-warn-700: var(--mk-warn-strong);
+  --v4-danger-50: var(--mk-danger-soft);
+  --v4-danger-100: var(--mk-danger-100);
+  --v4-danger-500: var(--mk-danger);
+  --v4-danger-700: var(--mk-danger-strong);
+  --v4-purple-50: var(--mk-purple-50);
+  --v4-purple-500: var(--mk-purple-500);
+  --v4-purple-700: var(--mk-purple-700);
+  --v4-sky-50: var(--mk-sky-50);
+  --v4-sky-500: var(--mk-sky-500);
+  --v4-sky-700: var(--mk-sky-700);
+  --v4-orange-50: #FFF6ED;
+  --v4-orange-500: var(--mk-orange-bright-500);
+  --v4-orange-700: var(--mk-orange-bright-700);
+
+  /* Priority palette */
+  --v4-p1: var(--mk-priority-p1);
+  --v4-p2: var(--mk-priority-p2);
+  --v4-p3: var(--mk-priority-p3);
+  --v4-p4: var(--mk-priority-p4);
+
+  /* Commit-heatmap intensity steps (4 buckets, light → dark accent) */
+  --v4-heat-1: var(--mk-heat-1);
+  --v4-heat-2: var(--mk-heat-2);
+  --v4-heat-3: var(--mk-heat-3);
+  --v4-heat-4: var(--mk-heat-4);
+
+  /* Radii */
+  --v4-r-sm: var(--mk-r-sm);
+  --v4-r-md: var(--mk-r-md);
+  --v4-r-lg: var(--mk-r-lg);
+  --v4-r-xl: var(--mk-r-xl);
+
+  /* Fonts */
+  --v4-sans: var(--mk-font-sans);
+  --v4-mono: var(--mk-font-mono);
+}
+
 /* ── Body / global reset for V4 ── */
 body.v4 {
-  background: var(--mk-bg);
-  color: var(--mk-ink-800);
-  font-family: var(--mk-font-sans);
+  background: var(--v4-bg);
+  color: var(--v4-ink-800);
+  font-family: var(--v4-sans);
   font-size: 13px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
@@ -45,7 +119,7 @@ body.v4 *::before,
 body.v4 *::after { box-sizing: border-box; }
 body.v4 .num,
 body.v4 .v4-mono { font-variant-numeric: tabular-nums; }
-body.v4 .v4-mono { font-family: var(--mk-font-mono); }
+body.v4 .v4-mono { font-family: var(--v4-mono); }
 
 /* ────────────────────────────────────────
    APP SHELL
@@ -55,16 +129,16 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   grid-template-columns: 240px 1fr;
   min-height: 100vh;
   min-height: 100dvh;
-  background: var(--mk-bg);
-  color: var(--mk-ink-800);
-  font-family: var(--mk-font-sans);
+  background: var(--v4-bg);
+  color: var(--v4-ink-800);
+  font-family: var(--v4-sans);
   font-size: 13px;
 }
 
 /* Sidebar */
 .v4-side {
-  background: var(--mk-paper);
-  border-right: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border-right: 1px solid var(--v4-line);
   position: sticky;
   top: 0;
   height: 100vh;
@@ -78,34 +152,34 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   display: flex;
   align-items: center;
   gap: 10px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   flex-shrink: 0;
 }
 .v4-brand-logo {
   width: 30px;
   height: 30px;
   border-radius: 8px;
-  background: var(--mk-ink-900);
+  background: var(--v4-ink-900);
   color: #fff;
   font-weight: 800;
   font-size: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
 }
 .v4-brand-name {
   font-weight: 700;
   font-size: 15px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   letter-spacing: -0.01em;
 }
 .v4-brand-ver {
   margin-left: auto;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
-  color: var(--mk-ink-400);
-  background: var(--mk-surface-2);
+  color: var(--v4-ink-400);
+  background: var(--v4-surface-2);
   padding: 2px 6px;
   border-radius: 4px;
 }
@@ -118,20 +192,20 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-nav-section {
   padding: 14px 12px 6px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .v4-nav-item {
   display: flex;
   align-items: center;
   gap: 10px;
   padding: 7px 12px;
-  border-radius: var(--mk-r-sm);
-  color: var(--mk-ink-700);
+  border-radius: var(--v4-r-sm);
+  color: var(--v4-ink-700);
   font-size: 13px;
   font-weight: 500;
   text-decoration: none;
@@ -144,34 +218,34 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   transition: background 120ms, color 120ms;
 }
 .v4-nav-item:hover {
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-900);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
 }
 .v4-nav-item.is-active {
-  background: var(--mk-brand-500);
+  background: var(--v4-accent-500);
   color: #fff;
 }
 .v4-nav-item.is-active svg { color: #fff; }
 .v4-nav-item svg {
   width: 15px;
   height: 15px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   flex-shrink: 0;
 }
 .v4-nav-count {
   margin-left: auto;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-weight: 500;
 }
 .v4-nav-item.is-active .v4-nav-count { color: rgba(255, 255, 255, 0.85); }
 .v4-nav-badge {
   margin-left: auto;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9px;
   font-weight: 700;
-  background: var(--mk-danger);
+  background: var(--v4-danger-500);
   color: #fff;
   border-radius: 4px;
   padding: 1px 6px;
@@ -181,11 +255,11 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
    gray .v4-nav-count (which holds margin-left:auto) on the right edge. */
 .sidebar-badge {
   margin-left: 6px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9px;
   font-weight: 700;
-  background: var(--mk-warn-soft);
-  color: var(--mk-warn-strong);
+  background: var(--v4-warn-50);
+  color: var(--v4-warn-700);
   border-radius: 4px;
   padding: 1px 6px;
 }
@@ -196,7 +270,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 
 .v4-side-foot {
   padding: 14px 16px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   display: flex;
   align-items: center;
   gap: 10px;
@@ -206,32 +280,32 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   width: 30px;
   height: 30px;
   border-radius: 50%;
-  background: var(--mk-ink-900);
+  background: var(--v4-ink-900);
   color: #fff;
   font-size: 11px;
   font-weight: 600;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
 }
 .v4-side-foot b {
   font-size: 12px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   display: block;
   line-height: 1.2;
 }
 .v4-side-foot span {
   font-size: 10px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 
 /* Main column */
 .v4-main { min-width: 0; }
 .v4-top {
   height: calc(56px + env(safe-area-inset-top));
-  border-bottom: 1px solid var(--mk-line);
-  background: var(--mk-paper);
+  border-bottom: 1px solid var(--v4-line);
+  background: var(--v4-paper);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -243,17 +317,17 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-crumbs {
   font-size: 13px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   display: flex;
   align-items: center;
   gap: 8px;
   min-width: 0;
 }
 .v4-crumbs b {
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-weight: 600;
 }
-.v4-crumbs .v4-sep { color: var(--mk-ink-300); }
+.v4-crumbs .v4-sep { color: var(--v4-ink-300); }
 .v4-crumb-link {
   appearance: none;
   background: none;
@@ -266,9 +340,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   border-radius: 4px;
   transition: color .12s ease, background .12s ease;
 }
-.v4-crumb-link:hover { color: var(--mk-ink-900); background: var(--mk-paper); }
+.v4-crumb-link:hover { color: var(--v4-ink-900); background: var(--v4-ink-50, #EEF1F6); }
 .v4-crumb-link:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: 1px;
 }
 .v4-live {
@@ -278,9 +352,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   margin-left: 14px;
   padding: 3px 10px;
   border-radius: 99px;
-  background: var(--mk-success-soft);
-  color: var(--mk-success-strong);
-  font-family: var(--mk-font-mono);
+  background: var(--v4-success-50);
+  color: var(--v4-success-700);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 600;
 }
@@ -288,7 +362,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--mk-success);
+  background: var(--v4-success-500);
   box-shadow: 0 0 0 3px rgba(18, 183, 106, 0.18);
   animation: v4-pulse 2s infinite;
 }
@@ -303,17 +377,17 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   margin-left: 10px;
   padding: 3px 10px;
   border-radius: 99px;
-  background: var(--mk-surface-3);
-  font-family: var(--mk-font-mono);
+  background: var(--v4-surface-3);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 600;
   cursor: default;
 }
-.v4-ratelimit-sep { color: var(--mk-ink-300); }
-.v4-ratelimit-seg--ok { color: var(--mk-success-strong); }
-.v4-ratelimit-seg--warn { color: var(--mk-warn-strong); }
-.v4-ratelimit-seg--crit { color: var(--mk-danger-strong); }
-.v4-ratelimit-reset { color: var(--mk-ink-500); }
+.v4-ratelimit-sep { color: var(--v4-ink-300); }
+.v4-ratelimit-seg--ok { color: var(--v4-success-700); }
+.v4-ratelimit-seg--warn { color: var(--v4-warn-700); }
+.v4-ratelimit-seg--crit { color: var(--v4-danger-700); }
+.v4-ratelimit-reset { color: var(--v4-ink-500); }
 .v4-top-right {
   display: flex;
   align-items: center;
@@ -336,19 +410,19 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   width: 100%;
   height: 32px;
   padding: 0 12px 0 32px;
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-sm);
-  background: var(--mk-surface-2);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-sm);
+  background: var(--v4-surface-2);
   font: inherit;
   font-size: 12px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   outline: none;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
 }
-.v4-search input::placeholder { color: var(--mk-ink-400); }
+.v4-search input::placeholder { color: var(--v4-ink-400); }
 .v4-search input:focus {
-  border-color: var(--mk-brand-500);
-  background: var(--mk-paper);
+  border-color: var(--v4-accent-500);
+  background: var(--v4-paper);
 }
 .v4-search svg {
   position: absolute;
@@ -357,37 +431,37 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   transform: translateY(-50%);
   width: 14px;
   height: 14px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .v4-search .v4-kbd {
   position: absolute;
   right: 8px;
   top: 50%;
   transform: translateY(-50%);
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
-  color: var(--mk-ink-400);
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  color: var(--v4-ink-400);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   padding: 1px 5px;
   border-radius: 3px;
 }
 .v4-ibtn {
   width: 32px;
   height: 32px;
-  border-radius: var(--mk-r-sm);
+  border-radius: var(--v4-r-sm);
   background: transparent;
   border: 1px solid transparent;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   cursor: pointer;
   position: relative;
 }
 .v4-ibtn:hover {
-  background: var(--mk-surface-2);
-  border-color: var(--mk-line);
+  background: var(--v4-surface-2);
+  border-color: var(--v4-line);
 }
 .v4-ibtn:disabled {
   opacity: 0.5;
@@ -401,8 +475,8 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--mk-danger);
-  border: 2px solid var(--mk-paper);
+  background: var(--v4-danger-500);
+  border: 2px solid var(--v4-paper);
 }
 .v4-ibtn.is-spin svg {
   animation: v4-spin 0.9s linear infinite;
@@ -427,12 +501,12 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   font-size: 24px;
   font-weight: 700;
   letter-spacing: -0.02em;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   margin: 0;
 }
 .v4-ph .v4-sub {
   font-size: 13px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-top: 4px;
 }
 .v4-ph-right {
@@ -447,38 +521,38 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   gap: 6px;
   height: 34px;
   padding: 0 14px;
-  border-radius: var(--mk-r-sm);
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  color: var(--mk-ink-700);
+  border-radius: var(--v4-r-sm);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  color: var(--v4-ink-700);
   font: inherit;
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   transition: border-color 120ms, color 120ms, background 120ms;
 }
 .v4-btn:hover {
-  border-color: var(--mk-line-strong);
-  color: var(--mk-ink-900);
+  border-color: var(--v4-line-strong);
+  color: var(--v4-ink-900);
 }
 .v4-btn--pri {
-  background: var(--mk-ink-900);
-  border-color: var(--mk-ink-900);
+  background: var(--v4-ink-900);
+  border-color: var(--v4-ink-900);
   color: #fff;
 }
 .v4-btn--pri:hover {
-  background: var(--mk-ink-800);
+  background: var(--v4-ink-800);
   color: #fff;
 }
 .v4-btn svg { width: 14px; height: 14px; }
 
 .v4-pillgrp {
   display: inline-flex;
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
   padding: 2px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 600;
 }
@@ -486,16 +560,16 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   appearance: none;
   border: 0;
   background: transparent;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   padding: 5px 12px;
   border-radius: 5px;
   cursor: pointer;
   font: inherit;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
 }
 .v4-pillgrp button.is-active {
   background: #fff;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   box-shadow: 0 1px 2px rgba(11, 16, 32, 0.08);
 }
 
@@ -510,9 +584,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   align-items: stretch;
 }
 .v4-kpi {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   padding: 14px 16px 12px;
   position: relative;
   overflow: hidden;
@@ -532,15 +606,15 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-kpi:hover {
   transform: translateY(-2px);
   box-shadow: 0 10px 28px rgba(11, 16, 32, 0.07);
-  border-color: var(--mk-line-strong);
+  border-color: var(--v4-line-strong);
 }
 .v4-kpi-lbl {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   display: flex;
   align-items: center;
   gap: 7px;
@@ -561,15 +635,15 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-600);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-600);
   flex-shrink: 0;
 }
 .v4-kpi-ic svg { width: 11px; height: 11px; }
-.v4-kpi-ic--b { background: var(--mk-brand-50); color: var(--mk-brand-700); }
-.v4-kpi-ic--g { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-kpi-ic--o { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.v4-kpi-ic--p { background: var(--mk-purple-50); color: var(--mk-purple-700); }
+.v4-kpi-ic--b { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.v4-kpi-ic--g { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-kpi-ic--o { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-kpi-ic--p { background: var(--v4-purple-50); color: var(--v4-purple-700); }
 
 .v4-kpi-num-row {
   display: flex;
@@ -582,10 +656,10 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   z-index: 1;
 }
 .v4-kpi-num {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 44px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   letter-spacing: -0.025em;
   font-variant-numeric: tabular-nums;
   line-height: 1;
@@ -594,7 +668,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-kpi-num-u {
   font-size: 14px;
   font-weight: 600;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-left: 2px;
   flex-shrink: 1;
   min-width: 0;
@@ -606,7 +680,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   margin-left: auto;
   align-self: center;
   flex-shrink: 0;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 700;
   white-space: nowrap;
@@ -620,9 +694,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-kpi--acc .v4-kpi-delta-chip--neg { color: #FECACA; }
 
 .v4-kpi-sub {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-bottom: 6px;
   z-index: 1;
 }
@@ -659,7 +733,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   margin-top: auto;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   padding-top: 8px;
   z-index: 1;
 }
@@ -669,27 +743,27 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-kpi-split {
   padding: 4px 6px;
   text-align: center;
-  border-left: 1px solid var(--mk-line-soft);
+  border-left: 1px solid var(--v4-line-soft);
   border-radius: 5px;
   cursor: default;
   transition: background .15s;
 }
 .v4-kpi-split:first-child { border-left: 0; }
-.v4-kpi-split.is-on { background: var(--mk-surface-2); }
+.v4-kpi-split.is-on { background: var(--v4-surface-2); }
 .v4-kpi-splits--acc .v4-kpi-split { border-left-color: rgba(255, 255, 255, 0.15); }
 .v4-kpi-splits--acc .v4-kpi-split.is-on { background: rgba(255, 255, 255, 0.10); }
 .v4-kpi-split-n {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 18px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-variant-numeric: tabular-nums;
   line-height: 1;
 }
 .v4-kpi-split-l {
   font-size: 9px;
-  font-family: var(--mk-font-mono);
-  color: var(--mk-ink-500);
+  font-family: var(--v4-mono);
+  color: var(--v4-ink-500);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -717,11 +791,11 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-kpi-spark-tip {
   position: absolute;
   top: -4px;
-  background: var(--mk-ink-900);
+  background: var(--v4-ink-900);
   color: #fff;
   padding: 5px 9px;
   border-radius: 6px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   white-space: nowrap;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
@@ -759,29 +833,29 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-fin-bar-stk {
   height: 10px;
   border-radius: 99px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   overflow: hidden;
   display: flex;
 }
 .v4-fin-bar-stk .v4-pp {
   height: 100%;
-  background: var(--mk-success);
+  background: var(--v4-success-500);
   transition: background .15s;
 }
-.v4-fin-bar-stk .v4-pp.is-on { background: var(--mk-success-strong); }
+.v4-fin-bar-stk .v4-pp.is-on { background: var(--v4-success-700); }
 .v4-fin-bar-stk .v4-ip {
   height: 100%;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   transition: background .15s;
 }
-.v4-fin-bar-stk .v4-ip.is-on { background: var(--mk-ink-300); }
+.v4-fin-bar-stk .v4-ip.is-on { background: var(--v4-ink-300); }
 .v4-fin-lg {
   display: flex;
   justify-content: space-between;
   gap: 8px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10.5px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   white-space: nowrap;
 }
 .v4-fin-lg-i {
@@ -790,7 +864,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   gap: 5px;
   transition: color .15s;
 }
-.v4-fin-lg-i.is-on { color: var(--mk-ink-900); }
+.v4-fin-lg-i.is-on { color: var(--v4-ink-900); }
 .v4-fin-lg-sw {
   width: 7px;
   height: 7px;
@@ -798,10 +872,10 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   flex-shrink: 0;
 }
 .v4-fin-lg-sw--out {
-  background: var(--mk-surface-3);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-surface-3);
+  border: 1px solid var(--v4-line);
 }
-.v4-fin-lg b { color: var(--mk-ink-900); font-weight: 700; }
+.v4-fin-lg b { color: var(--v4-ink-900); font-weight: 700; }
 
 /* ────────────────────────────────────────
    PANELS / GRID
@@ -815,9 +889,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-grid--rev { grid-template-columns: 1fr 1.6fr; }
 
 .v4-panel {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -827,7 +901,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   justify-content: space-between;
   align-items: center;
   padding: 14px 18px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   gap: 12px;
   flex-wrap: wrap;
   row-gap: 8px;
@@ -835,29 +909,29 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-panel-t {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   display: flex;
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
 }
-.v4-panel-t--danger { color: var(--mk-danger-strong); }
+.v4-panel-t--danger { color: var(--v4-danger-700); }
 .v4-tag {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9px;
   font-weight: 600;
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-500);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-500);
   padding: 2px 7px;
   border-radius: 99px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
-.v4-tag--danger { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
+.v4-tag--danger { background: var(--v4-danger-50); color: var(--v4-danger-700); }
 .v4-panel-meta {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .v4-panel-actions {
   display: flex;
@@ -866,7 +940,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-linkbtn {
   font-size: 12px;
-  color: var(--mk-brand-600);
+  color: var(--v4-accent-600);
   font-weight: 500;
   text-decoration: none;
   background: none;
@@ -876,7 +950,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   padding: 0;
 }
 .v4-linkbtn:hover {
-  color: var(--mk-brand-700);
+  color: var(--v4-accent-700);
   text-decoration: underline;
 }
 
@@ -890,10 +964,10 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   padding: 14px;
 }
 .v4-pcard {
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   padding: 14px 14px 14px 17px;
-  background: var(--mk-paper);
+  background: var(--v4-paper);
   display: flex;
   flex-direction: column;
   gap: 11px;
@@ -910,8 +984,8 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   bottom: 0;
   width: 3px;
 }
-.v4-pcard.is-risk-high::before { background: var(--mk-danger); }
-.v4-pcard.is-risk-med::before { background: var(--mk-warn); }
+.v4-pcard.is-risk-high::before { background: var(--v4-danger-500); }
+.v4-pcard.is-risk-med::before { background: var(--v4-warn-500); }
 
 .v4-pcard-row {
   display: flex;
@@ -923,16 +997,16 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   row-gap: 6px;
 }
 .v4-pcard-name {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 13px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   letter-spacing: -0.01em;
   text-decoration: none;
   white-space: nowrap;
   flex-shrink: 0;
 }
-.v4-pcard-name:hover { color: var(--mk-brand-600); }
+.v4-pcard-name:hover { color: var(--v4-accent-600); }
 .v4-pcard-badges {
   display: flex;
   gap: 5px;
@@ -945,7 +1019,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9.5px;
   font-weight: 600;
   padding: 2px 6px;
@@ -960,18 +1034,18 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   height: 6px;
   border-radius: 50%;
 }
-.v4-chip--alive { background: var(--mk-success-soft); color: var(--mk-success-strong); }
+.v4-chip--alive { background: var(--v4-success-50); color: var(--v4-success-700); }
 .v4-chip--alive .v4-chip-dot {
-  background: var(--mk-success);
+  background: var(--v4-success-500);
   box-shadow: 0 0 0 2px rgba(18, 183, 106, 0.2);
 }
-.v4-chip--down { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
-.v4-chip--down .v4-chip-dot { background: var(--mk-danger); }
-.v4-chip--paused { background: var(--mk-surface-2); color: var(--mk-ink-500); }
-.v4-chip--paused .v4-chip-dot { background: var(--mk-ink-400); }
-.v4-chip--dev { background: var(--mk-brand-50); color: var(--mk-brand-700); }
-.v4-chip--support { background: var(--mk-purple-50); color: var(--mk-purple-700); }
-.v4-chip--predev { background: var(--mk-surface-2); color: var(--mk-ink-600); }
+.v4-chip--down { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-chip--down .v4-chip-dot { background: var(--v4-danger-500); }
+.v4-chip--paused { background: var(--v4-surface-2); color: var(--v4-ink-500); }
+.v4-chip--paused .v4-chip-dot { background: var(--v4-ink-400); }
+.v4-chip--dev { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.v4-chip--support { background: var(--v4-purple-50); color: var(--v4-purple-700); }
+.v4-chip--predev { background: var(--v4-surface-2); color: var(--v4-ink-600); }
 
 .v4-pcard-open-row {
   display: flex;
@@ -982,21 +1056,21 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-pcard-open-num {
   font-size: 20px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-variant-numeric: tabular-nums;
 }
 .v4-pcard-open-num span {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 500;
   margin-left: 4px;
 }
 .v4-pcard-pri-group {
   display: flex;
   gap: 8px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 .v4-pcard-pri {
   display: inline-flex;
@@ -1008,10 +1082,10 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   height: 7px;
   border-radius: 50%;
 }
-.v4-pdot--p1 { background: var(--mk-priority-p1); }
-.v4-pdot--p2 { background: var(--mk-priority-p2); }
-.v4-pdot--p3 { background: var(--mk-priority-p3); }
-.v4-pdot--p4 { background: var(--mk-priority-p4); }
+.v4-pdot--p1 { background: var(--v4-p1); }
+.v4-pdot--p2 { background: var(--v4-p2); }
+.v4-pdot--p3 { background: var(--v4-p3); }
+.v4-pdot--p4 { background: var(--v4-p4); }
 
 .v4-pcard-progress {
   display: flex;
@@ -1021,7 +1095,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-ptrack {
   flex: 1;
   height: 6px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   border-radius: 99px;
   overflow: hidden;
 }
@@ -1034,7 +1108,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   .v4-pfill { transition: none; }
 }
 .v4-ppct {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 600;
   min-width: 64px;
@@ -1045,29 +1119,29 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   justify-content: space-between;
   align-items: center;
   padding-top: 8px;
-  border-top: 1px dashed var(--mk-line);
+  border-top: 1px dashed var(--v4-line);
   gap: 8px;
 }
 .v4-pcard-finance-l {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
-.v4-pcard-finance-l b { color: var(--mk-ink-900); }
+.v4-pcard-finance-l b { color: var(--v4-ink-900); }
 .v4-pcard-finance-r {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-success-strong);
+  color: var(--v4-success-700);
   font-weight: 600;
 }
-.v4-pcard-finance-r--warn { color: var(--mk-warn-strong); }
+.v4-pcard-finance-r--warn { color: var(--v4-warn-700); }
 
 .v4-pcard-stats {
   display: flex;
   gap: 14px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   flex-wrap: wrap;
 }
 .v4-pcard-stat {
@@ -1075,17 +1149,17 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   align-items: center;
   gap: 4px;
 }
-.v4-pcard-stat b { color: var(--mk-ink-900); font-weight: 600; }
+.v4-pcard-stat b { color: var(--v4-ink-900); font-weight: 600; }
 .v4-pcard-stat svg {
   width: 11px;
   height: 11px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   flex-shrink: 0;
 }
-.v4-pcard-stat--danger { color: var(--mk-danger-strong); }
-.v4-pcard-stat--danger svg { color: var(--mk-danger-strong); }
-.v4-pcard-stat--warn { color: var(--mk-warn-strong); }
-.v4-pcard-stat--warn svg { color: var(--mk-warn-strong); }
+.v4-pcard-stat--danger { color: var(--v4-danger-700); }
+.v4-pcard-stat--danger svg { color: var(--v4-danger-700); }
+.v4-pcard-stat--warn { color: var(--v4-warn-700); }
+.v4-pcard-stat--warn svg { color: var(--v4-warn-700); }
 
 /* ────────────────────────────────────────
    AI INSIGHTS LIST
@@ -1102,7 +1176,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-ai-list::-webkit-scrollbar { width: 6px; }
 .v4-ai-list::-webkit-scrollbar-thumb {
-  background: var(--mk-line-strong);
+  background: var(--v4-line-strong, #d6dbe5);
   border-radius: 3px;
 }
 .v4-ai-list::-webkit-scrollbar-track { background: transparent; }
@@ -1111,7 +1185,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   grid-template-columns: 28px 1fr auto;
   gap: 10px;
   padding: 8px 16px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   align-items: start;
 }
 .v4-ai-item:last-child { border-bottom: 0; }
@@ -1124,19 +1198,19 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   justify-content: center;
 }
 .v4-ai-item-ic svg { width: 13px; height: 13px; }
-.v4-ai-item--an .v4-ai-item-ic { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
-.v4-ai-item--gr .v4-ai-item-ic { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-ai-item--rk .v4-ai-item-ic { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.v4-ai-item--fc .v4-ai-item-ic { background: var(--mk-brand-50); color: var(--mk-brand-700); }
+.v4-ai-item--an .v4-ai-item-ic { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-ai-item--gr .v4-ai-item-ic { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-ai-item--rk .v4-ai-item-ic { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-ai-item--fc .v4-ai-item-ic { background: var(--v4-accent-50); color: var(--v4-accent-700); }
 .v4-ai-item-ttl {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   margin-bottom: 3px;
 }
 .v4-ai-item-ds {
   font-size: 12px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   line-height: 1.4;
   /* Clamp to 2 lines — the full text lives behind the "Открыть Health"
      button anyway, so an in-list teaser is enough. */
@@ -1146,9 +1220,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   overflow: hidden;
 }
 .v4-ai-item-meta {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   text-align: right;
   line-height: 1.4;
   white-space: nowrap;
@@ -1173,8 +1247,8 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-ai-repo {
   font-size: 11px;
-  color: var(--mk-ink-500);
-  background: var(--mk-line-soft);
+  color: var(--v4-ink-500);
+  background: var(--v4-line-soft, #eef0f4);
   padding: 1px 6px;
   border-radius: 4px;
 }
@@ -1211,10 +1285,10 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   border-radius: 50%;
   background: currentColor;
 }
-.v4-ai-sev--critical { color: var(--mk-danger-strong); background: var(--mk-danger-soft); }
-.v4-ai-sev--high     { color: var(--mk-danger-strong); background: var(--mk-danger-soft); }
-.v4-ai-sev--medium   { color: var(--mk-warn-strong);   background: var(--mk-warn-soft); }
-.v4-ai-sev--low      { color: var(--mk-ink-600);    background: var(--mk-line-soft); }
+.v4-ai-sev--critical { color: var(--v4-danger-700); background: var(--v4-danger-50); }
+.v4-ai-sev--high     { color: var(--v4-danger-700); background: var(--v4-danger-50); }
+.v4-ai-sev--medium   { color: var(--v4-warn-700);   background: var(--v4-warn-50); }
+.v4-ai-sev--low      { color: var(--v4-ink-600);    background: var(--v4-line-soft, #eef0f4); }
 
 /* ── Compact insight row (replaces the multi-section InsightCard).
    Whole row is a button → click opens Health for the repo. severity +
@@ -1228,7 +1302,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   width: 100%;
   padding: 8px 16px;
   border: 0;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   background: transparent;
   cursor: pointer;
   text-align: left;
@@ -1236,9 +1310,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   color: inherit;
 }
 .v4-ai-row:last-child { border-bottom: 0; }
-.v4-ai-row:hover { background: var(--mk-line-soft); }
+.v4-ai-row:hover { background: var(--v4-line-soft, #eef0f4); }
 .v4-ai-row:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: -2px;
 }
 .v4-ai-row-main {
@@ -1256,7 +1330,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-ai-row-title {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1265,7 +1339,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-ai-row-ds {
   font-size: 12px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   line-height: 1.35;
   display: -webkit-box;
   -webkit-line-clamp: 1;
@@ -1273,11 +1347,11 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   overflow: hidden;
 }
 .v4-ai-row-arrow {
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-size: 12px;
   text-align: right;
 }
-.v4-ai-row:hover .v4-ai-row-arrow { color: var(--mk-brand-600); }
+.v4-ai-row:hover .v4-ai-row-arrow { color: var(--v4-accent-600); }
 
 /* skeleton */
 .v4-ai-skel { grid-template-columns: 78px 1fr 40px; }
@@ -1285,9 +1359,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-ai-skel-line,
 .v4-ai-skel-meta {
   background: linear-gradient(90deg,
-    var(--mk-line-soft) 0%,
-    var(--mk-line) 50%,
-    var(--mk-line-soft) 100%);
+    var(--v4-line-soft, #eef0f4) 0%,
+    var(--v4-line-mid, #e2e5eb) 50%,
+    var(--v4-line-soft, #eef0f4) 100%);
   background-size: 200% 100%;
   animation: v4-ai-skel-shimmer 1.4s ease-in-out infinite;
   border-radius: 4px;
@@ -1310,7 +1384,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-ai-empty {
   padding: 16px 18px;
   font-size: 12px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 
 /* ────────────────────────────────────────
@@ -1318,18 +1392,18 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
    Theme-aware via --v4-* tokens (auto dark/light).
    ──────────────────────────────────────── */
 .v4-promise-empty {
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-style: italic;
 }
 .v4-promise-grp:not(:last-child) {
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .v4-promise-grp-h {
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   padding: 8px 16px 4px;
 }
 .v4-promise-row {
@@ -1348,8 +1422,8 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   height: 8px;
   border-radius: 50%;
 }
-.v4-promise-dot--overdue { background: var(--mk-danger); }
-.v4-promise-dot--due-week { background: var(--mk-warn); }
+.v4-promise-dot--overdue { background: var(--v4-danger-500); }
+.v4-promise-dot--due-week { background: var(--v4-warn-500); }
 .v4-promise-main {
   min-width: 0;
   display: flex;
@@ -1359,7 +1433,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-promise-text {
   font-size: 13px;
   font-weight: 500;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1373,8 +1447,8 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-promise-repo {
   font-size: 11px;
-  color: var(--mk-ink-500);
-  background: var(--mk-line-soft);
+  color: var(--v4-ink-500);
+  background: var(--v4-line-soft);
   padding: 1px 6px;
   border-radius: 4px;
 }
@@ -1382,8 +1456,8 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   font-size: 11px;
   font-weight: 600;
 }
-.v4-promise-due--overdue { color: var(--mk-danger-strong); }
-.v4-promise-due--due-week { color: var(--mk-warn-strong); }
+.v4-promise-due--overdue { color: var(--v4-danger-700); }
+.v4-promise-due--due-week { color: var(--v4-warn-700); }
 
 /* ────────────────────────────────────────
    PORTFOLIO RENEWALS (Epic-010 Task-04)
@@ -1407,28 +1481,28 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   border-radius: 6px;
 }
 .v4-renewal-icon--red {
-  color: var(--mk-danger-strong);
-  background: var(--mk-danger-soft);
+  color: var(--v4-danger-700);
+  background: var(--v4-danger-50);
 }
 .v4-renewal-icon--yellow {
-  color: var(--mk-warn-strong);
-  background: var(--mk-warn-soft);
+  color: var(--v4-warn-700);
+  background: var(--v4-warn-50);
 }
 .v4-renewal-icon--gray {
-  color: var(--mk-ink-500);
-  background: var(--mk-line-soft);
+  color: var(--v4-ink-500);
+  background: var(--v4-line-soft);
 }
 .v4-renewal-type {
   font-weight: 600;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-renewal-client {
   font-size: 11px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
-.v4-renewal-due--red { color: var(--mk-danger-strong); }
-.v4-renewal-due--yellow { color: var(--mk-warn-strong); }
-.v4-renewal-due--gray { color: var(--mk-ink-500); }
+.v4-renewal-due--red { color: var(--v4-danger-700); }
+.v4-renewal-due--yellow { color: var(--v4-warn-700); }
+.v4-renewal-due--gray { color: var(--v4-ink-500); }
 
 /* ────────────────────────────────────────
    LISTS: blocked + deadlines
@@ -1439,7 +1513,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   grid-template-columns: auto 1fr auto;
   gap: 10px;
   padding: 10px 16px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   align-items: center;
 }
 .v4-litem:last-child { border-bottom: 0; }
@@ -1448,22 +1522,22 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   padding-left: 14px;
 }
 .v4-litem--over {
-  border-left-color: var(--mk-danger);
-  background: var(--mk-danger-soft);
+  border-left-color: var(--v4-danger-500);
+  background: var(--v4-danger-50);
 }
-.v4-litem--today { border-left-color: var(--mk-warn); }
-.v4-litem--soon { border-left-color: var(--mk-brand-500); }
+.v4-litem--today { border-left-color: var(--v4-warn-500); }
+.v4-litem--soon { border-left-color: var(--v4-accent-500); }
 .v4-litem-repo {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 .v4-litem-ti {
   font-size: 13px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-weight: 500;
   min-width: 0;
 }
@@ -1471,9 +1545,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   color: inherit;
   text-decoration: none;
 }
-.v4-litem-ti a:hover { color: var(--mk-brand-600); }
+.v4-litem-ti a:hover { color: var(--v4-accent-600); }
 .v4-litem-badge {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 700;
   padding: 2px 7px;
@@ -1481,19 +1555,19 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   white-space: nowrap;
   flex-shrink: 0;
 }
-.v4-litem-badge--danger { background: var(--mk-danger); color: #fff; }
-.v4-litem-badge--warn { background: var(--mk-warn); color: #fff; }
-.v4-litem-badge--primary { background: var(--mk-brand-500); color: #fff; }
+.v4-litem-badge--danger { background: var(--v4-danger-500); color: #fff; }
+.v4-litem-badge--warn { background: var(--v4-warn-500); color: #fff; }
+.v4-litem-badge--primary { background: var(--v4-accent-500); color: #fff; }
 .v4-empty {
   padding: 24px 18px;
   text-align: center;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-size: 12px;
 }
 
 .v4-ptag {
   display: inline-block;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 700;
   padding: 2px 7px;
@@ -1501,10 +1575,10 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   letter-spacing: 0.02em;
   flex-shrink: 0;
 }
-.v4-ptag--p1 { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
-.v4-ptag--p2 { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.v4-ptag--p3 { background: var(--mk-brand-50); color: var(--mk-brand-700); }
-.v4-ptag--p4 { background: var(--mk-surface-2); color: var(--mk-ink-600); }
+.v4-ptag--p1 { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-ptag--p2 { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-ptag--p3 { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.v4-ptag--p4 { background: var(--v4-surface-2); color: var(--v4-ink-600); }
 
 /* ────────────────────────────────────────
    CLOSED CHART (30 days)
@@ -1525,8 +1599,8 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-closed-tip {
   position: absolute;
   top: 14px;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line-strong);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line-strong);
   box-shadow: 0 8px 24px rgba(11, 16, 32, 0.12), 0 2px 6px rgba(11, 16, 32, 0.06);
   border-radius: 8px;
   padding: 10px 12px;
@@ -1536,11 +1610,11 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   z-index: 5;
 }
 .v4-closed-tip-l {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-bottom: 6px;
 }
 .v4-closed-tip-row {
@@ -1550,14 +1624,14 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   margin-bottom: 8px;
 }
 .v4-closed-tip-v {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 24px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-variant-numeric: tabular-nums;
 }
 .v4-closed-tip-u {
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-size: 12px;
 }
 .v4-closed-tip-foot {
@@ -1566,31 +1640,31 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   align-items: center;
   gap: 10px;
   padding-top: 8px;
-  border-top: 1px solid var(--mk-line-soft);
-  color: var(--mk-ink-500);
+  border-top: 1px solid var(--v4-line-soft);
+  color: var(--v4-ink-500);
   font-size: 11px;
 }
 .v4-closed-tip-foot--tight { padding-top: 4px; border-top: 0; margin-top: 0; }
 .v4-closed-tip-tr {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-weight: 600;
   font-size: 11px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 .v4-closed-tip-delta {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-weight: 700;
   font-size: 11px;
 }
-.v4-closed-tip-delta--pos { color: var(--mk-success); }
-.v4-closed-tip-delta--neg { color: var(--mk-danger); }
+.v4-closed-tip-delta--pos { color: var(--v4-success-500); }
+.v4-closed-tip-delta--neg { color: var(--v4-danger-500); }
 .v4-cc-legend {
   display: flex;
   gap: 14px;
   padding: 0 18px 14px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   flex-wrap: wrap;
 }
 .v4-cc-lg {
@@ -1605,11 +1679,11 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-cc-peak {
   margin-left: auto;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
-.v4-cc-peak b { color: var(--mk-ink-900); }
+.v4-cc-peak b { color: var(--v4-ink-900); }
 
 /* ────────────────────────────────────────
    ORPHAN ISSUES PANEL
@@ -1620,7 +1694,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   gap: 4px;
   padding-top: 8px;
   margin-top: 4px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   max-height: 160px;
   overflow-y: auto;
 }
@@ -1630,22 +1704,22 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   align-items: center;
   gap: 10px;
   font-size: 11px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 .v4-orphan-tip-c {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-variant-numeric: tabular-nums;
 }
 .v4-orphan-tip-more {
   font-size: 10px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   padding-top: 2px;
 }
 .v4-orphan-tip-snap {
   font-size: 10px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   padding-top: 2px;
   font-style: italic;
 }
@@ -1661,9 +1735,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   flex: 1;
   background: linear-gradient(
     90deg,
-    var(--mk-line-soft) 0%,
-    var(--mk-surface-2) 50%,
-    var(--mk-line-soft) 100%
+    var(--v4-line-soft) 0%,
+    var(--v4-surface-2, #f4f5f9) 50%,
+    var(--v4-line-soft) 100%
   );
   background-size: 200% 100%;
   border-radius: 3px;
@@ -1680,10 +1754,10 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   display: flex;
   flex-direction: column;
   gap: 4px;
-  background: var(--mk-danger-soft);
-  color: var(--mk-danger-strong);
-  border-radius: var(--mk-r-md);
-  border: 1px solid var(--mk-danger-100);
+  background: var(--v4-danger-50);
+  color: var(--v4-danger-700);
+  border-radius: var(--v4-r-md);
+  border: 1px solid var(--v4-danger-100);
   padding: 18px 16px;
   margin: 8px;
 }
@@ -1707,17 +1781,17 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   padding: 14px;
 }
 .v4-mscard {
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   padding: 12px 14px;
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
-.v4-mscard--done { border-left: 3px solid var(--mk-success); }
-.v4-mscard--over { border-left: 3px solid var(--mk-danger); }
-.v4-mscard--warn { border-left: 3px solid var(--mk-warn); }
-.v4-mscard--norm { border-left: 3px solid var(--mk-brand-500); }
+.v4-mscard--done { border-left: 3px solid var(--v4-success-500); }
+.v4-mscard--over { border-left: 3px solid var(--v4-danger-500); }
+.v4-mscard--warn { border-left: 3px solid var(--v4-warn-500); }
+.v4-mscard--norm { border-left: 3px solid var(--v4-accent-500); }
 .v4-mscard-h {
   display: flex;
   justify-content: space-between;
@@ -1727,13 +1801,13 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-mscard-t {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   line-height: 1.3;
 }
 .v4-mscard-r {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -1748,7 +1822,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-mscard-track {
   flex: 1;
   height: 5px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   border-radius: 99px;
   overflow: hidden;
 }
@@ -1757,33 +1831,33 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   border-radius: 99px;
 }
 .v4-mscard-pct {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 600;
   min-width: 64px;
   text-align: right;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 .v4-mscard-due {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   display: flex;
   justify-content: space-between;
   gap: 8px;
 }
-.v4-mscard-due b { color: var(--mk-ink-900); }
+.v4-mscard-due b { color: var(--v4-ink-900); }
 .v4-mscard-done-chip {
-  background: var(--mk-success-soft);
-  color: var(--mk-success-strong);
-  border: 1px solid var(--mk-success-100);
+  background: var(--v4-success-50);
+  color: var(--v4-success-700);
+  border: 1px solid var(--v4-success-100);
   width: auto;
   height: 18px;
   border-radius: 99px;
   padding: 0 8px;
   font-size: 10px;
   font-weight: 700;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   display: inline-flex;
   align-items: center;
 }
@@ -1802,16 +1876,16 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   transition: opacity .15s;
 }
 .v4-commit-row .v4-nm {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-weight: 500;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   transition: color .15s, font-weight .15s;
 }
 .v4-commit-row.is-on .v4-nm {
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-weight: 600;
 }
 .v4-commit-cells {
@@ -1831,7 +1905,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   content: "";
   position: absolute;
   inset: -3px -1px;
-  background: var(--mk-brand-100);
+  background: var(--v4-accent-100);
   opacity: 0.45;
   border-radius: 4px;
   pointer-events: none;
@@ -1840,35 +1914,35 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   width: 100%;
   height: 18px;
   border-radius: 3px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   cursor: pointer;
   transition: opacity .14s, box-shadow .14s, background .14s;
   position: relative;
   z-index: 1;
 }
-.v4-cc[data-v="1"] { background: var(--mk-heat-1); }
-.v4-cc[data-v="2"] { background: var(--mk-heat-2); }
-.v4-cc[data-v="3"] { background: var(--mk-heat-3); }
-.v4-cc[data-v="4"] { background: var(--mk-heat-4); }
+.v4-cc[data-v="1"] { background: var(--v4-heat-1); }
+.v4-cc[data-v="2"] { background: var(--v4-heat-2); }
+.v4-cc[data-v="3"] { background: var(--v4-heat-3); }
+.v4-cc[data-v="4"] { background: var(--v4-heat-4); }
 .v4-cc.is-hover {
-  box-shadow: 0 0 0 2px var(--mk-ink-900), 0 4px 10px rgba(11, 16, 32, 0.18);
+  box-shadow: 0 0 0 2px var(--v4-ink-900), 0 4px 10px rgba(11, 16, 32, 0.18);
 }
 .v4-commit-row .v4-tot {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   text-align: right;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   font-weight: 600;
   transition: color .15s, font-weight .15s;
 }
 .v4-commit-row.is-on .v4-tot {
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-weight: 700;
 }
 
 .v4-heat-tip {
   position: absolute;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line-strong);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line-strong);
   box-shadow: 0 8px 24px rgba(11, 16, 32, 0.12), 0 2px 6px rgba(11, 16, 32, 0.06);
   border-radius: 8px;
   padding: 10px 12px;
@@ -1876,20 +1950,20 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   z-index: 10;
 }
 .v4-heat-tip-t {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .v4-heat-tip-d {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin: 4px 0 8px;
 }
 .v4-heat-tip-row {
@@ -1900,43 +1974,43 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-heat-tip-v {
   font-size: 22px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-variant-numeric: tabular-nums;
 }
-.v4-heat-tip-v--zero { color: var(--mk-ink-400); }
-.v4-heat-tip-u { color: var(--mk-ink-500); font-size: 12px; }
+.v4-heat-tip-v--zero { color: var(--v4-ink-400); }
+.v4-heat-tip-u { color: var(--v4-ink-500); font-size: 12px; }
 
 .v4-heat-foot {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 10px 18px 14px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
 }
 .v4-heat-range {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-heat-legend {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-heat-legend-sw {
   display: inline-block;
   width: 14px;
   height: 10px;
   border-radius: 2px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
 }
-.v4-heat-legend-sw[data-v="1"] { background: var(--mk-heat-1); }
-.v4-heat-legend-sw[data-v="2"] { background: var(--mk-heat-2); }
-.v4-heat-legend-sw[data-v="3"] { background: var(--mk-heat-3); }
-.v4-heat-legend-sw[data-v="4"] { background: var(--mk-heat-4); }
+.v4-heat-legend-sw[data-v="1"] { background: var(--v4-heat-1); }
+.v4-heat-legend-sw[data-v="2"] { background: var(--v4-heat-2); }
+.v4-heat-legend-sw[data-v="3"] { background: var(--v4-heat-3); }
+.v4-heat-legend-sw[data-v="4"] { background: var(--v4-heat-4); }
 
 /* ────────────────────────────────────────
    BANNER
@@ -1946,16 +2020,16 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   align-items: center;
   gap: 14px;
   padding: 14px 18px;
-  background: linear-gradient(90deg, var(--mk-brand-50), transparent);
-  border: 1px solid var(--mk-brand-100);
-  border-radius: var(--mk-r-lg);
+  background: linear-gradient(90deg, var(--v4-accent-50), transparent);
+  border: 1px solid var(--v4-accent-100);
+  border-radius: var(--v4-r-lg);
   margin-bottom: 14px;
 }
 .v4-banner-bi {
   width: 36px;
   height: 36px;
   border-radius: 8px;
-  background: var(--mk-brand-500);
+  background: var(--v4-accent-500);
   color: #fff;
   display: flex;
   align-items: center;
@@ -1966,14 +2040,14 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-banner-bt { flex: 1; min-width: 0; }
 .v4-banner-bt b {
   display: block;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-size: 13px;
   font-weight: 600;
   margin-bottom: 1px;
 }
 .v4-banner-bt span {
   font-size: 12px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
 }
 .v4-banner-bact {
   display: flex;
@@ -1998,10 +2072,10 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-error {
   margin: 14px 28px 0;
   padding: 12px 16px;
-  background: var(--mk-danger-soft);
-  border: 1px solid var(--mk-danger-100);
-  border-radius: var(--mk-r-md);
-  color: var(--mk-danger-strong);
+  background: var(--v4-danger-50);
+  border: 1px solid var(--v4-danger-100);
+  border-radius: var(--v4-r-md);
+  color: var(--v4-danger-700);
   font-size: 13px;
 }
 
@@ -2009,7 +2083,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-loading {
   padding: 60px 28px;
   text-align: center;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-size: 14px;
 }
 
@@ -2023,12 +2097,12 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   gap: 18px;
   padding: 100px 28px 80px;
   text-align: center;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-inline-loader-caption {
   font-size: 14px;
   font-weight: 500;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   letter-spacing: 0.01em;
 }
 
@@ -2044,8 +2118,8 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   inset: 0;
   display: grid;
   place-items: center;
-  background: var(--mk-bg);
-  color: var(--mk-ink-900);
+  background: var(--v4-bg);
+  color: var(--v4-ink-900);
   z-index: 50;
   overflow: hidden;
 }
@@ -2074,13 +2148,13 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .bl-stage {
   font-size: 14px;
   font-weight: 500;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   letter-spacing: 0.01em;
 }
 
 .bl-subtitle {
   font-size: 12px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-top: -10px;
 }
 
@@ -2090,9 +2164,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 
 /* Aggregate strip + tools toolbar */
 .v4-projects-toolbar {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   margin-bottom: 14px;
   display: grid;
   grid-template-columns: 1fr auto;
@@ -2113,21 +2187,21 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   justify-content: center;
   padding: 6px 14px;
   min-width: 78px;
-  border-right: 1px solid var(--mk-line-soft);
+  border-right: 1px solid var(--v4-line-soft);
   text-align: center;
 }
 .v4-projects-agg-cell:last-child { border-right: 0; }
 .v4-projects-agg-n {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 18px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   line-height: 1;
   letter-spacing: -0.01em;
 }
 .v4-projects-agg-l {
   font-size: 9px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -2147,20 +2221,20 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   right: 8px;
   top: 50%;
   transform: translateY(-50%);
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
   border: 0;
   width: 18px;
   height: 18px;
   border-radius: 50%;
   font-size: 14px;
   line-height: 1;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
 }
-.v4-projects-search-clear:hover { color: var(--mk-ink-900); background: var(--mk-surface-3); }
+.v4-projects-search-clear:hover { color: var(--v4-ink-900); background: var(--v4-surface-3); }
 
 .v4-projects-sort {
   position: relative;
@@ -2169,9 +2243,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   box-shadow: 0 8px 24px rgba(11, 16, 32, 0.08);
   padding: 4px;
   min-width: 220px;
@@ -2185,25 +2259,25 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   border: 0;
   padding: 7px 10px;
   font-size: 13px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   text-align: left;
   border-radius: 4px;
   cursor: pointer;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   font-weight: 500;
 }
 .v4-projects-sort-menu button:hover,
 .v4-projects-sort-menu a:hover {
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-900);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
 }
 .v4-projects-sort-menu .is-active {
-  background: var(--mk-brand-50);
-  color: var(--mk-brand-700);
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
 }
 .v4-projects-sort-sep {
   height: 1px;
-  background: var(--mk-line-soft);
+  background: var(--v4-line-soft);
   margin: 4px 0;
 }
 
@@ -2216,14 +2290,14 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-projects-group-title {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   margin: 0 0 10px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
 .v4-projects-group-count {
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-weight: 500;
 }
 .v4-projects-grid {
@@ -2248,12 +2322,12 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-pcard--full .v4-pcard-client {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 500;
 }
 .v4-pcard-section {
   padding: 11px 16px;
-  border-top: 1px dashed var(--mk-line);
+  border-top: 1px dashed var(--v4-line);
   display: flex;
   flex-direction: column;
   gap: 9px;
@@ -2267,13 +2341,13 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   gap: 8px;
 }
-.v4-pcard--full .v4-pcard-finance-line b { color: var(--mk-ink-900); font-weight: 700; }
-.v4-pcard--full .v4-pcard-finance-sep { color: var(--mk-ink-400); }
+.v4-pcard--full .v4-pcard-finance-line b { color: var(--v4-ink-900); font-weight: 700; }
+.v4-pcard--full .v4-pcard-finance-sep { color: var(--v4-ink-400); }
 .v4-pcard-finance-bar { height: 5px; }
 
 /* ---------------------------------------------------------------------
@@ -2283,29 +2357,29 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   display: flex;
   flex-direction: column;
   gap: 4px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 .v4-budget-line {
   display: flex;
   align-items: baseline;
   gap: 6px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-budget-pct {
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-size: 10.5px;
 }
 .v4-budget-track { height: 5px; }
 .v4-budget-widget--no-cap .v4-budget-line {
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-style: italic;
   font-size: 10.5px;
 }
 .v4-budget-alert {
   font-size: 10px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   letter-spacing: 0.02em;
 }
 /* Pulse at >=80% so the operator's eye catches the bar even when the
@@ -2326,7 +2400,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-pcard-risk-chip {
   display: inline-flex;
   align-items: center;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9.5px;
   font-weight: 600;
   padding: 2px 7px;
@@ -2335,22 +2409,22 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   white-space: nowrap;
 }
 .v4-pcard-risk-chip--low {
-  background: var(--mk-success-soft);
-  color: var(--mk-success-strong);
+  background: var(--v4-success-50);
+  color: var(--v4-success-700);
 }
 .v4-pcard-risk-chip--medium {
-  background: var(--mk-warn-soft);
-  color: var(--mk-warn-strong);
+  background: var(--v4-warn-50);
+  color: var(--v4-warn-700);
 }
 .v4-pcard-risk-chip--high,
 .v4-pcard-risk-chip--critical {
-  background: var(--mk-danger-soft);
-  color: var(--mk-danger-strong);
+  background: var(--v4-danger-50);
+  color: var(--v4-danger-700);
 }
 
 /* Unlabeled-priority chip */
 .v4-pcard-pri--unlabeled {
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-style: italic;
 }
 
@@ -2360,8 +2434,8 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   font-weight: 700;
   margin-left: 2px;
 }
-.v4-trend--up { color: var(--mk-success-strong); }
-.v4-trend--down { color: var(--mk-danger-strong); }
+.v4-trend--up { color: var(--v4-success-700); }
+.v4-trend--down { color: var(--v4-danger-700); }
 
 /* Risk factors row */
 .v4-pcard-risk-factors {
@@ -2371,23 +2445,23 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-risk-factor {
   display: inline-flex;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 600;
   padding: 2px 8px;
   border-radius: 99px;
   letter-spacing: 0.01em;
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-600);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-600);
 }
 .v4-risk-factor--medium {
-  background: var(--mk-warn-soft);
-  color: var(--mk-warn-strong);
+  background: var(--v4-warn-50);
+  color: var(--v4-warn-700);
 }
 .v4-risk-factor--high,
 .v4-risk-factor--critical {
-  background: var(--mk-danger-soft);
-  color: var(--mk-danger-strong);
+  background: var(--v4-danger-50);
+  color: var(--v4-danger-700);
 }
 
 /* Heatmap section */
@@ -2399,27 +2473,27 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   background: transparent;
   border: 0;
   padding: 0;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   font-size: 12px;
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   cursor: pointer;
   text-align: left;
 }
-.v4-pcard-heat-toggle:hover { color: var(--mk-ink-900); }
+.v4-pcard-heat-toggle:hover { color: var(--v4-ink-900); }
 .v4-pcard-heat-arrow {
   display: inline-block;
   transition: transform 120ms;
   font-size: 10px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .v4-pcard-heat-arrow.is-open { transform: rotate(90deg); }
 .v4-pcard-heat-meta {
   margin-left: auto;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-weight: 500;
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-pcard-heat-grid {
   display: grid;
@@ -2444,24 +2518,24 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   border-radius: 4px;
   border: 0;
   background: transparent;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
 }
 .v4-pcard-menu-btn:hover {
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-900);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
 }
 .v4-pcard-menu-btn svg { width: 14px; height: 14px; }
 .v4-pcard-menu-list {
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   box-shadow: 0 8px 24px rgba(11, 16, 32, 0.08);
   padding: 4px;
   min-width: 200px;
@@ -2475,19 +2549,19 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   border: 0;
   padding: 7px 10px;
   font-size: 12.5px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   text-align: left;
   border-radius: 4px;
   cursor: pointer;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   font-weight: 500;
   text-decoration: none;
   display: block;
 }
 .v4-pcard-menu-list a:hover,
 .v4-pcard-menu-list button:hover {
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-900);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
 }
 
 /* ────────────────────────────────────────
@@ -2496,9 +2570,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 
 /* Hero card — adapts to running / idle / offline / loading */
 .v4-pl-hero {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   padding: 18px 22px;
   display: flex;
   align-items: center;
@@ -2511,8 +2585,8 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   overflow: hidden;
 }
 .v4-pl-hero--running {
-  background: linear-gradient(135deg, var(--mk-brand-50), var(--mk-paper));
-  border-color: var(--mk-brand-100);
+  background: linear-gradient(135deg, var(--v4-accent-50), var(--v4-paper));
+  border-color: var(--v4-accent-100);
 }
 .v4-pl-hero--running::before {
   content: '';
@@ -2522,16 +2596,16 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   pointer-events: none;
 }
 .v4-pl-hero--offline {
-  background: var(--mk-danger-soft);
-  border-color: var(--mk-danger-100);
+  background: var(--v4-danger-50);
+  border-color: var(--v4-danger-100);
   flex-direction: column;
   align-items: flex-start;
 }
 .v4-pl-hero--idle {
-  background: var(--mk-paper);
+  background: var(--v4-paper);
 }
 .v4-pl-hero--loading {
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
 }
 
 .v4-pl-hero-status {
@@ -2549,33 +2623,33 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   position: relative;
 }
 .v4-pl-hero-dot--running {
-  background: var(--mk-success);
+  background: var(--v4-success-500);
   box-shadow: 0 0 0 5px rgba(18, 183, 106, 0.18);
   animation: v4-pulse 1.5s ease-in-out infinite;
 }
 .v4-pl-hero-dot--idle {
-  background: var(--mk-ink-300);
+  background: var(--v4-ink-300);
 }
 .v4-pl-hero-dot--offline {
-  background: var(--mk-danger);
+  background: var(--v4-danger-500);
   box-shadow: 0 0 0 5px rgba(239, 68, 68, 0.16);
 }
 .v4-pl-hero-title {
   font-size: 18px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   letter-spacing: -0.01em;
   line-height: 1.2;
 }
 .v4-pl-hero-sub-inline {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 13px;
   font-weight: 500;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-pl-hero-sub {
   font-size: 13px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   margin-top: 4px;
   display: flex;
   align-items: center;
@@ -2583,17 +2657,17 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   flex-wrap: wrap;
 }
 .v4-pl-hero-num {
-  font-family: var(--mk-font-mono);
-  color: var(--mk-ink-900);
+  font-family: var(--v4-mono);
+  color: var(--v4-ink-900);
   font-weight: 700;
 }
-.v4-pl-sep { color: var(--mk-ink-300); margin: 0 4px; }
-.v4-pl-mono { font-family: var(--mk-font-mono); font-variant-numeric: tabular-nums; }
-.v4-pl-text-muted { color: var(--mk-ink-500); }
-.v4-pl-text-warn { color: var(--mk-warn-strong); }
-.v4-pl-text-danger { color: var(--mk-danger-strong); }
-.v4-pl-text-success { color: var(--mk-success-strong); }
-.v4-pl-cost { color: var(--mk-success-strong); font-weight: 600; }
+.v4-pl-sep { color: var(--v4-ink-300); margin: 0 4px; }
+.v4-pl-mono { font-family: var(--v4-mono); font-variant-numeric: tabular-nums; }
+.v4-pl-text-muted { color: var(--v4-ink-500); }
+.v4-pl-text-warn { color: var(--v4-warn-700); }
+.v4-pl-text-danger { color: var(--v4-danger-700); }
+.v4-pl-text-success { color: var(--v4-success-700); }
+.v4-pl-cost { color: var(--v4-success-700); font-weight: 600; }
 
 .v4-pl-hero-actions {
   display: flex;
@@ -2602,22 +2676,22 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   flex-shrink: 0;
 }
 .v4-pl-btn-start {
-  background: var(--mk-success);
-  border-color: var(--mk-success);
+  background: var(--v4-success-500);
+  border-color: var(--v4-success-500);
   color: #fff;
 }
 .v4-pl-btn-start:hover {
-  background: var(--mk-success-strong);
-  border-color: var(--mk-success-strong);
+  background: var(--v4-success-700);
+  border-color: var(--v4-success-700);
 }
 .v4-pl-btn-stop {
-  background: var(--mk-danger);
-  border-color: var(--mk-danger);
+  background: var(--v4-danger-500);
+  border-color: var(--v4-danger-500);
   color: #fff;
 }
 .v4-pl-btn-stop:hover {
-  background: var(--mk-danger-strong);
-  border-color: var(--mk-danger-strong);
+  background: var(--v4-danger-700);
+  border-color: var(--v4-danger-700);
   color: #fff;
 }
 .v4-pl-btn-stop:disabled {
@@ -2626,13 +2700,13 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 
 .v4-pl-hero-cmd {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-danger-100);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-danger-100);
+  border-radius: var(--v4-r-md);
   padding: 10px 14px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   margin: 0;
   white-space: pre-wrap;
   width: 100%;
@@ -2640,9 +2714,9 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 
 /* Config panel (expandable) */
 .v4-pl-config {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   padding: 14px 18px;
   margin-bottom: 14px;
 }
@@ -2663,33 +2737,33 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-pl-config-label--narrow { flex-shrink: 0; }
 .v4-pl-config-key {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-pl-input {
   height: 32px;
   padding: 0 10px;
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-sm);
-  background: var(--mk-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-sm);
+  background: var(--v4-paper);
   font: inherit;
   font-size: 13px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   outline: none;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   min-width: 200px;
 }
 .v4-pl-input--narrow { width: 60px; min-width: 0; text-align: center; padding: 0 6px; }
 .v4-pl-input:focus {
-  border-color: var(--mk-brand-500);
+  border-color: var(--v4-accent-500);
 }
 .v4-pl-input:disabled {
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-500);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-500);
   cursor: not-allowed;
 }
 .v4-pl-chip-row {
@@ -2704,26 +2778,26 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   font-size: 11px;
   font-weight: 600;
   border-radius: 99px;
-  border: 1px solid var(--mk-line);
+  border: 1px solid var(--v4-line);
   background: transparent;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   cursor: pointer;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   letter-spacing: 0.02em;
   transition: all 0.15s;
 }
 .v4-pl-label-chip:hover:not(:disabled) {
-  border-color: var(--mk-line-strong);
-  color: var(--mk-ink-700);
+  border-color: var(--v4-line-strong);
+  color: var(--v4-ink-700);
 }
 .v4-pl-label-chip:disabled {
   opacity: 0.45;
   cursor: not-allowed;
 }
 .v4-pl-cx-chip--active {
-  border-color: var(--mk-brand-500) !important;
-  background: var(--mk-brand-50) !important;
-  color: var(--mk-brand-700) !important;
+  border-color: var(--v4-accent-500) !important;
+  background: var(--v4-accent-50) !important;
+  color: var(--v4-accent-700) !important;
 }
 .v4-pl-config-classify {
   margin-left: auto;
@@ -2744,18 +2818,18 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   align-items: center;
   gap: 10px;
   padding: 8px 16px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .v4-pl-active-row:last-child { border-bottom: 0; }
 .v4-pl-active-num {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   min-width: 38px;
 }
 .v4-pl-active-title {
   flex: 1;
   font-size: 13px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2763,15 +2837,15 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-pl-active-status {
   font-size: 11px;
-  color: var(--mk-ink-500);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
   padding: 2px 7px;
-  border: 1px solid var(--mk-line);
+  border: 1px solid var(--v4-line);
   border-radius: 99px;
 }
 .v4-pl-active-timer {
   font-size: 11px;
-  color: var(--mk-brand-600);
+  color: var(--v4-accent-600);
   font-weight: 600;
   min-width: 48px;
   text-align: right;
@@ -2783,17 +2857,17 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   width: 100%;
   background: transparent;
   border: 0;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   text-align: left;
   cursor: pointer;
   font: inherit;
   color: inherit;
 }
 .v4-pl-active-row-btn:hover:not(:disabled) {
-  background: var(--mk-surface-2);
+  background: var(--v4-bg-soft);
 }
 .v4-pl-active-row-btn:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: -2px;
 }
 .v4-pl-active-row-btn:disabled {
@@ -2806,12 +2880,12 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-pl-ctx-section + .v4-pl-ctx-section {
   margin-top: 18px;
   padding-top: 16px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
 }
 .v4-pl-ctx-h {
   font-size: 12px;
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   margin: 0 0 10px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -2819,12 +2893,12 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-pl-ctx-status {
   font-size: 11px;
   font-weight: 500;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-left: 10px;
   padding: 2px 8px;
-  border: 1px solid var(--mk-line);
+  border: 1px solid var(--v4-line);
   border-radius: 99px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
 }
 .v4-pl-ctx-grid {
   display: grid;
@@ -2841,12 +2915,12 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 .v4-pl-ctx-lbl {
   font-size: 10px;
   text-transform: uppercase;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   letter-spacing: 0.04em;
 }
 .v4-pl-ctx-val,
 .v4-pl-ctx-grid a {
-  color: var(--mk-brand-600);
+  color: var(--v4-accent-600);
   text-decoration: none;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2863,7 +2937,7 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
 }
 .v4-pl-ctx-phase {
   padding: 6px 0;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .v4-pl-ctx-phase:last-child { border-bottom: 0; }
 .v4-pl-ctx-phase-head {
@@ -2878,24 +2952,24 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   border-radius: 50%;
   flex: 0 0 auto;
 }
-.v4-pl-ctx-phase-ok { background: var(--mk-success); }
-.v4-pl-ctx-phase-bad { background: var(--mk-danger); }
-.v4-pl-ctx-phase-run { background: var(--mk-brand-500); }
+.v4-pl-ctx-phase-ok { background: var(--v4-success-500); }
+.v4-pl-ctx-phase-bad { background: var(--v4-danger-500); }
+.v4-pl-ctx-phase-run { background: var(--v4-accent-500); }
 .v4-pl-ctx-phase-name {
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-pl-ctx-phase-status {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-pl-ctx-phase-event {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-pl-ctx-phase-meta {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-left: auto;
   white-space: nowrap;
 }
@@ -2903,8 +2977,8 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   margin-top: 4px;
   margin-left: 16px;
   font-size: 11px;
-  color: var(--mk-danger-strong);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-danger-700);
+  font-family: var(--v4-mono);
   word-break: break-word;
 }
 .v4-pl-ctx-artifacts {
@@ -2919,25 +2993,25 @@ body.v4 .v4-mono { font-family: var(--mk-font-mono); }
   align-items: baseline;
 }
 .v4-pl-ctx-art-key {
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   min-width: 100px;
   flex: 0 0 auto;
 }
 .v4-pl-ctx-art-val {
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   word-break: break-all;
   min-width: 0;
   flex: 1;
 }
-a.v4-pl-ctx-art-val { color: var(--mk-brand-600); text-decoration: none; }
+a.v4-pl-ctx-art-val { color: var(--v4-accent-600); text-decoration: none; }
 a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-pl-ctx-err {
   padding: 12px 16px;
-  background: var(--mk-surface-2);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-bg-soft);
+  border: 1px solid var(--v4-line);
   border-radius: 8px;
   font-size: 12px;
-  color: var(--mk-danger-strong);
+  color: var(--v4-danger-700);
 }
 
 /* Phase dots (stage progress) */
@@ -2956,7 +3030,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-pl-phase-link {
   width: 16px;
   height: 1px;
-  background: var(--mk-line);
+  background: var(--v4-line);
   display: inline-block;
   opacity: 0.6;
 }
@@ -2969,21 +3043,21 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-shrink: 0;
 }
 .v4-pl-phases--compact .v4-pl-dot { width: 8px; height: 8px; }
-.v4-pl-dot--ok { background: var(--mk-success); }
-.v4-pl-dot--fail { background: var(--mk-danger); }
+.v4-pl-dot--ok { background: var(--v4-success-500); }
+.v4-pl-dot--fail { background: var(--v4-danger-500); }
 .v4-pl-dot--running {
-  background: var(--mk-brand-500);
-  box-shadow: 0 0 6px var(--mk-brand-500);
+  background: var(--v4-accent-500);
+  box-shadow: 0 0 6px var(--v4-accent-500);
   animation: v4-pulse 1.5s ease-in-out infinite;
 }
-.v4-pl-dot--pending { background: var(--mk-ink-300); opacity: 0.6; }
-.v4-pl-phase-link.v4-pl-dot--ok { background: var(--mk-success); opacity: 0.5; }
-.v4-pl-phase-link.v4-pl-dot--fail { background: var(--mk-danger); opacity: 0.5; }
-.v4-pl-phase-link.v4-pl-dot--running { background: var(--mk-brand-500); opacity: 0.5; animation: none; box-shadow: none; }
-.v4-pl-phase-link.v4-pl-dot--pending { background: var(--mk-line); opacity: 0.6; }
+.v4-pl-dot--pending { background: var(--v4-ink-300); opacity: 0.6; }
+.v4-pl-phase-link.v4-pl-dot--ok { background: var(--v4-success-500); opacity: 0.5; }
+.v4-pl-phase-link.v4-pl-dot--fail { background: var(--v4-danger-500); opacity: 0.5; }
+.v4-pl-phase-link.v4-pl-dot--running { background: var(--v4-accent-500); opacity: 0.5; animation: none; box-shadow: none; }
+.v4-pl-phase-link.v4-pl-dot--pending { background: var(--v4-line); opacity: 0.6; }
 .v4-pl-phase-label {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   letter-spacing: 0.02em;
   white-space: nowrap;
 }
@@ -2996,9 +3070,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-shrink: 0;
   display: inline-block;
 }
-.v4-pl-risk-dot.v4-pl-risk--low { background: var(--mk-success); }
-.v4-pl-risk-dot.v4-pl-risk--medium { background: var(--mk-warn); }
-.v4-pl-risk-dot.v4-pl-risk--high { background: var(--mk-danger); }
+.v4-pl-risk-dot.v4-pl-risk--low { background: var(--v4-success-500); }
+.v4-pl-risk-dot.v4-pl-risk--medium { background: var(--v4-warn-500); }
+.v4-pl-risk-dot.v4-pl-risk--high { background: var(--v4-danger-500); }
 
 /* Generic badge style */
 .v4-pl-badge {
@@ -3009,7 +3083,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   padding: 2px 7px;
   border-radius: 99px;
   letter-spacing: 0.04em;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   white-space: nowrap;
 }
 .v4-pl-badge-sub {
@@ -3019,29 +3093,29 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   text-transform: none;
 }
 /* Risk badge variants */
-.v4-pl-risk--low { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-pl-risk--medium { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.v4-pl-risk--high { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
+.v4-pl-risk--low { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-pl-risk--medium { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-pl-risk--high { background: var(--v4-danger-50); color: var(--v4-danger-700); }
 /* Complexity badge variants */
-.v4-pl-cx--auto { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-pl-cx--assisted { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.v4-pl-cx--manual { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
+.v4-pl-cx--auto { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-pl-cx--assisted { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-pl-cx--manual { background: var(--v4-danger-50); color: var(--v4-danger-700); }
 /* Outcome badge variants */
-.v4-pl-outcome--clean { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-pl-outcome--followup { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.v4-pl-outcome--missed { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
+.v4-pl-outcome--clean { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-pl-outcome--followup { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-pl-outcome--missed { background: var(--v4-danger-50); color: var(--v4-danger-700); }
 /* Category badge variants */
-.v4-pl-cat--err { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
-.v4-pl-cat--warn { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.v4-pl-cat--neutral { background: var(--mk-surface-2); color: var(--mk-ink-600); }
+.v4-pl-cat--err { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-pl-cat--warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-pl-cat--neutral { background: var(--v4-surface-2); color: var(--v4-ink-600); }
 /* Status badge variants */
-.v4-pl-status--done { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-pl-status--needs { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
-.v4-pl-status--inprog { background: var(--mk-brand-50); color: var(--mk-brand-700); }
+.v4-pl-status--done { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-pl-status--needs { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-pl-status--inprog { background: var(--v4-accent-50); color: var(--v4-accent-700); }
 /* Verdict badges */
-.v4-pl-verdict--ok { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-pl-verdict--changes { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.v4-pl-verdict--partial { background: var(--mk-brand-50); color: var(--mk-brand-700); }
+.v4-pl-verdict--ok { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-pl-verdict--changes { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-pl-verdict--partial { background: var(--v4-accent-50); color: var(--v4-accent-700); }
 
 /* Results panel */
 .v4-pl-results-tools {
@@ -3054,19 +3128,19 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-pl-results { padding: 6px 0; }
 .v4-pl-result-row {
   padding: 8px 16px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   border-left: 3px solid transparent;
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 .v4-pl-result-row:last-child { border-bottom: 0; }
-.v4-pl-result--ok { border-left-color: var(--mk-success); }
-.v4-pl-result--warn { border-left-color: var(--mk-warn); background: rgba(247, 144, 9, 0.04); }
-.v4-pl-result--err { border-left-color: var(--mk-danger); background: rgba(239, 68, 68, 0.04); }
+.v4-pl-result--ok { border-left-color: var(--v4-success-500); }
+.v4-pl-result--warn { border-left-color: var(--v4-warn-500); background: rgba(247, 144, 9, 0.04); }
+.v4-pl-result--err { border-left-color: var(--v4-danger-500); background: rgba(239, 68, 68, 0.04); }
 /* Issue #217: in-progress non-terminal statuses (pr_open, in_review, retry, …)
    share the accent palette used by the in-progress status badge. */
-.v4-pl-result--inprog { border-left-color: var(--mk-brand-500); }
+.v4-pl-result--inprog { border-left-color: var(--v4-accent-500); }
 .v4-pl-result-main {
   display: flex;
   align-items: center;
@@ -3075,9 +3149,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   row-gap: 6px;
 }
 .v4-pl-result-num {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12px;
-  color: var(--mk-brand-600);
+  color: var(--v4-accent-600);
   background: transparent;
   border: 0;
   padding: 0;
@@ -3087,43 +3161,43 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   min-width: 38px;
   text-align: left;
 }
-.v4-pl-result-num:hover { text-decoration: underline; color: var(--mk-brand-700); }
-.v4-pl-result-cost { color: var(--mk-success-strong); font-weight: 600; font-size: 11px; }
+.v4-pl-result-num:hover { text-decoration: underline; color: var(--v4-accent-700); }
+.v4-pl-result-cost { color: var(--v4-success-700); font-weight: 600; font-size: 11px; }
 .v4-pl-result-duration { font-size: 11px; }
 .v4-pl-result-spacer { flex: 1; }
 .v4-pl-result-pr {
   font-size: 11px;
   font-weight: 600;
-  color: var(--mk-brand-600);
+  color: var(--v4-accent-600);
   text-decoration: none;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
 }
-.v4-pl-result-pr:hover { text-decoration: underline; color: var(--mk-brand-700); }
+.v4-pl-result-pr:hover { text-decoration: underline; color: var(--v4-accent-700); }
 .v4-pl-why-btn { font-size: 11px; padding: 0 4px; }
 .v4-pl-why {
   margin-top: 4px;
   padding: 8px 12px;
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
-.v4-pl-why-summary { color: var(--mk-ink-800); line-height: 1.4; }
+.v4-pl-why-summary { color: var(--v4-ink-800); line-height: 1.4; }
 .v4-pl-why-error {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-danger-strong);
+  color: var(--v4-danger-700);
 }
 .v4-pl-why-key {
   font-weight: 700;
 }
 .v4-pl-why-meta {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-pl-run-sep {
   display: flex;
@@ -3134,13 +3208,13 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-pl-run-sep-line {
   flex: 1;
   height: 1px;
-  background: var(--mk-line-soft);
+  background: var(--v4-line-soft);
 }
 .v4-pl-run-sep-label {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 600;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   white-space: nowrap;
@@ -3164,33 +3238,33 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-size: 12px;
 }
 .v4-pl-chart-row--today .v4-pl-chart-day {
-  color: var(--mk-brand-700);
+  color: var(--v4-accent-700);
   font-weight: 600;
 }
 .v4-pl-chart-day {
   font-size: 11px;
-  color: var(--mk-ink-500);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
 }
 .v4-pl-chart-track {
   height: 14px;
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
   border-radius: 4px;
   overflow: hidden;
 }
 .v4-pl-chart-fill {
   height: 100%;
-  background: var(--mk-brand-500);
+  background: var(--v4-accent-500);
   border-radius: 4px;
   transition: width 200ms;
 }
 .v4-pl-chart-count {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   text-align: right;
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
-.v4-pl-chart-count--zero { color: var(--mk-ink-400); }
+.v4-pl-chart-count--zero { color: var(--v4-ink-400); }
 
 /* Complexity panel */
 .v4-pl-cx-grid {
@@ -3205,38 +3279,38 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 4px;
   padding: 8px;
-  border-right: 1px solid var(--mk-line-soft);
+  border-right: 1px solid var(--v4-line-soft);
 }
 .v4-pl-cx-cell:last-child { border-right: 0; }
 .v4-pl-cx-n {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 22px;
   font-weight: 700;
   line-height: 1;
 }
 .v4-pl-cx-l {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 500;
 }
 .v4-pl-cx-pct {
-  font-family: var(--mk-font-mono);
-  color: var(--mk-ink-400);
+  font-family: var(--v4-mono);
+  color: var(--v4-ink-400);
   margin-left: 4px;
 }
 .v4-pl-models {
   padding: 0 18px 14px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   margin-top: 8px;
   padding-top: 12px;
 }
 .v4-pl-models-l {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-bottom: 8px;
 }
 .v4-pl-models-list {
@@ -3245,17 +3319,17 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-wrap: wrap;
 }
 .v4-pl-model-chip {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   padding: 3px 8px;
   border-radius: 99px;
-  background: var(--mk-surface-2);
-  border: 1px solid var(--mk-line-soft);
-  color: var(--mk-ink-700);
+  background: var(--v4-surface-2);
+  border: 1px solid var(--v4-line-soft);
+  color: var(--v4-ink-700);
 }
 .v4-pl-model-count {
   margin-left: 6px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-weight: 400;
 }
 
@@ -3280,9 +3354,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   padding: 20px;
 }
 .v4-modal {
-  background: var(--mk-paper);
-  border-radius: var(--mk-r-lg);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border-radius: var(--v4-r-lg);
+  border: 1px solid var(--v4-line);
   max-width: 480px;
   width: 100%;
   max-height: 90vh;
@@ -3295,19 +3369,19 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .v4-modal-t {
   margin: 0;
   font-size: 15px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-modal-close {
   background: transparent;
   border: 0;
   font-size: 22px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   cursor: pointer;
   padding: 0;
   width: 28px;
@@ -3318,7 +3392,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   border-radius: 4px;
   line-height: 1;
 }
-.v4-modal-close:hover { background: var(--mk-surface-2); color: var(--mk-ink-900); }
+.v4-modal-close:hover { background: var(--v4-surface-2); color: var(--v4-ink-900); }
 .v4-modal-body {
   padding: 20px;
   overflow-y: auto;
@@ -3326,7 +3400,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-modal-footer {
   padding: 14px 20px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   display: flex;
   justify-content: flex-end;
   gap: 8px;
@@ -3341,13 +3415,13 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-pl-classify-current {
   font-size: 13px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   text-align: center;
 }
 .v4-pl-classify-meta {
   font-size: 12px;
-  color: var(--mk-ink-500);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
 }
 .v4-pl-classify-breakdown {
   font-size: 12px;
@@ -3356,7 +3430,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   gap: 4px;
   flex-wrap: wrap;
   justify-content: center;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
 }
 .v4-pl-classify-grid {
   display: grid;
@@ -3367,12 +3441,12 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-pl-classify-cell-l {
   font-size: 12px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-top: 4px;
 }
 .v4-pl-classify-summary {
   text-align: center;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   font-size: 13px;
   margin: 0;
 }
@@ -3397,27 +3471,27 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   gap: 10px;
 }
 .v4-ms-group-title {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   margin: 0;
   padding: 4px 6px 6px;
-  border-bottom: 1px dashed var(--mk-line);
+  border-bottom: 1px dashed var(--v4-line);
   display: flex;
   align-items: center;
   gap: 6px;
 }
 .v4-ms-group-count {
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-weight: 500;
 }
-.v4-ms-group-title--overdue { color: var(--mk-danger-strong); border-bottom-color: var(--mk-danger-100); }
-.v4-ms-group-title--week { color: var(--mk-warn-strong); border-bottom-color: var(--mk-warn-100); }
-.v4-ms-group-title--month { color: var(--mk-brand-700); }
-.v4-ms-group-title--noeta { color: var(--mk-ink-500); }
+.v4-ms-group-title--overdue { color: var(--v4-danger-700); border-bottom-color: var(--v4-danger-100); }
+.v4-ms-group-title--week { color: var(--v4-warn-700); border-bottom-color: var(--v4-warn-100); }
+.v4-ms-group-title--month { color: var(--v4-accent-700); }
+.v4-ms-group-title--noeta { color: var(--v4-ink-500); }
 .v4-ms-grid-full {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -3426,9 +3500,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 
 /* Full-size milestone card */
 .v4-mscard-full {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   padding: 0;
   position: relative;
   overflow: hidden;
@@ -3444,10 +3518,10 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   width: 3px;
   background: transparent;
 }
-.v4-mscard-full--overdue::before { background: var(--mk-danger); }
-.v4-mscard-full--warn::before { background: var(--mk-warn); }
-.v4-mscard-full--soon::before { background: var(--mk-brand-500); }
-.v4-mscard-full--done::before { background: var(--mk-success); }
+.v4-mscard-full--overdue::before { background: var(--v4-danger-500); }
+.v4-mscard-full--warn::before { background: var(--v4-warn-500); }
+.v4-mscard-full--soon::before { background: var(--v4-accent-500); }
+.v4-mscard-full--done::before { background: var(--v4-success-500); }
 
 .v4-mscard-full-h {
   padding: 12px 14px 10px 17px;
@@ -3456,7 +3530,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-direction: column;
   gap: 6px;
 }
-.v4-mscard-full-h:hover { background: var(--mk-surface-2); }
+.v4-mscard-full-h:hover { background: var(--v4-surface-2); }
 .v4-mscard-full-titlerow {
   display: flex;
   justify-content: space-between;
@@ -3470,16 +3544,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   min-width: 0;
 }
 .v4-mscard-full-repo {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-mscard-full-arrow {
   font-size: 10px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   display: inline-block;
   transition: transform 120ms;
   flex-shrink: 0;
@@ -3495,7 +3569,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-mscard-full-title {
   font-size: 14px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   line-height: 1.35;
   letter-spacing: -0.01em;
   min-width: 0;
@@ -3505,16 +3579,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   text-decoration: none;
 }
 .v4-mscard-full-titlelink:hover {
-  color: var(--mk-brand-700);
+  color: var(--v4-accent-700);
 }
 .v4-mscard-full-check {
-  color: var(--mk-success-strong);
+  color: var(--v4-success-700);
   font-weight: 700;
   margin-right: 2px;
 }
 .v4-mscard-full-desc {
   font-size: 12px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   line-height: 1.45;
   margin-top: 2px;
 }
@@ -3528,14 +3602,14 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 10px;
   padding: 8px 14px 12px 17px;
-  border-top: 1px dashed var(--mk-line);
+  border-top: 1px dashed var(--v4-line);
 }
 .v4-mscard-full-track { flex: 1; }
 .v4-mscard-full-pct {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   min-width: 88px;
   text-align: right;
 }
@@ -3549,19 +3623,19 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   padding: 2px 7px;
   border-radius: 99px;
   letter-spacing: 0.04em;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   white-space: nowrap;
 }
-.v4-ms-badge--overdue { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
-.v4-ms-badge--warn { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.v4-ms-badge--info { background: var(--mk-brand-50); color: var(--mk-brand-700); }
-.v4-ms-badge--neutral { background: var(--mk-surface-2); color: var(--mk-ink-600); }
-.v4-ms-badge--done { background: var(--mk-success-soft); color: var(--mk-success-strong); }
+.v4-ms-badge--overdue { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-ms-badge--warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-ms-badge--info { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.v4-ms-badge--neutral { background: var(--v4-surface-2); color: var(--v4-ink-600); }
+.v4-ms-badge--done { background: var(--v4-success-50); color: var(--v4-success-700); }
 
 /* Issue list inside expanded card */
 .v4-mscard-full-issues {
-  border-top: 1px solid var(--mk-line-soft);
-  background: var(--mk-surface-2);
+  border-top: 1px solid var(--v4-line-soft);
+  background: var(--v4-surface-2);
   padding: 6px 0;
   display: flex;
   flex-direction: column;
@@ -3569,7 +3643,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-mscard-full-issues--empty {
   padding: 14px;
   text-align: center;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-size: 12px;
 }
 
@@ -3577,28 +3651,28 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
    TRANSCRIPTS VIEW
    ──────────────────────────────────────── */
 
-.v4-tpc-text-muted { color: var(--mk-ink-500); }
+.v4-tpc-text-muted { color: var(--v4-ink-500); }
 
 /* Upload zone */
 .v4-tpc-upload {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   padding: 18px;
   margin-bottom: 14px;
 }
 .v4-tpc-dropzone {
-  border: 2px dashed var(--mk-line-strong);
-  border-radius: var(--mk-r-md);
+  border: 2px dashed var(--v4-line-strong);
+  border-radius: var(--v4-r-md);
   padding: 28px 18px;
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
   text-align: center;
   cursor: pointer;
   transition: border-color 120ms, background 120ms;
 }
 .v4-tpc-dropzone.is-active {
-  border-color: var(--mk-brand-500);
-  background: var(--mk-brand-50);
+  border-color: var(--v4-accent-500);
+  background: var(--v4-accent-50);
 }
 .v4-tpc-dropzone.has-files {
   text-align: left;
@@ -3611,23 +3685,23 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-direction: column;
   align-items: center;
   gap: 8px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-tpc-drop-placeholder svg {
   width: 36px;
   height: 36px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .v4-tpc-drop-placeholder p {
   margin: 0;
   font-size: 14px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   font-weight: 500;
 }
 .v4-tpc-drop-hint {
   font-size: 11px;
-  color: var(--mk-ink-500);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
 }
 .v4-tpc-file-list {
   display: flex;
@@ -3639,9 +3713,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 8px;
   padding: 6px 10px;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line-soft);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line-soft);
+  border-radius: var(--v4-r-sm);
   font-size: 13px;
 }
 .v4-tpc-file-badge {
@@ -3654,20 +3728,20 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-size: 12px;
   flex-shrink: 0;
 }
-.v4-tpc-file-badge--audio { background: var(--mk-brand-50); }
-.v4-tpc-file-badge--text { background: var(--mk-surface-3); }
+.v4-tpc-file-badge--audio { background: var(--v4-accent-50); }
+.v4-tpc-file-badge--text { background: var(--v4-surface-3); }
 .v4-tpc-file-name {
   flex: 1;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
 }
 .v4-tpc-file-size {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   flex-shrink: 0;
 }
 .v4-tpc-file-remove {
@@ -3675,7 +3749,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   height: 22px;
   border: 0;
   background: transparent;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   cursor: pointer;
   font-size: 16px;
   border-radius: 4px;
@@ -3683,8 +3757,8 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   line-height: 1;
 }
 .v4-tpc-file-remove:hover {
-  background: var(--mk-danger-soft);
-  color: var(--mk-danger-strong);
+  background: var(--v4-danger-50);
+  color: var(--v4-danger-700);
 }
 .v4-tpc-file-list-foot {
   display: flex;
@@ -3711,12 +3785,12 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   border: 0;
 }
 .v4-tpc-control-key {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-tpc-submit { margin-left: auto; }
 
@@ -3731,7 +3805,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-tpc-progress-pct {
   font-size: 12px;
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   min-width: 40px;
   text-align: right;
 }
@@ -3749,23 +3823,23 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-size: 12px;
 }
 .v4-tpc-step-label {
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   letter-spacing: 0.02em;
   font-weight: 500;
 }
-.v4-tpc-step-label.is-active { color: var(--mk-brand-700); font-weight: 600; }
-.v4-tpc-step-label.is-done { color: var(--mk-ink-700); }
+.v4-tpc-step-label.is-active { color: var(--v4-accent-700); font-weight: 600; }
+.v4-tpc-step-label.is-done { color: var(--v4-ink-700); }
 .v4-tpc-step-detail {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-left: 4px;
 }
 .v4-tpc-progress-stats {
   display: flex;
   gap: 18px;
   padding: 10px 18px 14px;
-  border-top: 1px dashed var(--mk-line);
+  border-top: 1px dashed var(--v4-line);
   flex-wrap: wrap;
 }
 .v4-tpc-progress-stat {
@@ -3773,22 +3847,22 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 6px;
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
-.v4-tpc-progress-stat svg { width: 14px; height: 14px; color: var(--mk-ink-400); }
-.v4-tpc-progress-stat b { color: var(--mk-ink-900); font-weight: 600; font-family: var(--mk-font-mono); }
+.v4-tpc-progress-stat svg { width: 14px; height: 14px; color: var(--v4-ink-400); }
+.v4-tpc-progress-stat b { color: var(--v4-ink-900); font-weight: 600; font-family: var(--v4-mono); }
 .v4-tpc-progress-error {
   margin: 0 18px 14px;
   padding: 12px 14px;
-  background: var(--mk-danger-soft);
-  border: 1px solid var(--mk-danger-100);
-  border-radius: var(--mk-r-md);
-  color: var(--mk-danger-strong);
+  background: var(--v4-danger-50);
+  border: 1px solid var(--v4-danger-100);
+  border-radius: var(--v4-r-md);
+  color: var(--v4-danger-700);
 }
 .v4-tpc-progress-error--soft {
-  background: var(--mk-warn-soft);
-  border-color: var(--mk-warn-100);
-  color: var(--mk-warn-strong);
+  background: var(--v4-warn-50);
+  border-color: var(--v4-warn-100);
+  color: var(--v4-warn-700);
 }
 .v4-tpc-progress-error p { margin: 0 0 8px; font-size: 13px; }
 .v4-tpc-progress-error p:last-of-type { margin-bottom: 12px; }
@@ -3807,7 +3881,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   gap: 10px;
   padding: 6px 18px;
   font-size: 12px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .v4-tpc-batch-row:last-child { border-bottom: 0; }
 .v4-tpc-batch-icon {
@@ -3820,37 +3894,37 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-size: 11px;
   font-weight: 700;
   flex-shrink: 0;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
 }
-.v4-tpc-batch-icon--pending { background: var(--mk-surface-3); color: var(--mk-ink-500); }
-.v4-tpc-batch-icon--uploading { background: var(--mk-brand-50); color: var(--mk-brand-700); }
+.v4-tpc-batch-icon--pending { background: var(--v4-surface-3); color: var(--v4-ink-500); }
+.v4-tpc-batch-icon--uploading { background: var(--v4-accent-50); color: var(--v4-accent-700); }
 .v4-tpc-batch-icon--processing {
-  background: var(--mk-brand-50);
-  color: var(--mk-brand-700);
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
   animation: v4-spin 1.5s linear infinite;
 }
-.v4-tpc-batch-icon--done { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-tpc-batch-icon--error { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
+.v4-tpc-batch-icon--done { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-tpc-batch-icon--error { background: var(--v4-danger-50); color: var(--v4-danger-700); }
 .v4-tpc-batch-name {
   flex: 1;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
 }
 .v4-tpc-batch-status {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   flex-shrink: 0;
   max-width: 320px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.v4-tpc-batch-status--done { color: var(--mk-success-strong); }
-.v4-tpc-batch-status--error { color: var(--mk-danger-strong); }
+.v4-tpc-batch-status--done { color: var(--v4-success-700); }
+.v4-tpc-batch-status--error { color: var(--v4-danger-700); }
 
 /* Brief panel */
 .v4-tpc-brief-panel { margin-bottom: 14px; }
@@ -3871,18 +3945,18 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-wrap: wrap;
 }
 .v4-tpc-counter {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 600;
   padding: 3px 10px;
   border-radius: 99px;
 }
-.v4-tpc-counter--ok { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-tpc-counter--warn { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.v4-tpc-counter--danger { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
+.v4-tpc-counter--ok { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-tpc-counter--warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-tpc-counter--danger { background: var(--v4-danger-50); color: var(--v4-danger-700); }
 
 .v4-tpc-quality-chip {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 700;
   padding: 3px 10px;
@@ -3892,15 +3966,15 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-tpc-quality-chip--static { cursor: default; }
 .v4-tpc-quality-chip--sm { padding: 2px 7px; font-size: 10px; }
-.v4-tpc-quality--pass { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-tpc-quality--warn { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
-.v4-tpc-quality--review { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
+.v4-tpc-quality--pass { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-tpc-quality--warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
+.v4-tpc-quality--review { background: var(--v4-danger-50); color: var(--v4-danger-700); }
 
 .v4-tpc-quality-report {
   margin: 8px 18px;
-  background: var(--mk-surface-2);
-  border: 1px solid var(--mk-line-soft);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-surface-2);
+  border: 1px solid var(--v4-line-soft);
+  border-radius: var(--v4-r-md);
   padding: 12px;
 }
 .v4-tpc-quality-report-h {
@@ -3912,11 +3986,11 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-tpc-quality-report-t {
   font-size: 12px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-tpc-quality-report-score {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-tpc-quality-checks {
   list-style: none;
@@ -3937,21 +4011,21 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-weight: 700;
   text-align: center;
 }
-.v4-tpc-quality-check--pass .v4-tpc-quality-check-icon { color: var(--mk-success-strong); }
-.v4-tpc-quality-check--warning .v4-tpc-quality-check-icon { color: var(--mk-warn-strong); }
-.v4-tpc-quality-check--fail .v4-tpc-quality-check-icon { color: var(--mk-danger-strong); }
-.v4-tpc-quality-check-name { font-weight: 600; color: var(--mk-ink-700); }
-.v4-tpc-quality-check-msg { color: var(--mk-ink-600); }
+.v4-tpc-quality-check--pass .v4-tpc-quality-check-icon { color: var(--v4-success-700); }
+.v4-tpc-quality-check--warning .v4-tpc-quality-check-icon { color: var(--v4-warn-700); }
+.v4-tpc-quality-check--fail .v4-tpc-quality-check-icon { color: var(--v4-danger-700); }
+.v4-tpc-quality-check-name { font-weight: 600; color: var(--v4-ink-700); }
+.v4-tpc-quality-check-msg { color: var(--v4-ink-600); }
 
 .v4-tpc-brief-content {
   padding: 8px 24px 18px;
   font-size: 13px;
   line-height: 1.6;
-  color: var(--mk-ink-800);
+  color: var(--v4-ink-800);
 }
 
 .v4-tpc-accordion {
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   padding: 0 18px;
 }
 .v4-tpc-accordion-toggle {
@@ -3963,17 +4037,17 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   padding: 12px 0;
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   cursor: pointer;
   width: 100%;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   text-align: left;
 }
-.v4-tpc-accordion-toggle:hover { color: var(--mk-ink-900); }
+.v4-tpc-accordion-toggle:hover { color: var(--v4-ink-900); }
 .v4-tpc-accordion-arrow {
   display: inline-block;
   font-size: 10px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   transition: transform 120ms;
 }
 .v4-tpc-accordion-arrow.is-open { transform: rotate(90deg); }
@@ -3981,7 +4055,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   padding: 4px 6px 18px;
   font-size: 13px;
   line-height: 1.6;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 
 /* Editor */
@@ -3997,14 +4071,14 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-tpc-editor-dirty {
   font-size: 11px;
-  color: var(--mk-warn-strong);
+  color: var(--v4-warn-700);
 }
 .v4-tpc-editor-panes {
   display: grid;
   height: 540px;
   gap: 1px;
-  background: var(--mk-line-soft);
-  border-top: 1px solid var(--mk-line-soft);
+  background: var(--v4-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
 }
 .v4-tpc-editor-panes--split { grid-template-columns: 1fr 1fr; }
 .v4-tpc-editor-panes--edit { grid-template-columns: 1fr; }
@@ -4012,23 +4086,23 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-tpc-editor-textarea {
   border: 0;
   padding: 14px 18px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 13px;
   line-height: 1.55;
-  background: var(--mk-paper);
-  color: var(--mk-ink-900);
+  background: var(--v4-paper);
+  color: var(--v4-ink-900);
   resize: none;
   outline: none;
   width: 100%;
   height: 100%;
 }
 .v4-tpc-editor-preview {
-  background: var(--mk-paper);
+  background: var(--v4-paper);
   padding: 14px 18px;
   overflow-y: auto;
   font-size: 13px;
   line-height: 1.6;
-  color: var(--mk-ink-800);
+  color: var(--v4-ink-800);
 }
 
 /* History */
@@ -4061,16 +4135,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   gap: 10px;
   align-items: center;
   padding: 8px 18px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   font-size: 12px;
 }
 .v4-tpc-history-row:last-child { border-bottom: 0; }
-.v4-tpc-history-row.is-active { background: var(--mk-brand-50); }
+.v4-tpc-history-row.is-active { background: var(--v4-accent-50); }
 .v4-tpc-history-cell { min-width: 0; }
-.v4-tpc-history-date { font-size: 11px; color: var(--mk-ink-500); }
-.v4-tpc-history-project { color: var(--mk-ink-700); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.v4-tpc-history-file { color: var(--mk-ink-900); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.v4-tpc-history-model { font-size: 11px; color: var(--mk-ink-700); }
+.v4-tpc-history-date { font-size: 11px; color: var(--v4-ink-500); }
+.v4-tpc-history-project { color: var(--v4-ink-700); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v4-tpc-history-file { color: var(--v4-ink-900); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v4-tpc-history-model { font-size: 11px; color: var(--v4-ink-700); }
 .v4-tpc-history-actions {
   display: flex;
   gap: 6px;
@@ -4080,22 +4154,22 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 600;
   padding: 2px 8px;
   border-radius: 99px;
   white-space: nowrap;
 }
-.v4-tpc-status--done { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-tpc-status--active { background: var(--mk-brand-50); color: var(--mk-brand-700); }
-.v4-tpc-status--err { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
+.v4-tpc-status--done { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-tpc-status--active { background: var(--v4-accent-50); color: var(--v4-accent-700); }
+.v4-tpc-status--err { background: var(--v4-danger-50); color: var(--v4-danger-700); }
 .v4-tpc-status-pulse {
   display: inline-block;
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--mk-brand-500);
+  background: var(--v4-accent-500);
   animation: v4-pulse 1.5s ease-in-out infinite;
 }
 .v4-tpc-btn-icon {
@@ -4109,8 +4183,8 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 /* ────────────────────────────────────────
    QUALITY (Quality Dashboard)
    ──────────────────────────────────────── */
-.v4-qa-text-muted { color: var(--mk-ink-500); }
-.v4-qa-text-warn { color: var(--mk-warn-strong); }
+.v4-qa-text-muted { color: var(--v4-ink-500); }
+.v4-qa-text-warn { color: var(--v4-warn-700); }
 
 /* — Hero — */
 .v4-qa-hero {
@@ -4119,16 +4193,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 16px;
   flex-wrap: wrap;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   padding: 18px 22px;
   margin-bottom: 14px;
 }
-.v4-qa-hero--ok { border-left: 4px solid var(--mk-success); }
-.v4-qa-hero--warn { border-left: 4px solid var(--mk-warn); }
-.v4-qa-hero--danger { border-left: 4px solid var(--mk-danger); }
-.v4-qa-hero--unknown { border-left: 4px solid var(--mk-ink-300); }
+.v4-qa-hero--ok { border-left: 4px solid var(--v4-success-500); }
+.v4-qa-hero--warn { border-left: 4px solid var(--v4-warn-500); }
+.v4-qa-hero--danger { border-left: 4px solid var(--v4-danger-500); }
+.v4-qa-hero--unknown { border-left: 4px solid var(--v4-ink-300); }
 
 .v4-qa-hero-status {
   display: flex;
@@ -4142,14 +4216,14 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   border-radius: 50%;
   flex-shrink: 0;
 }
-.v4-qa-hero-dot--ok { background: var(--mk-success); box-shadow: 0 0 0 4px var(--mk-success-soft); }
-.v4-qa-hero-dot--warn { background: var(--mk-warn); box-shadow: 0 0 0 4px var(--mk-warn-soft); }
+.v4-qa-hero-dot--ok { background: var(--v4-success-500); box-shadow: 0 0 0 4px var(--v4-success-50); }
+.v4-qa-hero-dot--warn { background: var(--v4-warn-500); box-shadow: 0 0 0 4px var(--v4-warn-50); }
 .v4-qa-hero-dot--danger {
-  background: var(--mk-danger);
-  box-shadow: 0 0 0 4px var(--mk-danger-soft);
+  background: var(--v4-danger-500);
+  box-shadow: 0 0 0 4px var(--v4-danger-50);
   animation: v4-qa-pulse 1.6s ease-in-out infinite;
 }
-.v4-qa-hero-dot--unknown { background: var(--mk-ink-300); }
+.v4-qa-hero-dot--unknown { background: var(--v4-ink-300); }
 @keyframes v4-qa-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.55; }
@@ -4158,19 +4232,19 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-qa-hero-title {
   font-size: 16px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   margin-bottom: 4px;
 }
 .v4-qa-hero-sub {
   font-size: 13px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
   align-items: center;
 }
-.v4-qa-hero-sub b { color: var(--mk-ink-900); font-weight: 600; }
-.v4-qa-sep { color: var(--mk-ink-300); margin: 0 4px; }
+.v4-qa-hero-sub b { color: var(--v4-ink-900); font-weight: 600; }
+.v4-qa-sep { color: var(--v4-ink-300); margin: 0 4px; }
 .v4-qa-hero-actions {
   display: flex;
   gap: 8px;
@@ -4186,20 +4260,20 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   margin-bottom: 14px;
 }
 .v4-qa-kpi {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   padding: 14px 16px;
   display: flex;
   flex-direction: column;
   gap: 6px;
   min-width: 0;
 }
-.v4-qa-kpi--ok { border-top: 3px solid var(--mk-success); }
-.v4-qa-kpi--warn { border-top: 3px solid var(--mk-warn); }
-.v4-qa-kpi--danger { border-top: 3px solid var(--mk-danger); }
+.v4-qa-kpi--ok { border-top: 3px solid var(--v4-success-500); }
+.v4-qa-kpi--warn { border-top: 3px solid var(--v4-warn-500); }
+.v4-qa-kpi--danger { border-top: 3px solid var(--v4-danger-500); }
 .v4-qa-kpi--unknown,
-.v4-qa-kpi--neutral { border-top: 3px solid var(--mk-line); }
+.v4-qa-kpi--neutral { border-top: 3px solid var(--v4-line); }
 
 .v4-qa-kpi-h {
   display: flex;
@@ -4212,7 +4286,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -4223,16 +4297,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-weight: 700;
 }
 .v4-qa-kpi-val {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-variant-numeric: tabular-nums;
   font-size: 24px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   line-height: 1;
 }
 .v4-qa-kpi-sub {
   font-size: 11px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .v4-qa-kpi-foot {
   display: flex;
@@ -4244,14 +4318,14 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-qa-spark { width: 88px; height: 24px; flex-shrink: 0; }
 .v4-qa-spark-empty {
   font-size: 10px;
-  color: var(--mk-ink-300);
+  color: var(--v4-ink-300);
   font-style: italic;
 }
 .v4-qa-kpi-delta {
   font-size: 11px;
   font-weight: 600;
 }
-.v4-qa-kpi-delta--mute { color: var(--mk-ink-400); font-weight: 400; }
+.v4-qa-kpi-delta--mute { color: var(--v4-ink-400); font-weight: 400; }
 
 /* — Trends chart — */
 .v4-qa-trends-body { padding: 16px 18px; }
@@ -4277,17 +4351,17 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 6px;
   padding: 4px 10px;
-  border: 1px solid var(--mk-line-strong);
-  background: var(--mk-paper);
+  border: 1px solid var(--v4-line-strong);
+  background: var(--v4-paper);
   border-radius: 16px;
   font-size: 12px;
   font-weight: 500;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   cursor: pointer;
   transition: all 100ms;
 }
-.v4-qa-metric-btn:hover { background: var(--mk-surface-2); }
-.v4-qa-metric-btn.is-active { background: var(--mk-paper); }
+.v4-qa-metric-btn:hover { background: var(--v4-surface-2); }
+.v4-qa-metric-btn.is-active { background: var(--v4-paper); }
 .v4-qa-metric-dot {
   width: 8px;
   height: 8px;
@@ -4297,15 +4371,15 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-qa-svg {
   width: 100%;
   height: auto;
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-md);
   padding: 8px 4px;
 }
-.v4-qa-grid-line { stroke: var(--mk-line); stroke-width: 1; stroke-dasharray: 2 4; }
+.v4-qa-grid-line { stroke: var(--v4-line); stroke-width: 1; stroke-dasharray: 2 4; }
 .v4-qa-y-label, .v4-qa-x-label {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
-  fill: var(--mk-ink-400);
+  fill: var(--v4-ink-400);
   text-anchor: end;
 }
 .v4-qa-x-label { text-anchor: middle; }
@@ -4322,7 +4396,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-weight: 600;
   border-radius: 12px;
   border: 1px solid;
-  background: var(--mk-paper);
+  background: var(--v4-paper);
 }
 
 /* — Findings/Errors bars — */
@@ -4340,7 +4414,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-qa-bar-label {
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   font-weight: 500;
   white-space: nowrap;
   overflow: hidden;
@@ -4348,7 +4422,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-qa-bar-track {
   height: 8px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -4360,7 +4434,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-qa-bar-value {
   font-size: 12px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   text-align: right;
 }
 
@@ -4370,13 +4444,13 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   user-select: none;
 }
 .v4-qa-config-h:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: -2px;
 }
 .v4-qa-arrow {
   display: inline-block;
   width: 10px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-size: 11px;
 }
 .v4-qa-config-summary {
@@ -4405,24 +4479,24 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 600;
 }
 .v4-qa-config-value {
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-weight: 700;
   text-transform: none;
   letter-spacing: 0;
 }
 .v4-qa-config-hint {
   font-size: 11px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   line-height: 1.4;
 }
 .v4-qa-slider {
   width: 100%;
   cursor: pointer;
-  accent-color: var(--mk-brand-500);
+  accent-color: var(--v4-accent-500);
 }
 .v4-qa-slider:disabled { cursor: not-allowed; opacity: 0.6; }
 .v4-qa-toggle {
@@ -4430,28 +4504,28 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 8px;
   padding: 6px 12px;
-  border: 1px solid var(--mk-line-strong);
-  background: var(--mk-paper);
-  border-radius: var(--mk-r-md);
+  border: 1px solid var(--v4-line-strong);
+  background: var(--v4-paper);
+  border-radius: var(--v4-r-md);
   font-size: 12px;
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   cursor: pointer;
   transition: all 120ms;
 }
 .v4-qa-toggle.is-on {
-  border-color: var(--mk-success);
-  color: var(--mk-success-strong);
-  background: var(--mk-success-soft);
+  border-color: var(--v4-success-500);
+  color: var(--v4-success-700);
+  background: var(--v4-success-50);
 }
 .v4-qa-toggle:disabled { opacity: 0.6; cursor: not-allowed; }
 .v4-qa-toggle-dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--mk-ink-300);
+  background: var(--v4-ink-300);
 }
-.v4-qa-toggle.is-on .v4-qa-toggle-dot { background: var(--mk-success); }
+.v4-qa-toggle.is-on .v4-qa-toggle-dot { background: var(--v4-success-500); }
 .v4-qa-config-actions {
   margin-top: 14px;
   display: flex;
@@ -4466,8 +4540,8 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   gap: 8px;
   align-items: center;
   padding: 10px 18px;
-  background: var(--mk-warn-soft);
-  border-bottom: 1px solid var(--mk-warn-100);
+  background: var(--v4-warn-50);
+  border-bottom: 1px solid var(--v4-warn-100);
 }
 .v4-qa-pending-list {
   display: flex;
@@ -4475,14 +4549,14 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   padding: 4px 0;
 }
 .v4-qa-pending {
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   padding: 12px 18px;
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 .v4-qa-pending:last-child { border-bottom: 0; }
-.v4-qa-pending.is-selected { background: var(--mk-brand-50); }
+.v4-qa-pending.is-selected { background: var(--v4-accent-50); }
 .v4-qa-pending-h {
   display: flex;
   justify-content: space-between;
@@ -4501,13 +4575,13 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   width: 14px;
   height: 14px;
   cursor: pointer;
-  accent-color: var(--mk-brand-500);
+  accent-color: var(--v4-accent-500);
 }
 .v4-qa-pending-target {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -4515,7 +4589,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-qa-pending-age {
   font-size: 11px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   margin-left: 4px;
 }
 .v4-qa-pending-conf {
@@ -4528,7 +4602,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-qa-pending-conf-bar {
   flex: 1;
   height: 6px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   border-radius: 3px;
   overflow: hidden;
 }
@@ -4545,21 +4619,21 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-qa-pending-content {
   font-size: 13px;
-  color: var(--mk-ink-800);
+  color: var(--v4-ink-800);
   line-height: 1.45;
   white-space: pre-wrap;
   word-break: break-word;
 }
 .v4-qa-pending-rationale {
   font-size: 12px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-style: italic;
 }
 .v4-qa-pending-details {
   font-size: 12px;
-  color: var(--mk-ink-700);
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-sm);
+  color: var(--v4-ink-700);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
   padding: 8px 10px;
   display: flex;
   flex-direction: column;
@@ -4567,9 +4641,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-qa-pending-json {
   margin: 0;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   white-space: pre-wrap;
   max-height: 220px;
   overflow: auto;
@@ -4586,12 +4660,12 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   margin-left: auto;
 }
 .v4-qa-btn-reject {
-  border-color: var(--mk-danger);
-  color: var(--mk-danger-strong);
+  border-color: var(--v4-danger-500);
+  color: var(--v4-danger-700);
 }
 .v4-qa-btn-reject:hover {
-  background: var(--mk-danger-soft);
-  border-color: var(--mk-danger);
+  background: var(--v4-danger-50);
+  border-color: var(--v4-danger-500);
 }
 
 /* — Tuning history — */
@@ -4605,7 +4679,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 12px;
   padding: 10px 18px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   flex-wrap: wrap;
 }
 .v4-qa-history-row:last-child { border-bottom: 0; }
@@ -4617,9 +4691,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   min-width: 0;
 }
 .v4-qa-history-target {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12px;
-  color: var(--mk-ink-800);
+  color: var(--v4-ink-800);
   font-weight: 500;
   max-width: 320px;
   white-space: nowrap;
@@ -4634,7 +4708,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-qa-history-foot {
   padding: 10px 18px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
 }
 
 /* — Retros — */
@@ -4646,9 +4720,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-qa-retro-card {
   text-align: left;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   padding: 12px 14px;
   cursor: pointer;
   display: flex;
@@ -4659,8 +4733,8 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   color: inherit;
 }
 .v4-qa-retro-card:hover {
-  border-color: var(--mk-brand-500);
-  box-shadow: 0 0 0 3px var(--mk-brand-50);
+  border-color: var(--v4-accent-500);
+  box-shadow: 0 0 0 3px var(--v4-accent-50);
 }
 .v4-qa-retro-period {
   display: flex;
@@ -4671,14 +4745,14 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-qa-retro-period .v4-pl-mono {
   font-size: 14px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-qa-retro-range {
   font-size: 11px;
 }
 .v4-qa-retro-summary {
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   line-height: 1.4;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -4709,7 +4783,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-qa-retro-detail-range {
   font-size: 13px;
@@ -4720,13 +4794,13 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 600;
 }
 .v4-qa-retro-text {
   margin: 0;
   font-size: 13px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   line-height: 1.5;
   white-space: pre-wrap;
 }
@@ -4738,8 +4812,8 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-qa-pattern,
 .v4-qa-rule {
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
   padding: 10px 12px;
 }
 .v4-qa-pattern-h,
@@ -4752,16 +4826,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-qa-pattern-name,
 .v4-qa-rule-name {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-qa-pattern-ex {
   margin: 8px 0 0;
   padding-left: 18px;
   font-size: 12px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -4769,7 +4843,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-qa-rule-rationale {
   margin-top: 6px;
   font-size: 12px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   line-height: 1.4;
 }
 .v4-qa-recs {
@@ -4779,7 +4853,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-direction: column;
   gap: 4px;
   font-size: 13px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 
 /* — Lessons viewer — */
@@ -4790,7 +4864,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   display: flex;
   gap: 4px;
   padding: 12px 18px 0;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   flex-wrap: wrap;
 }
 .v4-qa-lessons-tab {
@@ -4803,20 +4877,20 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   border-bottom: 2px solid transparent;
   font-size: 12px;
   font-weight: 500;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   cursor: pointer;
   margin-bottom: -1px;
 }
-.v4-qa-lessons-tab:hover:not(:disabled) { color: var(--mk-ink-800); }
+.v4-qa-lessons-tab:hover:not(:disabled) { color: var(--v4-ink-800); }
 .v4-qa-lessons-tab.is-active {
-  color: var(--mk-brand-700);
-  border-bottom-color: var(--mk-brand-500);
+  color: var(--v4-accent-700);
+  border-bottom-color: var(--v4-accent-500);
 }
 .v4-qa-lessons-tab:disabled { opacity: 0.4; cursor: not-allowed; }
 .v4-qa-lessons-count {
   font-size: 10px;
-  color: var(--mk-ink-400);
-  background: var(--mk-surface-3);
+  color: var(--v4-ink-400);
+  background: var(--v4-surface-3);
   border-radius: 8px;
   padding: 1px 6px;
 }
@@ -4825,18 +4899,18 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   gap: 12px;
   padding: 10px 18px;
   font-size: 11px;
-  background: var(--mk-surface-2);
-  border-bottom: 1px solid var(--mk-line-soft);
+  background: var(--v4-surface-2);
+  border-bottom: 1px solid var(--v4-line-soft);
   flex-wrap: wrap;
 }
 .v4-qa-lessons-pre {
   margin: 0;
   padding: 14px 18px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12px;
   line-height: 1.5;
-  color: var(--mk-ink-800);
-  background: var(--mk-paper);
+  color: var(--v4-ink-800);
+  background: var(--v4-paper);
   white-space: pre-wrap;
   max-height: 480px;
   overflow: auto;
@@ -4854,8 +4928,8 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   padding: 24px;
 }
 .v4-qa-modal {
-  background: var(--mk-paper);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border-radius: var(--v4-r-lg);
   width: 100%;
   max-width: 720px;
   max-height: 90vh;
@@ -4869,25 +4943,25 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   justify-content: space-between;
   align-items: center;
   padding: 14px 18px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .v4-qa-modal-t {
   font-size: 15px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-qa-modal-x {
   width: 28px;
   height: 28px;
-  border-radius: var(--mk-r-sm);
+  border-radius: var(--v4-r-sm);
   border: 0;
   background: transparent;
   font-size: 22px;
   line-height: 1;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   cursor: pointer;
 }
-.v4-qa-modal-x:hover { background: var(--mk-surface-2); }
+.v4-qa-modal-x:hover { background: var(--v4-surface-2); }
 .v4-qa-modal-body {
   padding: 16px 18px;
   overflow: auto;
@@ -4900,16 +4974,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 600;
 }
 .v4-qa-modal-content {
   font-size: 13px;
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
   padding: 10px 12px;
   white-space: pre-wrap;
-  color: var(--mk-ink-800);
+  color: var(--v4-ink-800);
   line-height: 1.45;
 }
 .v4-qa-modal-meta {
@@ -4917,8 +4991,8 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   gap: 18px;
   flex-wrap: wrap;
   padding: 10px 12px;
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
 }
 .v4-qa-modal-meta div {
   display: flex;
@@ -4929,7 +5003,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-weight: 600;
 }
 .v4-qa-modal-badges {
@@ -4943,23 +5017,23 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   gap: 4px;
 }
 .v4-qa-modal-target {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12px;
-  color: var(--mk-ink-700);
-  background: var(--mk-surface-3);
+  color: var(--v4-ink-700);
+  background: var(--v4-surface-3);
   padding: 4px 8px;
-  border-radius: var(--mk-r-sm);
+  border-radius: var(--v4-r-sm);
 }
 .v4-qa-modal-diff {
   margin: 0;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   padding: 10px 12px;
-  border-radius: var(--mk-r-sm);
+  border-radius: var(--v4-r-sm);
   max-height: 280px;
   overflow: auto;
-  color: var(--mk-ink-800);
+  color: var(--v4-ink-800);
   line-height: 1.5;
 }
 .v4-qa-modal-foot {
@@ -4967,31 +5041,31 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   justify-content: flex-end;
   gap: 8px;
   padding: 12px 18px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
 }
 
 .v4-qa-offline-cmd {
   margin: 14px 18px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12px;
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
   padding: 12px 14px;
-  border-radius: var(--mk-r-sm);
-  color: var(--mk-ink-700);
+  border-radius: var(--v4-r-sm);
+  color: var(--v4-ink-700);
   white-space: pre;
   overflow-x: auto;
 }
 
 /* Tag color extras for ok/warn/danger states (used across Quality) */
-.v4-tag--ok { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-tag--warn { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
+.v4-tag--ok { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-tag--warn { background: var(--v4-warn-50); color: var(--v4-warn-700); }
 
 /* ────────────────────────────────────────
    MONITORING (Better Stack uptime)
    ──────────────────────────────────────── */
-.v4-mon-text-muted { color: var(--mk-ink-500); }
-.v4-mon-text-success { color: var(--mk-success-strong); }
-.v4-mon-text-danger { color: var(--mk-danger-strong); }
+.v4-mon-text-muted { color: var(--v4-ink-500); }
+.v4-mon-text-success { color: var(--v4-success-700); }
+.v4-mon-text-danger { color: var(--v4-danger-700); }
 
 /* Visually-hidden helper for screen-reader-only labels next to icons. */
 .v4-sr-only {
@@ -5012,16 +5086,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 16px;
   flex-wrap: wrap;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   padding: 18px 22px;
   margin-bottom: 14px;
 }
-.v4-mon-hero--ok { border-left: 4px solid var(--mk-success); }
-.v4-mon-hero--warn { border-left: 4px solid var(--mk-warn); }
-.v4-mon-hero--danger { border-left: 4px solid var(--mk-danger); }
-.v4-mon-hero--unknown { border-left: 4px solid var(--mk-ink-300); }
+.v4-mon-hero--ok { border-left: 4px solid var(--v4-success-500); }
+.v4-mon-hero--warn { border-left: 4px solid var(--v4-warn-500); }
+.v4-mon-hero--danger { border-left: 4px solid var(--v4-danger-500); }
+.v4-mon-hero--unknown { border-left: 4px solid var(--v4-ink-300); }
 .v4-mon-hero-status {
   display: flex;
   gap: 14px;
@@ -5034,14 +5108,14 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   border-radius: 50%;
   flex-shrink: 0;
 }
-.v4-mon-hero-dot--ok { background: var(--mk-success); box-shadow: 0 0 0 4px var(--mk-success-soft); }
-.v4-mon-hero-dot--warn { background: var(--mk-warn); box-shadow: 0 0 0 4px var(--mk-warn-soft); }
+.v4-mon-hero-dot--ok { background: var(--v4-success-500); box-shadow: 0 0 0 4px var(--v4-success-50); }
+.v4-mon-hero-dot--warn { background: var(--v4-warn-500); box-shadow: 0 0 0 4px var(--v4-warn-50); }
 .v4-mon-hero-dot--danger {
-  background: var(--mk-danger);
-  box-shadow: 0 0 0 4px var(--mk-danger-soft);
+  background: var(--v4-danger-500);
+  box-shadow: 0 0 0 4px var(--v4-danger-50);
   animation: v4-mon-pulse 1.6s ease-in-out infinite;
 }
-.v4-mon-hero-dot--unknown { background: var(--mk-ink-300); }
+.v4-mon-hero-dot--unknown { background: var(--v4-ink-300); }
 @keyframes v4-mon-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.55; }
@@ -5049,19 +5123,19 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-mon-hero-title {
   font-size: 16px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   margin-bottom: 4px;
 }
 .v4-mon-hero-sub {
   font-size: 13px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
   align-items: center;
 }
-.v4-mon-hero-sub b { color: var(--mk-ink-900); font-weight: 600; }
-.v4-mon-sep { color: var(--mk-ink-300); margin: 0 4px; }
+.v4-mon-hero-sub b { color: var(--v4-ink-900); font-weight: 600; }
+.v4-mon-sep { color: var(--v4-ink-300); margin: 0 4px; }
 .v4-mon-hero-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 
 /* — Toolbar (search + filters) — */
@@ -5084,25 +5158,25 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   transform: translateY(-50%);
   width: 14px;
   height: 14px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   pointer-events: none;
 }
 .v4-mon-search input {
   width: 100%;
   height: 36px;
   padding: 0 14px 0 36px;
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
-  background: var(--mk-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
+  background: var(--v4-paper);
   font-size: 13px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-mon-search input:focus {
   outline: none;
-  border-color: var(--mk-brand-500);
-  box-shadow: 0 0 0 3px var(--mk-brand-50);
+  border-color: var(--v4-accent-500);
+  box-shadow: 0 0 0 3px var(--v4-accent-50);
 }
-.v4-mon-search input::placeholder { color: var(--mk-ink-400); }
+.v4-mon-search input::placeholder { color: var(--v4-ink-400); }
 
 /* — Card grid + groups — */
 .v4-mon-grid {
@@ -5125,15 +5199,15 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-mon-group-name {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-ink-900);
+  font-family: var(--v4-mono);
 }
 
 /* — Monitor card — */
 .v4-mon-card {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   padding: 14px 16px;
   display: flex;
   flex-direction: column;
@@ -5141,10 +5215,10 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   min-width: 0;
   transition: border-color 120ms;
 }
-.v4-mon-card--ok { border-top: 3px solid var(--mk-success); }
-.v4-mon-card--warn { border-top: 3px solid var(--mk-warn); }
-.v4-mon-card--danger { border-top: 3px solid var(--mk-danger); }
-.v4-mon-card--unknown { border-top: 3px solid var(--mk-line); }
+.v4-mon-card--ok { border-top: 3px solid var(--v4-success-500); }
+.v4-mon-card--warn { border-top: 3px solid var(--v4-warn-500); }
+.v4-mon-card--danger { border-top: 3px solid var(--v4-danger-500); }
+.v4-mon-card--unknown { border-top: 3px solid var(--v4-line); }
 
 .v4-mon-card-h {
   display: flex;
@@ -5165,17 +5239,17 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   border-radius: 50%;
   flex-shrink: 0;
 }
-.v4-mon-card-dot--ok { background: var(--mk-success); }
-.v4-mon-card-dot--warn { background: var(--mk-warn); }
+.v4-mon-card-dot--ok { background: var(--v4-success-500); }
+.v4-mon-card-dot--warn { background: var(--v4-warn-500); }
 .v4-mon-card-dot--danger {
-  background: var(--mk-danger);
+  background: var(--v4-danger-500);
   animation: v4-mon-pulse 1.6s ease-in-out infinite;
 }
-.v4-mon-card-dot--unknown { background: var(--mk-ink-300); }
+.v4-mon-card-dot--unknown { background: var(--v4-ink-300); }
 .v4-mon-card-title {
   font-size: 14px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -5186,14 +5260,14 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.v4-mon-status--up { background: var(--mk-success-soft); color: var(--mk-success-strong); }
-.v4-mon-status--down { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
-.v4-mon-status--paused { background: var(--mk-surface-3); color: var(--mk-ink-500); }
-.v4-mon-status--pending { background: var(--mk-warn-soft); color: var(--mk-warn-strong); }
+.v4-mon-status--up { background: var(--v4-success-50); color: var(--v4-success-700); }
+.v4-mon-status--down { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-mon-status--paused { background: var(--v4-surface-3); color: var(--v4-ink-500); }
+.v4-mon-status--pending { background: var(--v4-warn-50); color: var(--v4-warn-700); }
 
 .v4-mon-card-url {
   font-size: 12px;
-  color: var(--mk-brand-700);
+  color: var(--v4-accent-700);
   text-decoration: none;
   white-space: nowrap;
   overflow: hidden;
@@ -5224,7 +5298,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-mon-card-uptime-bar {
   height: 6px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   border-radius: 3px;
   overflow: hidden;
 }
@@ -5242,17 +5316,17 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-wrap: wrap;
 }
 .v4-mon-card-project {
-  background: var(--mk-brand-50);
-  color: var(--mk-brand-700);
-  font-family: var(--mk-font-mono);
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
+  font-family: var(--v4-mono);
   font-size: 11px;
 }
 .v4-mon-card-checked {
   font-size: 11px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .v4-mon-card-checked.is-stale {
-  color: var(--mk-warn-strong);
+  color: var(--v4-warn-700);
   font-weight: 600;
 }
 
@@ -5266,12 +5340,12 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-mon-setup-desc {
   margin: 0;
   font-size: 13px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   line-height: 1.5;
 }
 .v4-mon-setup-doc {
   font-size: 13px;
-  color: var(--mk-brand-700);
+  color: var(--v4-accent-700);
   text-decoration: none;
 }
 .v4-mon-setup-doc:hover { text-decoration: underline; }
@@ -5289,9 +5363,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 /* ────────────────────────────────────────
    AUDIT (code + UX)
    ──────────────────────────────────────── */
-.v4-au-text-muted { color: var(--mk-ink-500); }
-.v4-au-text-warn { color: var(--mk-warn-strong); }
-.v4-au-text-danger { color: var(--mk-danger-strong); }
+.v4-au-text-muted { color: var(--v4-ink-500); }
+.v4-au-text-warn { color: var(--v4-warn-700); }
+.v4-au-text-danger { color: var(--v4-danger-700); }
 
 /* — Hero — */
 .v4-au-hero {
@@ -5300,16 +5374,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 16px;
   flex-wrap: wrap;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   padding: 18px 22px;
   margin-bottom: 14px;
 }
-.v4-au-hero--ok { border-left: 4px solid var(--mk-success); }
-.v4-au-hero--warn { border-left: 4px solid var(--mk-warn); }
-.v4-au-hero--danger { border-left: 4px solid var(--mk-danger); }
-.v4-au-hero--unknown { border-left: 4px solid var(--mk-ink-300); }
+.v4-au-hero--ok { border-left: 4px solid var(--v4-success-500); }
+.v4-au-hero--warn { border-left: 4px solid var(--v4-warn-500); }
+.v4-au-hero--danger { border-left: 4px solid var(--v4-danger-500); }
+.v4-au-hero--unknown { border-left: 4px solid var(--v4-ink-300); }
 .v4-au-hero-status {
   display: flex;
   gap: 14px;
@@ -5322,14 +5396,14 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   border-radius: 50%;
   flex-shrink: 0;
 }
-.v4-au-hero-dot--ok { background: var(--mk-success); box-shadow: 0 0 0 4px var(--mk-success-soft); }
-.v4-au-hero-dot--warn { background: var(--mk-warn); box-shadow: 0 0 0 4px var(--mk-warn-soft); }
+.v4-au-hero-dot--ok { background: var(--v4-success-500); box-shadow: 0 0 0 4px var(--v4-success-50); }
+.v4-au-hero-dot--warn { background: var(--v4-warn-500); box-shadow: 0 0 0 4px var(--v4-warn-50); }
 .v4-au-hero-dot--danger {
-  background: var(--mk-danger);
-  box-shadow: 0 0 0 4px var(--mk-danger-soft);
+  background: var(--v4-danger-500);
+  box-shadow: 0 0 0 4px var(--v4-danger-50);
   animation: v4-au-pulse 1.6s ease-in-out infinite;
 }
-.v4-au-hero-dot--unknown { background: var(--mk-ink-300); }
+.v4-au-hero-dot--unknown { background: var(--v4-ink-300); }
 @keyframes v4-au-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.55; }
@@ -5337,19 +5411,19 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-au-hero-title {
   font-size: 16px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   margin-bottom: 4px;
 }
 .v4-au-hero-sub {
   font-size: 13px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
   align-items: center;
 }
-.v4-au-hero-sub b { color: var(--mk-ink-900); font-weight: 600; }
-.v4-au-sep { color: var(--mk-ink-300); margin: 0 4px; }
+.v4-au-hero-sub b { color: var(--v4-ink-900); font-weight: 600; }
+.v4-au-sep { color: var(--v4-ink-300); margin: 0 4px; }
 .v4-au-hero-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 
 /* — Toolbar (search + filter pills) — */
@@ -5370,9 +5444,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 
 /* — Project card — */
 .v4-au-card {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   padding: 16px 18px;
   display: flex;
   flex-direction: column;
@@ -5380,13 +5454,13 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   min-width: 0;
   transition: border-color 120ms;
 }
-.v4-au-card--ok { border-top: 3px solid var(--mk-success); }
-.v4-au-card--warn { border-top: 3px solid var(--mk-warn); }
-.v4-au-card--danger { border-top: 3px solid var(--mk-danger); }
-.v4-au-card--unknown { border-top: 3px solid var(--mk-line); }
+.v4-au-card--ok { border-top: 3px solid var(--v4-success-500); }
+.v4-au-card--warn { border-top: 3px solid var(--v4-warn-500); }
+.v4-au-card--danger { border-top: 3px solid var(--v4-danger-500); }
+.v4-au-card--unknown { border-top: 3px solid var(--v4-line); }
 .v4-au-card.is-running {
-  background: var(--mk-brand-50);
-  border-color: var(--mk-brand-500);
+  background: var(--v4-accent-50);
+  border-color: var(--v4-accent-500);
 }
 .v4-au-card-h {
   display: flex;
@@ -5405,16 +5479,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-au-card-title {
   font-size: 15px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 220px;
 }
 .v4-au-card-owner {
-  background: var(--mk-surface-3);
-  color: var(--mk-ink-500);
-  font-family: var(--mk-font-mono);
+  background: var(--v4-surface-3);
+  color: var(--v4-ink-500);
+  font-family: var(--v4-mono);
   font-size: 11px;
 }
 .v4-au-card-badges {
@@ -5437,13 +5511,13 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--mk-warn);
+  background: var(--v4-warn-500);
   animation: v4-au-pulse 1s ease-in-out infinite;
 }
 
 .v4-au-card-empty {
   font-size: 13px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   padding: 8px 0;
   text-align: center;
   font-style: italic;
@@ -5464,7 +5538,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-au-findings-total {
   font-size: 22px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-au-findings-pris {
   display: flex;
@@ -5486,7 +5560,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-au-sev-bar {
   height: 8px;
   display: flex;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -5501,8 +5575,8 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-direction: column;
   gap: 6px;
   padding: 10px 12px;
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
 }
 .v4-au-fixed-h {
   display: flex;
@@ -5512,18 +5586,18 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-au-fixed-cnt {
   font-size: 12px;
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
-.v4-au-fixed-cnt.is-done { color: var(--mk-success-strong); }
+.v4-au-fixed-cnt.is-done { color: var(--v4-success-700); }
 .v4-au-fixed-track {
   height: 6px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   border-radius: 3px;
   overflow: hidden;
 }
 .v4-au-fixed-fill {
   height: 100%;
-  background: var(--mk-success);
+  background: var(--v4-success-500);
   border-radius: 3px;
   transition: width 200ms ease;
 }
@@ -5536,8 +5610,8 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-wrap: wrap;
   font-size: 12px;
   padding: 8px 12px;
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
 }
 
 /* — Meta footer (cost / time / age) — */
@@ -5547,7 +5621,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   flex-wrap: wrap;
   font-size: 12px;
-  border-top: 1px dashed var(--mk-line-soft);
+  border-top: 1px dashed var(--v4-line-soft);
   padding-top: 10px;
 }
 .v4-au-meta-cell {
@@ -5564,7 +5638,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-au-meta-val {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 
 /* — Progress (running) — */
@@ -5573,9 +5647,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-direction: column;
   gap: 8px;
   padding: 12px 14px;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-brand-100);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-accent-100);
+  border-radius: var(--v4-r-sm);
 }
 .v4-au-progress-h {
   display: flex;
@@ -5585,36 +5659,36 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-au-progress-stage {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-brand-700);
+  color: var(--v4-accent-700);
 }
 .v4-au-progress-pct {
   font-size: 13px;
   font-weight: 700;
-  color: var(--mk-brand-700);
+  color: var(--v4-accent-700);
 }
 .v4-au-progress-track {
   height: 8px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   border-radius: 4px;
   overflow: hidden;
 }
 .v4-au-progress-fill {
   height: 100%;
-  background: var(--mk-brand-500);
+  background: var(--v4-accent-500);
   border-radius: 4px;
   transition: width 500ms ease-out;
 }
 .v4-au-progress-msg {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-style: italic;
 }
 
 /* — Error block — */
 .v4-au-card-error {
   padding: 10px 12px;
-  background: var(--mk-danger-soft);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-danger-50);
+  border-radius: var(--v4-r-sm);
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -5622,13 +5696,13 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-au-card-error-t {
   font-size: 12px;
   font-weight: 600;
-  color: var(--mk-danger-strong);
+  color: var(--v4-danger-700);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 .v4-au-card-error-b {
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   word-break: break-word;
 }
 
@@ -5641,25 +5715,25 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-au-card-actions .v4-btn { flex: 1 1 auto; min-width: 0; justify-content: center; }
 .v4-au-btn-cancel {
-  border-color: var(--mk-danger);
-  color: var(--mk-danger-strong);
+  border-color: var(--v4-danger-500);
+  color: var(--v4-danger-700);
 }
-.v4-au-btn-cancel:hover { background: var(--mk-danger-soft); }
+.v4-au-btn-cancel:hover { background: var(--v4-danger-50); }
 .v4-au-btn-ok {
-  border-color: var(--mk-success);
-  color: var(--mk-success-strong);
-  background: var(--mk-success-soft);
+  border-color: var(--v4-success-500);
+  color: var(--v4-success-700);
+  background: var(--v4-success-50);
 }
 
 /* — Offline panel CLI hint — */
 .v4-au-offline-cmd {
   margin: 14px 18px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12px;
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
   padding: 12px 14px;
-  border-radius: var(--mk-r-sm);
-  color: var(--mk-ink-700);
+  border-radius: var(--v4-r-sm);
+  color: var(--v4-ink-700);
   white-space: pre;
   overflow-x: auto;
 }
@@ -5675,14 +5749,14 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-direction: column;
   gap: 14px;
   padding-top: 12px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   margin-top: 4px;
 }
 .v4-au-ux-h {
   margin: 0;
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -5694,7 +5768,7 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-au-ux-page-name {
   font-size: 12px;
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   margin-bottom: 4px;
 }
 .v4-au-ux-shots-row {
@@ -5703,8 +5777,8 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-wrap: wrap;
 }
 .v4-au-ux-shot {
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
   padding: 8px 10px;
   font-size: 11px;
   display: flex;
@@ -5712,10 +5786,10 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   gap: 2px;
   min-width: 140px;
 }
-.v4-au-ux-shot-vp { color: var(--mk-ink-700); font-weight: 600; }
+.v4-au-ux-shot-vp { color: var(--v4-ink-700); font-weight: 600; }
 .v4-au-ux-shot-url {
-  color: var(--mk-ink-400);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-ink-400);
+  font-family: var(--v4-mono);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -5731,8 +5805,8 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   overflow-y: auto;
 }
 .v4-au-ux-finding {
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
   padding: 10px 12px;
   display: flex;
   flex-direction: column;
@@ -5745,20 +5819,20 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-size: 11px;
 }
 .v4-au-ux-finding-sev { font-weight: 700; }
-.v4-au-ux-finding-desc { font-size: 13px; color: var(--mk-ink-800); line-height: 1.4; }
+.v4-au-ux-finding-desc { font-size: 13px; color: var(--v4-ink-800); line-height: 1.4; }
 .v4-au-ux-finding-rec {
   font-size: 12px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   font-style: italic;
-  border-left: 3px solid var(--mk-brand-500);
+  border-left: 3px solid var(--v4-accent-500);
   padding-left: 8px;
 }
 
 /* ────────────────────────────────────────
    DEBATE
    ──────────────────────────────────────── */
-.v4-db-text-muted { color: var(--mk-ink-500); }
-.v4-db-sep { color: var(--mk-ink-300); margin: 0 4px; }
+.v4-db-text-muted { color: var(--v4-ink-500); }
+.v4-db-sep { color: var(--v4-ink-300); margin: 0 4px; }
 
 /* — Hero — */
 .v4-db-hero {
@@ -5767,16 +5841,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 16px;
   flex-wrap: wrap;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   padding: 18px 22px;
   margin-bottom: 14px;
 }
-.v4-db-hero--ok { border-left: 4px solid var(--mk-success); }
-.v4-db-hero--warn { border-left: 4px solid var(--mk-warn); }
-.v4-db-hero--danger { border-left: 4px solid var(--mk-danger); }
-.v4-db-hero--unknown { border-left: 4px solid var(--mk-ink-300); }
+.v4-db-hero--ok { border-left: 4px solid var(--v4-success-500); }
+.v4-db-hero--warn { border-left: 4px solid var(--v4-warn-500); }
+.v4-db-hero--danger { border-left: 4px solid var(--v4-danger-500); }
+.v4-db-hero--unknown { border-left: 4px solid var(--v4-ink-300); }
 .v4-db-hero-status {
   display: flex;
   gap: 14px;
@@ -5789,14 +5863,14 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   border-radius: 50%;
   flex-shrink: 0;
 }
-.v4-db-hero-dot--ok { background: var(--mk-success); box-shadow: 0 0 0 4px var(--mk-success-soft); }
+.v4-db-hero-dot--ok { background: var(--v4-success-500); box-shadow: 0 0 0 4px var(--v4-success-50); }
 .v4-db-hero-dot--warn {
-  background: var(--mk-warn);
-  box-shadow: 0 0 0 4px var(--mk-warn-soft);
+  background: var(--v4-warn-500);
+  box-shadow: 0 0 0 4px var(--v4-warn-50);
   animation: v4-db-pulse 1.6s ease-in-out infinite;
 }
-.v4-db-hero-dot--danger { background: var(--mk-danger); box-shadow: 0 0 0 4px var(--mk-danger-soft); }
-.v4-db-hero-dot--unknown { background: var(--mk-ink-300); }
+.v4-db-hero-dot--danger { background: var(--v4-danger-500); box-shadow: 0 0 0 4px var(--v4-danger-50); }
+.v4-db-hero-dot--unknown { background: var(--v4-ink-300); }
 @keyframes v4-db-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.55; }
@@ -5804,19 +5878,19 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-db-hero-title {
   font-size: 16px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   margin-bottom: 4px;
 }
 .v4-db-hero-sub {
   font-size: 13px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
   align-items: center;
 }
 .v4-db-hero-topic {
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-weight: 600;
   max-width: 480px;
   white-space: nowrap;
@@ -5834,9 +5908,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 
 /* — Card — */
 .v4-db-card {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   padding: 16px 18px;
   display: flex;
   flex-direction: column;
@@ -5849,23 +5923,23 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   min-width: 0;
 }
 .v4-db-card:hover {
-  border-color: var(--mk-brand-500);
-  box-shadow: 0 0 0 3px var(--mk-brand-50);
+  border-color: var(--v4-accent-500);
+  box-shadow: 0 0 0 3px var(--v4-accent-50);
 }
 .v4-db-card:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: 2px;
 }
-.v4-db-card--ok { border-top: 3px solid var(--mk-success); }
+.v4-db-card--ok { border-top: 3px solid var(--v4-success-500); }
 .v4-db-card--warn {
-  border-top: 3px solid var(--mk-warn);
-  background: var(--mk-warn-soft);
+  border-top: 3px solid var(--v4-warn-500);
+  background: var(--v4-warn-50);
 }
 /* Reset background on focus so the blue accent outline has enough
  * contrast against the warn-yellow tint. */
-.v4-db-card--warn:focus-visible { background: var(--mk-paper); }
-.v4-db-card--danger { border-top: 3px solid var(--mk-danger); }
-.v4-db-card--neutral { border-top: 3px solid var(--mk-line); }
+.v4-db-card--warn:focus-visible { background: var(--v4-paper); }
+.v4-db-card--danger { border-top: 3px solid var(--v4-danger-500); }
+.v4-db-card--neutral { border-top: 3px solid var(--v4-line); }
 
 .v4-db-card-h {
   display: flex;
@@ -5877,14 +5951,14 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--mk-warn);
+  background: var(--v4-warn-500);
   margin-left: auto;
   animation: v4-db-pulse 1s ease-in-out infinite;
 }
 .v4-db-card-topic {
   font-size: 14px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   line-height: 1.4;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -5901,9 +5975,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   font-size: 12px;
 }
 .v4-db-card-project {
-  background: var(--mk-brand-50);
-  color: var(--mk-brand-700);
-  font-family: var(--mk-font-mono);
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
+  font-family: var(--v4-mono);
   font-size: 11px;
   max-width: 160px;
   white-space: nowrap;
@@ -5912,11 +5986,11 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 }
 .v4-db-card-cost {
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 .v4-db-card-age {
   margin-left: auto;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-size: 11px;
 }
 
@@ -5932,17 +6006,17 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-db-empty svg {
   width: 48px;
   height: 48px;
-  color: var(--mk-ink-300);
+  color: var(--v4-ink-300);
 }
 .v4-db-empty h3 {
   margin: 0;
   font-size: 18px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-db-empty p {
   margin: 0;
   font-size: 13px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   max-width: 480px;
   line-height: 1.5;
 }
@@ -5951,9 +6025,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 /* ────────────────────────────────────────
    RESEARCH / DISCOVERY
    ──────────────────────────────────────── */
-.v4-rsh-text-muted { color: var(--mk-ink-500); }
-.v4-rsh-text-success { color: var(--mk-success-strong); }
-.v4-rsh-sep { color: var(--mk-ink-300); margin: 0 4px; }
+.v4-rsh-text-muted { color: var(--v4-ink-500); }
+.v4-rsh-text-success { color: var(--v4-success-700); }
+.v4-rsh-sep { color: var(--v4-ink-300); margin: 0 4px; }
 
 /* — Hero — */
 .v4-rsh-hero {
@@ -5962,53 +6036,53 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 16px;
   flex-wrap: wrap;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-lg);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-lg);
   padding: 18px 22px;
   margin-bottom: 14px;
 }
-.v4-rsh-hero--ok { border-left: 4px solid var(--mk-success); }
-.v4-rsh-hero--warn { border-left: 4px solid var(--mk-warn); }
-.v4-rsh-hero--danger { border-left: 4px solid var(--mk-danger); }
-.v4-rsh-hero--unknown { border-left: 4px solid var(--mk-ink-300); }
+.v4-rsh-hero--ok { border-left: 4px solid var(--v4-success-500); }
+.v4-rsh-hero--warn { border-left: 4px solid var(--v4-warn-500); }
+.v4-rsh-hero--danger { border-left: 4px solid var(--v4-danger-500); }
+.v4-rsh-hero--unknown { border-left: 4px solid var(--v4-ink-300); }
 .v4-rsh-hero-status { display: flex; gap: 14px; align-items: center; min-width: 0; }
 .v4-rsh-hero-dot { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; }
-.v4-rsh-hero-dot--ok { background: var(--mk-success); box-shadow: 0 0 0 4px var(--mk-success-soft); }
-.v4-rsh-hero-dot--warn { background: var(--mk-warn); box-shadow: 0 0 0 4px var(--mk-warn-soft); }
-.v4-rsh-hero-dot--danger { background: var(--mk-danger); box-shadow: 0 0 0 4px var(--mk-danger-soft); }
-.v4-rsh-hero-dot--unknown { background: var(--mk-ink-300); }
+.v4-rsh-hero-dot--ok { background: var(--v4-success-500); box-shadow: 0 0 0 4px var(--v4-success-50); }
+.v4-rsh-hero-dot--warn { background: var(--v4-warn-500); box-shadow: 0 0 0 4px var(--v4-warn-50); }
+.v4-rsh-hero-dot--danger { background: var(--v4-danger-500); box-shadow: 0 0 0 4px var(--v4-danger-50); }
+.v4-rsh-hero-dot--unknown { background: var(--v4-ink-300); }
 .v4-rsh-hero-title {
   font-size: 16px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   margin-bottom: 4px;
 }
 .v4-rsh-hero-sub {
   font-size: 13px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
   align-items: center;
 }
-.v4-rsh-hero-sub b { color: var(--mk-ink-900); font-weight: 600; }
+.v4-rsh-hero-sub b { color: var(--v4-ink-900); font-weight: 600; }
 .v4-rsh-hero-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 
 /* — Agent banner — */
 .v4-rsh-agent {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   padding: 12px 16px;
   margin: 14px 0;
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
-.v4-rsh-agent--ok { border-left: 4px solid var(--mk-success); }
-.v4-rsh-agent--warn { border-left: 4px solid var(--mk-warn); background: var(--mk-warn-soft); }
-.v4-rsh-agent--danger { border-left: 4px solid var(--mk-danger); background: var(--mk-danger-soft); }
+.v4-rsh-agent--ok { border-left: 4px solid var(--v4-success-500); }
+.v4-rsh-agent--warn { border-left: 4px solid var(--v4-warn-500); background: var(--v4-warn-50); }
+.v4-rsh-agent--danger { border-left: 4px solid var(--v4-danger-500); background: var(--v4-danger-50); }
 .v4-rsh-agent-h {
   display: flex;
   align-items: center;
@@ -6020,36 +6094,36 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   gap: 8px;
   font-size: 13px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-rsh-agent-dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
 }
-.v4-rsh-agent-dot--ok { background: var(--mk-success); }
+.v4-rsh-agent-dot--ok { background: var(--v4-success-500); }
 .v4-rsh-agent-dot--warn {
-  background: var(--mk-warn);
+  background: var(--v4-warn-500);
   animation: v4-rsh-pulse 1s ease-in-out infinite;
 }
-.v4-rsh-agent-dot--danger { background: var(--mk-danger); }
+.v4-rsh-agent-dot--danger { background: var(--v4-danger-500); }
 @keyframes v4-rsh-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
 .v4-rsh-agent-stage {
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   flex: 1;
   min-width: 0;
 }
 .v4-rsh-agent-dismiss { padding: 2px 10px; }
 .v4-rsh-agent-track {
   height: 6px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   border-radius: 3px;
   overflow: hidden;
 }
 .v4-rsh-agent-fill {
   height: 100%;
-  background: var(--mk-brand-500);
+  background: var(--v4-accent-500);
   border-radius: 3px;
   transition: width 400ms ease-out;
 }
@@ -6058,18 +6132,18 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
 .v4-rsh-list { display: flex; flex-direction: column; gap: 10px; }
 
 .v4-rsh-card {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-md);
   display: flex;
   flex-direction: column;
   overflow: hidden;
   transition: border-color 120ms;
 }
-.v4-rsh-card--ok { border-left: 3px solid var(--mk-success); }
-.v4-rsh-card--warn { border-left: 3px solid var(--mk-warn); }
-.v4-rsh-card--unknown { border-left: 3px solid var(--mk-line); }
-.v4-rsh-card.is-expanded { border-color: var(--mk-brand-500); }
+.v4-rsh-card--ok { border-left: 3px solid var(--v4-success-500); }
+.v4-rsh-card--warn { border-left: 3px solid var(--v4-warn-500); }
+.v4-rsh-card--unknown { border-left: 3px solid var(--v4-line); }
+.v4-rsh-card.is-expanded { border-color: var(--v4-accent-500); }
 
 .v4-rsh-card-h {
   display: flex;
@@ -6079,9 +6153,9 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   flex-wrap: wrap;
 }
 .v4-rsh-card-h.is-clickable { cursor: pointer; }
-.v4-rsh-card-h.is-clickable:hover { background: var(--mk-surface-2); }
+.v4-rsh-card-h.is-clickable:hover { background: var(--v4-surface-2); }
 .v4-rsh-card-h:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: -2px;
 }
 .v4-rsh-card-name {
@@ -6093,16 +6167,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   min-width: 200px;
 }
 .v4-rsh-card-title {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 14px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-rsh-card-loading {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--mk-warn);
+  background: var(--v4-warn-500);
   animation: v4-rsh-pulse 1s ease-in-out infinite;
 }
 .v4-rsh-card-stats {
@@ -6110,16 +6184,16 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   gap: 12px;
   flex-wrap: wrap;
   font-size: 12px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
-.v4-rsh-card-stat b { color: var(--mk-ink-900); font-weight: 600; }
+.v4-rsh-card-stat b { color: var(--v4-ink-900); font-weight: 600; }
 .v4-rsh-card-actions {
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
 }
 .v4-rsh-card-chevron {
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-size: 14px;
   width: 28px;
   height: 28px;
@@ -6127,19 +6201,19 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   align-items: center;
   justify-content: center;
   background: transparent;
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-sm);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-sm);
   cursor: pointer;
   font-family: inherit;
   transition: background 120ms, border-color 120ms;
 }
 .v4-rsh-card-chevron:hover:not(:disabled) {
-  background: var(--mk-surface-2);
-  border-color: var(--mk-brand-500);
-  color: var(--mk-brand-700);
+  background: var(--v4-surface-2);
+  border-color: var(--v4-accent-500);
+  color: var(--v4-accent-700);
 }
 .v4-rsh-card-chevron:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: 1px;
 }
 .v4-rsh-card-chevron:disabled { opacity: 0.4; cursor: not-allowed; }
@@ -6153,18 +6227,18 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   display: flex;
   flex-direction: column;
   gap: 10px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
 }
 
 /* — Collapsible sections inside card — */
 .v4-rsh-section {
-  border: 1px solid var(--mk-line-soft);
-  border-radius: var(--mk-r-sm);
+  border: 1px solid var(--v4-line-soft);
+  border-radius: var(--v4-r-sm);
   overflow: hidden;
 }
-.v4-rsh-section--ok { border-left: 3px solid var(--mk-success); }
-.v4-rsh-section--warn { border-left: 3px solid var(--mk-warn); }
-.v4-rsh-section--neutral { border-left: 3px solid var(--mk-brand-500); }
+.v4-rsh-section--ok { border-left: 3px solid var(--v4-success-500); }
+.v4-rsh-section--warn { border-left: 3px solid var(--v4-warn-500); }
+.v4-rsh-section--neutral { border-left: 3px solid var(--v4-accent-500); }
 .v4-rsh-section-h {
   display: flex;
   align-items: center;
@@ -6178,23 +6252,23 @@ a.v4-pl-ctx-art-val:hover { text-decoration: underline; }
   color: inherit;
   text-align: left;
 }
-.v4-rsh-section-h:hover { background: var(--mk-surface-2); }
+.v4-rsh-section-h:hover { background: var(--v4-surface-2); }
 .v4-rsh-section-h-static {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
 }
-.v4-rsh-section-arrow { color: var(--mk-ink-500); font-size: 11px; width: 12px; }
+.v4-rsh-section-arrow { color: var(--v4-ink-500); font-size: 11px; width: 12px; }
 .v4-rsh-section-title {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-rsh-section-body {
   padding: 10px 12px 12px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
 }
 
 .v4-rsh-list ul.v4-rsh-list,
@@ -6205,7 +6279,7 @@ ul.v4-rsh-list {
   flex-direction: column;
   gap: 4px;
   font-size: 13px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 
 /* — Competitor matrix — */
@@ -6221,22 +6295,22 @@ ul.v4-rsh-list {
 .v4-rsh-matrix td {
   text-align: left;
   padding: 6px 10px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .v4-rsh-matrix th {
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 600;
 }
 .v4-rsh-matrix-feature {
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
-.v4-rsh-cell-yes { color: var(--mk-success-strong); font-weight: 600; }
-.v4-rsh-cell-no { color: var(--mk-danger-strong); }
+.v4-rsh-cell-yes { color: var(--v4-success-700); font-weight: 600; }
+.v4-rsh-cell-no { color: var(--v4-danger-700); }
 
 /* — Competitor cards (fallback when no matrix) — */
 .v4-rsh-comp-grid {
@@ -6245,49 +6319,49 @@ ul.v4-rsh-list {
   gap: 10px;
 }
 .v4-rsh-comp {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-radius: var(--v4-r-sm);
   padding: 10px 12px;
   display: flex;
   flex-direction: column;
   gap: 4px;
   font-size: 12px;
 }
-.v4-rsh-comp-name { font-weight: 600; color: var(--mk-ink-900); font-size: 13px; }
-.v4-rsh-comp-url { color: var(--mk-brand-700); font-size: 11px; }
-.v4-rsh-comp-meta { color: var(--mk-ink-500); }
+.v4-rsh-comp-name { font-weight: 600; color: var(--v4-ink-900); font-size: 13px; }
+.v4-rsh-comp-url { color: var(--v4-accent-700); font-size: 11px; }
+.v4-rsh-comp-meta { color: var(--v4-ink-500); }
 .v4-rsh-comp-features {
   margin: 4px 0 0;
   padding-left: 16px;
   display: flex;
   flex-direction: column;
   gap: 2px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 
 /* — Discovery section — */
 .v4-rsh-disc { display: flex; flex-direction: column; gap: 12px; }
 .v4-rsh-disc-group {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line-soft);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line-soft);
+  border-radius: var(--v4-r-sm);
   overflow: hidden;
 }
-.v4-rsh-disc-group--ok { border-left: 3px solid var(--mk-success); }
-.v4-rsh-disc-group--warn { border-left: 3px solid var(--mk-warn); }
-.v4-rsh-disc-group--neutral { border-left: 3px solid var(--mk-line); }
+.v4-rsh-disc-group--ok { border-left: 3px solid var(--v4-success-500); }
+.v4-rsh-disc-group--warn { border-left: 3px solid var(--v4-warn-500); }
+.v4-rsh-disc-group--neutral { border-left: 3px solid var(--v4-line); }
 .v4-rsh-disc-group-h {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 8px 12px;
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
   font-size: 12px;
 }
 .v4-rsh-disc-group-t {
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -6298,8 +6372,8 @@ ul.v4-rsh-list {
   padding: 10px 12px;
 }
 .v4-rsh-disc-item {
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
   padding: 10px 12px;
   display: flex;
   flex-direction: column;
@@ -6314,7 +6388,7 @@ ul.v4-rsh-list {
 }
 .v4-rsh-disc-name {
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-size: 13px;
 }
 .v4-rsh-disc-badges {
@@ -6324,12 +6398,12 @@ ul.v4-rsh-list {
 }
 .v4-rsh-disc-desc {
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   line-height: 1.4;
 }
 .v4-rsh-disc-evidence {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-style: italic;
 }
 
@@ -6345,17 +6419,17 @@ ul.v4-rsh-list {
 .v4-rsh-empty svg {
   width: 48px;
   height: 48px;
-  color: var(--mk-ink-300);
+  color: var(--v4-ink-300);
 }
 .v4-rsh-empty h3 {
   margin: 0;
   font-size: 18px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-rsh-empty p {
   margin: 0;
   font-size: 13px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   max-width: 480px;
   line-height: 1.5;
 }
@@ -6364,24 +6438,24 @@ ul.v4-rsh-list {
 /* ────────────────────────────────────────
    SPECS — PRD → Epic → Tasks
    ──────────────────────────────────────── */
-.v4-spc-text-muted { color: var(--mk-ink-500); }
+.v4-spc-text-muted { color: var(--v4-ink-500); }
 
 .v4-spc-list { display: flex; flex-direction: column; gap: 10px; }
 
 /* — PRD card — */
 .v4-spc-card {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-card);
+  border: 1px solid var(--v4-line);
   border-radius: 14px;
   padding: 14px 18px;
   transition: border-color 150ms, box-shadow 150ms;
 }
-.v4-spc-card--ok { border-left: 3px solid var(--mk-success); }
-.v4-spc-card--warn { border-left: 3px solid var(--mk-warn); }
-.v4-spc-card--unknown { border-left: 3px solid var(--mk-line); }
-.v4-spc-card--danger { border-left: 3px solid var(--mk-danger); }
+.v4-spc-card--ok { border-left: 3px solid var(--v4-success-500); }
+.v4-spc-card--warn { border-left: 3px solid var(--v4-warn-500); }
+.v4-spc-card--unknown { border-left: 3px solid var(--v4-line); }
+.v4-spc-card--danger { border-left: 3px solid var(--v4-danger-500); }
 .v4-spc-card.is-expanded {
-  border-color: var(--mk-brand-500);
+  border-color: var(--v4-accent-500);
   box-shadow: 0 2px 6px rgba(11, 16, 32, 0.05);
 }
 
@@ -6399,7 +6473,7 @@ ul.v4-rsh-list {
 }
 .v4-spc-card-id {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -6407,7 +6481,7 @@ ul.v4-rsh-list {
   margin: 0;
   font-size: 15px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   line-height: 1.35;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -6421,37 +6495,37 @@ ul.v4-rsh-list {
 }
 .v4-spc-card-stat {
   font-size: 12px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   white-space: nowrap;
 }
 .v4-spc-card-toggle {
   background: transparent;
-  border: 1px solid var(--mk-line);
+  border: 1px solid var(--v4-line);
   border-radius: 8px;
   width: 30px;
   height: 30px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   font-size: 13px;
   cursor: pointer;
   transition: background 120ms, border-color 120ms;
 }
 .v4-spc-card-toggle:hover {
-  background: var(--mk-surface-2);
-  border-color: var(--mk-brand-500);
-  color: var(--mk-brand-500);
+  background: var(--v4-soft);
+  border-color: var(--v4-accent-500);
+  color: var(--v4-accent-500);
 }
 .v4-spc-card-toggle:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: 2px;
 }
 
 .v4-spc-card-body {
   margin-top: 14px;
   padding-top: 14px;
-  border-top: 1px dashed var(--mk-line);
+  border-top: 1px dashed var(--v4-line);
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -6474,27 +6548,27 @@ ul.v4-rsh-list {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: var(--mk-line);
+  background: var(--v4-line);
   flex-shrink: 0;
   transition: background 200ms, box-shadow 200ms;
 }
 .v4-spc-flow-dot.is-active {
-  background: var(--mk-success);
-  box-shadow: 0 0 0 3px var(--mk-success-soft);
+  background: var(--v4-success-500);
+  box-shadow: 0 0 0 3px var(--v4-success-50);
 }
 .v4-spc-flow-label {
   font-size: 12px;
-  color: var(--mk-ink-800);
+  color: var(--v4-ink-800);
   white-space: nowrap;
 }
-.v4-spc-flow-label.is-inactive { color: var(--mk-ink-400); }
+.v4-spc-flow-label.is-inactive { color: var(--v4-ink-400); }
 .v4-spc-flow-line {
   width: 28px;
   height: 2px;
-  background: var(--mk-line);
+  background: var(--v4-line);
   margin: 0 2px;
 }
-.v4-spc-flow-line.is-active { background: var(--mk-success-soft); }
+.v4-spc-flow-line.is-active { background: var(--v4-success-300, var(--v4-success-500)); }
 
 /* — PRD meta block — */
 .v4-spc-prd-meta {
@@ -6502,7 +6576,7 @@ ul.v4-rsh-list {
   flex-wrap: wrap;
   gap: 6px 16px;
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 
 /* — Epic list — */
@@ -6513,14 +6587,14 @@ ul.v4-rsh-list {
 }
 
 .v4-spc-epic {
-  border: 1px solid var(--mk-line);
+  border: 1px solid var(--v4-line);
   border-radius: 10px;
-  background: var(--mk-surface-2);
+  background: var(--v4-soft);
   overflow: hidden;
 }
 .v4-spc-epic.is-expanded {
-  background: var(--mk-paper);
-  border-color: var(--mk-brand-500);
+  background: var(--v4-card);
+  border-color: var(--v4-accent-500);
 }
 
 .v4-spc-epic-header {
@@ -6540,12 +6614,12 @@ ul.v4-rsh-list {
 }
 .v4-spc-epic-header:hover { background: rgba(0, 0, 0, 0.02); }
 .v4-spc-epic-header:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: -2px;
 }
 .v4-spc-epic-id {
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   white-space: nowrap;
@@ -6553,7 +6627,7 @@ ul.v4-rsh-list {
 .v4-spc-epic-title {
   font-size: 13px;
   font-weight: 500;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -6568,11 +6642,11 @@ ul.v4-rsh-list {
 }
 .v4-spc-epic-stat {
   font-size: 11px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   white-space: nowrap;
 }
 .v4-spc-chevron {
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-size: 12px;
   width: 16px;
   text-align: center;
@@ -6587,14 +6661,14 @@ ul.v4-rsh-list {
 .v4-spc-epic-overview {
   margin: 0;
   font-size: 13px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   line-height: 1.5;
 }
 
 /* — Tasks table — */
 .v4-spc-table-wrap {
   overflow-x: auto;
-  border: 1px solid var(--mk-line);
+  border: 1px solid var(--v4-line);
   border-radius: 8px;
 }
 .v4-spc-table {
@@ -6603,7 +6677,7 @@ ul.v4-rsh-list {
   font-size: 12px;
 }
 .v4-spc-table thead {
-  background: var(--mk-surface-2);
+  background: var(--v4-soft);
 }
 .v4-spc-table th {
   padding: 8px 12px;
@@ -6612,20 +6686,20 @@ ul.v4-rsh-list {
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--mk-ink-600);
-  border-bottom: 1px solid var(--mk-line);
+  color: var(--v4-ink-600);
+  border-bottom: 1px solid var(--v4-line);
 }
 .v4-spc-table td {
   padding: 8px 12px;
-  border-bottom: 1px solid var(--mk-line);
-  color: var(--mk-ink-800);
+  border-bottom: 1px solid var(--v4-line);
+  color: var(--v4-ink-800);
   vertical-align: top;
 }
 .v4-spc-table tr:last-child td { border-bottom: 0; }
 .v4-spc-th-num,
-.v4-spc-td-num { width: 60px; white-space: nowrap; color: var(--mk-ink-500); }
+.v4-spc-td-num { width: 60px; white-space: nowrap; color: var(--v4-ink-500); }
 .v4-spc-th-size { width: 80px; }
-.v4-spc-td-title { font-weight: 500; color: var(--mk-ink-900); }
+.v4-spc-td-title { font-weight: 500; color: var(--v4-ink-900); }
 .v4-spc-td-deps,
 .v4-spc-td-repo { font-size: 11px; }
 
@@ -6633,9 +6707,9 @@ ul.v4-rsh-list {
 .v4-spc-empty-inline {
   padding: 12px;
   font-size: 12px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   text-align: center;
-  background: var(--mk-surface-2);
+  background: var(--v4-soft);
   border-radius: 8px;
 }
 
@@ -6651,29 +6725,29 @@ ul.v4-rsh-list {
 .v4-spc-empty svg {
   width: 56px;
   height: 56px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .v4-spc-empty h3 {
   margin: 0;
   font-size: 18px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-spc-empty p {
   margin: 0;
   max-width: 480px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   line-height: 1.5;
 }
 .v4-spc-empty-cmd {
-  background: var(--mk-surface-2);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-soft);
+  border: 1px solid var(--v4-line);
   padding: 8px 14px;
   border-radius: 8px;
 }
 .v4-spc-empty-cmd code {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-font-mono, ui-monospace, SFMono-Regular, monospace);
   font-size: 13px;
-  color: var(--mk-brand-500);
+  color: var(--v4-accent-500);
 }
 
 @media (max-width: 768px) {
@@ -6809,8 +6883,8 @@ ul.v4-rsh-list {
   margin-top: 14px;
 }
 .v4-mshero-tile {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 12px;
   padding: 18px 20px;
   display: flex;
@@ -6833,7 +6907,7 @@ ul.v4-rsh-list {
 .v4-mshero-tile:hover {
   transform: translateY(-2px);
   box-shadow: 0 10px 28px rgba(11, 16, 32, 0.07);
-  border-color: var(--mk-line-strong);
+  border-color: var(--v4-line-strong);
 }
 .v4-mshero-tile--main {
   background:
@@ -6858,10 +6932,10 @@ ul.v4-rsh-list {
 
 .v4-mshero-lbl {
   display: flex; align-items: center; gap: 8px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px; font-weight: 600;
   text-transform: uppercase; letter-spacing: 0.08em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   height: 18px;
   z-index: 1;
 }
@@ -6869,8 +6943,8 @@ ul.v4-rsh-list {
   display: inline-flex; align-items: center; justify-content: center;
   width: 18px; height: 18px;
   border-radius: 5px;
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-600);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-600);
   flex-shrink: 0;
 }
 .v4-mshero-lbl-ic svg { width: 11px; height: 11px; }
@@ -6895,11 +6969,11 @@ ul.v4-rsh-list {
   display: flex; flex-direction: column; align-items: center; justify-content: center;
 }
 .v4-mshero-ring-pct {
-  font-family: var(--mk-font-mono); font-size: 32px; font-weight: 700;
+  font-family: var(--v4-mono); font-size: 32px; font-weight: 700;
   color: #fff; letter-spacing: -0.025em; line-height: 1;
 }
 .v4-mshero-ring-lbl {
-  font-family: var(--mk-font-mono); font-size: 9px; color: rgba(255,255,255,0.7);
+  font-family: var(--v4-mono); font-size: 9px; color: rgba(255,255,255,0.7);
   margin-top: 5px; text-transform: uppercase; letter-spacing: 0.08em;
   font-weight: 600;
 }
@@ -6918,7 +6992,7 @@ ul.v4-rsh-list {
   color: rgba(255,255,255,0.85);
 }
 .v4-mshero-row b {
-  font-family: var(--mk-font-mono); font-weight: 700; color: #fff;
+  font-family: var(--v4-mono); font-weight: 700; color: #fff;
   font-size: 18px; min-width: 32px; text-align: right;
   letter-spacing: -0.02em;
 }
@@ -6929,30 +7003,30 @@ ul.v4-rsh-list {
   margin-top: 2px;
 }
 .v4-mshero-num {
-  font-family: var(--mk-font-mono); font-size: 48px; font-weight: 700;
-  color: var(--mk-ink-900); line-height: 1; letter-spacing: -0.025em;
+  font-family: var(--v4-mono); font-size: 48px; font-weight: 700;
+  color: var(--v4-ink-900); line-height: 1; letter-spacing: -0.025em;
 }
 .v4-mshero-num-u {
   font-size: 14px; font-weight: 600;
-  color: var(--mk-ink-500); margin-left: 4px;
+  color: var(--v4-ink-500); margin-left: 4px;
 }
 .v4-mshero-delta-chip {
   margin-left: auto; align-self: center;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px; font-weight: 700;
   padding: 4px 8px;
   border-radius: 6px;
   white-space: nowrap;
 }
-.v4-mshero-delta-chip--pos { background: var(--mk-success-soft); color: var(--mk-success-strong); }
+.v4-mshero-delta-chip--pos { background: var(--v4-success-50); color: var(--v4-success-700); }
 .v4-mshero-delta-chip--neg { background: #FEE4E2; color: #B42318; }
 
 .v4-mshero-meta {
-  font-family: var(--mk-font-mono); font-size: 11px;
-  color: var(--mk-ink-500);
+  font-family: var(--v4-mono); font-size: 11px;
+  color: var(--v4-ink-500);
 }
 .v4-mshero-meta-strong {
-  color: var(--mk-ink-700); font-weight: 600;
+  color: var(--v4-ink-700); font-weight: 600;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   display: block;
 }
@@ -6966,7 +7040,7 @@ ul.v4-rsh-list {
 .v4-mshero-spark svg { width: 100%; height: 100%; display: block; overflow: visible; }
 .v4-mshero-spark-line {
   fill: none;
-  stroke: var(--mk-success);
+  stroke: var(--v4-success-500);
   stroke-width: 2;
   stroke-linecap: round;
   stroke-linejoin: round;
@@ -6980,9 +7054,9 @@ ul.v4-rsh-list {
 .v4-mshero-spark-tip {
   position: absolute;
   top: 0;
-  background: var(--mk-ink-900); color: #fff;
+  background: var(--v4-ink-900); color: #fff;
   padding: 5px 9px; border-radius: 6px;
-  font-family: var(--mk-font-mono); font-size: 11px;
+  font-family: var(--v4-mono); font-size: 11px;
   white-space: nowrap; pointer-events: none;
   box-shadow: 0 4px 12px rgba(0,0,0,.18);
   display: none;
@@ -7004,26 +7078,26 @@ ul.v4-rsh-list {
   display: grid; grid-template-columns: repeat(3, 1fr);
   margin-top: auto;
   padding-top: 10px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
 }
 .v4-mshero-break-it {
   text-align: center;
   padding: 0 4px;
-  border-left: 1px solid var(--mk-line-soft);
+  border-left: 1px solid var(--v4-line-soft);
   transition: background .15s;
   border-radius: 4px;
 }
 .v4-mshero-break-it:first-child { border-left: 0; }
-.v4-mshero-break-it:hover { background: var(--mk-surface-2); }
+.v4-mshero-break-it:hover { background: var(--v4-surface-2); }
 .v4-mshero-break-n {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 18px; font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   line-height: 1;
 }
 .v4-mshero-break-l {
-  font-family: var(--mk-font-mono);
-  font-size: 9px; color: var(--mk-ink-500);
+  font-family: var(--v4-mono);
+  font-size: 9px; color: var(--v4-ink-500);
   text-transform: uppercase; letter-spacing: 0.06em;
   font-weight: 600;
   margin-top: 5px;
@@ -7031,8 +7105,8 @@ ul.v4-rsh-list {
 
 /* Gantt */
 .v4-msgantt {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 12px;
   margin-top: 14px;
   overflow: hidden;
@@ -7040,33 +7114,33 @@ ul.v4-rsh-list {
 .v4-msgantt-h {
   display: flex; align-items: center; justify-content: space-between;
   padding: 14px 18px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   flex-wrap: wrap; gap: 12px;
 }
 .v4-msgantt-t {
-  font-size: 13px; font-weight: 600; color: var(--mk-ink-900);
+  font-size: 13px; font-weight: 600; color: var(--v4-ink-900);
   display: inline-flex; align-items: center; gap: 8px;
 }
 .v4-msgantt-t svg { width: 14px; height: 14px; }
 .v4-msgantt-controls { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .v4-msgantt-legend {
   display: flex; gap: 14px;
-  font-family: var(--mk-font-mono); font-size: 11px; color: var(--mk-ink-500);
+  font-family: var(--v4-mono); font-size: 11px; color: var(--v4-ink-500);
   flex-wrap: wrap;
 }
 .v4-msgantt-lg { display: inline-flex; align-items: center; gap: 6px; }
 .v4-msgantt-dot { width: 8px; height: 8px; border-radius: 99px; }
 .v4-msgantt-mini-bar {
   width: 18px; height: 6px; border-radius: 99px;
-  background: var(--mk-surface-3); position: relative;
+  background: var(--v4-surface-3); position: relative;
 }
 .v4-msgantt-mini-bar::after {
   content: ''; position: absolute; left: 0; top: 0; bottom: 0;
-  width: 60%; border-radius: 99px; background: var(--mk-brand-500);
+  width: 60%; border-radius: 99px; background: var(--v4-accent-500);
 }
 .v4-msgantt-empty {
   padding: 36px 18px; text-align: center;
-  color: var(--mk-ink-500); font-size: 13px;
+  color: var(--v4-ink-500); font-size: 13px;
 }
 .v4-msgantt-body {
   display: grid;
@@ -7074,24 +7148,24 @@ ul.v4-rsh-list {
 }
 
 .v4-msgantt-list {
-  background: var(--mk-paper);
-  border-right: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border-right: 1px solid var(--v4-line);
   display: flex; flex-direction: column;
   min-width: 0;
 }
 .v4-msgantt-list-h {
   height: 56px; padding: 0 14px;
   display: flex; align-items: center;
-  font-family: var(--mk-font-mono); font-size: 10px; font-weight: 700;
+  font-family: var(--v4-mono); font-size: 10px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.06em;
-  color: var(--mk-ink-500);
-  border-bottom: 1px solid var(--mk-line-soft);
-  background: var(--mk-surface-2);
+  color: var(--v4-ink-500);
+  border-bottom: 1px solid var(--v4-line-soft);
+  background: var(--v4-surface-2);
 }
 .v4-msgantt-row {
   height: 44px; padding: 0 14px;
   display: flex; align-items: center; gap: 10px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   cursor: pointer;
   transition: background 120ms;
   position: relative;
@@ -7099,35 +7173,35 @@ ul.v4-rsh-list {
   color: inherit;
   min-width: 0;
 }
-.v4-msgantt-row:hover { background: var(--mk-surface-2); }
+.v4-msgantt-row:hover { background: var(--v4-surface-2); }
 .v4-msgantt-row:last-child { border-bottom: 0; }
 .v4-msgantt-row::before {
   content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 3px;
 }
-.v4-msgantt-row--overdue::before { background: var(--mk-danger); }
-.v4-msgantt-row--warn::before    { background: var(--mk-warn); }
-.v4-msgantt-row--soon::before    { background: var(--mk-brand-500); }
-.v4-msgantt-row--norm::before    { background: var(--mk-ink-300); }
-.v4-msgantt-row--done::before    { background: var(--mk-success); }
-.v4-msgantt-row--noeta::before   { background: var(--mk-ink-300); }
+.v4-msgantt-row--overdue::before { background: var(--v4-danger-500); }
+.v4-msgantt-row--warn::before    { background: var(--v4-warn-500); }
+.v4-msgantt-row--soon::before    { background: var(--v4-accent-500); }
+.v4-msgantt-row--norm::before    { background: var(--v4-ink-300); }
+.v4-msgantt-row--done::before    { background: var(--v4-success-500); }
+.v4-msgantt-row--noeta::before   { background: var(--v4-ink-300); }
 .v4-msgantt-row-glyph { width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; }
 .v4-msgantt-row-info { flex: 1; min-width: 0; line-height: 1.1; }
 .v4-msgantt-row-title {
-  font-size: 12.5px; font-weight: 600; color: var(--mk-ink-900);
+  font-size: 12.5px; font-weight: 600; color: var(--v4-ink-900);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   letter-spacing: -0.005em;
 }
 .v4-msgantt-row-sub {
-  font-family: var(--mk-font-mono); font-size: 10px; color: var(--mk-ink-500);
+  font-family: var(--v4-mono); font-size: 10px; color: var(--v4-ink-500);
   margin-top: 2px;
   display: flex; gap: 6px; align-items: center;
 }
 .v4-msgantt-row-dot {
-  width: 2px; height: 2px; border-radius: 50%; background: var(--mk-ink-400);
+  width: 2px; height: 2px; border-radius: 50%; background: var(--v4-ink-400);
 }
 .v4-msgantt-row-pct {
-  font-family: var(--mk-font-mono); font-size: 11px; font-weight: 700;
-  color: var(--mk-ink-700); flex-shrink: 0;
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 700;
+  color: var(--v4-ink-700); flex-shrink: 0;
   min-width: 36px; text-align: right;
 }
 
@@ -7140,55 +7214,55 @@ ul.v4-rsh-list {
 .v4-msgantt-axis {
   height: 56px;
   position: sticky; top: 0; z-index: 3;
-  background: var(--mk-surface-2);
-  border-bottom: 1px solid var(--mk-line-soft);
+  background: var(--v4-surface-2);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .v4-msgantt-axis-months {
   display: flex; height: 26px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .v4-msgantt-axis-month {
   display: flex; align-items: center; justify-content: center;
-  font-family: var(--mk-font-mono); font-size: 11px; font-weight: 700;
-  color: var(--mk-ink-700);
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 700;
+  color: var(--v4-ink-700);
   text-transform: uppercase; letter-spacing: 0.05em;
-  border-right: 1px solid var(--mk-line-soft);
+  border-right: 1px solid var(--v4-line-soft);
 }
 .v4-msgantt-axis-month:last-child { border-right: 0; }
 .v4-msgantt-axis-days { display: flex; height: 30px; }
 .v4-msgantt-axis-day {
   display: flex; flex-direction: column;
   align-items: center; justify-content: center;
-  border-right: 1px solid var(--mk-line-soft);
-  font-family: var(--mk-font-mono);
+  border-right: 1px solid var(--v4-line-soft);
+  font-family: var(--v4-mono);
   flex-shrink: 0;
 }
 .v4-msgantt-axis-day:last-child { border-right: 0; }
 .v4-msgantt-axis-day-num {
   font-size: 11px; font-weight: 600;
-  color: var(--mk-ink-700); line-height: 1;
+  color: var(--v4-ink-700); line-height: 1;
 }
 .v4-msgantt-axis-day-dow {
-  font-size: 9px; color: var(--mk-ink-400);
+  font-size: 9px; color: var(--v4-ink-400);
   margin-top: 2px; text-transform: uppercase;
 }
 .v4-msgantt-axis-day--weekend { background: rgba(148,160,184,0.08); }
 .v4-msgantt-axis-day--weekend .v4-msgantt-axis-day-num,
 .v4-msgantt-axis-day--weekend .v4-msgantt-axis-day-dow {
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
-.v4-msgantt-axis-day--today { background: var(--mk-brand-50); }
-.v4-msgantt-axis-day--today .v4-msgantt-axis-day-num { color: var(--mk-brand-700); }
+.v4-msgantt-axis-day--today { background: var(--v4-accent-50); }
+.v4-msgantt-axis-day--today .v4-msgantt-axis-day-num { color: var(--v4-accent-700); }
 
 .v4-msgantt-grid {
   position: relative;
-  background-color: var(--mk-paper);
-  background-image: linear-gradient(to right, var(--mk-line-soft) 0, var(--mk-line-soft) 1px, transparent 1px);
+  background-color: var(--v4-paper);
+  background-image: linear-gradient(to right, var(--v4-line-soft) 0, var(--v4-line-soft) 1px, transparent 1px);
   background-repeat: repeat;
 }
 .v4-msgantt-grid-row {
   height: 44px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   position: relative;
 }
 .v4-msgantt-grid-row:last-child { border-bottom: 0; }
@@ -7202,30 +7276,30 @@ ul.v4-rsh-list {
   height: 34px;
   padding: 0 14px 0 18px;
   display: flex; align-items: center; gap: 10px;
-  background: var(--mk-paper);
-  border-bottom: 1px solid var(--mk-line-soft);
+  background: var(--v4-ink-50, #EEF1F6);
+  border-bottom: 1px solid var(--v4-line-soft);
   position: relative;
 }
 .v4-msgantt-list-group-name {
-  font-family: var(--mk-font-mono); font-size: 11.5px; font-weight: 800;
-  color: var(--mk-ink-900);
+  font-family: var(--v4-mono); font-size: 11.5px; font-weight: 800;
+  color: var(--v4-ink-900);
   text-transform: uppercase; letter-spacing: 0.08em;
   flex: 1; min-width: 0;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .v4-msgantt-list-group-count {
   font-size: 11px; font-weight: 700;
-  color: var(--mk-ink-700);
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  color: var(--v4-ink-700);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   padding: 1px 8px;
   border-radius: 99px;
   flex-shrink: 0;
 }
 .v4-msgantt-grid-group {
   height: 34px;
-  background: var(--mk-paper);
-  border-bottom: 1px solid var(--mk-line-soft);
+  background: var(--v4-ink-50, #EEF1F6);
+  border-bottom: 1px solid var(--v4-line-soft);
   position: relative;
   z-index: 0;
 }
@@ -7238,14 +7312,14 @@ ul.v4-rsh-list {
 }
 .v4-msgantt-today {
   position: absolute; top: 0; bottom: 0;
-  width: 2px; background: var(--mk-brand-500);
+  width: 2px; background: var(--v4-accent-500);
   z-index: 4; pointer-events: none;
 }
 .v4-msgantt-today::before {
   content: 'СЕГОДНЯ';
   position: absolute; top: -4px; left: 50%; transform: translateX(-50%);
-  background: var(--mk-brand-500); color: #fff;
-  font-family: var(--mk-font-mono); font-size: 9px; font-weight: 700;
+  background: var(--v4-accent-500); color: #fff;
+  font-family: var(--v4-mono); font-size: 9px; font-weight: 700;
   padding: 2px 7px; border-radius: 4px; letter-spacing: 0.05em;
   white-space: nowrap; z-index: 5;
 }
@@ -7260,7 +7334,7 @@ ul.v4-rsh-list {
   transition: transform 120ms, box-shadow 120ms;
   display: flex; align-items: center;
   padding: 0 8px;
-  font-family: var(--mk-font-mono); font-size: 11px; font-weight: 600;
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 600;
   color: #fff; white-space: nowrap;
   text-decoration: none;
 }
@@ -7314,7 +7388,7 @@ ul.v4-rsh-list {
   height: 26px;
   border-radius: 6px;
   background: rgba(37, 99, 235, 0.18);
-  border: 1.5px dashed var(--mk-brand-500);
+  border: 1.5px dashed var(--v4-accent-500);
   z-index: 7;
   pointer-events: none;
 }
@@ -7325,7 +7399,7 @@ ul.v4-rsh-list {
 .v4-mscconfirm-lead {
   margin: 0;
   font-size: 14px;
-  color: var(--mk-ink-800);
+  color: var(--v4-ink-800);
 }
 .v4-mscconfirm-tbl {
   width: 100%;
@@ -7336,54 +7410,54 @@ ul.v4-rsh-list {
   text-align: left;
   padding: 8px 6px;
   font-weight: 600;
-  color: var(--mk-ink-700);
-  border-bottom: 1px solid var(--mk-line-soft);
+  color: var(--v4-ink-700);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .v4-mscconfirm-tbl thead th {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-weight: 600;
 }
 .v4-mscconfirm-tbl td {
   padding: 8px 6px;
-  font-family: var(--mk-font-mono);
-  color: var(--mk-ink-700);
-  border-bottom: 1px solid var(--mk-line-soft);
+  font-family: var(--v4-mono);
+  color: var(--v4-ink-700);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .v4-mscconfirm-tbl tr.is-changed th,
 .v4-mscconfirm-tbl tr.is-changed td {
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-weight: 700;
 }
 .v4-mscconfirm-tbl tr.is-changed td:last-child {
-  background: var(--mk-success-soft);
-  color: var(--mk-success-strong);
+  background: var(--v4-success-50);
+  color: var(--v4-success-700);
   border-radius: 4px;
 }
 .v4-mscconfirm-tag {
   display: inline-block;
   margin-left: 6px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 9px;
   font-weight: 600;
   padding: 2px 6px;
   border-radius: 99px;
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-500);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-500);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 .v4-mscconfirm-tag--gh {
-  background: var(--mk-brand-50);
-  color: var(--mk-brand-700);
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
 }
 .v4-mscconfirm-note {
   font-size: 12px;
-  color: var(--mk-ink-500);
-  background: var(--mk-surface-2);
+  color: var(--v4-ink-500);
+  background: var(--v4-surface-2);
   border-radius: 8px;
   padding: 10px 12px;
 }
@@ -7392,14 +7466,14 @@ ul.v4-rsh-list {
   justify-content: flex-end;
   gap: 8px;
   padding: 12px 20px 16px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
 }
 
 .v4-msgantt-bar--overdue {
-  background: var(--mk-danger-100); color: var(--mk-danger-strong);
-  border: 1px solid var(--mk-danger);
+  background: var(--v4-danger-100); color: var(--v4-danger-700);
+  border: 1px solid var(--v4-danger-500);
 }
-.v4-msgantt-bar--overdue .v4-msgantt-bar-fill { background: var(--mk-danger); }
+.v4-msgantt-bar--overdue .v4-msgantt-bar-fill { background: var(--v4-danger-500); }
 .v4-msgantt-bar--overdue .v4-msgantt-bar-text { text-shadow: none; }
 .v4-msgantt-bar--overdue.has-fill .v4-msgantt-bar-text {
   color: #fff; text-shadow: 0 1px 2px rgba(0,0,0,0.18);
@@ -7408,41 +7482,41 @@ ul.v4-rsh-list {
   background: rgba(255,255,255,0.3); border-color: rgba(255,255,255,0.25);
 }
 .v4-msgantt-bar--warn {
-  background: var(--mk-warn-100); color: var(--mk-warn-strong);
-  border: 1px solid var(--mk-warn);
+  background: var(--v4-warn-100); color: var(--v4-warn-700);
+  border: 1px solid var(--v4-warn-500);
 }
-.v4-msgantt-bar--warn .v4-msgantt-bar-fill { background: var(--mk-warn); }
+.v4-msgantt-bar--warn .v4-msgantt-bar-fill { background: var(--v4-warn-500); }
 .v4-msgantt-bar--warn .v4-msgantt-bar-text { text-shadow: none; }
 .v4-msgantt-bar--soon {
-  background: var(--mk-brand-100); color: var(--mk-brand-700);
-  border: 1px solid var(--mk-brand-500);
+  background: var(--v4-accent-100); color: var(--v4-accent-700);
+  border: 1px solid var(--v4-accent-500);
 }
-.v4-msgantt-bar--soon .v4-msgantt-bar-fill { background: var(--mk-brand-500); }
+.v4-msgantt-bar--soon .v4-msgantt-bar-fill { background: var(--v4-accent-500); }
 .v4-msgantt-bar--soon .v4-msgantt-bar-text { text-shadow: none; }
 .v4-msgantt-bar--norm {
-  background: #DDE3EE; color: var(--mk-ink-800);
-  border: 1px solid var(--mk-ink-400);
+  background: #DDE3EE; color: var(--v4-ink-800);
+  border: 1px solid var(--v4-ink-400);
 }
-.v4-msgantt-bar--norm .v4-msgantt-bar-fill { background: var(--mk-ink-500); }
+.v4-msgantt-bar--norm .v4-msgantt-bar-fill { background: var(--v4-ink-500); }
 .v4-msgantt-bar--norm .v4-msgantt-bar-text { text-shadow: none; }
 .v4-msgantt-bar--done {
-  background: var(--mk-success-100); color: var(--mk-success-strong);
-  border: 1px solid var(--mk-success);
+  background: var(--v4-success-100); color: var(--v4-success-700);
+  border: 1px solid var(--v4-success-500);
 }
-.v4-msgantt-bar--done .v4-msgantt-bar-fill { background: var(--mk-success); }
+.v4-msgantt-bar--done .v4-msgantt-bar-fill { background: var(--v4-success-500); }
 .v4-msgantt-bar--done .v4-msgantt-bar-text { text-shadow: none; }
 .v4-msgantt-bar--noeta {
   background: repeating-linear-gradient(135deg, #F4F5F8 0 6px, #EDEFF3 6px 12px);
-  color: var(--mk-ink-600);
-  border: 1px dashed var(--mk-ink-400);
+  color: var(--v4-ink-600);
+  border: 1px dashed var(--v4-ink-400);
 }
 .v4-msgantt-bar--noeta .v4-msgantt-bar-fill { background: rgba(74,85,112,0.25); }
 .v4-msgantt-bar--noeta .v4-msgantt-bar-text { text-shadow: none; }
 
 /* Closed section (collapsible) */
 .v4-msclosed {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 12px;
   margin-top: 14px;
   overflow: hidden;
@@ -7460,45 +7534,45 @@ ul.v4-rsh-list {
   color: inherit;
   font: inherit;
 }
-.v4-msclosed-h:hover { background: var(--mk-surface-2); }
-.v4-msclosed-h.is-open { border-bottom: 1px solid var(--mk-line-soft); }
+.v4-msclosed-h:hover { background: var(--v4-surface-2); }
+.v4-msclosed-h.is-open { border-bottom: 1px solid var(--v4-line-soft); }
 .v4-msclosed-t {
-  font-size: 13px; font-weight: 600; color: var(--mk-ink-900);
+  font-size: 13px; font-weight: 600; color: var(--v4-ink-900);
   display: inline-flex; align-items: center; gap: 10px;
 }
 .v4-msclosed-chev {
-  width: 18px; height: 18px; color: var(--mk-ink-500);
+  width: 18px; height: 18px; color: var(--v4-ink-500);
   transition: transform 160ms;
   flex-shrink: 0;
 }
 .v4-msclosed-h.is-open .v4-msclosed-chev { transform: rotate(90deg); }
 .v4-msclosed-count {
-  font-family: var(--mk-font-mono); font-size: 11px; font-weight: 600;
-  background: var(--mk-success-soft); color: var(--mk-success-strong);
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 600;
+  background: var(--v4-success-50); color: var(--v4-success-700);
   padding: 2px 8px; border-radius: 99px;
 }
 .v4-msclosed-meta {
-  font-family: var(--mk-font-mono); font-size: 11px; color: var(--mk-ink-500);
+  font-family: var(--v4-mono); font-size: 11px; color: var(--v4-ink-500);
 }
 .v4-msclosed-body { display: grid; grid-template-columns: 1fr; }
 .v4-msclosed-search {
   padding: 10px 18px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   display: flex; gap: 10px; align-items: center;
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
 }
-.v4-msclosed-search svg { width: 14px; height: 14px; color: var(--mk-ink-400); }
+.v4-msclosed-search svg { width: 14px; height: 14px; color: var(--v4-ink-400); }
 .v4-msclosed-search input {
   flex: 1;
-  border: 1px solid var(--mk-line);
-  background: var(--mk-paper);
+  border: 1px solid var(--v4-line);
+  background: var(--v4-paper);
   border-radius: 8px;
   padding: 6px 10px;
   font-family: inherit; font-size: 12px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   outline: none;
 }
-.v4-msclosed-search input:focus { border-color: var(--mk-brand-500); }
+.v4-msclosed-search input:focus { border-color: var(--v4-accent-500); }
 .v4-msclosed-table {
   display: grid;
   grid-template-columns: 14px 1.2fr 1fr 110px 90px 70px;
@@ -7507,11 +7581,11 @@ ul.v4-rsh-list {
 .v4-msclosed-table-head { display: contents; }
 .v4-msclosed-table-head > div {
   padding: 10px 12px;
-  background: var(--mk-surface-2);
-  border-bottom: 1px solid var(--mk-line);
-  font-family: var(--mk-font-mono); font-size: 10px; font-weight: 700;
+  background: var(--v4-surface-2);
+  border-bottom: 1px solid var(--v4-line);
+  font-family: var(--v4-mono); font-size: 10px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.06em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-msclosed-th-pct { display: flex; justify-content: flex-end; }
 .v4-msclosed-row {
@@ -7522,60 +7596,60 @@ ul.v4-rsh-list {
 }
 .v4-msclosed-row > div {
   padding: 10px 12px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   display: flex; align-items: center;
   min-width: 0;
 }
-.v4-msclosed-row:hover > div { background: var(--mk-surface-2); }
+.v4-msclosed-row:hover > div { background: var(--v4-surface-2); }
 .v4-msclosed-row:last-child > div { border-bottom: 0; }
 .v4-msclosed-row-glyph { width: 8px; height: 8px; border-radius: 2px; margin: auto; }
 .v4-msclosed-row-title {
-  font-weight: 600; color: var(--mk-ink-900);
+  font-weight: 600; color: var(--v4-ink-900);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   display: block; max-width: 100%;
 }
-.v4-msclosed-row-repo { font-family: var(--mk-font-mono); color: var(--mk-ink-600); }
-.v4-msclosed-row-date { font-family: var(--mk-font-mono); color: var(--mk-ink-500); }
+.v4-msclosed-row-repo { font-family: var(--v4-mono); color: var(--v4-ink-600); }
+.v4-msclosed-row-date { font-family: var(--v4-mono); color: var(--v4-ink-500); }
 .v4-msclosed-row-issues {
-  font-family: var(--mk-font-mono); color: var(--mk-ink-700); font-weight: 600;
+  font-family: var(--v4-mono); color: var(--v4-ink-700); font-weight: 600;
 }
 .v4-msclosed-row-pct {
-  font-family: var(--mk-font-mono); color: var(--mk-success-strong); font-weight: 700;
+  font-family: var(--v4-mono); color: var(--v4-success-700); font-weight: 700;
   justify-content: flex-end;
 }
 .v4-msclosed-pager {
   padding: 10px 18px;
   display: flex; justify-content: space-between; align-items: center;
-  border-top: 1px solid var(--mk-line-soft);
-  background: var(--mk-surface-2);
-  font-family: var(--mk-font-mono); font-size: 11px; color: var(--mk-ink-500);
+  border-top: 1px solid var(--v4-line-soft);
+  background: var(--v4-surface-2);
+  font-family: var(--v4-mono); font-size: 11px; color: var(--v4-ink-500);
   gap: 12px;
 }
 .v4-msclosed-pager-ctrl { display: flex; gap: 8px; align-items: center; }
 .v4-msclosed-pager-num { padding: 4px 8px; }
 .v4-msclosed-pager button {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 6px;
   padding: 4px 10px;
-  font-family: var(--mk-font-mono); font-size: 11px; font-weight: 600;
-  color: var(--mk-ink-700);
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 600;
+  color: var(--v4-ink-700);
   cursor: pointer;
 }
-.v4-msclosed-pager button:hover:not(:disabled) { background: var(--mk-surface-2); }
+.v4-msclosed-pager button:hover:not(:disabled) { background: var(--v4-surface-2); }
 .v4-msclosed-pager button:disabled { opacity: 0.4; cursor: not-allowed; }
 .v4-msclosed-empty {
   padding: 30px 18px;
   text-align: center;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-size: 12px;
 }
 
 /* Status bar */
 .v4-msstatus-wrap { margin-top: 14px; }
 .v4-msstatus {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 12px;
   padding: 14px 18px;
   display: flex;
@@ -7586,19 +7660,19 @@ ul.v4-rsh-list {
   margin-bottom: 14px; gap: 8px; flex-wrap: wrap;
 }
 .v4-msstatus-t {
-  font-size: 13px; font-weight: 600; color: var(--mk-ink-900);
+  font-size: 13px; font-weight: 600; color: var(--v4-ink-900);
   display: inline-flex; align-items: center; gap: 8px;
 }
 .v4-msstatus-tag {
-  font-family: var(--mk-font-mono); font-size: 10px; font-weight: 600;
-  background: var(--mk-surface-2); color: var(--mk-ink-600);
+  font-family: var(--v4-mono); font-size: 10px; font-weight: 600;
+  background: var(--v4-surface-2); color: var(--v4-ink-600);
   padding: 2px 6px; border-radius: 4px;
 }
 .v4-msstatus-bar {
   display: flex; height: 36px;
   border-radius: 8px; overflow: hidden;
-  border: 1px solid var(--mk-line-soft);
-  font-family: var(--mk-font-mono); font-size: 11px; font-weight: 700;
+  border: 1px solid var(--v4-line-soft);
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 700;
 }
 .v4-msstatus-seg {
   display: flex; align-items: center; justify-content: center;
@@ -7613,18 +7687,18 @@ ul.v4-rsh-list {
 }
 .v4-msstatus-legend-it {
   display: flex; align-items: center; gap: 8px;
-  font-size: 12px; color: var(--mk-ink-700);
+  font-size: 12px; color: var(--v4-ink-700);
 }
 .v4-msstatus-sw { width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; }
 .v4-msstatus-legend-it b {
   margin-left: auto;
-  font-family: var(--mk-font-mono); color: var(--mk-ink-900);
+  font-family: var(--v4-mono); color: var(--v4-ink-900);
 }
 
 /* Toolbar */
 .v4-mstoolbar {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 12px;
   display: flex; justify-content: space-between; align-items: center;
   flex-wrap: wrap; gap: 14px;
@@ -7643,44 +7717,44 @@ ul.v4-rsh-list {
 .v4-msgroup { display: flex; flex-direction: column; gap: 12px; }
 .v4-msgroup-head {
   display: flex; align-items: center; gap: 12px;
-  border-bottom: 1px solid var(--mk-line);
+  border-bottom: 1px solid var(--v4-line);
   padding-bottom: 10px;
 }
 .v4-msgroup-title {
-  font-family: var(--mk-font-mono); font-size: 11px; font-weight: 700;
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.08em;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   display: inline-flex; align-items: center; gap: 8px;
 }
 .v4-msgroup-dot {
   width: 8px; height: 8px; border-radius: 99px;
-  background: var(--mk-ink-400);
+  background: var(--v4-ink-400);
 }
-.v4-msgroup-head--overdue .v4-msgroup-dot { background: var(--mk-danger); }
-.v4-msgroup-head--week    .v4-msgroup-dot { background: var(--mk-warn); }
-.v4-msgroup-head--month   .v4-msgroup-dot { background: var(--mk-brand-500); }
-.v4-msgroup-head--later   .v4-msgroup-dot { background: var(--mk-ink-300); }
-.v4-msgroup-head--noeta   .v4-msgroup-dot { background: var(--mk-ink-400); }
-.v4-msgroup-head--norm    .v4-msgroup-dot { background: var(--mk-ink-400); }
-.v4-msgroup-count { color: var(--mk-ink-400); font-weight: 500; }
+.v4-msgroup-head--overdue .v4-msgroup-dot { background: var(--v4-danger-500); }
+.v4-msgroup-head--week    .v4-msgroup-dot { background: var(--v4-warn-500); }
+.v4-msgroup-head--month   .v4-msgroup-dot { background: var(--v4-accent-500); }
+.v4-msgroup-head--later   .v4-msgroup-dot { background: var(--v4-ink-300); }
+.v4-msgroup-head--noeta   .v4-msgroup-dot { background: var(--v4-ink-400); }
+.v4-msgroup-head--norm    .v4-msgroup-dot { background: var(--v4-ink-400); }
+.v4-msgroup-count { color: var(--v4-ink-400); font-weight: 500; }
 .v4-msgroup-rollup {
   margin-left: auto;
   display: flex; align-items: center; gap: 10px;
-  font-family: var(--mk-font-mono); font-size: 11px; color: var(--mk-ink-500);
+  font-family: var(--v4-mono); font-size: 11px; color: var(--v4-ink-500);
 }
 .v4-msgroup-rollup-bar {
   width: 140px; height: 5px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   border-radius: 99px; overflow: hidden;
 }
 .v4-msgroup-rollup-fill {
   height: 100%; border-radius: 99px;
-  background: var(--mk-ink-400);
+  background: var(--v4-ink-400);
 }
-.v4-msgroup-head--overdue .v4-msgroup-rollup-fill { background: var(--mk-danger); }
-.v4-msgroup-head--week    .v4-msgroup-rollup-fill { background: var(--mk-warn); }
-.v4-msgroup-head--month   .v4-msgroup-rollup-fill { background: var(--mk-brand-500); }
-.v4-msgroup-head--later   .v4-msgroup-rollup-fill { background: var(--mk-ink-300); }
+.v4-msgroup-head--overdue .v4-msgroup-rollup-fill { background: var(--v4-danger-500); }
+.v4-msgroup-head--week    .v4-msgroup-rollup-fill { background: var(--v4-warn-500); }
+.v4-msgroup-head--month   .v4-msgroup-rollup-fill { background: var(--v4-accent-500); }
+.v4-msgroup-head--later   .v4-msgroup-rollup-fill { background: var(--v4-ink-300); }
 
 .v4-msgrid {
   display: grid;
@@ -7699,8 +7773,8 @@ ul.v4-rsh-list {
 
 /* Card (v4-mscv namespace) */
 .v4-mscv {
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 12px;
   position: relative;
   overflow: hidden;
@@ -7710,19 +7784,19 @@ ul.v4-rsh-list {
   transition: border-color 120ms, box-shadow 120ms;
 }
 .v4-mscv:hover {
-  border-color: var(--mk-line-strong);
+  border-color: var(--v4-line-strong);
   box-shadow: 0 4px 16px rgba(14,19,32,0.06);
 }
 .v4-mscv::before {
   content: ''; position: absolute; left: 0; top: 0; bottom: 0;
   width: 3px;
 }
-.v4-mscv--overdue::before { background: var(--mk-danger); }
-.v4-mscv--warn::before    { background: var(--mk-warn); }
-.v4-mscv--soon::before    { background: var(--mk-brand-500); }
-.v4-mscv--norm::before    { background: var(--mk-ink-300); }
-.v4-mscv--done::before    { background: var(--mk-success); }
-.v4-mscv--noeta::before   { background: var(--mk-ink-300); }
+.v4-mscv--overdue::before { background: var(--v4-danger-500); }
+.v4-mscv--warn::before    { background: var(--v4-warn-500); }
+.v4-mscv--soon::before    { background: var(--v4-accent-500); }
+.v4-mscv--norm::before    { background: var(--v4-ink-300); }
+.v4-mscv--done::before    { background: var(--v4-success-500); }
+.v4-mscv--noeta::before   { background: var(--v4-ink-300); }
 .v4-mscv--compact { padding: 14px; gap: 10px; }
 .v4-mscv--compact .v4-mscv-title { font-size: 13.5px; }
 
@@ -7732,7 +7806,7 @@ ul.v4-rsh-list {
   outline: none;
 }
 .v4-mscv-head:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: 2px;
   border-radius: 6px;
 }
@@ -7742,41 +7816,41 @@ ul.v4-rsh-list {
 }
 .v4-mscv-repo {
   display: inline-flex; align-items: center; gap: 7px;
-  font-family: var(--mk-font-mono); font-size: 11px; font-weight: 600;
-  color: var(--mk-ink-700);
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 600;
+  color: var(--v4-ink-700);
   text-transform: lowercase;
   min-width: 0;
 }
 .v4-mscv-repo-glyph { width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; }
 .v4-mscv-chev {
   width: 12px; height: 12px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   transition: transform 160ms;
   flex-shrink: 0;
 }
-.v4-mscv-chev.is-open { transform: rotate(90deg); color: var(--mk-ink-700); }
+.v4-mscv-chev.is-open { transform: rotate(90deg); color: var(--v4-ink-700); }
 .v4-mscv-meta-right { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
 .v4-mscv-due {
   display: inline-flex; align-items: center; gap: 4px;
-  font-family: var(--mk-font-mono); font-size: 11px; font-weight: 600;
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 600;
   white-space: nowrap;
 }
 .v4-mscv-due svg { width: 11px; height: 11px; }
-.v4-mscv-due--overdue { color: var(--mk-danger-strong); }
-.v4-mscv-due--warn    { color: var(--mk-warn-strong); }
-.v4-mscv-due--soon    { color: var(--mk-brand-700); }
-.v4-mscv-due--norm    { color: var(--mk-ink-500); }
-.v4-mscv-due--done    { color: var(--mk-success-strong); }
-.v4-mscv-due--noeta   { color: var(--mk-ink-400); }
+.v4-mscv-due--overdue { color: var(--v4-danger-700); }
+.v4-mscv-due--warn    { color: var(--v4-warn-700); }
+.v4-mscv-due--soon    { color: var(--v4-accent-700); }
+.v4-mscv-due--norm    { color: var(--v4-ink-500); }
+.v4-mscv-due--done    { color: var(--v4-success-700); }
+.v4-mscv-due--noeta   { color: var(--v4-ink-400); }
 
 .v4-mscv-title {
-  font-size: 16px; font-weight: 600; color: var(--mk-ink-900);
+  font-size: 16px; font-weight: 600; color: var(--v4-ink-900);
   line-height: 1.35; letter-spacing: -0.01em;
 }
 .v4-mscv-titlelink { color: inherit; }
-.v4-mscv-titlelink:hover { color: var(--mk-brand-700); text-decoration: underline; }
+.v4-mscv-titlelink:hover { color: var(--v4-accent-700); text-decoration: underline; }
 .v4-mscv-desc {
-  font-size: 12px; color: var(--mk-ink-500); line-height: 1.45;
+  font-size: 12px; color: var(--v4-ink-500); line-height: 1.45;
 }
 
 .v4-mscv-bar { display: flex; flex-direction: column; gap: 7px; }
@@ -7784,49 +7858,49 @@ ul.v4-rsh-list {
   display: flex; justify-content: space-between; align-items: baseline;
 }
 .v4-mscv-bar-meta-left {
-  font-family: var(--mk-font-mono); font-size: 12px; color: var(--mk-ink-700);
+  font-family: var(--v4-mono); font-size: 12px; color: var(--v4-ink-700);
 }
-.v4-mscv-bar-closed { font-weight: 700; color: var(--mk-ink-900); }
-.v4-mscv-bar-total { color: var(--mk-ink-500); }
+.v4-mscv-bar-closed { font-weight: 700; color: var(--v4-ink-900); }
+.v4-mscv-bar-total { color: var(--v4-ink-500); }
 .v4-mscv-bar-pct {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 18px; font-weight: 700; line-height: 1;
   letter-spacing: -0.02em;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
-.v4-mscv-pct--good { color: var(--mk-success-strong); }
-.v4-mscv-pct--warn { color: var(--mk-warn-strong); }
-.v4-mscv-pct--bad  { color: var(--mk-danger-strong); }
+.v4-mscv-pct--good { color: var(--v4-success-700); }
+.v4-mscv-pct--warn { color: var(--v4-warn-700); }
+.v4-mscv-pct--bad  { color: var(--v4-danger-700); }
 .v4-mscv-track {
-  height: 6px; background: var(--mk-surface-3); border-radius: 99px;
+  height: 6px; background: var(--v4-surface-3); border-radius: 99px;
   overflow: hidden; position: relative;
 }
 .v4-mscv-fill { height: 100%; border-radius: 99px; }
-.v4-mscv-fill--overdue { background: var(--mk-danger); }
-.v4-mscv-fill--warn    { background: var(--mk-warn); }
-.v4-mscv-fill--soon    { background: var(--mk-brand-500); }
-.v4-mscv-fill--norm    { background: var(--mk-ink-400); }
-.v4-mscv-fill--done    { background: var(--mk-success); }
-.v4-mscv-fill--noeta   { background: var(--mk-ink-400); }
+.v4-mscv-fill--overdue { background: var(--v4-danger-500); }
+.v4-mscv-fill--warn    { background: var(--v4-warn-500); }
+.v4-mscv-fill--soon    { background: var(--v4-accent-500); }
+.v4-mscv-fill--norm    { background: var(--v4-ink-400); }
+.v4-mscv-fill--done    { background: var(--v4-success-500); }
+.v4-mscv-fill--noeta   { background: var(--v4-ink-400); }
 
 .v4-mscv-foot {
   display: flex; gap: 6px; flex-wrap: wrap;
-  border-top: 1px dashed var(--mk-line-soft);
+  border-top: 1px dashed var(--v4-line-soft);
   padding-top: 12px;
   margin-top: -2px;
 }
 .v4-mscv-chip {
   display: inline-flex; align-items: center; gap: 5px;
-  font-family: var(--mk-font-mono); font-size: 11px; font-weight: 600;
-  background: var(--mk-surface-2); color: var(--mk-ink-600);
+  font-family: var(--v4-mono); font-size: 11px; font-weight: 600;
+  background: var(--v4-surface-2); color: var(--v4-ink-600);
   padding: 3px 8px; border-radius: 99px;
 }
-.v4-mscv-chip--p1      { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
-.v4-mscv-chip--p2      { background: var(--mk-warn-soft);   color: var(--mk-warn-strong); }
-.v4-mscv-chip--blocked { background: var(--mk-danger-soft); color: var(--mk-danger-strong); }
+.v4-mscv-chip--p1      { background: var(--v4-danger-50); color: var(--v4-danger-700); }
+.v4-mscv-chip--p2      { background: var(--v4-warn-50);   color: var(--v4-warn-700); }
+.v4-mscv-chip--blocked { background: var(--v4-danger-50); color: var(--v4-danger-700); }
 
 .v4-mscv-issues {
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   padding-top: 10px;
   display: flex; flex-direction: column; gap: 4px;
   max-height: 280px;
@@ -7834,7 +7908,7 @@ ul.v4-rsh-list {
 }
 .v4-mscv-issues-empty {
   padding: 8px 0;
-  font-size: 12px; color: var(--mk-ink-500);
+  font-size: 12px; color: var(--v4-ink-500);
   text-align: center;
 }
 
@@ -8037,7 +8111,7 @@ ul.v4-rsh-list {
   box-shadow:
     0 14px 32px -14px rgba(11, 16, 32, 0.18),
     0 4px 10px -4px rgba(11, 16, 32, 0.08);
-  border-color: var(--mk-line-strong);
+  border-color: var(--v4-line-strong);
 }
 .v4-pcard::after {
   content: '';
@@ -8067,13 +8141,13 @@ ul.v4-rsh-list {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--mk-brand-500);
+  background: var(--v4-accent-500);
   box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.55);
   animation: wow-pulse-ring 1.6s cubic-bezier(0.16, 1, 0.3, 1) infinite;
 }
-.v4-nav-pulse--success { background: var(--mk-success); box-shadow: 0 0 0 0 rgba(18, 183, 106, 0.55); }
-.v4-nav-pulse--warn    { background: var(--mk-warn);    box-shadow: 0 0 0 0 rgba(247, 144, 9, 0.55); }
-.v4-nav-pulse--danger  { background: var(--mk-danger);  box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.55); }
+.v4-nav-pulse--success { background: var(--v4-success-500); box-shadow: 0 0 0 0 rgba(18, 183, 106, 0.55); }
+.v4-nav-pulse--warn    { background: var(--v4-warn-500);    box-shadow: 0 0 0 0 rgba(247, 144, 9, 0.55); }
+.v4-nav-pulse--danger  { background: var(--v4-danger-500);  box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.55); }
 .v4-nav-item.is-active .v4-nav-pulse { background: #fff; box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.55); }
 @keyframes wow-pulse-ring {
   0%   { box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.55); }
@@ -8094,10 +8168,10 @@ ul.v4-rsh-list {
 }
 .wow-toast {
   pointer-events: auto;
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
-  border-left: 3px solid var(--mk-ink-400);
-  border-radius: var(--mk-r-md);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
+  border-left: 3px solid var(--v4-ink-400);
+  border-radius: var(--v4-r-md);
   box-shadow:
     0 16px 36px -16px rgba(11, 16, 32, 0.22),
     0 4px 12px -4px rgba(11, 16, 32, 0.08);
@@ -8108,15 +8182,15 @@ ul.v4-rsh-list {
   min-width: 260px;
   max-width: 380px;
   font-size: 13px;
-  color: var(--mk-ink-800);
+  color: var(--v4-ink-800);
   animation: wow-toast-in 280ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }
 .wow-toast.is-leaving {
   animation: wow-toast-out 200ms ease both;
 }
-.wow-toast--success { border-left-color: var(--mk-success); }
-.wow-toast--error   { border-left-color: var(--mk-danger); }
-.wow-toast--info    { border-left-color: var(--mk-brand-500); }
+.wow-toast--success { border-left-color: var(--v4-success-500); }
+.wow-toast--error   { border-left-color: var(--v4-danger-500); }
+.wow-toast--info    { border-left-color: var(--v4-accent-500); }
 .wow-toast-ic {
   width: 18px;
   height: 18px;
@@ -8126,32 +8200,32 @@ ul.v4-rsh-list {
   justify-content: center;
   margin-top: 1px;
 }
-.wow-toast--success .wow-toast-ic { color: var(--mk-success); }
-.wow-toast--error   .wow-toast-ic { color: var(--mk-danger); }
-.wow-toast--info    .wow-toast-ic { color: var(--mk-brand-500); }
+.wow-toast--success .wow-toast-ic { color: var(--v4-success-500); }
+.wow-toast--error   .wow-toast-ic { color: var(--v4-danger-500); }
+.wow-toast--info    .wow-toast-ic { color: var(--v4-accent-500); }
 .wow-toast-ic svg { width: 16px; height: 16px; }
 .wow-toast-body { flex: 1; min-width: 0; line-height: 1.4; }
-.wow-toast-body b { display: block; color: var(--mk-ink-900); margin-bottom: 1px; font-size: 13px; font-weight: 600; }
-.wow-toast-body span { color: var(--mk-ink-500); font-size: 12px; }
+.wow-toast-body b { display: block; color: var(--v4-ink-900); margin-bottom: 1px; font-size: 13px; font-weight: 600; }
+.wow-toast-body span { color: var(--v4-ink-500); font-size: 12px; }
 .wow-toast-close {
   appearance: none;
   background: transparent;
   border: 0;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   cursor: pointer;
   padding: 2px 4px;
   font-size: 14px;
   line-height: 1;
   border-radius: 4px;
 }
-.wow-toast-close:hover { color: var(--mk-ink-700); background: var(--mk-surface-2); }
+.wow-toast-close:hover { color: var(--v4-ink-700); background: var(--v4-surface-2); }
 .wow-toast-action {
   display: inline-block;
   margin-top: 6px;
   appearance: none;
-  background: var(--mk-surface-2);
-  border: 1px solid var(--mk-line);
-  color: var(--mk-ink-900);
+  background: var(--v4-surface-2, rgba(0,0,0,0.04));
+  border: 1px solid var(--v4-border, rgba(0,0,0,0.08));
+  color: var(--v4-ink-900);
   font-size: 12px;
   font-weight: 600;
   padding: 4px 10px;
@@ -8159,7 +8233,7 @@ ul.v4-rsh-list {
   cursor: pointer;
   line-height: 1.2;
 }
-.wow-toast-action:hover { background: var(--mk-surface-3); }
+.wow-toast-action:hover { background: var(--v4-surface-3, rgba(0,0,0,0.07)); }
 @keyframes wow-toast-in {
   from { opacity: 0; transform: translateX(40px) scale(0.95); }
   to   { opacity: 1; transform: translateX(0)    scale(1); }
@@ -8186,8 +8260,8 @@ ul.v4-rsh-list {
 @keyframes wow-cmdk-fade { from { opacity: 0; } to { opacity: 1; } }
 .wow-cmdk {
   width: min(620px, 92vw);
-  background: var(--mk-paper);
-  border: 1px solid var(--mk-line);
+  background: var(--v4-paper);
+  border: 1px solid var(--v4-line);
   border-radius: 14px;
   box-shadow:
     0 30px 80px -20px rgba(11, 16, 32, 0.35),
@@ -8207,12 +8281,12 @@ ul.v4-rsh-list {
   align-items: center;
   gap: 10px;
   padding: 14px 16px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .wow-cmdk-input-wrap svg {
   width: 18px;
   height: 18px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   flex-shrink: 0;
 }
 .wow-cmdk-input {
@@ -8221,16 +8295,16 @@ ul.v4-rsh-list {
   outline: none;
   background: transparent;
   font: inherit;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
   font-size: 15px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
-.wow-cmdk-input::placeholder { color: var(--mk-ink-400); }
+.wow-cmdk-input::placeholder { color: var(--v4-ink-400); }
 .wow-cmdk-hint {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10.5px;
-  color: var(--mk-ink-400);
-  border: 1px solid var(--mk-line);
+  color: var(--v4-ink-400);
+  border: 1px solid var(--v4-line);
   border-radius: 4px;
   padding: 1px 6px;
 }
@@ -8242,12 +8316,12 @@ ul.v4-rsh-list {
 }
 .wow-cmdk-section {
   padding: 8px 10px 4px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .wow-cmdk-item {
   display: flex;
@@ -8256,22 +8330,22 @@ ul.v4-rsh-list {
   padding: 9px 10px;
   border-radius: 8px;
   cursor: pointer;
-  color: var(--mk-ink-800);
+  color: var(--v4-ink-800);
   font-size: 13.5px;
   border: 0;
   background: transparent;
   width: 100%;
   text-align: left;
-  font-family: var(--mk-font-sans);
+  font-family: var(--v4-sans);
 }
 .wow-cmdk-item:hover,
 .wow-cmdk-item.is-active {
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-900);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
 }
 .wow-cmdk-item.is-active {
-  background: var(--mk-brand-50);
-  color: var(--mk-brand-700);
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
 }
 .wow-cmdk-item-ic {
   width: 28px;
@@ -8280,13 +8354,13 @@ ul.v4-rsh-list {
   align-items: center;
   justify-content: center;
   border-radius: 6px;
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-500);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-500);
   flex-shrink: 0;
 }
 .wow-cmdk-item.is-active .wow-cmdk-item-ic {
-  background: var(--mk-brand-100);
-  color: var(--mk-brand-700);
+  background: var(--v4-accent-100);
+  color: var(--v4-accent-700);
 }
 .wow-cmdk-item-ic svg { width: 14px; height: 14px; }
 .wow-cmdk-item-body { flex: 1; min-width: 0; }
@@ -8298,17 +8372,17 @@ ul.v4-rsh-list {
 }
 .wow-cmdk-item-sub {
   font-size: 11.5px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.wow-cmdk-item.is-active .wow-cmdk-item-sub { color: var(--mk-brand-600); }
+.wow-cmdk-item.is-active .wow-cmdk-item-sub { color: var(--v4-accent-600); }
 .wow-cmdk-item-kbd {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10.5px;
-  color: var(--mk-ink-400);
-  border: 1px solid var(--mk-line);
+  color: var(--v4-ink-400);
+  border: 1px solid var(--v4-line);
   border-radius: 4px;
   padding: 1px 6px;
   flex-shrink: 0;
@@ -8318,16 +8392,16 @@ ul.v4-rsh-list {
   align-items: center;
   gap: 14px;
   padding: 8px 14px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   font-size: 11px;
-  color: var(--mk-ink-400);
-  font-family: var(--mk-font-mono);
+  color: var(--v4-ink-400);
+  font-family: var(--v4-mono);
 }
 .wow-cmdk-foot .wow-cmdk-hint { font-size: 9.5px; }
 .wow-cmdk-empty {
   padding: 28px 16px;
   text-align: center;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   font-size: 13px;
 }
 
@@ -8400,7 +8474,7 @@ ul.v4-rsh-list {
 }
 @keyframes v4-mspopup-fade { from { opacity: 0; } }
 .v4-mspopup {
-  background: var(--mk-paper);
+  background: var(--v4-paper);
   border-radius: 14px;
   box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
   width: 100%;
@@ -8423,7 +8497,7 @@ ul.v4-rsh-list {
   align-items: center;
   gap: 12px;
   padding: 16px 20px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
 }
 .v4-mspopup-glyph {
   width: 10px;
@@ -8433,18 +8507,18 @@ ul.v4-rsh-list {
 }
 .v4-mspopup-h-text { min-width: 0; }
 .v4-mspopup-repo {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-bottom: 2px;
 }
 .v4-mspopup-title {
   font-size: 16px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   margin: 0;
   line-height: 1.3;
   overflow: hidden;
@@ -8460,18 +8534,18 @@ ul.v4-rsh-list {
   border-radius: 8px;
   font-size: 22px;
   line-height: 1;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   cursor: pointer;
   transition: background .15s, color .15s;
 }
 .v4-mspopup-close:hover {
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-900);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-900);
 }
 
 .v4-mspopup-meta {
   padding: 12px 20px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -8480,21 +8554,21 @@ ul.v4-rsh-list {
   display: flex;
   align-items: center;
   gap: 12px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   font-weight: 600;
 }
 .v4-mspopup-progress-bar {
   flex: 1;
   height: 6px;
-  background: var(--mk-surface-3);
+  background: var(--v4-surface-3);
   border-radius: 99px;
   overflow: hidden;
 }
 .v4-mspopup-progress-fill {
   height: 100%;
-  background: var(--mk-success);
+  background: var(--v4-success-500);
   border-radius: 99px;
   transition: width .3s ease-out;
 }
@@ -8502,21 +8576,21 @@ ul.v4-rsh-list {
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   align-items: center;
 }
 .v4-mspopup-meta-row b {
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-weight: 600;
 }
 .v4-mspopup-ghlink {
   margin-left: auto;
-  color: var(--mk-brand-600);
+  color: var(--v4-accent-600);
   font-weight: 600;
   text-decoration: none;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
 }
 .v4-mspopup-ghlink:hover { text-decoration: underline; }
@@ -8525,7 +8599,7 @@ ul.v4-rsh-list {
   appearance: none;
   border: 0;
   background: transparent;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   cursor: pointer;
   margin-left: 6px;
   padding: 2px 6px;
@@ -8534,8 +8608,8 @@ ul.v4-rsh-list {
   transition: background .15s, color .15s;
 }
 .v4-mspopup-edit-btn:hover {
-  background: var(--mk-surface-2);
-  color: var(--mk-brand-600);
+  background: var(--v4-surface-2);
+  color: var(--v4-accent-600);
 }
 .v4-mspopup-edit {
   display: inline-flex;
@@ -8544,20 +8618,20 @@ ul.v4-rsh-list {
   flex-wrap: wrap;
 }
 .v4-mspopup-edit input[type="date"] {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   padding: 4px 6px;
-  border: 1px solid var(--mk-line-strong);
+  border: 1px solid var(--v4-line-strong);
   border-radius: 6px;
-  background: var(--mk-paper);
-  color: var(--mk-ink-900);
+  background: var(--v4-paper);
+  color: var(--v4-ink-900);
 }
 .v4-mspopup-edit-save,
 .v4-mspopup-edit-clear,
 .v4-mspopup-edit-cancel {
   appearance: none;
   border: 0;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 700;
   padding: 5px 10px;
@@ -8566,20 +8640,20 @@ ul.v4-rsh-list {
   transition: background .15s, opacity .15s;
 }
 .v4-mspopup-edit-save {
-  background: var(--mk-brand-500);
+  background: var(--v4-accent-500);
   color: #fff;
 }
-.v4-mspopup-edit-save:hover:not(:disabled) { background: var(--mk-brand-600); }
+.v4-mspopup-edit-save:hover:not(:disabled) { background: var(--v4-accent-600); }
 .v4-mspopup-edit-clear {
   background: #FEE4E2;
   color: #B42318;
 }
 .v4-mspopup-edit-clear:hover:not(:disabled) { background: #FCC8C5; }
 .v4-mspopup-edit-cancel {
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-700);
+  background: var(--v4-surface-2);
+  color: var(--v4-ink-700);
 }
-.v4-mspopup-edit-cancel:hover:not(:disabled) { background: var(--mk-surface-3); }
+.v4-mspopup-edit-cancel:hover:not(:disabled) { background: var(--v4-surface-3); }
 .v4-mspopup-edit button:disabled,
 .v4-mspopup-edit input:disabled { opacity: 0.55; cursor: not-allowed; }
 
@@ -8595,14 +8669,14 @@ ul.v4-rsh-list {
   font-size: 14px;
   font-weight: 600;
   padding: 4px 8px;
-  border: 1px solid var(--mk-line-strong);
+  border: 1px solid var(--v4-line-strong);
   border-radius: 6px;
-  background: var(--mk-paper);
-  color: var(--mk-ink-900);
+  background: var(--v4-paper);
+  color: var(--v4-ink-900);
 }
 .v4-mspopup-title-edit input[type="text"]:focus {
   outline: none;
-  border-color: var(--mk-brand-500);
+  border-color: var(--v4-accent-500);
 }
 
 .v4-mspopup-danger-row {
@@ -8611,20 +8685,20 @@ ul.v4-rsh-list {
   gap: 8px;
   flex-wrap: wrap;
   padding-top: 8px;
-  border-top: 1px dashed var(--mk-line-soft);
-  font-family: var(--mk-font-mono);
+  border-top: 1px dashed var(--v4-line-soft);
+  font-family: var(--v4-mono);
   font-size: 11px;
 }
 .v4-mspopup-danger-prompt {
   flex: 1 1 240px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 .v4-mspopup-danger-btn {
   appearance: none;
   border: 1px solid #FCC8C5;
   background: transparent;
   color: #B42318;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 600;
   padding: 5px 10px;
@@ -8641,7 +8715,7 @@ ul.v4-rsh-list {
   border: 0;
   background: #B42318;
   color: #fff;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 700;
   padding: 5px 10px;
@@ -8656,8 +8730,8 @@ ul.v4-rsh-list {
   display: flex;
   gap: 4px;
   padding: 8px 16px;
-  border-bottom: 1px solid var(--mk-line-soft);
-  background: var(--mk-surface-2);
+  border-bottom: 1px solid var(--v4-line-soft);
+  background: var(--v4-surface-2);
 }
 .v4-mspopup-tabs button {
   appearance: none;
@@ -8665,27 +8739,27 @@ ul.v4-rsh-list {
   background: transparent;
   padding: 6px 12px;
   border-radius: 6px;
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 600;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   cursor: pointer;
   transition: background .15s, color .15s;
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
-.v4-mspopup-tabs button:hover { background: var(--mk-surface-3); }
+.v4-mspopup-tabs button:hover { background: var(--v4-surface-3); }
 .v4-mspopup-tabs button.is-active {
-  background: var(--mk-paper);
-  color: var(--mk-ink-900);
+  background: var(--v4-paper);
+  color: var(--v4-ink-900);
   box-shadow: 0 1px 3px rgba(11, 16, 32, 0.06);
 }
 .v4-mspopup-tabs button .num {
   font-size: 10px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
-.v4-mspopup-tabs button.is-active .num { color: var(--mk-ink-700); }
+.v4-mspopup-tabs button.is-active .num { color: var(--v4-ink-700); }
 
 .v4-mspopup-body {
   flex: 1;
@@ -8695,7 +8769,7 @@ ul.v4-rsh-list {
 .v4-mspopup-empty {
   padding: 32px 20px;
   text-align: center;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-size: 13px;
 }
 .v4-mspopup-list {
@@ -8711,7 +8785,7 @@ ul.v4-rsh-list {
   align-items: center;
   gap: 10px;
   padding: 8px 20px;
-  border-bottom: 1px solid var(--mk-line-soft);
+  border-bottom: 1px solid var(--v4-line-soft);
   font-size: 13px;
 }
 .v4-mspopup-issue--dense {
@@ -8722,7 +8796,7 @@ ul.v4-rsh-list {
 }
 .v4-mspopup-issue--dense .v4-mspopup-issue-date { display: none; }
 .v4-mspopup-issue:last-child { border-bottom: 0; }
-.v4-mspopup-issue:hover { background: var(--mk-surface-2); }
+.v4-mspopup-issue:hover { background: var(--v4-surface-2); }
 .v4-mspopup-issue-st {
   display: inline-flex;
   align-items: center;
@@ -8735,29 +8809,29 @@ ul.v4-rsh-list {
   flex-shrink: 0;
 }
 .v4-mspopup-issue-st--open {
-  background: var(--mk-brand-50);
-  color: var(--mk-brand-700);
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
 }
 .v4-mspopup-issue-st--closed {
-  background: var(--mk-success-soft);
-  color: var(--mk-success-strong);
+  background: var(--v4-success-50);
+  color: var(--v4-success-700);
 }
-.v4-mspopup-issue.is-closed .v4-mspopup-issue-title { color: var(--mk-ink-500); }
-.v4-mspopup-issue.is-closed .v4-mspopup-issue-num { color: var(--mk-ink-400); }
+.v4-mspopup-issue.is-closed .v4-mspopup-issue-title { color: var(--v4-ink-500); }
+.v4-mspopup-issue.is-closed .v4-mspopup-issue-num { color: var(--v4-ink-400); }
 .v4-mspopup-issue-title {
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   text-decoration: none;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
 }
-.v4-mspopup-issue-title:hover { color: var(--mk-brand-600); }
+.v4-mspopup-issue-title:hover { color: var(--v4-accent-600); }
 .v4-mspopup-issue-num {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
   font-weight: 600;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   margin-right: 4px;
 }
 .v4-mspopup-issue-tags {
@@ -8766,20 +8840,20 @@ ul.v4-rsh-list {
   gap: 4px;
 }
 .v4-mspopup-issue-date {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   white-space: nowrap;
 }
 
 .v4-mspopup-trunc {
   padding: 12px 20px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   font-size: 12px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 .v4-mspopup-trunc a {
-  color: var(--mk-brand-600);
+  color: var(--v4-accent-600);
   font-weight: 600;
 }
 
@@ -8856,13 +8930,13 @@ ul.v4-rsh-list {
   padding: 4px 8px;
   margin-left: -8px;
   font-size: 13px;
-  color: var(--mk-brand-600);
+  color: var(--v4-accent-600);
   cursor: pointer;
   border-radius: 6px;
 }
-.v4-hub-back-link:hover { background: var(--mk-surface-2); }
+.v4-hub-back-link:hover { background: var(--v4-bg-soft); }
 .v4-hub-back-link:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: 2px;
 }
 
@@ -8874,9 +8948,9 @@ ul.v4-rsh-list {
     "nba   nba";
   gap: 12px 24px;
   padding: 16px 20px;
-  border: 1px solid var(--mk-line);
+  border: 1px solid var(--v4-line);
   border-radius: 12px;
-  background: var(--mk-bg);
+  background: var(--v4-bg);
 }
 .v4-hub-header-id { grid-area: id; min-width: 0; }
 .v4-hub-header-health { grid-area: health; display: flex; flex-direction: column; align-items: flex-end; gap: 4px; }
@@ -8886,11 +8960,11 @@ ul.v4-rsh-list {
   align-items: center;
   gap: 8px;
   padding-top: 8px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
   font-size: 13px;
 }
-.v4-hub-nba-label { color: var(--mk-ink-500); font-weight: 600; }
-.v4-hub-nba-text { color: var(--mk-ink-900); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v4-hub-nba-label { color: var(--v4-ink-500); font-weight: 600; }
+.v4-hub-nba-text { color: var(--v4-ink-900); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .v4-hub-title { margin: 0 0 6px; font-size: 18px; font-weight: 700; }
 .v4-hub-header-tags {
@@ -8903,32 +8977,32 @@ ul.v4-rsh-list {
 .v4-hub-phase {
   padding: 2px 8px;
   border-radius: 999px;
-  background: var(--mk-surface-2);
-  color: var(--mk-ink-700);
+  background: var(--v4-bg-soft);
+  color: var(--v4-ink-700);
   font-size: 11px;
 }
-.v4-hub-client { color: var(--mk-ink-700); }
-.v4-hub-meta { color: var(--mk-ink-500); font-family: var(--mk-font-mono); font-size: 11px; }
+.v4-hub-client { color: var(--v4-ink-700); }
+.v4-hub-meta { color: var(--v4-ink-500); font-family: var(--v4-mono); font-size: 11px; }
 
 .v4-hub-grade {
   font-size: 32px;
   font-weight: 800;
   line-height: 1;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
-.v4-hub-grade--a { color: var(--mk-success-strong); }
-.v4-hub-grade--b { color: var(--mk-success-strong); }
-.v4-hub-grade--c { color: var(--mk-warn-strong); }
-.v4-hub-grade--d { color: var(--mk-danger); }
-.v4-hub-grade--f { color: var(--mk-danger); }
-.v4-hub-score { font-size: 13px; font-weight: 600; color: var(--mk-ink-700); }
+.v4-hub-grade--a { color: var(--v4-success-700); }
+.v4-hub-grade--b { color: var(--v4-success-700); }
+.v4-hub-grade--c { color: var(--v4-warning-700, var(--v4-accent-600)); }
+.v4-hub-grade--d { color: var(--v4-danger-600); }
+.v4-hub-grade--f { color: var(--v4-danger-600); }
+.v4-hub-score { font-size: 13px; font-weight: 600; color: var(--v4-ink-700); }
 
 .v4-sparkline-placeholder {
   width: 80px;
   height: 18px;
   border-radius: 4px;
-  background: var(--mk-surface-2);
-  border: 1px dashed var(--mk-line);
+  background: var(--v4-bg-soft);
+  border: 1px dashed var(--v4-line);
 }
 
 /* Tab strip — horizontal list of 5 buttons. Underline-style active state
@@ -8937,7 +9011,7 @@ ul.v4-rsh-list {
   display: flex;
   flex-wrap: wrap;
   gap: 2px;
-  border-bottom: 1px solid var(--mk-line);
+  border-bottom: 1px solid var(--v4-line);
   padding: 0;
 }
 .v4-hub-tab {
@@ -8949,20 +9023,20 @@ ul.v4-rsh-list {
   background: transparent;
   border: 0;
   border-bottom: 2px solid transparent;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
   border-radius: 6px 6px 0 0;
 }
-.v4-hub-tab:hover { background: var(--mk-surface-2); color: var(--mk-ink-900); }
+.v4-hub-tab:hover { background: var(--v4-bg-soft); color: var(--v4-ink-900); }
 .v4-hub-tab:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: -2px;
 }
 .v4-hub-tab.is-active {
-  color: var(--mk-brand-600);
-  border-bottom-color: var(--mk-brand-500);
+  color: var(--v4-accent-600);
+  border-bottom-color: var(--v4-accent-500);
   font-weight: 600;
 }
 .v4-hub-tab-label { white-space: nowrap; }
@@ -8974,7 +9048,7 @@ ul.v4-rsh-list {
   height: 18px;
   padding: 0 6px;
   border-radius: 999px;
-  background: var(--mk-brand-500);
+  background: var(--v4-accent-500);
   color: #fff;
   font-size: 11px;
   font-weight: 700;
@@ -8990,9 +9064,9 @@ ul.v4-rsh-list {
   border-radius: 10px;
   background: linear-gradient(
     90deg,
-    var(--mk-surface-2) 0%,
-    var(--mk-line-soft) 50%,
-    var(--mk-surface-2) 100%
+    var(--v4-bg-soft) 0%,
+    var(--v4-line-soft) 50%,
+    var(--v4-bg-soft) 100%
   );
   background-size: 200% 100%;
   animation: v4-tab-skeleton-shimmer 1.2s ease-in-out infinite;
@@ -9010,22 +9084,22 @@ ul.v4-rsh-list {
   align-items: flex-start;
   gap: 12px;
   padding: 24px 20px;
-  border: 1px dashed var(--mk-line);
+  border: 1px dashed var(--v4-line);
   border-radius: 10px;
-  background: var(--mk-bg);
-  color: var(--mk-ink-700);
+  background: var(--v4-bg);
+  color: var(--v4-ink-700);
   font-size: 13px;
   line-height: 1.5;
 }
 .v4-hub-tab-stub strong {
   display: block;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   font-weight: 600;
   margin-bottom: 4px;
 }
 .v4-hub-tab-stub p { margin: 0; }
 .v4-hub-tab-stub a {
-  color: var(--mk-brand-600);
+  color: var(--v4-accent-600);
   font-weight: 600;
   text-decoration: none;
 }
@@ -9068,9 +9142,9 @@ ul.v4-rsh-list {
   flex-direction: column;
   gap: 12px;
   padding: 16px 18px;
-  border: 1px solid var(--mk-line);
+  border: 1px solid var(--v4-line);
   border-radius: 12px;
-  background: var(--mk-paper);
+  background: var(--v4-paper);
   min-height: 200px;
 }
 
@@ -9083,7 +9157,7 @@ ul.v4-rsh-list {
   margin: 0;
   font-size: 14px;
   font-weight: 700;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   letter-spacing: -0.005em;
 }
 .v4-hub-mini-ic {
@@ -9096,20 +9170,20 @@ ul.v4-rsh-list {
   font-size: 16px;
 }
 .v4-hub-mini-ic--nba {
-  background: var(--mk-brand-50);
-  color: var(--mk-brand-700);
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
 }
 .v4-hub-mini-ic--pulse {
-  background: var(--mk-sky-50);
-  color: var(--mk-sky-700);
+  background: var(--v4-sky-50);
+  color: var(--v4-sky-700);
 }
 .v4-hub-mini-ic--risks {
-  background: var(--mk-danger-soft);
-  color: var(--mk-danger-strong);
+  background: var(--v4-danger-50);
+  color: var(--v4-danger-700);
 }
 .v4-hub-mini-ic--commitments {
-  background: var(--mk-warn-soft);
-  color: var(--mk-warn-strong);
+  background: var(--v4-warn-50);
+  color: var(--v4-warn-700);
 }
 
 .v4-hub-mini-body {
@@ -9126,20 +9200,20 @@ ul.v4-rsh-list {
 .v4-hub-mini-foot {
   margin-top: auto;
   padding-top: 8px;
-  border-top: 1px solid var(--mk-line-soft);
+  border-top: 1px solid var(--v4-line-soft);
 }
 .v4-hub-mini-link {
   background: transparent;
   border: 0;
   padding: 2px 0;
-  color: var(--mk-brand-600);
+  color: var(--v4-accent-600);
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
 }
-.v4-hub-mini-link:hover { color: var(--mk-brand-700); text-decoration: underline; }
+.v4-hub-mini-link:hover { color: var(--v4-accent-700); text-decoration: underline; }
 .v4-hub-mini-link:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: 2px;
   border-radius: 4px;
 }
@@ -9152,24 +9226,24 @@ ul.v4-rsh-list {
   align-items: flex-start;
   gap: 4px;
   padding: 12px 0;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-size: 13px;
 }
 .v4-hub-mini-empty-ic {
   display: inline-flex;
   font-size: 18px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
   margin-bottom: 2px;
 }
 .v4-hub-mini-empty-text {
   margin: 0;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   font-weight: 500;
 }
 .v4-hub-mini-empty-hint {
   margin: 0;
   font-size: 12px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
 }
 
 /* NBA block */
@@ -9177,18 +9251,18 @@ ul.v4-rsh-list {
   margin: 0;
   font-size: 14px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   line-height: 1.4;
 }
 .v4-hub-nba-reason {
   margin: 0;
   font-size: 12px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   line-height: 1.5;
 }
 .v4-hub-nba-reason-label {
   font-weight: 600;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 /* Follow-up actions (ranks 2–3): compact, de-emphasised vs the top-1
    block above so the primary recommendation still dominates. */
@@ -9196,7 +9270,7 @@ ul.v4-rsh-list {
   list-style: none;
   margin: 6px 0 0;
   padding: 8px 0 0;
-  border-top: 1px solid var(--mk-line);
+  border-top: 1px solid var(--v4-border, rgba(0, 0, 0, 0.08));
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -9206,12 +9280,12 @@ ul.v4-rsh-list {
   align-items: flex-start;
   gap: 6px;
   font-size: 12px;
-  color: var(--mk-ink-600);
+  color: var(--v4-ink-600);
   line-height: 1.4;
 }
 .v4-hub-nba-list-item::before {
   content: "→";
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   flex-shrink: 0;
 }
 .v4-hub-nba-list-text {
@@ -9234,30 +9308,30 @@ ul.v4-rsh-list {
   align-items: baseline;
   gap: 10px;
   font-size: 12px;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
 }
 .v4-hub-pulse-type {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 10px;
   font-weight: 600;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   text-transform: lowercase;
   padding: 1px 6px;
   border-radius: 4px;
-  background: var(--mk-surface-2);
+  background: var(--v4-surface-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 14ch;
 }
 .v4-hub-pulse-label {
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .v4-hub-pulse-time {
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-size: 11px;
   white-space: nowrap;
 }
@@ -9280,12 +9354,12 @@ ul.v4-rsh-list {
   gap: 8px;
   padding: 8px 10px;
   border-radius: 8px;
-  background: var(--mk-surface-2);
-  border-left: 3px solid var(--mk-ink-300);
+  background: var(--v4-surface-2);
+  border-left: 3px solid var(--v4-ink-300);
   font-size: 13px;
 }
-.v4-hub-risk-item--critical { border-left-color: var(--mk-danger); }
-.v4-hub-risk-item--high     { border-left-color: var(--mk-danger); }
+.v4-hub-risk-item--critical { border-left-color: var(--v4-danger-500); }
+.v4-hub-risk-item--high     { border-left-color: var(--v4-danger-500); }
 .v4-hub-risk-sev {
   display: inline-flex;
   align-items: center;
@@ -9295,33 +9369,33 @@ ul.v4-rsh-list {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  background: var(--mk-ink-300);
-  color: var(--mk-ink-900);
+  background: var(--v4-ink-300);
+  color: var(--v4-ink-900);
 }
 .v4-hub-risk-sev--critical,
 .v4-hub-risk-sev--high {
-  background: var(--mk-danger-soft);
-  color: var(--mk-danger-strong);
+  background: var(--v4-danger-50);
+  color: var(--v4-danger-700);
 }
 .v4-hub-risk-sev--med {
-  background: var(--mk-warn-soft);
-  color: var(--mk-warn-strong);
+  background: var(--v4-warn-50);
+  color: var(--v4-warn-700);
 }
 .v4-hub-risk-sev--low {
-  background: var(--mk-surface-3);
-  color: var(--mk-ink-700);
+  background: var(--v4-surface-3);
+  color: var(--v4-ink-700);
 }
 .v4-hub-risk-title {
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .v4-hub-risk-owner,
 .v4-hub-commit-owner {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 11px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   white-space: nowrap;
 }
 
@@ -9335,13 +9409,13 @@ ul.v4-rsh-list {
   gap: 8px;
   padding: 8px 10px;
   border-radius: 8px;
-  background: var(--mk-surface-2);
-  border-left: 3px solid var(--mk-warn);
+  background: var(--v4-surface-2);
+  border-left: 3px solid var(--v4-warn-500);
   font-size: 13px;
 }
 .v4-hub-commit-item--overdue {
-  border-left-color: var(--mk-danger);
-  background: var(--mk-danger-soft);
+  border-left-color: var(--v4-danger-500);
+  background: var(--v4-danger-50);
 }
 .v4-hub-commit-badge {
   display: inline-flex;
@@ -9355,15 +9429,15 @@ ul.v4-rsh-list {
   white-space: nowrap;
 }
 .v4-hub-commit-badge--overdue {
-  background: var(--mk-danger-100);
-  color: var(--mk-danger-strong);
+  background: var(--v4-danger-100);
+  color: var(--v4-danger-700);
 }
 .v4-hub-commit-badge--soon {
-  background: var(--mk-warn-soft);
-  color: var(--mk-warn-strong);
+  background: var(--v4-warn-50);
+  color: var(--v4-warn-700);
 }
 .v4-hub-commit-title {
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -9437,15 +9511,15 @@ ul.v4-rsh-list {
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 
 .delivery-tab .delivery-empty {
   margin: 0;
   padding: 16px;
-  border: 1px dashed var(--mk-line);
+  border: 1px dashed var(--v4-line);
   border-radius: 10px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-size: 13px;
 }
 
@@ -9470,9 +9544,9 @@ ul.v4-rsh-list {
    so unread events read as the priority surface. */
 .v4-hub-activity .v4-hub-activity-inbox {
   padding: 16px 18px;
-  border: 1px solid var(--mk-brand-100);
+  border: 1px solid var(--v4-accent-100);
   border-radius: 12px;
-  background: var(--mk-brand-50);
+  background: var(--v4-accent-50);
 }
 
 .v4-hub-activity .v4-hub-activity-head {
@@ -9488,12 +9562,12 @@ ul.v4-rsh-list {
   height: 28px;
   border-radius: 8px;
   font-size: 16px;
-  background: var(--mk-sky-50);
-  color: var(--mk-sky-700);
+  background: var(--v4-sky-50);
+  color: var(--v4-sky-700);
 }
 .v4-hub-activity .v4-hub-activity-inbox .v4-hub-activity-ic {
-  background: var(--mk-brand-100);
-  color: var(--mk-brand-700);
+  background: var(--v4-accent-100);
+  color: var(--v4-accent-700);
 }
 .v4-hub-activity .v4-hub-activity-title {
   display: flex;
@@ -9502,7 +9576,7 @@ ul.v4-rsh-list {
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-hub-activity .v4-hub-activity-count {
   display: inline-flex;
@@ -9512,7 +9586,7 @@ ul.v4-rsh-list {
   height: 20px;
   padding: 0 6px;
   border-radius: 999px;
-  background: var(--mk-brand-600);
+  background: var(--v4-accent-600);
   color: #fff;
   font-size: 12px;
   font-weight: 700;
@@ -9526,24 +9600,24 @@ ul.v4-rsh-list {
 }
 .v4-hub-activity .v4-hub-activity-chip {
   padding: 4px 12px;
-  border: 1px solid var(--mk-line);
+  border: 1px solid var(--v4-line);
   border-radius: 999px;
-  background: var(--mk-paper);
-  color: var(--mk-ink-700);
+  background: var(--v4-paper);
+  color: var(--v4-ink-700);
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
 }
 .v4-hub-activity .v4-hub-activity-chip:hover {
-  border-color: var(--mk-brand-600);
+  border-color: var(--v4-accent-600);
 }
 .v4-hub-activity .v4-hub-activity-chip--on {
-  background: var(--mk-brand-600);
-  border-color: var(--mk-brand-600);
+  background: var(--v4-accent-600);
+  border-color: var(--v4-accent-600);
   color: #fff;
 }
 .v4-hub-activity .v4-hub-activity-chip:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: 2px;
 }
 
@@ -9565,13 +9639,13 @@ ul.v4-rsh-list {
   align-items: center;
   gap: 10px;
   font-size: 13px;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-hub-activity .v4-hub-activity-inbox-item {
   padding: 8px 10px;
-  border: 1px solid var(--mk-brand-100);
+  border: 1px solid var(--v4-accent-100);
   border-radius: 8px;
-  background: var(--mk-paper);
+  background: var(--v4-paper);
 }
 .v4-hub-activity .v4-hub-activity-inbox-src,
 .v4-hub-activity .v4-hub-activity-pr-num,
@@ -9579,8 +9653,8 @@ ul.v4-rsh-list {
   flex-shrink: 0;
   padding: 1px 7px;
   border-radius: 999px;
-  background: var(--mk-line-soft);
-  color: var(--mk-ink-700);
+  background: var(--v4-line-soft);
+  color: var(--v4-ink-700);
   font-size: 11px;
   font-weight: 600;
 }
@@ -9601,29 +9675,29 @@ ul.v4-rsh-list {
   flex: 1;
   min-width: 0;
   padding: 8px 10px;
-  border: 1px solid var(--mk-line);
+  border: 1px solid var(--v4-line);
   border-radius: 8px;
-  background: var(--mk-paper);
+  background: var(--v4-paper);
   color: inherit;
   text-decoration: none;
 }
 .v4-hub-activity .v4-hub-activity-pr-link:hover,
 .v4-hub-activity .v4-hub-activity-run-link:hover {
-  border-color: var(--mk-brand-600);
+  border-color: var(--v4-accent-600);
 }
 .v4-hub-activity .v4-hub-activity-pr-badge {
   flex-shrink: 0;
   padding: 1px 7px;
   border-radius: 999px;
-  background: var(--mk-warn-soft);
-  color: var(--mk-warn-strong);
+  background: var(--v4-warn-50);
+  color: var(--v4-warn-700);
   font-size: 11px;
   font-weight: 600;
 }
 .v4-hub-activity .v4-hub-activity-pr-author,
 .v4-hub-activity .v4-hub-activity-run-status {
   flex-shrink: 0;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-size: 12px;
 }
 
@@ -9634,15 +9708,15 @@ ul.v4-rsh-list {
   gap: 8px;
   margin: 0;
   padding: 16px;
-  border: 1px dashed var(--mk-line);
+  border: 1px dashed var(--v4-line);
   border-radius: 10px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   font-size: 13px;
 }
 .v4-hub-activity .v4-hub-activity-empty-ic {
   display: inline-flex;
   font-size: 16px;
-  color: var(--mk-ink-400);
+  color: var(--v4-ink-400);
 }
 .v4-hub-activity .v4-hub-activity-empty-text {
   margin: 0;
@@ -9681,9 +9755,9 @@ ul.v4-rsh-list {
   gap: 6px;
   padding: 6px;
   overflow-x: auto;
-  border: 1px solid var(--mk-line);
+  border: 1px solid var(--v4-line);
   border-radius: 12px;
-  background: var(--mk-paper);
+  background: var(--v4-paper);
 }
 @media (min-width: 1100px) {
   .v4-hub-decisions .v4-hub-decisions-nav {
@@ -9703,7 +9777,7 @@ ul.v4-rsh-list {
   border: 0;
   border-radius: 8px;
   background: transparent;
-  color: var(--mk-ink-700);
+  color: var(--v4-ink-700);
   font-size: 13px;
   font-weight: 600;
   text-align: left;
@@ -9711,14 +9785,14 @@ ul.v4-rsh-list {
   white-space: nowrap;
 }
 .v4-hub-decisions .v4-hub-decisions-navlink:hover {
-  background: var(--mk-line-soft);
+  background: var(--v4-line-soft);
 }
 .v4-hub-decisions .v4-hub-decisions-navlink--on {
-  background: var(--mk-brand-50);
-  color: var(--mk-brand-700);
+  background: var(--v4-accent-50);
+  color: var(--v4-accent-700);
 }
 .v4-hub-decisions .v4-hub-decisions-navlink:focus-visible {
-  outline: 2px solid var(--mk-brand-500);
+  outline: 2px solid var(--v4-accent-500);
   outline-offset: 2px;
 }
 .v4-hub-decisions .v4-hub-decisions-nav-ic {
@@ -9737,14 +9811,14 @@ ul.v4-rsh-list {
   height: 18px;
   padding: 0 5px;
   border-radius: 999px;
-  background: var(--mk-line-soft);
-  color: var(--mk-ink-700);
+  background: var(--v4-line-soft);
+  color: var(--v4-ink-700);
   font-size: 11px;
   font-weight: 700;
 }
 .v4-hub-decisions .v4-hub-decisions-navlink--on .v4-hub-decisions-nav-count {
-  background: var(--mk-brand-100);
-  color: var(--mk-brand-700);
+  background: var(--v4-accent-100);
+  color: var(--v4-accent-700);
 }
 
 .v4-hub-decisions .v4-hub-decisions-main {
@@ -9776,8 +9850,8 @@ ul.v4-rsh-list {
   height: 28px;
   border-radius: 8px;
   font-size: 16px;
-  background: var(--mk-sky-50);
-  color: var(--mk-sky-700);
+  background: var(--v4-sky-50);
+  color: var(--v4-sky-700);
 }
 .v4-hub-decisions .v4-hub-decisions-title {
   display: flex;
@@ -9786,7 +9860,7 @@ ul.v4-rsh-list {
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
 }
 .v4-hub-decisions .v4-hub-decisions-count {
   display: inline-flex;
@@ -9796,8 +9870,8 @@ ul.v4-rsh-list {
   height: 20px;
   padding: 0 6px;
   border-radius: 999px;
-  background: var(--mk-line-soft);
-  color: var(--mk-ink-700);
+  background: var(--v4-line-soft);
+  color: var(--v4-ink-700);
   font-size: 12px;
   font-weight: 700;
 }
@@ -9809,7 +9883,7 @@ ul.v4-rsh-list {
 .v4-pdigest-md {
   font-size: 13px;
   line-height: 1.55;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   overflow-wrap: anywhere;
 }
 .v4-pdigest-md :first-child {
@@ -9823,7 +9897,7 @@ ul.v4-rsh-list {
 .v4-pdigest-md h3 {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mk-ink-900);
+  color: var(--v4-ink-900);
   margin: 12px 0 6px;
 }
 .v4-pdigest-md h1 {
@@ -9842,29 +9916,29 @@ ul.v4-rsh-list {
   margin: 2px 0;
 }
 .v4-pdigest-md a {
-  color: var(--mk-brand-600);
+  color: var(--v4-accent-600);
 }
 .v4-pdigest-md code {
-  font-family: var(--mk-font-mono);
+  font-family: var(--v4-mono);
   font-size: 12px;
-  background: var(--mk-surface-2);
-  border-radius: var(--mk-r-sm);
+  background: var(--v4-surface-2);
+  border-radius: var(--v4-r-sm);
   padding: 1px 5px;
 }
 .v4-pdigest-md blockquote {
   margin: 8px 0;
   padding: 4px 12px;
-  border-left: 3px solid var(--mk-line-strong);
-  color: var(--mk-ink-700);
+  border-left: 3px solid var(--v4-line-strong);
+  color: var(--v4-ink-700);
 }
 .v4-pdigest-error-t {
   font-weight: 600;
-  color: var(--mk-danger-strong);
+  color: var(--v4-danger-700);
 }
 .v4-pdigest-error-m {
   margin-top: 4px;
   font-size: 12px;
-  color: var(--mk-ink-500);
+  color: var(--v4-ink-500);
   overflow-wrap: anywhere;
 }
 .v4-pdigest-modal {


### PR DESCRIPTION
## Зачем этот PR

Сессии J и K (миграция дизайн-токенов на единый `--mk-*`-namespace) были запушены напрямую в `main` коммитами [ed718a6](https://github.com/Sergio1990-1/makeit-dashboard/commit/ed718a6) (Session J) и [592298e](https://github.com/Sergio1990-1/makeit-dashboard/commit/592298e) (Session K). PR не было — это позволяет посмотреть полную картину изменений построчно перед окончательным решением.

**Этот PR ревертит обе сессии.** Если ты ревьюишь и решаешь, что миграция OK → закрой PR без merge (J+K остаются в main как есть). Если хочешь откатиться → merge → потом мы сделаем чистый «reapply»-PR с теми же изменениями для повторного ревью.

## Что было в Session J — `var(--v4-*)` → `var(--mk-*)` в TSX

- 303 ссылки в 60 TSX/TS-компонентах
- Phantom-токены (`--v4-card`, `--v4-surface`, `--v4-warn-600`, `--v4-ink-*, inherit`) заменены на реальные `--mk-*`
- Scope-конфликт разрулен:
  - Quality severity (`--v4-p0/p1/p2/*-text/clean-soft`) → `--mk-quality-*` (новые токены в `.v4-quality-tab`)
  - Project priority (Pipeline/KpiRow/ProjectsView) → `--mk-priority-p*`
- В `src/styles/v4-quality.css` добавлены `--mk-quality-*` (объявлены первыми, `--v4-*` стали алиасами для backward compat — убраны в K)
- Багфикс в `main.tsx`: SW update banner использовал несуществующий `--color-bg-elevated` с dark hex-фоллбэком на light-теме — переписан на `--mk-paper`/`--mk-ink-900`

## Что было в Session K — CSS-файлы и удаление bridge

- 6 CSS-файлов мигрированы на `--mk-*` напрямую: `App.css`, `v4.css`, `v4-quality.css`, `v4-health.css`, `v4-bizproc.css`, `PipelineActiveTasksBlock/styles.css` (~2000 ref)
- **Bridge `:root` блоки полностью удалены:**
  - `App.css`: `--gray-*` (11), `--blue-*` (3), `--green/red/orange/yellow/purple/cyan-500`, `--color-*` (28), `--font-*`/`--text-*`/`--sp-*`/`--radius-*`/`--shadow-*` (28). Остался только `--bg-pattern` (декоративный, единственный потребитель).
  - `v4.css`: `--v4-*` (54 алиаса) полностью удалены.
  - `v4-quality.css`: `--v4-p*` алиасы внутри `.v4-quality-tab` тоже убраны (оставлены только `--mk-quality-*`).
- Phantom-токены без bridge (`--v4-border/-card/-soft/-bg-soft/-surface-1/-accent-300/-danger-300/600/-ink-50/-line-mid/-success-300/-warn-200/-warning-700/-font-mono`) — правильно расчитаны и заменены на `--mk-*`.
- **2 реальных бага найдены и починены:**
  - `v4-health.css:1161` — `--v4-success-700` fallback указывал на `--mk-brand-600` (СИНИЙ для зелёного success-токена). Поправлен на `--mk-success-strong`.
  - `v4.css:8995` — `--v4-warning-700` fallback указывал на `--mk-brand-600`. Поправлен на `--mk-warn-strong`.
- `.claude/worktrees` добавлены в ESLint `globalIgnores` (засоряли lint stale-копиями).
- `AnnotationModal.tsx:45` — `color: "#666"` → `var(--mk-ink-500)` (последний hex-литерал в src/).

## Verify состояния после J+K (до этого revert)

- `npx tsc --noEmit` → clean
- `npm run build` → 305ms
- `npm run lint` → exit 0, 0 warnings
- `grep -rE 'var\(--(color|v4|gray|blue|green|red|orange|yellow|purple|cyan)-' src` → 0 ref
- Preview Dashboard + Pipeline — визуально идентичны исходному состоянию

## Полный diff J+K

[Сравнение `16db3d2..592298e`](https://github.com/Sergio1990-1/makeit-dashboard/compare/16db3d2...592298e) — оригинальные коммиты в ветке `design/sessions-j-k`.

## Решение reviewer'а

- [ ] **Закрыть без merge** → J+K остаются в main (если миграция OK)
- [ ] **Merge revert** → откатить J+K, потом подготовлю чистый reapply-PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)