### PR TITLE
feat(quality): rolling avg trend line + «clean = no P0/P1» metric

### DIFF
--- a/src/components/quality/QualityChart.tsx
+++ b/src/components/quality/QualityChart.tsx
@@ -261,16 +261,15 @@ export function QualityChart({
 
       {buckets.map((b, i) => {
         const total = b.total_pr;
-        const heightPct = (total / scale) * 100;
         // worst-wins: P0+P1 объединены в crit (один красный сегмент)
         const critCount = b.with_p0 + b.with_p1_only;
         const cleanCount = Math.max(0, total - critCount - b.with_p2_only);
         const lowSample = total > 0 && total < LOW_SAMPLE;
         const hasP0 = b.with_p0 > 0;
 
-        // Под фильтром оставляем ТОЛЬКО релевантный сегмент (вместо стека).
-        // Высоту фильтрованного бара берём пропорционально соответствующего
-        // count'а — так на чарте сразу виден объём метрики, без шума соседей.
+        // Под фильтром оставляем ТОЛЬКО релевантный сегмент. Высота бара
+        // в фильтр-моде = высоте этого сегмента (а не всего стека), чтобы
+        // визуально бар «съезжал вниз» к baseline вместо парения в воздухе.
         type Seg = { kind: "clean" | "p2" | "crit"; count: number };
         const segments: Seg[] =
           focus === "all"
@@ -286,6 +285,12 @@ export function QualityChart({
                 : focus === "p1"
                   ? [{ kind: "crit", count: b.with_p1_only }]
                   : /* dirty */ [{ kind: "crit", count: critCount }];
+
+        // Effective height: в "all" — весь стек; под фильтром — сумма видимых
+        // сегментов / scale. Так столбик растягивается ровно до значения
+        // метрики и опускается к baseline, а не висит на верхней позиции.
+        const effectiveCount = segments.reduce((a, s) => a + s.count, 0);
+        const heightPct = (effectiveCount / scale) * 100;
 
         const classNames = [
           "bar",
@@ -315,20 +320,35 @@ export function QualityChart({
             {showP0Topper && (
               <div className="bar-topper-p0">P0:{b.with_p0}</div>
             )}
-            <div className="bar-stack" style={{ height: `${heightPct}%` }}>
+            <div
+              className="bar-stack"
+              style={{
+                height: `${heightPct}%`,
+                // Анимация роста/спадания бара при смене фильтра. cubic-bezier
+                // и длительность подобраны к фейду сегментов и линии overlay,
+                // чтобы переход воспринимался цельно. Изменение height
+                // триггерит layout, но 30 баров — это копеечно.
+                transition: "height 0.45s cubic-bezier(0.16, 1, 0.3, 1)",
+              }}
+            >
               {segments.map((seg) =>
                 seg.count > 0 ? (
                   <div
                     key={seg.kind}
                     className={`bar-${seg.kind}`}
-                    style={{ height: `${(seg.count / total) * 100}%` }}
+                    style={{
+                      // Нормируем к effectiveCount, а не к total: в фильтр-моде
+                      // в стеке только один сегмент, и он должен занимать 100%
+                      // нового parent'а (а не свою долю от исходного total).
+                      height: `${(seg.count / effectiveCount) * 100}%`,
+                    }}
                   />
                 ) : null,
               )}
             </div>
             {heightPct === 0 && <div className="bar-empty" />}
             <div className="bar-chip">
-              {total} PR
+              {focus === "all" ? `${total} PR` : `${effectiveCount}/${total}`}
               {showP0Topper && (
                 <>
                   {" · "}

--- a/src/components/quality/QualityChart.tsx
+++ b/src/components/quality/QualityChart.tsx
@@ -12,8 +12,9 @@ import type { QualityBucket } from "../../types/quality";
  *  - tooltip-структура создаётся один раз, на hover обновляются только textContent
  *    (refs → tipRefsObj), никаких `innerHTML = ...`;
  *  - dim non-hovered баров — через class toggle `is-hovering`/`is-active`, НЕ `:has()`;
- *  - height баров не анимируется (transition: height триггерит layout) —
- *    высоты выставляются в style на mount, на period switch DOM пересоздаётся;
+ *  - height баров анимируется ТОЛЬКО при смене focus-фильтра (~5 клик/сек max,
+ *    30 баров — layout-cost копеечный). На period switch (30d↔12w) DOM
+ *    пересоздаётся, transition там не запускается;
  *  - hover-эффекты — только opacity / transform.
  *
  * Метрика (worst-wins, см. spec):
@@ -143,10 +144,28 @@ export function QualityChart({
   const tipRef = useRef<HTMLDivElement>(null);
   const tipRefsObj = useRef<TipRefs>({});
 
+  // В фильтр-режиме шкала Y должна отражать максимум выбранной метрики,
+  // а не полный total_pr — иначе бары визуально крошечные на старой шкале,
+  // и подпись «N/total» в chip не бьётся с тиками на оси.
   const scale = useMemo(() => {
-    const max = Math.max(1, ...buckets.map((b) => b.total_pr));
+    const valueOf = (b: QualityBucket): number => {
+      switch (focus) {
+        case "p0":
+          return b.with_p0;
+        case "p1":
+          return b.with_p1_only;
+        case "p2":
+          return b.with_p2_only;
+        case "dirty":
+          return b.with_p0 + b.with_p1_only;
+        case "all":
+        default:
+          return b.total_pr;
+      }
+    };
+    const max = Math.max(1, ...buckets.map(valueOf));
     return niceCeil(max);
-  }, [buckets]);
+  }, [buckets, focus]);
 
   // Окно для скользящего среднего. Главный график: 7 (для 30d) / 3 (для 12w);
   // compact-мини в карточках overlay не показывает (мелко и шумно).
@@ -167,25 +186,40 @@ export function QualityChart({
   const overlayColor = useMemo(() => lineColor(focus), [focus]);
   const overlayLabel = useMemo(() => badgeLabel(focus), [focus]);
 
-  // Точки SVG-линии overlay: Y инвертирован (100% наверху), null значения
-  // прерывают линию (выходные/пустые дни). Координаты в долях 0–1.
-  const linePoints = useMemo(() => {
-    if (effectiveWindow === 0 || buckets.length === 0) return "";
-    const segments: string[] = [];
-    let current: string[] = [];
+  // Сегменты SVG-линии overlay: Y инвертирован (100% наверху), null значения
+  // прерывают линию (выходные/пустые дни). Каждый сегмент — отдельный
+  // <polyline>, чтобы корректно работать с gap'ами (атрибут `points` НЕ
+  // понимает "M" moveto — это команда для <path d>). Одиночные точки
+  // отдаются как `singlePoints` и рисуются <circle> — иначе единственный
+  // нон-нул среди gap'ов остаётся невидимым.
+  const { lineSegments, singlePoints } = useMemo(() => {
+    type Pt = { x: number; y: number };
+    const segs: Pt[][] = [];
+    const dots: Pt[] = [];
+    if (effectiveWindow === 0 || buckets.length === 0) {
+      return { lineSegments: segs, singlePoints: dots };
+    }
+    let current: Pt[] = [];
+    const flush = () => {
+      if (current.length >= 2) segs.push(current);
+      else if (current.length === 1) dots.push(current[0]);
+      current = [];
+    };
     rollingAvgPct.forEach((pct, i) => {
       if (pct === null) {
-        if (current.length > 1) segments.push(current.join(" "));
-        current = [];
+        flush();
         return;
       }
-      const x = ((i + 0.5) / buckets.length) * 100;
-      const y = 100 - pct;
-      current.push(`${x.toFixed(2)},${y.toFixed(2)}`);
+      current.push({
+        x: ((i + 0.5) / buckets.length) * 100,
+        y: 100 - pct,
+      });
     });
-    if (current.length > 1) segments.push(current.join(" "));
-    return segments.join(" M ");
+    flush();
+    return { lineSegments: segs, singlePoints: dots };
   }, [rollingAvgPct, buckets.length, effectiveWindow]);
+
+  const hasLineData = lineSegments.length > 0 || singlePoints.length > 0;
 
   const latestRollingPct = useMemo(() => {
     for (let i = rollingAvgPct.length - 1; i >= 0; i--) {
@@ -362,7 +396,7 @@ export function QualityChart({
 
       {/* SVG overlay: 7-day rolling avg «% чистых PR» (без P0/P1).
           Правая Y-ось 0–100%. Pointer-events: none — чтобы не ломать hover баров. */}
-      {effectiveWindow > 0 && linePoints && (
+      {effectiveWindow > 0 && hasLineData && (
         <>
           <svg
             className="chart-trend-overlay"
@@ -385,16 +419,30 @@ export function QualityChart({
               strokeDasharray="0.6 0.6"
               vectorEffect="non-scaling-stroke"
             />
-            <polyline
-              points={linePoints}
-              fill="none"
-              stroke={overlayColor}
-              strokeWidth="2"
-              strokeLinejoin="round"
-              strokeLinecap="round"
-              vectorEffect="non-scaling-stroke"
-              opacity="0.9"
-            />
+            {lineSegments.map((seg, idx) => (
+              <polyline
+                key={`seg-${idx}`}
+                points={seg.map((p) => `${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(" ")}
+                fill="none"
+                stroke={overlayColor}
+                strokeWidth="2"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                vectorEffect="non-scaling-stroke"
+                opacity="0.9"
+              />
+            ))}
+            {singlePoints.map((p, idx) => (
+              <circle
+                key={`dot-${idx}`}
+                cx={p.x}
+                cy={p.y}
+                r="0.6"
+                fill={overlayColor}
+                vectorEffect="non-scaling-stroke"
+                opacity="0.9"
+              />
+            ))}
           </svg>
           {/* Правая Y-ось (0–100%) + бейдж с актуальным значением */}
           <div

--- a/src/components/quality/QualityChart.tsx
+++ b/src/components/quality/QualityChart.tsx
@@ -27,9 +27,35 @@ export interface QualityChartProps {
   buckets: QualityBucket[];
   labels: string[];
   compact: boolean;
+  /** Окно скользящего среднего (баров). Дефолт: 7 для main, без overlay для compact. */
+  rollingWindow?: number;
 }
 
 const LOW_SAMPLE = 8;
+
+/** «Чистый PR» по новой метрике = без P0 и без P1. P2-нит не считается грязью.
+ * Возвращает null если в бакете нет PR (чтобы не загрязнять rolling avg нулями). */
+function cleanPct(b: QualityBucket): number | null {
+  if (b.total_pr === 0) return null;
+  const dirty = b.with_p0 + b.with_p1_only;
+  return ((b.total_pr - dirty) / b.total_pr) * 100;
+}
+
+/** Скользящее среднее «% чистых PR» по последним `window` бакетам.
+ * Пустые бакеты (нет PR) пропускаем — иначе выходные/праздники дают
+ * ложные провалы в линии. Возвращаем null если в окне совсем нет данных. */
+function computeRollingAvg(
+  buckets: QualityBucket[],
+  window: number,
+): Array<number | null> {
+  return buckets.map((_, i) => {
+    const start = Math.max(0, i - window + 1);
+    const slice = buckets.slice(start, i + 1);
+    const pcts = slice.map(cleanPct).filter((p): p is number => p !== null);
+    if (pcts.length === 0) return null;
+    return pcts.reduce((a, b) => a + b, 0) / pcts.length;
+  });
+}
 
 function niceCeil(n: number): number {
   if (n <= 5) return 5;
@@ -51,7 +77,12 @@ interface TipRefs {
   dirty?: HTMLElement;
 }
 
-export function QualityChart({ buckets, labels, compact }: QualityChartProps) {
+export function QualityChart({
+  buckets,
+  labels,
+  compact,
+  rollingWindow,
+}: QualityChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const tipRef = useRef<HTMLDivElement>(null);
   const tipRefsObj = useRef<TipRefs>({});
@@ -60,6 +91,46 @@ export function QualityChart({ buckets, labels, compact }: QualityChartProps) {
     const max = Math.max(1, ...buckets.map((b) => b.total_pr));
     return niceCeil(max);
   }, [buckets]);
+
+  // Окно для скользящего среднего. Главный график: 7 (для 30d) / 3 (для 12w);
+  // compact-мини в карточках overlay не показывает (мелко и шумно).
+  const effectiveWindow = useMemo(() => {
+    if (compact) return 0;
+    if (rollingWindow !== undefined) return rollingWindow;
+    return buckets.length >= 20 ? 7 : 3;
+  }, [compact, rollingWindow, buckets.length]);
+
+  const rollingAvgPct = useMemo(
+    () => (effectiveWindow > 0 ? computeRollingAvg(buckets, effectiveWindow) : []),
+    [buckets, effectiveWindow],
+  );
+
+  // Точки SVG-линии overlay: Y инвертирован (100% наверху), null значения
+  // прерывают линию (выходные/пустые дни). Координаты в долях 0–1.
+  const linePoints = useMemo(() => {
+    if (effectiveWindow === 0 || buckets.length === 0) return "";
+    const segments: string[] = [];
+    let current: string[] = [];
+    rollingAvgPct.forEach((pct, i) => {
+      if (pct === null) {
+        if (current.length > 1) segments.push(current.join(" "));
+        current = [];
+        return;
+      }
+      const x = ((i + 0.5) / buckets.length) * 100;
+      const y = 100 - pct;
+      current.push(`${x.toFixed(2)},${y.toFixed(2)}`);
+    });
+    if (current.length > 1) segments.push(current.join(" "));
+    return segments.join(" M ");
+  }, [rollingAvgPct, buckets.length, effectiveWindow]);
+
+  const latestRollingPct = useMemo(() => {
+    for (let i = rollingAvgPct.length - 1; i >= 0; i--) {
+      if (rollingAvgPct[i] !== null) return rollingAvgPct[i];
+    }
+    return null;
+  }, [rollingAvgPct]);
 
   const handleEnter = (
     b: QualityBucket,
@@ -72,8 +143,9 @@ export function QualityChart({ buckets, labels, compact }: QualityChartProps) {
 
     const crit = b.with_p0 + b.with_p1_only;
     const clean = Math.max(0, b.total_pr - crit - b.with_p2_only);
+    // Новая метрика «грязный» = только P0/P1 (P2-нит — фон, не блокирует ship).
     const dirtyPct =
-      b.total_pr > 0 ? ((crit + b.with_p2_only) / b.total_pr) * 100 : 0;
+      b.total_pr > 0 ? (crit / b.total_pr) * 100 : 0;
 
     // textContent only — no innerHTML (perf rule #4)
     if (refs.label) refs.label.textContent = label;
@@ -191,6 +263,89 @@ export function QualityChart({ buckets, labels, compact }: QualityChartProps) {
           </div>
         );
       })}
+
+      {/* SVG overlay: 7-day rolling avg «% чистых PR» (без P0/P1).
+          Правая Y-ось 0–100%. Pointer-events: none — чтобы не ломать hover баров. */}
+      {effectiveWindow > 0 && linePoints && (
+        <>
+          <svg
+            className="chart-trend-overlay"
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+            style={{
+              position: "absolute",
+              inset: 0,
+              width: "100%",
+              height: "100%",
+              pointerEvents: "none",
+              overflow: "visible",
+            }}
+          >
+            {/* Опорные линии 50% и 100% — eдва видны, но дают шкалу */}
+            <line
+              x1="0" y1="50" x2="100" y2="50"
+              stroke="var(--mk-line-soft, rgba(127,127,127,0.18))"
+              strokeWidth="0.15"
+              strokeDasharray="0.6 0.6"
+              vectorEffect="non-scaling-stroke"
+            />
+            <polyline
+              points={linePoints}
+              fill="none"
+              stroke="var(--mk-success-100, #16a34a)"
+              strokeWidth="2"
+              strokeLinejoin="round"
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+              opacity="0.9"
+            />
+          </svg>
+          {/* Правая Y-ось (0–100%) + бейдж с актуальным значением */}
+          <div
+            className="chart-trend-axis"
+            style={{
+              position: "absolute",
+              right: -36,
+              top: 0,
+              bottom: 0,
+              width: 32,
+              fontFamily: "var(--mk-font-mono)",
+              fontSize: 10,
+              color: "var(--mk-success-100, #16a34a)",
+              opacity: 0.85,
+              pointerEvents: "none",
+            }}
+          >
+            <div style={{ position: "absolute", top: -2 }}>100%</div>
+            <div style={{ position: "absolute", top: "calc(50% - 6px)" }}>50%</div>
+            <div style={{ position: "absolute", bottom: -2 }}>0%</div>
+          </div>
+          {latestRollingPct !== null && (
+            <div
+              className="chart-trend-badge"
+              style={{
+                position: "absolute",
+                right: 4,
+                top: `calc(${100 - latestRollingPct}% - 10px)`,
+                padding: "2px 6px",
+                background: "var(--mk-success-100, #16a34a)",
+                color: "white",
+                fontFamily: "var(--mk-font-mono)",
+                fontSize: 10,
+                fontWeight: 700,
+                borderRadius: 4,
+                pointerEvents: "none",
+                whiteSpace: "nowrap",
+                transform: "translateY(-50%)",
+                boxShadow: "0 1px 4px rgba(0,0,0,0.15)",
+              }}
+            >
+              {latestRollingPct.toFixed(0)}% чистых · {effectiveWindow}
+              {buckets.length >= 20 ? "д" : "нед"} avg
+            </div>
+          )}
+        </>
+      )}
 
       {/* Pre-created tooltip — refs обновляют только textContent (perf rule #4) */}
       <div

--- a/src/components/quality/QualityChart.tsx
+++ b/src/components/quality/QualityChart.tsx
@@ -23,35 +23,90 @@ import type { QualityBucket } from "../../types/quality";
  *  - has-p0: bucket с ≥1 P0 → постоянный gradient + topper-pill (main only)
  */
 
+/** Какой срез данных подсвечивать. Управляется кликом по KPI-плиткам:
+ * "all" = дефолт (стек целиком + линия %-чистых), остальные изолируют
+ * один сегмент бара и переключают линию overlay на эту метрику. */
+export type FocusMode = "all" | "p0" | "p1" | "p2" | "dirty";
+
 export interface QualityChartProps {
   buckets: QualityBucket[];
   labels: string[];
   compact: boolean;
   /** Окно скользящего среднего (баров). Дефолт: 7 для main, без overlay для compact. */
   rollingWindow?: number;
+  /** Активный фильтр от KPI-плиток (только для main-чарта). */
+  focus?: FocusMode;
 }
 
 const LOW_SAMPLE = 8;
 
-/** «Чистый PR» по новой метрике = без P0 и без P1. P2-нит не считается грязью.
- * Возвращает null если в бакете нет PR (чтобы не загрязнять rolling avg нулями). */
-function cleanPct(b: QualityBucket): number | null {
+/** Извлекает значение для конкретной метрики из бакета.
+ * Возвращает null если бакет пустой — пропускаем такие точки в rolling avg
+ * (выходные/праздники иначе дают ложные провалы линии). */
+function bucketPct(b: QualityBucket, mode: FocusMode): number | null {
   if (b.total_pr === 0) return null;
-  const dirty = b.with_p0 + b.with_p1_only;
-  return ((b.total_pr - dirty) / b.total_pr) * 100;
+  switch (mode) {
+    case "p0":
+      return (b.with_p0 / b.total_pr) * 100;
+    case "p1":
+      return (b.with_p1_only / b.total_pr) * 100;
+    case "p2":
+      return (b.with_p2_only / b.total_pr) * 100;
+    case "dirty":
+      return ((b.with_p0 + b.with_p1_only) / b.total_pr) * 100;
+    case "all":
+    default:
+      // % чистых = без P0/P1. P2-нит не делает PR «грязным».
+      return ((b.total_pr - b.with_p0 - b.with_p1_only) / b.total_pr) * 100;
+  }
 }
 
-/** Скользящее среднее «% чистых PR» по последним `window` бакетам.
+function lineColor(mode: FocusMode): string {
+  switch (mode) {
+    case "p0":
+      return "var(--mk-quality-p0, #dc2626)";
+    case "p1":
+      return "var(--mk-quality-p1, #f59e0b)";
+    case "p2":
+      return "var(--mk-quality-p2, #eab308)";
+    case "dirty":
+      return "var(--mk-danger-100, #ef4444)";
+    case "all":
+    default:
+      return "var(--mk-success-100, #16a34a)";
+  }
+}
+
+function badgeLabel(mode: FocusMode): string {
+  switch (mode) {
+    case "p0":
+      return "с P0";
+    case "p1":
+      return "с P1";
+    case "p2":
+      return "с P2";
+    case "dirty":
+      return "грязных";
+    case "all":
+    default:
+      return "чистых";
+  }
+}
+
+/** Скользящее среднее выбранной метрики по последним `window` бакетам.
  * Пустые бакеты (нет PR) пропускаем — иначе выходные/праздники дают
  * ложные провалы в линии. Возвращаем null если в окне совсем нет данных. */
 function computeRollingAvg(
   buckets: QualityBucket[],
   window: number,
+  mode: FocusMode,
 ): Array<number | null> {
   return buckets.map((_, i) => {
     const start = Math.max(0, i - window + 1);
     const slice = buckets.slice(start, i + 1);
-    const pcts = slice.map(cleanPct).filter((p): p is number => p !== null);
+    const pcts = slice
+      .map((b) => bucketPct(b, mode))
+      .filter((p): p is number => p !== null);
     if (pcts.length === 0) return null;
     return pcts.reduce((a, b) => a + b, 0) / pcts.length;
   });
@@ -82,6 +137,7 @@ export function QualityChart({
   labels,
   compact,
   rollingWindow,
+  focus = "all",
 }: QualityChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const tipRef = useRef<HTMLDivElement>(null);
@@ -101,9 +157,15 @@ export function QualityChart({
   }, [compact, rollingWindow, buckets.length]);
 
   const rollingAvgPct = useMemo(
-    () => (effectiveWindow > 0 ? computeRollingAvg(buckets, effectiveWindow) : []),
-    [buckets, effectiveWindow],
+    () =>
+      effectiveWindow > 0
+        ? computeRollingAvg(buckets, effectiveWindow, focus)
+        : [],
+    [buckets, effectiveWindow, focus],
   );
+
+  const overlayColor = useMemo(() => lineColor(focus), [focus]);
+  const overlayLabel = useMemo(() => badgeLabel(focus), [focus]);
 
   // Точки SVG-линии overlay: Y инвертирован (100% наверху), null значения
   // прерывают линию (выходные/пустые дни). Координаты в долях 0–1.
@@ -203,19 +265,42 @@ export function QualityChart({
         // worst-wins: P0+P1 объединены в crit (один красный сегмент)
         const critCount = b.with_p0 + b.with_p1_only;
         const cleanCount = Math.max(0, total - critCount - b.with_p2_only);
-        const critPct = total > 0 ? (critCount / total) * heightPct : 0;
-        const p2Pct = total > 0 ? (b.with_p2_only / total) * heightPct : 0;
-        const cleanPct = heightPct - critPct - p2Pct;
         const lowSample = total > 0 && total < LOW_SAMPLE;
         const hasP0 = b.with_p0 > 0;
+
+        // Под фильтром оставляем ТОЛЬКО релевантный сегмент (вместо стека).
+        // Высоту фильтрованного бара берём пропорционально соответствующего
+        // count'а — так на чарте сразу виден объём метрики, без шума соседей.
+        type Seg = { kind: "clean" | "p2" | "crit"; count: number };
+        const segments: Seg[] =
+          focus === "all"
+            ? [
+                { kind: "clean", count: cleanCount },
+                { kind: "p2", count: b.with_p2_only },
+                { kind: "crit", count: critCount },
+              ]
+            : focus === "p2"
+              ? [{ kind: "p2", count: b.with_p2_only }]
+              : focus === "p0"
+                ? [{ kind: "crit", count: b.with_p0 }]
+                : focus === "p1"
+                  ? [{ kind: "crit", count: b.with_p1_only }]
+                  : /* dirty */ [{ kind: "crit", count: critCount }];
 
         const classNames = [
           "bar",
           lowSample ? "is-low-sample" : "",
-          hasP0 ? "has-p0" : "",
+          hasP0 && focus !== "p2" ? "has-p0" : "",
         ]
           .filter(Boolean)
           .join(" ");
+
+        // В фильтр-моде P0:N топпер виден только если он входит в выборку,
+        // иначе ярлык про блокеры под фильтром «P2» сбивает с толку.
+        const showP0Topper =
+          !compact &&
+          hasP0 &&
+          (focus === "all" || focus === "p0" || focus === "dirty");
 
         return (
           <div
@@ -227,33 +312,24 @@ export function QualityChart({
               el.onmouseleave = () => handleLeave(el);
             }}
           >
-            {!compact && hasP0 && (
+            {showP0Topper && (
               <div className="bar-topper-p0">P0:{b.with_p0}</div>
             )}
             <div className="bar-stack" style={{ height: `${heightPct}%` }}>
-              {cleanPct > 0 && (
-                <div
-                  className="bar-clean"
-                  style={{ height: `${(cleanCount / total) * 100}%` }}
-                />
-              )}
-              {p2Pct > 0 && (
-                <div
-                  className="bar-p2"
-                  style={{ height: `${(b.with_p2_only / total) * 100}%` }}
-                />
-              )}
-              {critPct > 0 && (
-                <div
-                  className="bar-crit"
-                  style={{ height: `${(critCount / total) * 100}%` }}
-                />
+              {segments.map((seg) =>
+                seg.count > 0 ? (
+                  <div
+                    key={seg.kind}
+                    className={`bar-${seg.kind}`}
+                    style={{ height: `${(seg.count / total) * 100}%` }}
+                  />
+                ) : null,
               )}
             </div>
             {heightPct === 0 && <div className="bar-empty" />}
             <div className="bar-chip">
               {total} PR
-              {hasP0 && (
+              {showP0Topper && (
                 <>
                   {" · "}
                   <b style={{ color: "var(--mk-danger-100)" }}>P0:{b.with_p0}</b>
@@ -292,7 +368,7 @@ export function QualityChart({
             <polyline
               points={linePoints}
               fill="none"
-              stroke="var(--mk-success-100, #16a34a)"
+              stroke={overlayColor}
               strokeWidth="2"
               strokeLinejoin="round"
               strokeLinecap="round"
@@ -311,7 +387,7 @@ export function QualityChart({
               width: 32,
               fontFamily: "var(--mk-font-mono)",
               fontSize: 10,
-              color: "var(--mk-success-100, #16a34a)",
+              color: overlayColor,
               opacity: 0.85,
               pointerEvents: "none",
             }}
@@ -328,7 +404,7 @@ export function QualityChart({
                 right: 4,
                 top: `calc(${100 - latestRollingPct}% - 10px)`,
                 padding: "2px 6px",
-                background: "var(--mk-success-100, #16a34a)",
+                background: overlayColor,
                 color: "white",
                 fontFamily: "var(--mk-font-mono)",
                 fontSize: 10,
@@ -340,7 +416,7 @@ export function QualityChart({
                 boxShadow: "0 1px 4px rgba(0,0,0,0.15)",
               }}
             >
-              {latestRollingPct.toFixed(0)}% чистых · {effectiveWindow}
+              {latestRollingPct.toFixed(0)}% {overlayLabel} · {effectiveWindow}
               {buckets.length >= 20 ? "д" : "нед"} avg
             </div>
           )}

--- a/src/components/quality/QualityKPIs.tsx
+++ b/src/components/quality/QualityKPIs.tsx
@@ -1,12 +1,16 @@
 import type { CSSProperties } from "react";
 import type { QualityPayload, PeriodMode } from "../../types/quality";
+import type { FocusMode } from "./QualityChart";
 
 interface Props {
   data: QualityPayload;
   mode: PeriodMode;
+  focus?: FocusMode;
+  /** Toggle handler — клик по уже активной плитке снимает фильтр. */
+  onToggleFocus?: (mode: FocusMode) => void;
 }
 
-export function QualityKPIs({ data, mode }: Props) {
+export function QualityKPIs({ data, mode, focus = "all", onToggleFocus }: Props) {
   const buckets = data.buckets[mode].summary;
   const total = buckets.reduce((a, b) => a + b.total_pr, 0);
   const totalP0 = buckets.reduce((a, b) => a + b.with_p0, 0);
@@ -21,12 +25,51 @@ export function QualityKPIs({ data, mode }: Props) {
   const periodLabel = mode === "12w" ? "за 12 нед." : "за 30 дней";
   const avgLabel = mode === "12w" ? "среднем за неделю" : "среднем за день";
 
-  const kpiStyle = (i: number): CSSProperties => ({ ["--i" as string]: i } as CSSProperties);
+  const kpiStyle = (i: number, active: boolean): CSSProperties =>
+    ({
+      ["--i" as string]: i,
+      // Active state — рамка цветом метрики + лёгкий лифт. Не трогаем CSS-файл,
+      // чтобы не плодить -active классы по всем темам.
+      ...(active
+        ? {
+            outline: "2px solid currentColor",
+            outlineOffset: -2,
+            boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
+          }
+        : null),
+    }) as CSSProperties;
+
+  const tileButtonProps = (m: FocusMode) =>
+    onToggleFocus
+      ? {
+          role: "button" as const,
+          tabIndex: 0,
+          onClick: () => onToggleFocus(m),
+          onKeyDown: (e: React.KeyboardEvent) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onToggleFocus(m);
+            }
+          },
+          "aria-pressed": focus === m,
+          style: { cursor: "pointer" as const },
+        }
+      : {};
 
   return (
     <div className="kpis">
       {totalP0 > 0 && (
-        <div className="kpi-p0-alert" title="Блокирующие баги от Codex. Требуют немедленного внимания.">
+        <div
+          className="kpi-p0-alert"
+          title="Блокирующие баги от Codex. Клик — отфильтровать чарт по P0."
+          {...tileButtonProps("p0")}
+          style={{
+            ...(tileButtonProps("p0").style ?? {}),
+            ...(focus === "p0"
+              ? { outline: "2px solid white", outlineOffset: -3 }
+              : null),
+          }}
+        >
           <span className="kpi-p0-icon">🔴</span>
           <div className="kpi-p0-text">
             <b>P0: {totalP0}</b>
@@ -34,20 +77,43 @@ export function QualityKPIs({ data, mode }: Props) {
           </div>
         </div>
       )}
-      <div className="kpi" style={kpiStyle(0)} title="PR с P0 или P1 находкой codex (P2-нит не считается).">
+      <div
+        className="kpi"
+        style={kpiStyle(0, focus === "dirty")}
+        title="PR с P0 или P1 находкой codex (P2-нит не считается). Клик — фильтр чарта."
+        {...tileButtonProps("dirty")}
+      >
         <div className="kpi-lbl">% грязных PR · {periodLabel}</div>
-        <div className="kpi-v">{dirtyPct}%</div>
+        <div className="kpi-v" style={focus === "dirty" ? { color: "var(--mk-danger-100)" } : undefined}>
+          {dirtyPct}%
+        </div>
         <div className="kpi-sub">{dirty} из {total} PR · только P0/P1</div>
       </div>
-      <div className="kpi" style={kpiStyle(1)} title="Доля PR с хотя бы одной P1 находкой codex.">
+      <div
+        className="kpi"
+        style={{
+          ...kpiStyle(1, focus === "p1"),
+          color: focus === "p1" ? "var(--mk-quality-p1)" : undefined,
+        }}
+        title="Доля PR с хотя бы одной P1 находкой codex. Клик — фильтр чарта."
+        {...tileButtonProps("p1")}
+      >
         <div className="kpi-lbl">% P1 · {periodLabel}</div>
         <div className="kpi-v" style={{ color: "var(--mk-quality-p1-text)" }}>{p1Pct}%</div>
       </div>
-      <div className="kpi" style={kpiStyle(2)} title="Фоновый шум — стиль, нейминг, мелкие нитпики. Не блокирует ship.">
+      <div
+        className="kpi"
+        style={{
+          ...kpiStyle(2, focus === "p2"),
+          color: focus === "p2" ? "var(--mk-quality-p2)" : undefined,
+        }}
+        title="Фоновый шум — стиль, нейминг, мелкие нитпики. Клик — фильтр чарта."
+        {...tileButtonProps("p2")}
+      >
         <div className="kpi-lbl">% P2 · {periodLabel} <span style={{ opacity: 0.6 }}>· фон</span></div>
         <div className="kpi-v" style={{ color: "var(--mk-quality-p2-text)" }}>{p2Pct}%</div>
       </div>
-      <div className="kpi" style={kpiStyle(3)}>
+      <div className="kpi" style={kpiStyle(3, false)}>
         <div className="kpi-lbl">PR {periodLabel}</div>
         <div className="kpi-v">{total}</div>
         <div className="kpi-sub">{avgPerPeriod} в {avgLabel}</div>

--- a/src/components/quality/QualityKPIs.tsx
+++ b/src/components/quality/QualityKPIs.tsx
@@ -12,7 +12,8 @@ export function QualityKPIs({ data, mode }: Props) {
   const totalP0 = buckets.reduce((a, b) => a + b.with_p0, 0);
   const totalP1 = buckets.reduce((a, b) => a + b.with_p1_only, 0);
   const totalP2 = buckets.reduce((a, b) => a + b.with_p2_only, 0);
-  const dirty = totalP0 + totalP1 + totalP2;
+  // Новая метрика «грязный»: только P0+P1 (нит-P2 — фон, не блокирует ship).
+  const dirty = totalP0 + totalP1;
   const dirtyPct = total ? Math.round((dirty / total) * 100) : 0;
   const p1Pct = total ? Math.round((totalP1 / total) * 100) : 0;
   const p2Pct = total ? Math.round((totalP2 / total) * 100) : 0;
@@ -33,17 +34,17 @@ export function QualityKPIs({ data, mode }: Props) {
           </div>
         </div>
       )}
-      <div className="kpi" style={kpiStyle(0)}>
+      <div className="kpi" style={kpiStyle(0)} title="PR с P0 или P1 находкой codex (P2-нит не считается).">
         <div className="kpi-lbl">% грязных PR · {periodLabel}</div>
         <div className="kpi-v">{dirtyPct}%</div>
-        <div className="kpi-sub">{dirty} из {total} PR</div>
+        <div className="kpi-sub">{dirty} из {total} PR · только P0/P1</div>
       </div>
-      <div className="kpi" style={kpiStyle(1)}>
+      <div className="kpi" style={kpiStyle(1)} title="Доля PR с хотя бы одной P1 находкой codex.">
         <div className="kpi-lbl">% P1 · {periodLabel}</div>
         <div className="kpi-v" style={{ color: "var(--mk-quality-p1-text)" }}>{p1Pct}%</div>
       </div>
-      <div className="kpi" style={kpiStyle(2)}>
-        <div className="kpi-lbl">% P2 · {periodLabel}</div>
+      <div className="kpi" style={kpiStyle(2)} title="Фоновый шум — стиль, нейминг, мелкие нитпики. Не блокирует ship.">
+        <div className="kpi-lbl">% P2 · {periodLabel} <span style={{ opacity: 0.6 }}>· фон</span></div>
         <div className="kpi-v" style={{ color: "var(--mk-quality-p2-text)" }}>{p2Pct}%</div>
       </div>
       <div className="kpi" style={kpiStyle(3)}>

--- a/src/components/quality/QualityKPIs.tsx
+++ b/src/components/quality/QualityKPIs.tsx
@@ -56,15 +56,19 @@ export function QualityKPIs({ data, mode, focus = "all", onToggleFocus }: Props)
         }
       : {};
 
+  // Извлечено в const — иначе spread + style-override вызывают tileButtonProps
+  // дважды, что хрупко: добавив в props функцию с эффектом мы её задвоим.
+  const p0Props = tileButtonProps("p0");
+
   return (
     <div className="kpis">
       {totalP0 > 0 && (
         <div
           className="kpi-p0-alert"
           title="Блокирующие баги от Codex. Клик — отфильтровать чарт по P0."
-          {...tileButtonProps("p0")}
+          {...p0Props}
           style={{
-            ...(tileButtonProps("p0").style ?? {}),
+            ...p0Props.style,
             ...(focus === "p0"
               ? { outline: "2px solid white", outlineOffset: -3 }
               : null),

--- a/src/components/quality/QualityProjectCard.tsx
+++ b/src/components/quality/QualityProjectCard.tsx
@@ -57,7 +57,8 @@ export function QualityProjectCard({ repo, client, data, mode, index }: Props) {
   const totalP0 = repoData.buckets.reduce((a, b) => a + b.with_p0, 0);
   const totalP1 = repoData.buckets.reduce((a, b) => a + b.with_p1_only, 0);
   const totalP2 = repoData.buckets.reduce((a, b) => a + b.with_p2_only, 0);
-  const totalDirty = totalP0 + totalP1 + totalP2;
+  // «Грязный» по новой метрике: только P0+P1 (P2-нит — фон, ship не блокирует).
+  const totalDirty = totalP0 + totalP1;
 
   if (totalPR < 3) {
     return (

--- a/src/components/quality/QualitySummaryPanel.tsx
+++ b/src/components/quality/QualitySummaryPanel.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import type { QualityPayload, Annotation, PeriodMode } from "../../types/quality";
-import { QualityChart } from "./QualityChart";
+import { QualityChart, type FocusMode } from "./QualityChart";
 import { QualityKPIs } from "./QualityKPIs";
 import { QualityAnnotations } from "./QualityAnnotations";
 
@@ -10,9 +11,15 @@ interface Props {
 }
 
 export function QualitySummaryPanel({ data, annotations, mode }: Props) {
+  const [focus, setFocus] = useState<FocusMode>("all");
   const buckets = data.buckets[mode].summary;
   const labels = data.buckets[mode].labels;
   const errored = Object.entries(data.repo_status).filter(([, s]) => s.status === "error");
+
+  // Click on the same focused tile → release filter; otherwise switch.
+  // Keeping toggle logic in one place so KPI tile components stay dumb.
+  const toggleFocus = (mode: FocusMode) =>
+    setFocus((prev) => (prev === mode ? "all" : mode));
 
   return (
     <div className="panel summary">
@@ -30,30 +37,88 @@ export function QualitySummaryPanel({ data, annotations, mode }: Props) {
           )}
         </div>
         <div className="chart-area">
-          <QualityChart buckets={buckets} labels={labels} compact={false} />
+          <QualityChart buckets={buckets} labels={labels} compact={false} focus={focus} />
           <QualityAnnotations annotations={annotations} mode={mode} bucketCount={buckets.length} />
         </div>
         <div className="chart-legend">
-          <span><i className="dot dot-p1" /> P0 / P1 (грязные)</span>
-          <span><i className="dot dot-p2" /> P2 (нит)</span>
-          <span><i className="dot dot-clean" /> чистые</span>
+          {focus === "all" ? (
+            <>
+              <span><i className="dot dot-p1" /> P0 / P1 (грязные)</span>
+              <span><i className="dot dot-p2" /> P2 (нит)</span>
+              <span><i className="dot dot-clean" /> чистые</span>
+            </>
+          ) : (
+            <span style={{ opacity: 0.7 }}>
+              Фильтр: {focusLabel(focus)} · клик по карточке ещё раз — снять
+            </span>
+          )}
           <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
             <i
               style={{
                 display: "inline-block",
                 width: 18,
                 height: 2,
-                background: "var(--mk-success-100, #16a34a)",
+                background: focusLineColor(focus),
                 borderRadius: 2,
               }}
             />
-            {mode === "30d"
-              ? "7-дневное скользящее среднее «% PR без P0/P1»"
-              : "3-недельное скользящее среднее «% PR без P0/P1»"}
+            {mode === "30d" ? "7-дневное" : "3-недельное"} скользящее среднее «
+            {focusLineLabel(focus)}»
           </span>
         </div>
       </div>
-      <QualityKPIs data={data} mode={mode} />
+      <QualityKPIs data={data} mode={mode} focus={focus} onToggleFocus={toggleFocus} />
     </div>
   );
+}
+
+// Centralised because three places reference the same focus-mode → display
+// mapping (legend swatch colour, legend label, KPI tile hover). Keeping them
+// here means a new mode lands in one diff, not three.
+function focusLineColor(f: FocusMode): string {
+  switch (f) {
+    case "p0":
+      return "var(--mk-quality-p0, #dc2626)";
+    case "p1":
+      return "var(--mk-quality-p1, #f59e0b)";
+    case "p2":
+      return "var(--mk-quality-p2, #eab308)";
+    case "dirty":
+      return "var(--mk-danger-100, #ef4444)";
+    case "all":
+    default:
+      return "var(--mk-success-100, #16a34a)";
+  }
+}
+
+function focusLineLabel(f: FocusMode): string {
+  switch (f) {
+    case "p0":
+      return "% PR с P0";
+    case "p1":
+      return "% PR с P1";
+    case "p2":
+      return "% PR с P2";
+    case "dirty":
+      return "% грязных PR (P0+P1)";
+    case "all":
+    default:
+      return "% PR без P0/P1";
+  }
+}
+
+function focusLabel(f: FocusMode): string {
+  switch (f) {
+    case "p0":
+      return "только P0";
+    case "p1":
+      return "только P1";
+    case "p2":
+      return "только P2";
+    case "dirty":
+      return "только грязные (P0+P1)";
+    case "all":
+    default:
+      return "все";
+  }
 }

--- a/src/components/quality/QualitySummaryPanel.tsx
+++ b/src/components/quality/QualitySummaryPanel.tsx
@@ -34,9 +34,23 @@ export function QualitySummaryPanel({ data, annotations, mode }: Props) {
           <QualityAnnotations annotations={annotations} mode={mode} bucketCount={buckets.length} />
         </div>
         <div className="chart-legend">
-          <span><i className="dot dot-p1" /> P1 (критическое)</span>
-          <span><i className="dot dot-p2" /> P2 (высокое)</span>
-          <span><i className="dot dot-clean" /> чистые PR</span>
+          <span><i className="dot dot-p1" /> P0 / P1 (грязные)</span>
+          <span><i className="dot dot-p2" /> P2 (нит)</span>
+          <span><i className="dot dot-clean" /> чистые</span>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+            <i
+              style={{
+                display: "inline-block",
+                width: 18,
+                height: 2,
+                background: "var(--mk-success-100, #16a34a)",
+                borderRadius: 2,
+              }}
+            />
+            {mode === "30d"
+              ? "7-дневное скользящее среднее «% PR без P0/P1»"
+              : "3-недельное скользящее среднее «% PR без P0/P1»"}
+          </span>
         </div>
       </div>
       <QualityKPIs data={data} mode={mode} />

--- a/src/components/quality/QualityTab.tsx
+++ b/src/components/quality/QualityTab.tsx
@@ -10,7 +10,7 @@ import "../../styles/v4-quality.css";
 
 export function QualityTab() {
   const { data, annotations, loading, error, unavailable, isStale, refresh, reloadAnnotations } = useCodexQuality();
-  const [mode, setMode] = useState<PeriodMode>("12w");
+  const [mode, setMode] = useState<PeriodMode>("30d");
   const [showAddModal, setShowAddModal] = useState(false);
 
   const handleAddAnnotation = async (p: AnnotationCreatePayload) => {

--- a/src/components/quality/QualityTab.tsx
+++ b/src/components/quality/QualityTab.tsx
@@ -101,23 +101,45 @@ export function QualityTab() {
       <div className="pageH">
         <div>
           <h1>Качество кода</h1>
-          <div className="sub">
-            Доля PR с критическими/высокими замечаниями <b>chatgpt-codex-connector[bot]</b> от общего числа merged PR · события на временной оси
-          </div>
+          <div className="sub">Доля PR с критическими/высокими замечаниями review</div>
         </div>
         <div className="ctrls">
           <div className="seg">
-            <button className={mode === "30d" ? "active" : ""} onClick={() => setMode("30d")}>30 дней · По дням</button>
-            <button className={mode === "12w" ? "active" : ""} onClick={() => setMode("12w")}>12 недель · По неделям</button>
+            <button
+              className={mode === "30d" ? "active" : ""}
+              onClick={() => setMode("30d")}
+              title="30 дней · По дням"
+            >
+              30 дн.
+            </button>
+            <button
+              className={mode === "12w" ? "active" : ""}
+              onClick={() => setMode("12w")}
+              title="12 недель · По неделям"
+            >
+              12 нед.
+            </button>
           </div>
           <button className="btn-add-event" onClick={() => setShowAddModal(true)}>+ событие</button>
-          <div style={{ fontFamily: "var(--mk-font-mono)", fontSize: 10, color: "var(--mk-ink-500)", textAlign: "right" }}>
-            <div>Синхр. ежедневно · 03:00 Бали</div>
-            <div style={{ color: "var(--mk-ink-400)" }}>
-              последняя: {new Date(data.generated_at).toLocaleString("ru")}
-            </div>
+          <div
+            title={`Синхр. ежедневно · 03:00 Бали\nпоследняя: ${new Date(data.generated_at).toLocaleString("ru")}`}
+            style={{ fontFamily: "var(--mk-font-mono)", fontSize: 10, color: "var(--mk-ink-500)", whiteSpace: "nowrap" }}
+          >
+            ↻ {new Date(data.generated_at).toLocaleString("ru", {
+              day: "2-digit",
+              month: "2-digit",
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
           </div>
-          <button className="btn-refresh" onClick={() => refresh()} disabled={loading}>↻ Сейчас</button>
+          <button
+            className="btn-refresh"
+            onClick={() => refresh()}
+            disabled={loading}
+            title="Обновить сейчас"
+          >
+            ↻
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Главный чарт «Качество кода» получил SVG-overlay: **зелёная линия 7-day rolling avg «% PR без P0/P1»** с правой осью 0–100% и бейджем текущего значения. Для weekly mode окно 3 нед.
- Метрика **«грязный»** на KPI-плитках и per-project карточках переведена с `P0+P1+P2` на `P0+P1` (P2-нит — фон, не блокирует ship). Sublabel «только P0/P1» поясняет.
- Header ужат: subtitle сокращён, переключатели/события/refresh теперь на одной строке с заголовком — основной контент поднимается.

## Background
Этот PR — UI-слой ответа на вопрос «стало ли чище?». Раньше график показывал три stacked-сегмента и сухие проценты, без явного тренда. Теперь линия идёт вверх/вниз — ответ виден за 1 секунду.

## Known issue (not in this PR)
**Парсер `scripts/sweep_codex_quality.py` сейчас не извлекает severity из codex-bot badge-картинок** (`![P1 Badge](https://img.shields.io/badge/P1-orange...)` — `bodyText` стрипает картинку, alt-текст теряется). Реальные данные в проде искажены: все находки фолбэчатся в P2 → `with_p1_only ≈ 0`. UI на этом PR ничего не маскирует — после фикса парсера цифры станут реальными.

## Coordination note
Эта ветка зарелизована поверх текущего `main` (J+K applied, `592298e`). Если [#507](https://github.com/Sergio1990-1/makeit-dashboard/pull/507) (Revert J+K) будет смержен — этот PR потребуется ребейзнуть на новую базу. Конфликт ожидается на тех же строках, что Session J трогал в Quality*.tsx (4 файла); resolve = принять `--mk-*` ref.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] Превью локально на mock-данных (1440px viewport): чарт + overlay + KPI цифры по новой формуле + header в одну строку
- [ ] После merge — sweep данные пока сломаны (badge bug), но UI-логика и тесты не зависят от формы данных
- [ ] Полная сверка на реальных данных — после фикса `sweep_codex_quality.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)