### PR TITLE
fix(transcripts): align UI with draft/quality models

### DIFF
--- a/src/components/TranscriptBrief.tsx
+++ b/src/components/TranscriptBrief.tsx
@@ -141,7 +141,7 @@ export function TranscriptBrief({ result, onNewUpload, onEdit }: Props) {
           <div className="tpc-quality-report-header">
             <span className="tpc-quality-report-title">Отчёт о качестве</span>
             <span className="tpc-quality-report-score">
-              Score: {result.quality_report.score}
+              Оценка: {result.quality_report.score}
             </span>
           </div>
           <ul className="tpc-quality-report-checks">
@@ -150,7 +150,7 @@ export function TranscriptBrief({ result, onNewUpload, onEdit }: Props) {
                 <span className="tpc-quality-check-icon" aria-hidden="true">
                   {CHECK_ICON[check.status]}
                 </span>
-                <span className="tpc-quality-check-name">{check.name}</span>
+                <span className="tpc-quality-check-name">{check.label}</span>
                 <span className="tpc-quality-check-message">{check.message}</span>
               </li>
             ))}

--- a/src/components/TranscriptHistory.tsx
+++ b/src/components/TranscriptHistory.tsx
@@ -209,8 +209,8 @@ export function TranscriptHistory({ onOpen, onResume, onRetry, refreshKey }: Pro
                     <td className="tpc-history-model">
                       {item.transcription_model === "quality" ? (
                         <span title="Качественная (диаризация)">&#127919;</span>
-                      ) : item.transcription_model === "fast" ? (
-                        <span title="Быстрая">&#9889;</span>
+                      ) : item.transcription_model === "draft" ? (
+                        <span title="Черновик без надёжных спикеров">&#9889;</span>
                       ) : (
                         <span className="tpc-text-muted">—</span>
                       )}

--- a/src/components/TranscriptsTab.tsx
+++ b/src/components/TranscriptsTab.tsx
@@ -44,7 +44,7 @@ export function TranscriptsTab({ projects }: Props) {
   const [editing, setEditing] = useState(false);
   const [loadingBrief, setLoadingBrief] = useState(false);
   const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
-  const [transcriptionModel, setTranscriptionModel] = useState<TranscriptionModel>("fast");
+  const [transcriptionModel, setTranscriptionModel] = useState<TranscriptionModel>("quality");
 
   // Batch upload state
   const [batchFiles, setBatchFiles] = useState<BatchFile[]>([]);
@@ -274,7 +274,7 @@ export function TranscriptsTab({ projects }: Props) {
       try {
         const res = await retryTranscript(
           taskId,
-          originalModel ?? "fast",
+          originalModel ?? "quality",
           originalProject,
         );
         setActiveTaskId(res.task_id);
@@ -491,12 +491,12 @@ export function TranscriptsTab({ projects }: Props) {
                 <div className="tpc-model-toggle">
                   <button
                     type="button"
-                    className={`tpc-model-option${transcriptionModel === "fast" ? " tpc-model-option--active" : ""}`}
-                    onClick={() => setTranscriptionModel("fast")}
-                    title="30 секунд, спикеры определяются по контексту"
+                    className={`tpc-model-option${transcriptionModel === "draft" ? " tpc-model-option--active" : ""}`}
+                    onClick={() => setTranscriptionModel("draft")}
+                    title="Быстрый черновик без надёжных спикеров и таймкодов"
                   >
                     <span className="tpc-model-icon">&#9889;</span>
-                    Быстрая
+                    Черновик
                   </button>
                   <button
                     type="button"

--- a/src/components/v4/health/Hero.tsx
+++ b/src/components/v4/health/Hero.tsx
@@ -1,5 +1,5 @@
 import type { HealthReport, HealthReportDiscovery } from "../../../types/health";
-import { Icon } from "./Icon";
+import { Icon, type IconName } from "./Icon";
 import { KpiRow } from "./KpiRow";
 import { formatScanTime } from "./utils";
 
@@ -7,7 +7,7 @@ import { formatScanTime } from "./utils";
 // not derived from findings). Color/text depends on status + freshness.
 function DiscoveryBadge({ discovery }: { discovery: HealthReportDiscovery }) {
   // Map status → CSS modifier + visible text + tooltip
-  const parts: { mod: string; text: string; icon?: string; tooltip: string } = (() => {
+  const parts: { mod: string; text: string; icon?: IconName; tooltip: string } = (() => {
     switch (discovery.status) {
       case "completed":
         // Code review d2e717b D3: fresh === undefined означает «не могу определить»

--- a/src/components/v4/transcripts/TranscriptBriefV4.tsx
+++ b/src/components/v4/transcripts/TranscriptBriefV4.tsx
@@ -140,7 +140,7 @@ export function TranscriptBriefV4({ result, onNewUpload, onEdit }: Props) {
           <div className="v4-tpc-quality-report-h">
             <span className="v4-tpc-quality-report-t">Отчёт о качестве</span>
             <span className="v4-pl-mono v4-tpc-quality-report-score">
-              Score: {result.quality_report.score}
+              Оценка: {result.quality_report.score}
             </span>
           </div>
           <ul className="v4-tpc-quality-checks">
@@ -152,7 +152,7 @@ export function TranscriptBriefV4({ result, onNewUpload, onEdit }: Props) {
                 <span className="v4-tpc-quality-check-icon" aria-hidden="true">
                   {CHECK_ICON[check.status]}
                 </span>
-                <span className="v4-tpc-quality-check-name">{check.name}</span>
+                <span className="v4-tpc-quality-check-name">{check.label}</span>
                 <span className="v4-tpc-quality-check-msg">{check.message}</span>
               </li>
             ))}

--- a/src/components/v4/transcripts/TranscriptHistoryV4.tsx
+++ b/src/components/v4/transcripts/TranscriptHistoryV4.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   fetchTranscriptList,
   deleteTranscript,
+  normalizeTranscriptionModel,
   type TranscriptListItem,
   type TranscriptionModel,
 } from "../../../utils/transcript";
@@ -68,22 +69,20 @@ const STORAGE_KEY = "makeit.transcriptsHistory.v1";
 
 const VALID_FILTERS: readonly StatusFilter[] = ["all", "active", "done", "error"];
 const VALID_SORTS: readonly SortKey[] = ["date", "filename", "project", "model", "status"];
-const VALID_MODELS: readonly (TranscriptionModel | "all")[] = ["all", "fast", "quality"];
 
 function loadState(): ToolbarState {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
       const p = JSON.parse(raw) as Partial<ToolbarState>;
+      const model = p.model === "all" ? "all" : normalizeTranscriptionModel(p.model);
       return {
         filter: VALID_FILTERS.includes(p.filter as StatusFilter)
           ? (p.filter as StatusFilter)
           : "all",
         query: "",
         project: typeof p.project === "string" ? p.project : "",
-        model: VALID_MODELS.includes(p.model as TranscriptionModel | "all")
-          ? (p.model as TranscriptionModel | "all")
-          : "all",
+        model: model ?? "all",
         sort: VALID_SORTS.includes(p.sort as SortKey) ? (p.sort as SortKey) : "date",
         asc: typeof p.asc === "boolean" ? p.asc : false,
       };
@@ -364,7 +363,7 @@ export function TranscriptHistoryV4({ onOpen, onResume, onRetry, refreshKey, onI
             aria-label="Фильтр по модели"
           >
             <option value="all">Все модели</option>
-            <option value="fast">Быстрая</option>
+            <option value="draft">Черновик</option>
             <option value="quality">Качественная</option>
           </select>
           <div className="v4-projects-sort" ref={sortMenuRef}>
@@ -456,8 +455,8 @@ export function TranscriptHistoryV4({ onOpen, onResume, onRetry, refreshKey, onI
                 <div className="v4-tpc-history-cell v4-tpc-history-model">
                   {item.transcription_model === "quality" ? (
                     <span title="Качественная (диаризация)">🎯 quality</span>
-                  ) : item.transcription_model === "fast" ? (
-                    <span title="Быстрая">⚡ fast</span>
+                  ) : item.transcription_model === "draft" ? (
+                    <span title="Черновик без надёжных спикеров">⚡ draft</span>
                   ) : (
                     <span className="v4-tpc-text-muted">—</span>
                   )}

--- a/src/components/v4/transcripts/TranscriptsView.tsx
+++ b/src/components/v4/transcripts/TranscriptsView.tsx
@@ -4,6 +4,7 @@ import {
   retryTranscript,
   fetchTranscriptResult,
   fetchTranscriptList,
+  normalizeTranscriptionModel,
   type TranscriptResult,
   type TranscriptionModel,
 } from "../../../utils/transcript";
@@ -32,8 +33,7 @@ export function TranscriptsView({ projects }: Props) {
     return localStorage.getItem(STORAGE.project) || projects[0]?.repo || "";
   });
   const [selectedModel, setSelectedModel] = useState<TranscriptionModel>(() => {
-    const v = localStorage.getItem(STORAGE.model);
-    return v === "fast" || v === "quality" ? v : "fast";
+    return normalizeTranscriptionModel(localStorage.getItem(STORAGE.model)) ?? "quality";
   });
 
   useEffect(() => { localStorage.setItem(STORAGE.project, selectedProject); }, [selectedProject]);
@@ -238,7 +238,7 @@ export function TranscriptsView({ projects }: Props) {
       try {
         const res = await retryTranscript(
           taskId,
-          originalModel ?? "fast",
+          originalModel ?? "quality",
           originalProject,
         );
         setActiveTaskId(res.task_id);

--- a/src/components/v4/transcripts/UploadZone.tsx
+++ b/src/components/v4/transcripts/UploadZone.tsx
@@ -240,17 +240,17 @@ export function UploadZone({
             <div className="v4-pillgrp">
               <button
                 type="button"
-                className={selectedModel === "fast" ? "is-active" : ""}
-                onClick={() => setSelectedModel("fast")}
-                title="30 секунд, спикеры по контексту"
+                className={selectedModel === "draft" ? "is-active" : ""}
+                onClick={() => setSelectedModel("draft")}
+                title="Быстрый черновик без надёжных спикеров и таймкодов"
               >
-                ⚡ Быстрая
+                ⚡ Черновик
               </button>
               <button
                 type="button"
                 className={selectedModel === "quality" ? "is-active" : ""}
                 onClick={() => setSelectedModel("quality")}
-                title="7-15 минут, точная диаризация"
+                title="Production BRIEF с полной обработкой спикеров"
               >
                 🎯 Качественная
               </button>

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -149,6 +149,7 @@ export type TranscriptQuality = "pass" | "warning" | "needs_review";
 
 export interface QualityCheck {
   name: string;
+  label: string;
   status: "pass" | "warning" | "fail";
   message: string;
 }
@@ -159,6 +160,29 @@ export interface QualityReport {
 }
 
 const QUALITY_VERDICTS = new Set<TranscriptQuality>(["pass", "warning", "needs_review"]);
+
+const QUALITY_CHECK_LABELS: Record<string, string> = {
+  speaker_coverage: "Метки спикеров",
+  speaker_resolution: "Имена спикеров",
+  uncertain_density: "Неразборчивые места",
+  contradiction_density: "Противоречия",
+  business_term_hit_rate: "Бизнес-термины",
+  numeric_facts: "Числа и суммы",
+  numeric_facts_confidence: "Уверенность в числах",
+  numeric_facts_avg_confidence: "Уверенность в числах",
+  action_items_recall: "Action items",
+  required_sections: "Разделы брифа",
+  section_coverage: "Разделы брифа",
+};
+
+function formatQualityCheckLabel(name: string): string {
+  return QUALITY_CHECK_LABELS[name] ?? name.replace(/_/g, " ");
+}
+
+function formatMetric(value: number): string {
+  if (Number.isInteger(value)) return String(value);
+  return value.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+}
 
 /** Pull the overall quality verdict out of the backend `quality_report.json`.
  * The result endpoint (`TranscriptResultResponse`) carries no standalone
@@ -184,7 +208,7 @@ function adaptQualityReport(raw: unknown): QualityReport | null {
   const entries = Object.entries(r.checks as Record<string, unknown>);
   const checks: QualityCheck[] = entries.map(([name, raw]) => {
     if (!raw || typeof raw !== "object") {
-      return { name, status: "warning", message: "" };
+      return { name, label: formatQualityCheckLabel(name), status: "warning", message: "" };
     }
     const e = raw as { status?: string; value?: number; threshold?: number; empty?: number };
     const status: QualityCheck["status"] =
@@ -192,10 +216,10 @@ function adaptQualityReport(raw: unknown): QualityReport | null {
         ? e.status
         : "warning";
     const parts: string[] = [];
-    if (typeof e.value === "number") parts.push(`value=${e.value}`);
-    if (typeof e.threshold === "number") parts.push(`threshold=${e.threshold}`);
-    if (typeof e.empty === "number") parts.push(`empty=${e.empty}`);
-    return { name, status, message: parts.join(", ") };
+    if (typeof e.value === "number") parts.push(`значение ${formatMetric(e.value)}`);
+    if (typeof e.threshold === "number") parts.push(`порог ${formatMetric(e.threshold)}`);
+    if (typeof e.empty === "number") parts.push(`пустых ${formatMetric(e.empty)}`);
+    return { name, label: formatQualityCheckLabel(name), status, message: parts.join(", ") };
   });
   return {
     checks,
@@ -248,22 +272,25 @@ export async function fetchTranscriptResult(taskId: string): Promise<TranscriptR
 
 /**
  * STT model choice — a DELIBERATE FRONTEND-OWNED enum (#447 rule 3). The
- * backend types `transcription_model` as a free-text `string` (generated
- * `Body_upload_transcript_transcript_upload_post.transcription_model` and
- * `TranscriptListItem.transcription_model`, pydantic default `"fast"`).
- * The UI deliberately narrows it to the two values it offers as an upload
- * choice and renders in the history list; it is not aliased to the
- * backend's `string` so a typo in a consumer is still caught by `tsc`.
+ * backend types `transcription_model` as a free-text `string` in the
+ * generated snapshot, but the canonical Phase 4 values are `draft` and
+ * `quality`; legacy `fast` rows are read-side normalized to `draft`.
  */
-export type TranscriptionModel = "fast" | "quality";
+export type TranscriptionModel = "draft" | "quality";
+
+export function normalizeTranscriptionModel(raw: unknown): TranscriptionModel | undefined {
+  if (raw === "quality") return "quality";
+  if (raw === "draft" || raw === "fast") return "draft";
+  return undefined;
+}
 
 /**
  * `/transcript/list` item — the dashboard's normalized refinement of the
  * backend `TranscriptListItem` (raw shape typed below as
  * `BackendTranscriptListItem`). Deliberate frontend-derived shape, NOT a
  * plain alias: the client renames `job_id`→`task_id`, `file_name`→
- * `filename`, narrows the free-text backend `transcription_model` to the
- * UI's `TranscriptionModel` enum (or `undefined`), and narrows the
+ * `filename`, normalizes the free-text backend `transcription_model` to the
+ * UI's canonical `TranscriptionModel` enum (or `undefined`), and narrows the
  * free-text backend `status` to the known lifecycle set. The backend
  * `file_type` is intentionally not surfaced — not drift. The `status`
  * narrowing is best-effort: `fetchTranscriptList` passes the backend
@@ -292,16 +319,15 @@ export async function fetchTranscriptList(): Promise<TranscriptListItem[]> {
   // The backend declares `project`/`file_name`/`created_at`/
   // `transcription_model` required (pydantic defaults), so the `|| ""` /
   // `|| undefined` guards are now harmless defensive no-ops. The backend
-  // `status`/`transcription_model` are free-text `string`; the casts below
-  // narrow them to the UI vocabularies (consumers tolerate unknown values).
-  // Runtime unchanged.
+  // `status`/`transcription_model` are free-text `string`; the normalization
+  // below preserves legacy `fast` rows as canonical `draft`.
   return data.map((item) => ({
     task_id: item.job_id,
     project: item.project || "",
     filename: item.file_name || "",
     status: item.status as TranscriptListItem["status"],
     created_at: item.created_at || "",
-    transcription_model: (item.transcription_model as TranscriptionModel) || undefined,
+    transcription_model: normalizeTranscriptionModel(item.transcription_model),
   }));
 }
 
@@ -361,7 +387,7 @@ const UPLOAD_FIELDS: Record<
 export async function uploadTranscript(
   file: File,
   project: string,
-  transcriptionModel: TranscriptionModel = "fast",
+  transcriptionModel: TranscriptionModel = "quality",
   resumeJobId?: string,
 ): Promise<TranscriptUploadResponse> {
   const form = new FormData();

--- a/tests/health/health-engine.test.ts
+++ b/tests/health/health-engine.test.ts
@@ -6,7 +6,7 @@ import {
   summarizeDiscovery,
   type RunCtx,
 } from "../../src/utils/health-engine";
-import type { ChecklistDocument, ProjectClassification, ProjectYaml } from "../../src/types/health";
+import type { ChecklistDocument, ProjectClassification } from "../../src/types/health";
 import * as github from "../../src/utils/github-actions";
 
 // Mocked во всех тестах ниже. Per-test override через mockResolvedValue/mockRejectedValue.

--- a/tests/transcript-client.test.ts
+++ b/tests/transcript-client.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchTranscriptList,
+  fetchTranscriptResult,
+  normalizeTranscriptionModel,
+} from "../src/utils/transcript";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("transcript client", () => {
+  it("normalizes legacy fast model to canonical draft", async () => {
+    expect(normalizeTranscriptionModel("fast")).toBe("draft");
+    expect(normalizeTranscriptionModel("draft")).toBe("draft");
+    expect(normalizeTranscriptionModel("quality")).toBe("quality");
+    expect(normalizeTranscriptionModel("unknown")).toBeUndefined();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify([
+            {
+              job_id: "job-1",
+              project: "mankassa-app",
+              file_name: "meeting.mp3",
+              status: "done",
+              created_at: "2026-05-28T10:00:00Z",
+              transcription_model: "fast",
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(fetchTranscriptList()).resolves.toMatchObject([
+      { task_id: "job-1", transcription_model: "draft" },
+    ]);
+  });
+
+  it("adapts quality checks into readable labels and metric messages", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            job_id: "job-2",
+            brief_content: "# BRIEF",
+            transcript_text: "Speaker 1: hello",
+            quality_report: {
+              status: "needs_review",
+              score: 0.85,
+              checks: {
+                speaker_coverage: { status: "pass", value: 1, threshold: 0.9 },
+                speaker_resolution: { status: "fail", value: 0, threshold: 0.8 },
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(fetchTranscriptResult("job-2")).resolves.toMatchObject({
+      quality: "needs_review",
+      quality_report: {
+        score: 0.85,
+        checks: [
+          {
+            name: "speaker_coverage",
+            label: "Метки спикеров",
+            status: "pass",
+            message: "значение 1, порог 0.9",
+          },
+          {
+            name: "speaker_resolution",
+            label: "Имена спикеров",
+            status: "fail",
+            message: "значение 0, порог 0.8",
+          },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- migrate transcript UI from deprecated `fast` value to canonical `draft`/`quality` while reading legacy `fast` as `draft`
- default audio uploads to production-safe `quality` and keep the draft option explicit in the UI
- render transcript quality checks with readable Russian labels, including separate speaker-label vs real-name checks
- fix a small health icon type issue that was blocking `npm run build`

Fixes #512.

## Verification
- npm run build
- npm test
- npx eslint src/utils/transcript.ts src/components/TranscriptsTab.tsx src/components/TranscriptHistory.tsx src/components/TranscriptBrief.tsx src/components/v4/transcripts/TranscriptsView.tsx src/components/v4/transcripts/UploadZone.tsx src/components/v4/transcripts/TranscriptHistoryV4.tsx src/components/v4/transcripts/TranscriptBriefV4.tsx tests/transcript-client.test.ts --max-warnings 0
- local visual smoke: transcripts tab shows default `🎯 Качественная`; legacy `tpc:lastModel=fast` migrates to `⚡ Черновик`; no visible `fast` text in model controls