### PR TITLE
fix(quality): trust Codex badge over prose to stop false P0 escalation

### DIFF
--- a/scripts/sweep_codex_quality.py
+++ b/scripts/sweep_codex_quality.py
@@ -33,6 +33,15 @@ must look at **both** to avoid silently mis-classifying findings:
    (or synonyms BLOCKER / CRITICAL). Cheap and safe against `bodyText`,
    which is plain text and won't false-positive on URL fragments.
 
+**Badge takes precedence.** When an entry carries a badge, that badge IS
+the bot's severity for it — we trust it and do NOT also run the text-marker
+regex on its prose. The regex is a FALLBACK applied only to badge-less
+entries. Reason: finding prose routinely contains words like "blocker" /
+"critical" or task names like "P0 bridge", which the loose regex would
+promote to P0; worst-wins then flips the whole PR into the blocker bucket,
+inflating P0 counts versus Codex's own analytics (where a P2-badged finding
+stays P2). See PR description / test_classify_pr_badged_entry_not_*.
+
 Worst-wins across all bot bodies on the PR. If a bot left a comment
 but neither check matched, default to P2 — new bot output formats
 degrade to "low signal" rather than dropping off the chart entirely.
@@ -309,9 +318,18 @@ def classify_pr(pr_node: dict[str, Any]) -> PRSummary:
     severity: str | None = None
     if has_codex:
         for body_md, body_text in bot_entries:
-            entry_sev = _best_severity(
-                detect_badge_severity(body_md),
-                detect_severity(body_text),
+            # The badge is the bot's authoritative severity for this entry.
+            # When present, trust it and DON'T also run the loose text-marker
+            # regex on the prose: bot findings routinely mention "blocker" /
+            # "critical" or name tasks like "P0 bridge" descriptively, and the
+            # regex would wrongly promote those to P0 (worst-wins then flips
+            # the entire PR into the blocker bucket — inflating P0 vs Codex's
+            # own analytics, which counts a badged P2 as P2). The text marker
+            # is a FALLBACK only for badge-less entries (older / non-inline
+            # summary comments) where it's the sole severity signal.
+            badge_sev = detect_badge_severity(body_md)
+            entry_sev = (
+                badge_sev if badge_sev is not None else detect_severity(body_text)
             )
             severity = _best_severity(severity, entry_sev)
         if severity is None:

--- a/scripts/test_sweep_codex_quality.py
+++ b/scripts/test_sweep_codex_quality.py
@@ -170,6 +170,81 @@ def test_classify_pr_worst_wins_across_badge_and_text_marker() -> None:
     assert sweep.classify_pr(pr).severity == "P0"
 
 
+def test_classify_pr_badged_entry_not_escalated_by_prose_words() -> None:
+    """Real-world false-P0 bug: a P2-badged inline finding whose PROSE happens
+    to contain words like "blocker" / "P0 bridge" must stay P2.
+
+    These cases were observed live in mankassa-app / makeit-dashboard:
+    Codex tags the finding P2 via its badge, but the prose references a
+    "blocker" descriptively or names a task like "P0 bridge backfill". The
+    loose text-marker regex caught those words on `bodyText` and worst-wins
+    promoted the whole PR to P0 — inflating the blocker count vs Codex's own
+    analytics (which showed P0=0). When a badge is present, it is the bot's
+    authoritative severity for that entry; the prose must not override it.
+    """
+    # Case A: prose uses the word "blocker" descriptively.
+    pr_a = {
+        "number": 1769,
+        "mergedAt": "2026-05-27T12:17:59Z",
+        "reviewThreads": {
+            "nodes": [
+                {
+                    "comments": {
+                        "nodes": [
+                            {
+                                "author": {"login": "chatgpt-codex-connector"},
+                                "body": (
+                                    "**<sub><sub>![P2 Badge]"
+                                    "(https://img.shields.io/badge/P2-yellow?style=flat)"
+                                    "</sub></sub>  Make the IRMC discovery reachable**\n\n"
+                                    "This blocker points future agents to commit `024dcb58`."
+                                ),
+                                # bodyText strips the badge image; prose "blocker" remains.
+                                "bodyText": (
+                                    "Make the IRMC discovery reachable\n\n"
+                                    "This blocker points future agents to commit 024dcb58."
+                                ),
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "reviews": {"nodes": []},
+        "comments": {"nodes": []},
+    }
+    assert sweep.classify_pr(pr_a).severity == "P2", (
+        "badge says P2; the word 'blocker' in prose must not promote to P0"
+    )
+
+    # Case B: prose names a task "P0 bridge" — literal P0 token, not severity.
+    pr_b = {
+        "number": 1770,
+        "mergedAt": "2026-05-27T13:00:00Z",
+        "reviews": {
+            "nodes": [
+                {
+                    "author": {"login": "chatgpt-codex-connector"},
+                    "body": (
+                        "![P2 Badge](https://img.shields.io/badge/P2-yellow)\n"
+                        "When this audit is used to plan the P0 bridge backfill, "
+                        "these totals are inconsistent."
+                    ),
+                    "bodyText": (
+                        "When this audit is used to plan the P0 bridge backfill, "
+                        "these totals are inconsistent."
+                    ),
+                }
+            ]
+        },
+        "reviewThreads": {"nodes": []},
+        "comments": {"nodes": []},
+    }
+    assert sweep.classify_pr(pr_b).severity == "P2", (
+        "badge says P2; the literal 'P0' inside a task name must not promote to P0"
+    )
+
+
 def test_classify_pr_handles_missing_body_field_gracefully() -> None:
     """Defensive: if GraphQL returns no `body` (only `bodyText`), no crash."""
     pr = {


### PR DESCRIPTION
## Проблема

P0-блокеры на вкладке «Качество кода» расходятся с аналитикой самого Codex: дашборд показывал, напр., `P0=3` за день, тогда как Codex за тот же день — `P0=0`.

## Root cause

`classify_pr` в `scripts/sweep_codex_quality.py` для **каждой** записи бота брал худшее из (бейдж, текстовый регекс по `bodyText`). Codex помечает реальную severity бейджем-картинкой (`shields.io/badge/PN-`), но текст находки сплошь и рядом содержит слова `blocker` / `critical` или имена задач вроде `P0 bridge` — грубая регулярка ловила их как severity. Worst-wins затем флипал **весь PR** в бакет P0.

## Фикс

Если у записи есть бейдж — доверяем ему как авторитетной severity и **не** прогоняем прозу через текстовый регекс. Регекс остаётся fallback'ом только для записей **без** бейджа (старые / non-inline summary-комментарии), где это единственный сигнал.

## Доказательства

- **TDD:** добавлен регрессионный тест `test_classify_pr_badged_entry_not_escalated_by_prose_words` на двух реальных кейсах (прозаический `blocker` и имя задачи `P0 bridge` при бейдже P2). Сначала падал (`'P0' == 'P2'`), после фикса — зелёный.
- **Вся сюита:** `30 passed`. Старый `test_classify_pr_worst_wins_across_badge_and_text_marker` проходит → fallback для summary-комментариев не сломан.
- **Эмпирика на 555 живых комментариях бота (6 репо):** ложные эскалации по прозе **8 → 0** (6× P0→P2, 1× P0→P1, 1× P1→P2). Примеры: mankassa-app#2008, #1981, #1939, #1927; makeit-dashboard#466, #169; moliyakg#3081; solotax-kg#264.

## После мержа

Изменён только сборщик, не сам JSON. Дашборд подхватит исправленные числа после следующего sweep (`codex-quality-sweep.yml`, крон ежедневно 19:17 UTC, либо ручной `workflow_dispatch` / кнопка «Обновить»).

🤖 Generated with [Claude Code](https://claude.com/claude-code)