### PR TITLE
feat(tracker): auto-reconcile Project #1 membership across all repos

### DIFF
--- a/.github/workflows/tracker-sweep.yml
+++ b/.github/workflows/tracker-sweep.yml
@@ -48,11 +48,10 @@ jobs:
 
       - name: Reconcile Tracker membership
         env:
-          # PAT needs: read issues on every MakeIT repo + read/write Project #1.
-          #   Fine-grained: Repository → Issues: Read; Account → Projects: R/W.
-          #   Classic (fallback): scopes `repo` + `project`.
-          # The default GITHUB_TOKEN can't write a user-owned project across
-          # repos, so a PAT secret is required.
+          # PAT needs to read issues on every MakeIT repo + read/write Project #1.
+          # Project #1 is USER-owned, which fine-grained PATs cannot access, so
+          # use a CLASSIC PAT with scopes: repo + project. The default
+          # GITHUB_TOKEN can't write a user-owned project across repos.
           GH_TRACKER_PAT: ${{ secrets.MAKEIT_TRACKER_PAT }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: python scripts/sweep_tracker_membership.py

--- a/.github/workflows/tracker-sweep.yml
+++ b/.github/workflows/tracker-sweep.yml
@@ -1,0 +1,58 @@
+name: tracker-sweep
+
+# Reconciles MakeIT Tracker (Projects V2 #1) membership: adds every open issue
+# across all MakeIT repos that isn't on the board yet. Source-agnostic and
+# self-healing — issues land on the Tracker regardless of whether an agent (or
+# a human) remembered to run the add step. See scripts/sweep_tracker_membership.py.
+#
+# Cadence: every 15 min. makeit-dashboard is a PUBLIC repo, so Actions minutes
+# are free — no cost concern. Cron is approximate on GitHub Actions (≈10-20 min
+# drift on shared runners), so real freshness is ~15-30 min. Loosen to
+# "*/30 * * * *" or "0 * * * *" if you want fewer runs.
+#
+# Manual trigger: workflow_dispatch is enabled. Run it once with DRY_RUN to
+# preview what would be added before the first real sweep (set the input below).
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview only — log what would be added, mutate nothing"
+        type: boolean
+        default: false
+
+# Never overlap two reconciliations — the mutation is idempotent so overlap is
+# harmless, but cancelling keeps the run list clean.
+concurrency:
+  group: tracker-sweep
+  cancel-in-progress: true
+
+permissions:
+  contents: read # Only need to check out the script. Project writes use the PAT.
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install deps
+        run: pip install --no-cache-dir 'httpx==0.27.2'
+
+      - name: Reconcile Tracker membership
+        env:
+          # PAT needs: read issues on every MakeIT repo + read/write Project #1.
+          #   Fine-grained: Repository → Issues: Read; Account → Projects: R/W.
+          #   Classic (fallback): scopes `repo` + `project`.
+          # The default GITHUB_TOKEN can't write a user-owned project across
+          # repos, so a PAT secret is required.
+          GH_TRACKER_PAT: ${{ secrets.MAKEIT_TRACKER_PAT }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: python scripts/sweep_tracker_membership.py

--- a/scripts/sweep_tracker_membership.py
+++ b/scripts/sweep_tracker_membership.py
@@ -30,13 +30,12 @@ number of OPEN issues (~hundreds), not board size (~thousands).
 
 Token
 -----
-`GH_TRACKER_PAT` must be able to read issues on every repo AND read+write the
-user-owned Project #1. Two options:
-  * Fine-grained PAT: Repository → Issues: Read; Account → Projects: Read and
-    write. (Direct addProjectV2ItemById works; the historical fine-grained
-    limitation was specific to the `actions/add-to-project` action.)
-  * Classic PAT: scopes `repo` + `project`. Guaranteed to work if the
-    fine-grained token ever misbehaves with Projects GraphQL.
+`GH_TRACKER_PAT` must read issues on every repo AND read+write Project #1.
+Project #1 is USER-owned, and fine-grained PATs cannot access user-owned
+Projects at all (GitHub limitation — there is no "Projects" permission to
+grant for a personal project), so use a **classic PAT** with scopes
+`repo` + `project`. The default GITHUB_TOKEN can't write a user-owned
+project across repos either, which is why a PAT secret is required.
 
 Set DRY_RUN=1 to log what WOULD be added without mutating — handy for the
 first manual `workflow_dispatch`.

--- a/scripts/sweep_tracker_membership.py
+++ b/scripts/sweep_tracker_membership.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+Reconcile MakeIT Tracker (Projects V2 #1) membership: make sure EVERY open
+issue across all MakeIT repos is on the board — without relying on an agent
+(or a human) remembering to run `gh project item-add`.
+
+Why a sweep and not the built-in "Auto-add to project" workflow
+---------------------------------------------------------------
+GitHub's built-in auto-add workflow is one-repo-per-workflow and capped by
+plan, so it doesn't scale to our 12 repos. A scheduled reconciliation sweep
+instead is:
+  * source-agnostic — catches issues created by agents, the UI, the API, or
+    `gh issue create`, regardless of whether anyone ran the add step;
+  * self-healing — anything that slips through is picked up on the next run,
+    so a single missed add never becomes a permanent gap;
+  * self-backfilling — the first run adds every pre-existing untracked issue.
+
+Idempotency
+-----------
+`addProjectV2ItemById` is idempotent: adding an issue that's already on the
+board returns the existing item, no error, no duplicate. So even if the diff
+is imperfect (pagination race, projectItems cap), re-adding is harmless — the
+worst case is a wasted GraphQL point, never a double entry.
+
+Membership check is per-issue, not per-project
+----------------------------------------------
+We ask each open issue for its own `projectItems` and look for project #1,
+rather than enumerating the whole board (~4500 items). Cost scales with the
+number of OPEN issues (~hundreds), not board size (~thousands).
+
+Token
+-----
+`GH_TRACKER_PAT` must be able to read issues on every repo AND read+write the
+user-owned Project #1. Two options:
+  * Fine-grained PAT: Repository → Issues: Read; Account → Projects: Read and
+    write. (Direct addProjectV2ItemById works; the historical fine-grained
+    limitation was specific to the `actions/add-to-project` action.)
+  * Classic PAT: scopes `repo` + `project`. Guaranteed to work if the
+    fine-grained token ever misbehaves with Projects GraphQL.
+
+Set DRY_RUN=1 to log what WOULD be added without mutating — handy for the
+first manual `workflow_dispatch`.
+
+Dependency-light (only `httpx`) on purpose — a batch job, not a service.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Any
+
+import httpx
+
+# ── Configuration ──────────────────────────────────────────────────────
+
+GITHUB_OWNER = "Sergio1990-1"
+PROJECT_NUMBER = 1  # the MakeIT Tracker
+
+# Kept in sync with `src/utils/config.ts DEFAULT_PROJECTS` and
+# `scripts/sweep_codex_quality.py REPOS`. Add a repo in all three.
+REPOS: list[str] = [
+    "Sewing-ERP",
+    "mankassa-app",
+    "solotax-kg",
+    "Business-News",
+    "Beer_bot",
+    "Uchet_bot",
+    "quiet-walls",
+    "moliyakg",
+    "MyMoney",
+    "makeit-auditor",
+    "makeit-pipeline",
+    "makeit-dashboard",
+]
+
+GRAPHQL_URL = "https://api.github.com/graphql"
+
+PAGE_SIZE = 50
+MAX_PAGES = 40  # 2000 open issues/repo — far above any real repo.
+ADD_BATCH_SIZE = 20  # aliased mutations per request.
+
+PROJECT_ID_QUERY = """
+query($owner: String!, $number: Int!) {
+  user(login: $owner) { projectV2(number: $number) { id title } }
+}
+"""
+
+OPEN_ISSUES_QUERY = """
+query($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    issues(states: OPEN, first: %(page_size)d, after: $cursor,
+           orderBy: {field: CREATED_AT, direction: DESC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id
+        number
+        projectItems(first: 20) { nodes { project { number } } }
+      }
+    }
+  }
+}
+""" % {"page_size": PAGE_SIZE}
+
+
+# ── Pure helpers (unit-tested) ─────────────────────────────────────────
+
+
+def issue_needs_tracking(issue: dict[str, Any], target_project_number: int) -> bool:
+    """True if `issue` is NOT already an item of project #target_project_number."""
+    project_items = issue.get("projectItems") or {}
+    nodes = project_items.get("nodes") or []
+    for node in nodes:
+        proj = (node or {}).get("project") or {}
+        if proj.get("number") == target_project_number:
+            return False
+    return True
+
+
+def chunk(seq: list[Any], size: int) -> list[list[Any]]:
+    """Split `seq` into consecutive lists of at most `size` items."""
+    return [seq[i : i + size] for i in range(0, len(seq), size)]
+
+
+def build_add_mutation(project_id: str, content_ids: list[str]) -> str:
+    """Batched addProjectV2ItemById mutation — one aliased call per content id."""
+    parts = [
+        f'a{i}: addProjectV2ItemById('
+        f'input: {{projectId: "{project_id}", contentId: "{cid}"}}'
+        f') {{ item {{ id }} }}'
+        for i, cid in enumerate(content_ids)
+    ]
+    return "mutation {\n  " + "\n  ".join(parts) + "\n}"
+
+
+# ── GraphQL plumbing ───────────────────────────────────────────────────
+
+
+def gh_graphql(
+    client: httpx.Client, token: str, query: str, variables: dict[str, Any]
+) -> dict[str, Any]:
+    """POST one GraphQL request with basic retry on transient 5xx."""
+    for attempt in range(4):
+        r = client.post(
+            GRAPHQL_URL,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "makeit-tracker-sweep",
+            },
+            json={"query": query, "variables": variables},
+        )
+        if r.status_code == 200:
+            body = r.json()
+            if body.get("errors"):
+                raise RuntimeError(f"GraphQL error: {body['errors'][0]}")
+            return body["data"]
+        if r.status_code in (502, 503, 504) and attempt < 3:
+            time.sleep(2**attempt)
+            continue
+        raise RuntimeError(f"HTTP {r.status_code}: {r.text[:300]}")
+    raise RuntimeError("retry budget exhausted")
+
+
+def fetch_project_id(client: httpx.Client, token: str) -> str:
+    data = gh_graphql(
+        client, token, PROJECT_ID_QUERY,
+        {"owner": GITHUB_OWNER, "number": PROJECT_NUMBER},
+    )
+    project = (data.get("user") or {}).get("projectV2")
+    if not project or not project.get("id"):
+        raise RuntimeError(
+            f"Project #{PROJECT_NUMBER} not found for {GITHUB_OWNER} — "
+            "check PAT has Projects read access."
+        )
+    return project["id"]
+
+
+def fetch_untracked_open_issues(
+    client: httpx.Client, token: str, repo: str
+) -> list[dict[str, Any]]:
+    """Return open issues in `repo` that are NOT yet on the Tracker."""
+    out: list[dict[str, Any]] = []
+    cursor: str | None = None
+    for _page in range(MAX_PAGES):
+        data = gh_graphql(
+            client, token, OPEN_ISSUES_QUERY,
+            {"owner": GITHUB_OWNER, "name": repo, "cursor": cursor},
+        )
+        repo_node = data.get("repository")
+        if repo_node is None:
+            raise RuntimeError(
+                f"repository null — PAT may lack Issues:Read on {GITHUB_OWNER}/{repo}"
+            )
+        conn = repo_node.get("issues") or {}
+        for node in conn.get("nodes") or []:
+            if issue_needs_tracking(node, PROJECT_NUMBER):
+                out.append(node)
+        page_info = conn.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+    return out
+
+
+def add_items(
+    client: httpx.Client, token: str, project_id: str, content_ids: list[str]
+) -> None:
+    """Add content ids to the project in batched, idempotent mutations."""
+    for group in chunk(content_ids, ADD_BATCH_SIZE):
+        gh_graphql(client, token, build_add_mutation(project_id, group), {})
+
+
+# ── Main ───────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    token = os.environ.get("GH_TRACKER_PAT", "").strip()
+    if not token:
+        print("ERROR: GH_TRACKER_PAT env var is required", file=sys.stderr)
+        return 2
+    dry_run = os.environ.get("DRY_RUN", "").strip() in ("1", "true", "yes")
+
+    total_added = 0
+    n_errors = 0
+    with httpx.Client(timeout=30.0) as client:
+        project_id = fetch_project_id(client, token)
+        print(f"Tracker project id: {project_id} (DRY_RUN={dry_run})")
+        for repo in REPOS:
+            try:
+                missing = fetch_untracked_open_issues(client, token, repo)
+            except Exception as exc:  # noqa: BLE001 — keep sweeping other repos
+                print(f"[{repo}] FAILED: {exc}", file=sys.stderr)
+                n_errors += 1
+                continue
+            if not missing:
+                print(f"[{repo}] ok — all open issues tracked")
+                continue
+            nums = ", ".join(f"#{m['number']}" for m in missing)
+            if dry_run:
+                print(f"[{repo}] WOULD add {len(missing)}: {nums}")
+                continue
+            add_items(client, token, project_id, [m["id"] for m in missing])
+            total_added += len(missing)
+            print(f"[{repo}] added {len(missing)}: {nums}")
+
+    verb = "would add" if dry_run else "added"
+    print(f"\nDone — {verb} {total_added} issue(s) to the Tracker.")
+    if n_errors:
+        print(f"WARNING: {n_errors}/{len(REPOS)} repos failed", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_sweep_tracker_membership.py
+++ b/scripts/test_sweep_tracker_membership.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for pure helpers in `sweep_tracker_membership.py`. The GraphQL
+plumbing (project-id lookup, issue pagination, add mutation round-trip) is
+integration-tested by running the workflow against a real PAT.
+
+Run from repo root:
+    python -m pytest scripts/test_sweep_tracker_membership.py -v
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow running with `python scripts/test_sweep_tracker_membership.py` too.
+sys.path.insert(0, str(Path(__file__).parent))
+
+import sweep_tracker_membership as sweep  # noqa: E402
+
+
+# ── issue_needs_tracking ───────────────────────────────────────────────
+
+def test_needs_tracking_true_when_not_in_any_project() -> None:
+    issue = {"id": "I_1", "number": 5, "projectItems": {"nodes": []}}
+    assert sweep.issue_needs_tracking(issue, target_project_number=1) is True
+
+
+def test_needs_tracking_false_when_already_in_target_project() -> None:
+    issue = {
+        "id": "I_2",
+        "number": 6,
+        "projectItems": {"nodes": [{"project": {"number": 1}}]},
+    }
+    assert sweep.issue_needs_tracking(issue, target_project_number=1) is False
+
+
+def test_needs_tracking_true_when_only_in_other_project() -> None:
+    # Issue is on Project #2 but NOT the Tracker (#1) — must still be added.
+    issue = {
+        "id": "I_3",
+        "number": 7,
+        "projectItems": {"nodes": [{"project": {"number": 2}}]},
+    }
+    assert sweep.issue_needs_tracking(issue, target_project_number=1) is True
+
+
+def test_needs_tracking_false_when_in_target_among_several() -> None:
+    issue = {
+        "id": "I_4",
+        "number": 8,
+        "projectItems": {
+            "nodes": [{"project": {"number": 3}}, {"project": {"number": 1}}]
+        },
+    }
+    assert sweep.issue_needs_tracking(issue, target_project_number=1) is False
+
+
+def test_needs_tracking_handles_missing_or_null_fields() -> None:
+    # Defensive: GraphQL can hand back null nodes / absent projectItems.
+    assert sweep.issue_needs_tracking({"id": "x"}, 1) is True
+    assert sweep.issue_needs_tracking({"projectItems": None}, 1) is True
+    assert sweep.issue_needs_tracking({"projectItems": {"nodes": [None]}}, 1) is True
+
+
+# ── chunk ──────────────────────────────────────────────────────────────
+
+def test_chunk_splits_with_remainder() -> None:
+    assert sweep.chunk([1, 2, 3, 4, 5], 2) == [[1, 2], [3, 4], [5]]
+
+
+def test_chunk_empty_is_empty() -> None:
+    assert sweep.chunk([], 10) == []
+
+
+def test_chunk_size_larger_than_seq() -> None:
+    assert sweep.chunk([1, 2], 10) == [[1, 2]]
+
+
+# ── build_add_mutation ─────────────────────────────────────────────────
+
+def test_build_add_mutation_aliases_each_content_id() -> None:
+    q = sweep.build_add_mutation("PVT_proj", ["I_a", "I_b"])
+    assert "a0: addProjectV2ItemById" in q
+    assert "a1: addProjectV2ItemById" in q
+    # Each content id and the project id must appear.
+    assert "PVT_proj" in q
+    assert "I_a" in q and "I_b" in q
+    # Aliases must be unique so GitHub doesn't reject the batched mutation.
+    assert q.count("addProjectV2ItemById") == 2
+
+
+def test_build_add_mutation_single_item() -> None:
+    q = sweep.build_add_mutation("PVT_x", ["I_only"])
+    assert "a0: addProjectV2ItemById" in q
+    assert q.count("addProjectV2ItemById") == 1
+    assert q.strip().startswith("mutation")


### PR DESCRIPTION
## Проблема

Issues перестали надёжно попадать в MakeIT Tracker (Project #1): это зависело от того, что агент/человек после `gh issue create` запустит `gh project item-add` — а шаг забывается. Живой замер нашёл **22 открытых issue вне доски** (moliyakg 18, makeit-pipeline 4), хотя по правилу всё должно быть в Трекере.

## Решение

Cron-воркфлоу-реконсиляция (зеркало `codex-quality-sweep`). Каждые ~15 мин:
1. собирает open-issues по всем 12 репо;
2. у каждого issue смотрит его собственные `projectItems` — есть ли там Project #1;
3. батчем добавляет недостающие через `addProjectV2ItemById`.

**Почему надёжно против «агенты забыли»:** добавляет не агент, а сервер.
- **Source-agnostic** — ловит issue из любого источника (агент / UI / API / `gh`).
- **Self-healing** — пропущенное добавление подберётся на следующем проходе.
- **Self-backfilling** — первый запуск добавит существующие 22.
- `addProjectV2ItemById` идемпотентен → повторные добавления безвредны.

Проверка членства — **по-issue** (масштабируется с ~сотнями открытых issue), а не перечислением ~4500-элементной доски.

## Доказательства

- **TDD:** 10 unit-тестов на чистые хелперы (`issue_needs_tracking`, `chunk`, `build_add_mutation`); сначала RED (модуля нет), потом GREEN.
- **Integration (DRY_RUN на живом API):** скрипт находит ровно 22 известных пропущенных issue (moliyakg #3114…#2598, makeit-pipeline #1286/#1276/#1274/#1273), 10/12 репо чисты.

## Один ручной шаг перед мержем

Нужен секрет **`MAKEIT_TRACKER_PAT`**. Project #1 — **личный (user-owned)**, а fine-grained PAT с такими проектами не работает (у GitHub нет права «Projects» для личных проектов). Поэтому — **classic PAT**: github.com/settings/tokens → Tokens (classic) → scopes **`repo`** + **`project`**. Дефолтный `GITHUB_TOKEN` писать в user-проект между репо не может.

## Раскатка

1. Создать секрет `MAKEIT_TRACKER_PAT`.
2. Смержить PR.
3. (Опц.) `workflow_dispatch` с `dry_run=true` — предпросмотр; затем обычный запуск забэкфиллит 22.

> Версии экшенов (`checkout@v4`, `setup-python@v5`) совпадают с существующим sweep; отслеживаемый bump Node-20 (дедлайн 2026-06-16) накроет и этот воркфлоу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
