### PR TITLE
fix(milestones): local-day daysUntil, unified urgency thresholds, state-only done

### DIFF
--- a/src/components/v4/milestones/MilestonesHero.tsx
+++ b/src/components/v4/milestones/MilestonesHero.tsx
@@ -3,7 +3,7 @@ import type { Milestone, ProjectData } from "../../../types";
 import { daysUntil } from "../../../utils/date";
 import { calcPortfolioVelocity } from "../../../utils/dashboardMetrics";
 import { classifyMilestone } from "./classifyMilestone";
-import { stripEpicPrefix } from "./utils";
+import { deadlineTier, stripEpicPrefix } from "./utils";
 
 interface Props {
   /**
@@ -186,16 +186,21 @@ export function MilestonesHero({ milestones, projects, now }: Props) {
       .filter((x) => x.cls !== "done" && x.days !== null && x.days >= 0)
       .sort((a, b) => (a.days ?? 0) - (b.days ?? 0))[0];
 
+    // Breakdown derives from the canonical deadline tiers (utils.deadlineTier)
+    // so "≤ 7 дн / ≤ 30 дн / дальше" stay in lock-step with the card group
+    // headers and status-bar legend. Overdue milestones are not upcoming, so
+    // they're excluded from all three counters. `noeta` (no dueOn) rolls into
+    // "дальше".
     const cnt7 = enriched.filter(
-      (x) =>
-        x.cls !== "done" && x.days !== null && x.days >= 0 && x.days <= 7
+      (x) => x.cls !== "done" && deadlineTier(x.days) === "week"
     ).length;
     const cnt30 = enriched.filter(
-      (x) =>
-        x.cls !== "done" && x.days !== null && x.days > 7 && x.days <= 30
+      (x) => x.cls !== "done" && deadlineTier(x.days) === "month"
     ).length;
     const cntFar = enriched.filter(
-      (x) => x.cls !== "done" && (x.days === null || x.days > 30)
+      (x) =>
+        x.cls !== "done" &&
+        (deadlineTier(x.days) === "later" || deadlineTier(x.days) === "noeta")
     ).length;
 
     return {

--- a/src/components/v4/milestones/MilestonesStatusBar.tsx
+++ b/src/components/v4/milestones/MilestonesStatusBar.tsx
@@ -8,16 +8,21 @@ interface Props {
   now: Date;
 }
 
+// Labels MUST match the canonical deadline-tier headers used by the card
+// grouping (utils.deadlineBucket): week → "Эта неделя" (≤7), month →
+// "Этот месяц" (≤30), later → "Дальше" (>30). Keeping them in sync means a
+// milestone never appears under "≤ 3 дн" here while sitting in "Эта неделя"
+// on the cards below.
 const ORDER: {
   k: MilestoneStatusKind;
   l: string;
   c: string;
 }[] = [
   { k: "overdue", l: "Просрочено", c: "var(--mk-danger)" },
-  { k: "warn", l: "≤ 3 дн", c: "var(--mk-warn)" },
-  { k: "soon", l: "≤ 14 дн", c: "var(--mk-brand-500)" },
+  { k: "warn", l: "Эта неделя", c: "var(--mk-warn)" },
+  { k: "soon", l: "Этот месяц", c: "var(--mk-brand-500)" },
   { k: "norm", l: "Дальше", c: "var(--mk-ink-400)" },
-  { k: "noeta", l: "Без даты", c: "var(--mk-ink-300)" },
+  { k: "noeta", l: "Без дедлайна", c: "var(--mk-ink-300)" },
   { k: "done", l: "Завершено", c: "var(--mk-success)" },
 ];
 

--- a/src/components/v4/milestones/classifyMilestone.ts
+++ b/src/components/v4/milestones/classifyMilestone.ts
@@ -1,18 +1,35 @@
 import type { Milestone } from "../../../types";
+import { deadlineTier } from "./utils";
 
 export type MilestoneStatusKind = "done" | "overdue" | "warn" | "soon" | "norm" | "noeta";
+
+/**
+ * Map the canonical deadline tier (single source in `utils.deadlineTier`) onto
+ * the visual status-kind enum. The enum keeps its historic names — `warn` =
+ * week (≤7), `soon` = month (≤30), `norm` = later (>30) — because CSS classes,
+ * `clsPriority`, `FILL_BY_CLS` and the status-bar `ORDER` key off them. The
+ * labels shown to the user (status-bar legend / card group headers) come from
+ * the canonical table so the *named* bucket is identical everywhere.
+ */
+const TIER_TO_KIND = {
+  overdue: "overdue",
+  week: "warn",
+  month: "soon",
+  later: "norm",
+  noeta: "noeta",
+} as const;
 
 /**
  * Classify a milestone into a visual bucket. Pure — `days` should be
  * pre-computed from `daysUntil(m.dueOn)` so the caller controls the time
  * anchor.
+ *
+ * "done" is driven ONLY by `m.state === "CLOSED"`. An OPEN milestone whose
+ * issues all happen to be closed keeps its normal deadline classification so it
+ * stays visible in the deadline plan (it isn't actually finished until GitHub
+ * closes the milestone).
  */
 export function classifyMilestone(m: Milestone, days: number | null): MilestoneStatusKind {
-  const total = m.openIssues + m.closedIssues;
-  if (m.state === "CLOSED" || (total > 0 && m.openIssues === 0)) return "done";
-  if (days === null) return "noeta";
-  if (days < 0) return "overdue";
-  if (days <= 3) return "warn";
-  if (days <= 14) return "soon";
-  return "norm";
+  if (m.state === "CLOSED") return "done";
+  return TIER_TO_KIND[deadlineTier(days)];
 }

--- a/src/components/v4/milestones/utils.ts
+++ b/src/components/v4/milestones/utils.ts
@@ -35,16 +35,45 @@ export function ruDow(d: Date): string {
   return RU_DOW[d.getDay()];
 }
 
+/**
+ * SINGLE canonical deadline-tier table. Every milestone tile (card grouping,
+ * status bar, hero breakdown, gantt colour via `classifyMilestone`) derives
+ * its bucket from this one place, so the same milestone never lands in two
+ * differently-named groups.
+ *
+ * Thresholds (days until due):
+ *   overdue: < 0   week: ≤ 7   month: ≤ 30   later: > 30   noeta: no dueOn
+ */
+export type DeadlineTier = "overdue" | "week" | "month" | "later" | "noeta";
+
+export function deadlineTier(days: number | null): DeadlineTier {
+  if (days === null) return "noeta";
+  if (days < 0) return "overdue";
+  if (days <= 7) return "week";
+  if (days <= 30) return "month";
+  return "later";
+}
+
+/** Human label + sort order for each canonical tier (card group headers,
+ *  status-bar legend). Labels MUST match across every consumer. */
+const TIER_META: Record<
+  DeadlineTier,
+  { label: string; order: number }
+> = {
+  overdue: { label: "Просрочено", order: 0 },
+  week: { label: "Эта неделя", order: 1 },
+  month: { label: "Этот месяц", order: 2 },
+  later: { label: "Дальше", order: 3 },
+  noeta: { label: "Без дедлайна", order: 99 },
+};
+
 export function deadlineBucket(days: number | null): {
-  key: "overdue" | "week" | "month" | "later" | "noeta";
+  key: DeadlineTier;
   label: string;
   order: number;
 } {
-  if (days === null) return { key: "noeta", label: "Без дедлайна", order: 99 };
-  if (days < 0) return { key: "overdue", label: "Просрочено", order: 0 };
-  if (days <= 7) return { key: "week", label: "Эта неделя", order: 1 };
-  if (days <= 30) return { key: "month", label: "Этот месяц", order: 2 };
-  return { key: "later", label: "Дальше", order: 3 };
+  const key = deadlineTier(days);
+  return { key, ...TIER_META[key] };
 }
 
 export function diffDays(a: Date, b: Date): number {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,14 +1,35 @@
 /** Shared date helpers used across deadline / chart components. */
 
 /**
- * Whole-day distance between a reference time and `dueOn` (ISO string).
- * Negative = overdue. Pass `reference` (e.g. the `lastUpdated` data anchor)
- * to keep classification consistent with positions computed against the
- * same anchor — without it, Date.now() drifts every render.
+ * Truncate a `Date` to local midnight (00:00 in the browser's timezone),
+ * dropping the time-of-day. Use this when comparing *calendar* days so the
+ * result never depends on the wall-clock hour or on UTC↔local offset.
+ *
+ * Distinct from `toLocalDay` (which returns a `YYYY-MM-DD` string) — this
+ * returns a `Date` so the difference can be divided by `86400000`.
+ */
+export function startOfLocalDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+/**
+ * Whole-day distance between a reference time and `dueOn` (ISO string),
+ * measured in LOCAL calendar days. Negative = overdue, 0 = due today,
+ * positive = upcoming.
+ *
+ * `dueOn` from GitHub is midnight-UTC (`YYYY-MM-DDT00:00:00Z`) while the
+ * reference is an arbitrary wall-clock time, so a raw millisecond diff would
+ * report a milestone due *today* as "1 дн" in eastern timezones (verified for
+ * UTC+6). Comparing `startOfLocalDay` of both sides removes that off-by-one.
+ *
+ * Pass `reference` (e.g. the `lastUpdated` data anchor) to keep classification
+ * consistent with positions computed against the same anchor — without it,
+ * Date.now() drifts every render.
  */
 export function daysUntil(dueOn: string, reference?: Date): number {
-  const ref = reference ? reference.getTime() : Date.now();
-  return Math.ceil((new Date(dueOn).getTime() - ref) / 86400000);
+  const ref = reference ?? new Date();
+  const due = startOfLocalDay(new Date(dueOn));
+  return Math.round((due.getTime() - startOfLocalDay(ref).getTime()) / 86400000);
 }
 
 /** Localised "DD MMM" (Russian short month) — used in deadline badges. */

--- a/tests/milestones/classifyMilestone.test.ts
+++ b/tests/milestones/classifyMilestone.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import type { Milestone } from "../../src/types";
+import { classifyMilestone } from "../../src/components/v4/milestones/classifyMilestone";
+
+function makeMilestone(overrides: Partial<Milestone> = {}): Milestone {
+  return {
+    title: "M",
+    description: "",
+    dueOn: "2026-06-10T00:00:00Z",
+    url: "https://example.com/m/1",
+    state: "OPEN",
+    openIssues: 1,
+    closedIssues: 0,
+    repo: "Sewing-ERP",
+    issues: [],
+    createdAt: null,
+    closedAt: null,
+    ...overrides,
+  };
+}
+
+describe("classifyMilestone — done detection (M5)", () => {
+  it("marks a milestone done only when its state is CLOSED", () => {
+    const m = makeMilestone({ state: "CLOSED", openIssues: 0, closedIssues: 5 });
+    expect(classifyMilestone(m, 3)).toBe("done");
+  });
+
+  it("does NOT force an OPEN milestone to done when all its issues are closed", () => {
+    // Regression: an open milestone with 0 open issues must keep its normal
+    // deadline classification so it stays in the deadline plan.
+    const m = makeMilestone({ state: "OPEN", openIssues: 0, closedIssues: 5 });
+    expect(classifyMilestone(m, 2)).not.toBe("done");
+    expect(classifyMilestone(m, 2)).toBe("warn"); // ≤7 → week tier
+  });
+
+  it("keeps an open milestone with no issues at all on its deadline track", () => {
+    const m = makeMilestone({ state: "OPEN", openIssues: 0, closedIssues: 0 });
+    expect(classifyMilestone(m, 5)).not.toBe("done");
+  });
+});
+
+describe("classifyMilestone — deadline tiers (M3/M4 canonical thresholds)", () => {
+  const open = (over: Partial<Milestone> = {}) =>
+    makeMilestone({ state: "OPEN", openIssues: 1, closedIssues: 0, ...over });
+
+  it("noeta when days is null", () => {
+    expect(classifyMilestone(open(), null)).toBe("noeta");
+  });
+
+  it("overdue when days < 0", () => {
+    expect(classifyMilestone(open(), -1)).toBe("overdue");
+  });
+
+  it("week tier (warn) at the ≤7 boundary", () => {
+    expect(classifyMilestone(open(), 0)).toBe("warn");
+    expect(classifyMilestone(open(), 7)).toBe("warn");
+  });
+
+  it("month tier (soon) between >7 and ≤30", () => {
+    expect(classifyMilestone(open(), 8)).toBe("soon");
+    expect(classifyMilestone(open(), 30)).toBe("soon");
+  });
+
+  it("later tier (norm) when days > 30", () => {
+    expect(classifyMilestone(open(), 31)).toBe("norm");
+    expect(classifyMilestone(open(), 365)).toBe("norm");
+  });
+});

--- a/tests/milestones/daysUntil.test.ts
+++ b/tests/milestones/daysUntil.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { daysUntil, startOfLocalDay } from "../../src/utils/date";
+
+/**
+ * Helper: midnight-UTC ISO string for a given LOCAL calendar day. GitHub's
+ * milestone `dueOn` is always a `YYYY-MM-DDT00:00:00Z` value — the date the
+ * user picked, serialised at UTC midnight. We mirror that so the off-by-one
+ * regression is reproduced exactly the way the API delivers it.
+ */
+function dueOnForLocalDay(y: number, m: number, d: number): string {
+  const utcMidnight = new Date(Date.UTC(y, m, d, 0, 0, 0));
+  return utcMidnight.toISOString();
+}
+
+describe("startOfLocalDay", () => {
+  it("truncates to local midnight, preserving the calendar day", () => {
+    const ref = new Date(2026, 5, 3, 17, 45, 12, 500); // local wall-clock
+    const start = startOfLocalDay(ref);
+    expect(start.getFullYear()).toBe(2026);
+    expect(start.getMonth()).toBe(5);
+    expect(start.getDate()).toBe(3);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getSeconds()).toBe(0);
+    expect(start.getMilliseconds()).toBe(0);
+  });
+
+  it("does not mutate its argument", () => {
+    const ref = new Date(2026, 5, 3, 17, 45, 0);
+    const copy = new Date(ref.getTime());
+    startOfLocalDay(ref);
+    expect(ref.getTime()).toBe(copy.getTime());
+  });
+});
+
+describe("daysUntil", () => {
+  it("returns 0 when due on the local 'today' (M2 off-by-one regression)", () => {
+    // reference is late in the local day; due is the SAME local calendar day,
+    // delivered as UTC-midnight (exactly how GitHub serialises milestone dueOn).
+    const reference = new Date(2026, 5, 3, 23, 30, 0); // 3 Jun, 23:30 local
+    const dueOn = dueOnForLocalDay(2026, 5, 3); // 3 Jun, midnight UTC
+    expect(daysUntil(dueOn, reference)).toBe(0);
+  });
+
+  it("returns 0 for due-today even when the reference is early in the day", () => {
+    const reference = new Date(2026, 5, 3, 0, 5, 0); // 3 Jun, 00:05 local
+    const dueOn = dueOnForLocalDay(2026, 5, 3);
+    expect(daysUntil(dueOn, reference)).toBe(0);
+  });
+
+  it("returns negative for an overdue milestone", () => {
+    const reference = new Date(2026, 5, 10, 12, 0, 0); // 10 Jun
+    const dueOn = dueOnForLocalDay(2026, 5, 3); // 3 Jun → 7 days ago
+    expect(daysUntil(dueOn, reference)).toBe(-7);
+  });
+
+  it("returns positive for a future milestone", () => {
+    const reference = new Date(2026, 5, 3, 12, 0, 0); // 3 Jun
+    const dueOn = dueOnForLocalDay(2026, 5, 13); // 13 Jun → in 10 days
+    expect(daysUntil(dueOn, reference)).toBe(10);
+  });
+
+  it("counts whole local calendar days, ignoring time-of-day within each day", () => {
+    // due tomorrow at local midnight; reference late today → exactly 1 day,
+    // never 2 (which a ceil over raw ms would produce).
+    const reference = new Date(2026, 5, 3, 23, 59, 0);
+    const dueOn = dueOnForLocalDay(2026, 5, 4);
+    expect(daysUntil(dueOn, reference)).toBe(1);
+  });
+
+  it("is symmetric for the previous local day", () => {
+    const reference = new Date(2026, 5, 3, 0, 1, 0);
+    const dueOn = dueOnForLocalDay(2026, 5, 2);
+    expect(daysUntil(dueOn, reference)).toBe(-1);
+  });
+});


### PR DESCRIPTION
Closes #517 · из аудита аналитики.

- **M2** `daysUntil` сравнивает локальные календарные дни (new `startOfLocalDay`, `toLocalDay` не тронут) — «сегодня» больше не уезжает в «1 дн» на UTC+6.
- **M3/M4** единая таблица порогов `deadlineTier` (overdue<0 / ≤7 / ≤30 / >30 / noeta) — переиспользована в card-группировке, `classifyMilestone` и Hero; подписи StatusBar согласованы.
- **M5** «done» только при `state==="CLOSED"` — OPEN-milestone со всеми закрытыми issues больше не исчезает из плана.

TDD: `tests/milestones/*` (16) RED→GREEN. `tsc` clean, полный vitest 96 pass. Enum-имена (`warn/soon/norm`) сохранены (CSS/сорт зависят), переотображена семантика.

🤖 Generated with [Claude Code](https://claude.com/claude-code)