### PR TITLE
fix(monitoring): boundary-safe monitor match + floor uptime display

### DIFF
--- a/src/components/UptimeBar.tsx
+++ b/src/components/UptimeBar.tsx
@@ -1,5 +1,6 @@
 import type { Monitor, MonitorStatus } from "../types";
 import { getWorkerUrl, setWorkerUrl, MONITOR_MATCH } from "../utils/config";
+import { formatUptime } from "./v4/monitoring/utils";
 import { useState } from "react";
 
 /** Reverse lookup: find project name for a monitor */
@@ -24,7 +25,7 @@ const STATUS_LABEL: Record<MonitorStatus, string> = {
 
 function MonitorRow({ monitor }: { monitor: Monitor }) {
   const uptime =
-    monitor.uptimePct != null ? `${monitor.uptimePct.toFixed(2)}%` : "—";
+    monitor.uptimePct != null ? `${formatUptime(monitor.uptimePct)}%` : "—";
   const checked = monitor.lastCheckedAt
     ? new Date(monitor.lastCheckedAt).toLocaleString("ru-RU", {
         day: "2-digit",

--- a/src/components/v4/monitoring/MonitorCard.tsx
+++ b/src/components/v4/monitoring/MonitorCard.tsx
@@ -1,6 +1,7 @@
 import type { Monitor } from "../../../types";
 import {
   fmtAge,
+  formatUptime,
   getProjectName,
   isStale,
   monitorHealth,
@@ -53,7 +54,7 @@ export function MonitorCard({ monitor, nowMs }: Props) {
         <div className="v4-mon-card-uptime-row">
           <span className="v4-mon-text-muted">Uptime</span>
           <span className="v4-pl-mono v4-mon-card-uptime-val" style={{ color: uColor }}>
-            {uptime !== null ? `${uptime.toFixed(2)}%` : "—"}
+            {uptime !== null ? `${formatUptime(uptime)}%` : "—"}
           </span>
         </div>
         {uptime !== null && (

--- a/src/components/v4/monitoring/MonitoringKpiStrip.tsx
+++ b/src/components/v4/monitoring/MonitoringKpiStrip.tsx
@@ -1,4 +1,5 @@
 import type { Monitor } from "../../../types";
+import { formatUptime } from "./utils";
 
 interface Props {
   monitors: Monitor[];
@@ -68,7 +69,7 @@ export function MonitoringKpiStrip({ monitors }: Props) {
                     : "var(--mk-warn-strong)",
             }}
           >
-            {avgUptime !== null ? `${avgUptime.toFixed(2)}%` : "—"}
+            {avgUptime !== null ? `${formatUptime(avgUptime)}%` : "—"}
           </div>
           <div className="v4-projects-agg-l">средний uptime</div>
         </div>

--- a/src/components/v4/monitoring/utils.ts
+++ b/src/components/v4/monitoring/utils.ts
@@ -46,16 +46,46 @@ export function uptimeColor(pct: number | null): string {
   return "var(--mk-danger-strong)";
 }
 
+/**
+ * Does `haystack` contain `keyword`?
+ *
+ * For purely-numeric keywords (ports like "8000") we require a real boundary
+ * on both sides so that ":8000" does NOT match inside ":18000" / ":80001".
+ * Non-numeric keywords ("sewing", "biznews") keep plain substring matching.
+ */
+function keywordMatches(haystack: string, keyword: string): boolean {
+  const kw = keyword.toLowerCase();
+  if (/^\d+$/.test(kw)) {
+    // Boundary-safe: digit must not be glued to other digits on either side.
+    const re = new RegExp(`(?:^|[^0-9])${kw}(?:[^0-9]|$)`);
+    return re.test(haystack);
+  }
+  return haystack.includes(kw);
+}
+
 /** Reverse-lookup project repo for a monitor via MONITOR_MATCH keywords. */
 export function getProjectName(monitor: Monitor): string | null {
   const name = monitor.name.toLowerCase();
   const url = monitor.url.toLowerCase();
   for (const [project, keywords] of Object.entries(MONITOR_MATCH)) {
-    if (keywords.some((kw) => name.includes(kw.toLowerCase()) || url.includes(kw.toLowerCase()))) {
+    if (keywords.some((kw) => keywordMatches(name, kw) || keywordMatches(url, kw))) {
       return project;
     }
   }
   return null;
+}
+
+/**
+ * Format an uptime percentage for display.
+ *
+ * FLOORS to 2 decimals so a value like 99.999 renders "99.99" instead of
+ * rounding up to "100.00" and hiding real downtime. Only an exact 100 (or a
+ * value that floors to 100) yields "100.00". Null / non-finite → em-dash,
+ * matching the previous `?? "—"` render behaviour.
+ */
+export function formatUptime(pct: number | null): string {
+  if (pct === null || !isFinite(pct)) return "—";
+  return (Math.floor(pct * 100) / 100).toFixed(2);
 }
 
 export function fmtAge(iso: string | null, nowMs: number): string {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -196,7 +196,7 @@ export const MONITOR_MATCH: Record<string, string[]> = {
   "Beer_bot": ["8003", "beer"],
   "Uchet_bot": ["8002", "uchet"],
   "solotax-kg": ["solotax", "api.solotax"],
-  "Business-News": ["8000", "biznews", "content"],
+  "Business-News": ["8000", "biznews"],
   "moliyakg": ["moliya", "8005"],
   "MyMoney": ["3010", "mymoney"],
 };

--- a/tests/monitoring/utils.test.ts
+++ b/tests/monitoring/utils.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { getProjectName, formatUptime } from "../../src/components/v4/monitoring/utils";
+import { MONITOR_MATCH } from "../../src/utils/config";
+import type { Monitor } from "../../src/types";
+
+function makeMonitor(partial: Partial<Monitor>): Monitor {
+  return {
+    id: "1",
+    name: "",
+    url: "",
+    status: "up",
+    uptimePct: 100,
+    lastCheckedAt: null,
+    ...partial,
+  };
+}
+
+describe("getProjectName — port boundary safety (U2)", () => {
+  it("does NOT match :8000 keyword against a :18000 URL (substring collision)", () => {
+    // Business-News owns the "8000" keyword. A monitor on :18000 must not
+    // be misattributed to Business-News via bare substring matching.
+    const m = makeMonitor({
+      name: "Some unrelated service",
+      url: "https://example.com:18000/health",
+    });
+    expect(getProjectName(m)).not.toBe("Business-News");
+  });
+
+  it("does NOT match :8001 keyword against a :80012 URL", () => {
+    // Sewing-ERP owns "8001"; :80012 must not collide.
+    const m = makeMonitor({
+      name: "Other service",
+      url: "https://example.com:80012/status",
+    });
+    expect(getProjectName(m)).not.toBe("Sewing-ERP");
+  });
+
+  it("does match the port at a real boundary (:8000 → Business-News)", () => {
+    const m = makeMonitor({
+      name: "biznews backend",
+      url: "https://node.example.com:8000/healthz",
+    });
+    expect(getProjectName(m)).toBe("Business-News");
+  });
+
+  it("matches port when URL ends exactly with the port (no trailing path)", () => {
+    const m = makeMonitor({
+      name: "Sewing service",
+      url: "https://node.example.com:8001",
+    });
+    expect(getProjectName(m)).toBe("Sewing-ERP");
+  });
+});
+
+describe("getProjectName — keyword matching (U2)", () => {
+  it("matches Business-News by the 'biznews' keyword (content keyword removed)", () => {
+    const m = makeMonitor({
+      name: "biznews-kg production",
+      url: "https://biznews.example.com",
+    });
+    expect(getProjectName(m)).toBe("Business-News");
+  });
+
+  it("does NOT match Business-News via the generic word 'content'", () => {
+    // The "content" keyword was removed because it collides with unrelated
+    // monitors that merely contain the word "content".
+    expect(MONITOR_MATCH["Business-News"]).not.toContain("content");
+    const m = makeMonitor({
+      name: "Some content delivery service",
+      url: "https://cdn.example.com/content",
+    });
+    expect(getProjectName(m)).not.toBe("Business-News");
+  });
+
+  it("still matches non-numeric keywords as substrings (sewing → Sewing-ERP)", () => {
+    const m = makeMonitor({
+      name: "sewing-erp api",
+      url: "https://sewing.example.com",
+    });
+    expect(getProjectName(m)).toBe("Sewing-ERP");
+  });
+
+  it("returns null when nothing matches", () => {
+    const m = makeMonitor({
+      name: "totally unrelated",
+      url: "https://nowhere.example.com",
+    });
+    expect(getProjectName(m)).toBeNull();
+  });
+});
+
+describe("formatUptime — floor to 2 decimals (U5)", () => {
+  it("floors 99.999 to 99.99 (does not round up to 100.00)", () => {
+    expect(formatUptime(99.999)).toBe("99.99");
+  });
+
+  it("floors 99.995 to 99.99 (the U5 reported case)", () => {
+    expect(formatUptime(99.995)).toBe("99.99");
+  });
+
+  it("shows 100.00 only when value is exactly 100", () => {
+    expect(formatUptime(100)).toBe("100.00");
+  });
+
+  it("does not invent extra precision (99.9 → 99.90)", () => {
+    expect(formatUptime(99.9)).toBe("99.90");
+  });
+
+  it("floors a mid value (95.678 → 95.67)", () => {
+    expect(formatUptime(95.678)).toBe("95.67");
+  });
+
+  it("returns the em-dash for null (preserves existing null handling)", () => {
+    expect(formatUptime(null)).toBe("—");
+  });
+
+  it("returns the em-dash for NaN / non-finite", () => {
+    expect(formatUptime(NaN)).toBe("—");
+    expect(formatUptime(Infinity)).toBe("—");
+  });
+});


### PR DESCRIPTION
Closes #518 · из аудита аналитики.

- **U2** убран generic-`content`; числовые ключи (порты) матчатся по границам `(?:^|[^0-9])PORT(?:[^0-9]|$)` — `:8000` больше не ловит `:18000`. Нечисловые — как раньше substring.
- **U5** `formatUptime` флорит до 2 знаков (99.999→«99.99»), «100.00» только при реальном 100; применён в MonitorCard/KpiStrip/UptimeBar. Null/NaN→«—» сохранено.

TDD: `tests/monitoring/utils.test.ts` (15) RED→GREEN. `tsc` clean, полный vitest 95 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)