### PR TITLE
fix(pipeline): honest closed-chart average + steady phase timer

### DIFF
--- a/src/components/ClosedChart.tsx
+++ b/src/components/ClosedChart.tsx
@@ -1,5 +1,6 @@
 import type { ProjectData } from "../types";
 import { toLocalDay, getLast7Days, formatDay } from "../utils/date";
+import { closedChartAvgPerDay } from "./v4/pipeline/utils";
 
 interface Props {
   projects: ProjectData[];
@@ -41,12 +42,13 @@ export function ClosedChart({ projects }: Props) {
     0,
   );
 
-  const previous6Days = days.slice(0, 6);
-  const sum6Days = previous6Days.reduce(
-    (sum, day) => sum + countsByDay[day].manual + countsByDay[day].pipeline,
-    0,
-  );
-  const avg6Days = Math.round(sum6Days / 6);
+  // Average over the same 7-day window shown — keeps the badge honest
+  // (avg ≈ total/7); the old slice(0,6)/6 silently dropped today (#524).
+  const totalsByDay: Record<string, number> = {};
+  for (const day of days) {
+    totalsByDay[day] = countsByDay[day].manual + countsByDay[day].pipeline;
+  }
+  const avgPerDay = closedChartAvgPerDay(totalsByDay, days);
 
   return (
     <div className="bento-panel span-8 panel-chart">
@@ -59,7 +61,7 @@ export function ClosedChart({ projects }: Props) {
               Pipeline: {totalPipeline}
             </span>
           )}
-          <span className="closed-chart-total-badge">Среднее в день: {avg6Days}</span>
+          <span className="closed-chart-total-badge">Среднее в день: {avgPerDay}</span>
         </div>
       </div>
 

--- a/src/components/PipelineActiveTasksBlock/ActiveTaskCard.tsx
+++ b/src/components/PipelineActiveTasksBlock/ActiveTaskCard.tsx
@@ -1,12 +1,14 @@
 import { useState } from "react";
 import {
   type ActiveTask,
+  type PhaseAnchor,
   PHASES,
   PHASE_LABEL,
   currentPhase,
   detectAnomalies,
   fmtCost,
   fmtDuration,
+  phaseElapsedSeconds,
   phaseStateMap,
   stripVariant,
   useNow,
@@ -58,26 +60,26 @@ export function ActiveTaskCard({
   const cur = currentPhase(task.stages);
   const a = detectAnomalies(task);
 
-  // Live timer: backend returned `cur.duration_seconds` at last poll;
-  // keep ticking client-side. Re-anchor in render when the running phase
-  // identity changes so the displayed duration stays in sync with the
-  // server's reported value at fetch time. (React's "storing prior render"
-  // pattern: https://react.dev/reference/react/useState#storing-information-from-previous-renders.)
+  // Live timer: the backend returns `cur.duration_seconds` at each ~2s poll.
+  // We capture that value + the client clock once at PHASE ENTRY (the anchor)
+  // and tick client-side between polls. Re-anchor ONLY when the phase identity
+  // changes — re-anchoring on every poll (because `duration_seconds` grows)
+  // made the timer snap/jitter each poll instead of ticking smoothly (#524).
+  // `PipelineStageEntry` exposes no per-entry timestamp, so phase identity is
+  // the phase name. (React "storing prior render" pattern:
+  // https://react.dev/reference/react/useState#storing-information-from-previous-renders.)
   const now = useNow(true, 1000);
-  const phaseKey = cur ? `${cur.phase}:${(cur as { ts?: number }).ts ?? ""}` : "";
+  const phaseKey = cur ? cur.phase : "";
   const baseSecs = cur?.duration_seconds || 0;
-  const [anchor, setAnchor] = useState<{ key: string; baseSecs: number; nowMs: number }>(() => ({
+  const [anchor, setAnchor] = useState<PhaseAnchor>(() => ({
     key: phaseKey,
     baseSecs,
     nowMs: now,
   }));
-  if (anchor.key !== phaseKey || anchor.baseSecs !== baseSecs) {
+  if (anchor.key !== phaseKey) {
     setAnchor({ key: phaseKey, baseSecs, nowMs: now });
   }
-  const liveSecs =
-    cur?.status === "running" && anchor.key === phaseKey
-      ? anchor.baseSecs + Math.max(0, Math.floor((now - anchor.nowMs) / 1000))
-      : baseSecs;
+  const liveSecs = phaseElapsedSeconds(cur?.status, phaseKey, anchor, now, baseSecs);
 
   const stripCls = `pl2-card-strip--${stripVariant(a)}`;
   const isPlaceholderTitle = !task.title || /^Issue\s+#/.test(task.title);

--- a/src/components/PipelineActiveTasksBlock/helpers.ts
+++ b/src/components/PipelineActiveTasksBlock/helpers.ts
@@ -155,6 +155,45 @@ export function sumStageCost(stages: PipelineStageEntry[] | undefined): number {
   return stages.reduce((acc, s) => acc + (s.cost_usd || 0), 0);
 }
 
+/**
+ * Anchor captured at phase entry for the live phase timer. `baseSecs` is the
+ * server-reported `duration_seconds` at the moment the running phase was first
+ * seen; `nowMs` is the client wall-clock at that same moment. The client ticks
+ * `now - nowMs` on top of `baseSecs` between polls. Re-anchor ONLY when `key`
+ * (the phase identity) changes — never on every poll just because `baseSecs`
+ * grew, which is what caused the per-poll snap/jitter (#524).
+ */
+export interface PhaseAnchor {
+  key: string;
+  baseSecs: number;
+  nowMs: number;
+}
+
+/**
+ * Elapsed seconds to display for a phase's duration.
+ *
+ * - Running phase whose identity matches the anchor → `anchor.baseSecs` plus
+ *   the client-side wall-clock delta since the anchor, floored and clamped at
+ *   0. This ticks smoothly every second between ~2s polls instead of snapping
+ *   when the server's `duration_seconds` jumps on each poll.
+ * - Any other case (non-running status, or phase identity differs from the
+ *   anchor because we haven't re-anchored yet) → render `serverBaseSecs`
+ *   verbatim with no live ticking, so stale phases show no fake elapsed.
+ */
+export function phaseElapsedSeconds(
+  status: PhaseStatus | undefined,
+  phaseKey: string,
+  anchor: PhaseAnchor,
+  nowMs: number,
+  serverBaseSecs: number = anchor.baseSecs,
+): number {
+  if (status === "running" && anchor.key === phaseKey) {
+    const clientDelta = Math.max(0, Math.floor((nowMs - anchor.nowMs) / 1000));
+    return anchor.baseSecs + clientDelta;
+  }
+  return serverBaseSecs;
+}
+
 // Live-clock hook: re-renders every `intervalMs` while `active`. Used to tick
 // a phase's running-duration without polling the backend.
 export function useNow(active: boolean, intervalMs = 1000): number {

--- a/src/components/PipelineClosedChart.tsx
+++ b/src/components/PipelineClosedChart.tsx
@@ -1,5 +1,6 @@
 import type { ProjectData } from "../types";
 import { toLocalDay, getLast7Days, formatDay } from "../utils/date";
+import { closedChartAvgPerDay } from "./v4/pipeline/utils";
 
 interface Props {
   projects: ProjectData[];
@@ -27,9 +28,9 @@ export function PipelineClosedChart({ projects }: Props) {
   const maxCount = Math.max(...Object.values(countsByDay), 1);
   const total = Object.values(countsByDay).reduce((a, b) => a + b, 0);
 
-  const previous6Days = days.slice(0, 6);
-  const sum6Days = previous6Days.reduce((sum, day) => sum + countsByDay[day], 0);
-  const avg6Days = Math.round(sum6Days / 6);
+  // Average over the same 7-day window shown — keeps the badge honest
+  // (avg ≈ total/7); the old slice(0,6)/6 silently dropped today (#524).
+  const avgPerDay = closedChartAvgPerDay(countsByDay, days);
 
   return (
     <div className="bento-panel pipeline-closed-chart-panel">
@@ -39,7 +40,7 @@ export function PipelineClosedChart({ projects }: Props) {
           <span className="closed-chart-total-badge closed-chart-badge-pipeline">
             Всего: {total}
           </span>
-          <span className="closed-chart-total-badge">Среднее в день: {avg6Days}</span>
+          <span className="closed-chart-total-badge">Среднее в день: {avgPerDay}</span>
         </div>
       </div>
 

--- a/src/components/v4/pipeline/PipelineClosedChartV4.tsx
+++ b/src/components/v4/pipeline/PipelineClosedChartV4.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import type { ProjectData } from "../../../types";
 import { toLocalDay, getLast7Days, formatDay } from "../../../utils/date";
+import { closedChartAvgPerDay } from "./utils";
 
 interface Props {
   projects: ProjectData[];
@@ -11,7 +12,7 @@ interface Props {
 const PIPELINE_LABEL = "agent-completed";
 
 export function PipelineClosedChartV4({ projects, lastUpdated }: Props) {
-  const { days, countsByDay, total, avg6Days } = useMemo(() => {
+  const { days, countsByDay, total, avgPerDay } = useMemo(() => {
     const days = getLast7Days();
     const countsByDay: Record<string, number> = {};
     for (const day of days) countsByDay[day] = 0;
@@ -24,10 +25,10 @@ export function PipelineClosedChartV4({ projects, lastUpdated }: Props) {
       }
     }
     const total = Object.values(countsByDay).reduce((a, b) => a + b, 0);
-    const previous6 = days.slice(0, 6);
-    const sum6 = previous6.reduce((s, d) => s + countsByDay[d], 0);
-    const avg6 = Math.round(sum6 / 6);
-    return { days, countsByDay, total, avg6Days: avg6 };
+    // Average over the same 7-day window shown — keeps "ср. в день" honest
+    // (avg ≈ total/7); the old slice(0,6)/6 silently dropped today (#524).
+    const avgPerDay = closedChartAvgPerDay(countsByDay, days);
+    return { days, countsByDay, total, avgPerDay };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projects, lastUpdated?.getTime()]);
 
@@ -41,7 +42,7 @@ export function PipelineClosedChartV4({ projects, lastUpdated }: Props) {
           Закрыто Pipeline за неделю <span className="v4-tag">7 дней</span>
         </div>
         <div className="v4-panel-meta">
-          всего {total} · ср. в день {avg6Days}
+          всего {total} · ср. в день {avgPerDay}
         </div>
       </div>
       <div className="v4-pl-chart">

--- a/src/components/v4/pipeline/utils.ts
+++ b/src/components/v4/pipeline/utils.ts
@@ -60,3 +60,22 @@ export function activeTaskCount(status: PipelineStatus | null): number {
   if (typeof status.active_tasks === "number") return status.active_tasks;
   return Object.keys(status.issue_stages ?? {}).length;
 }
+
+/**
+ * Average closed-per-day for the closed-Pipeline chart.
+ *
+ * Averages over the SAME window that the chart renders (`days`), so the
+ * displayed "ср. в день" honestly describes the bars shown: `avg ≈ total/N`.
+ * The previous implementation summed `days.slice(0, 6)/6`, silently dropping
+ * the current (partial) day from the average while `total` summed all 7 — so
+ * the per-day label lied (#524). Missing day keys count as 0; an empty window
+ * yields 0. Result is rounded to the nearest integer to match the badge format.
+ */
+export function closedChartAvgPerDay(
+  countsByDay: Record<string, number>,
+  days: string[],
+): number {
+  if (days.length === 0) return 0;
+  const sum = days.reduce((s, d) => s + (countsByDay[d] ?? 0), 0);
+  return Math.round(sum / days.length);
+}

--- a/tests/quality/phase-elapsed.test.ts
+++ b/tests/quality/phase-elapsed.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  phaseElapsedSeconds,
+  type PhaseAnchor,
+} from "../../src/components/PipelineActiveTasksBlock/helpers";
+
+describe("phaseElapsedSeconds", () => {
+  const anchor: PhaseAnchor = {
+    key: "dev",
+    baseSecs: 100,
+    nowMs: 10_000,
+  };
+
+  it("ticks smoothly between polls for a running phase (base + client elapsed)", () => {
+    // 3s of wall-clock have passed since the anchor was taken.
+    expect(phaseElapsedSeconds("running", "dev", anchor, 13_000)).toBe(103);
+  });
+
+  it("does NOT re-snap when a new poll grows baseSecs (steady ticking)", () => {
+    // Two consecutive polls 2s apart. The server's baseSecs grew 100 -> 102
+    // but the anchor (taken at phase entry, baseSecs=100) is unchanged, so the
+    // displayed value depends only on wall-clock, never jumping backward/forward.
+    const at5s = phaseElapsedSeconds("running", "dev", anchor, 15_000); // 105
+    const at7s = phaseElapsedSeconds("running", "dev", anchor, 17_000); // 107
+    expect(at5s).toBe(105);
+    expect(at7s).toBe(107);
+    // Monotonic, +1 per second, no snap.
+    expect(at7s - at5s).toBe(2);
+  });
+
+  it("falls back to server baseSecs when the phase identity differs from the anchor", () => {
+    // Phase advanced to 'review' but anchor still points at 'dev' (not yet
+    // re-anchored). We render the server value verbatim, no stale ticking.
+    expect(phaseElapsedSeconds("running", "review", anchor, 99_999, 42)).toBe(42);
+  });
+
+  it("shows no live elapsed for a non-running phase (renders server baseSecs)", () => {
+    // success/failure/pending must not tick; show the server-reported duration.
+    expect(phaseElapsedSeconds("success", "dev", anchor, 999_999, 250)).toBe(250);
+    expect(phaseElapsedSeconds("failure", "dev", anchor, 999_999, 250)).toBe(250);
+  });
+
+  it("never returns a negative elapsed if clock skews backward", () => {
+    // nowMs before anchor.nowMs → clamp the client delta at 0.
+    expect(phaseElapsedSeconds("running", "dev", anchor, 9_000)).toBe(100);
+  });
+
+  it("floors fractional seconds", () => {
+    // 1900ms since anchor → 1 whole second, base 100 → 101.
+    expect(phaseElapsedSeconds("running", "dev", anchor, 11_900)).toBe(101);
+  });
+});
+
+describe("phaseElapsedSeconds anchoring contract", () => {
+  it("uses anchor.baseSecs (captured at phase entry), not the live server baseSecs", () => {
+    // anchor captured base=100 at 10_000ms. A later poll reports server base=130
+    // (passed as the 5th arg). For the matching running phase we ignore the live
+    // server value and use anchor.baseSecs + client delta → deterministic ticking.
+    const anchor: PhaseAnchor = { key: "review", baseSecs: 100, nowMs: 10_000 };
+    expect(phaseElapsedSeconds("running", "review", anchor, 12_000, 130)).toBe(102);
+  });
+});

--- a/tests/quality/pipeline-closed-chart.test.ts
+++ b/tests/quality/pipeline-closed-chart.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { closedChartAvgPerDay } from "../../src/components/v4/pipeline/utils";
+
+describe("closedChartAvgPerDay", () => {
+  const days = ["d1", "d2", "d3", "d4", "d5", "d6", "d7"];
+
+  it("averages over the full 7-day window shown (does not drop today)", () => {
+    // total = 7+7+7+7+7+7+7 = 49, avg = 49/7 = 7
+    const counts: Record<string, number> = {
+      d1: 7,
+      d2: 7,
+      d3: 7,
+      d4: 7,
+      d5: 7,
+      d6: 7,
+      d7: 7,
+    };
+    expect(closedChartAvgPerDay(counts, days)).toBe(7);
+  });
+
+  it("keeps avg consistent with the displayed total (avg*7 ≈ total)", () => {
+    // total = 14, over 7 days → avg 2 (rounded)
+    const counts: Record<string, number> = {
+      d1: 2,
+      d2: 2,
+      d3: 2,
+      d4: 2,
+      d5: 2,
+      d6: 2,
+      d7: 2,
+    };
+    const total = days.reduce((s, d) => s + counts[d], 0);
+    const avg = closedChartAvgPerDay(counts, days);
+    expect(avg).toBe(2);
+    expect(avg * days.length).toBe(total);
+  });
+
+  it("counts today's bar in the average (regression for silent-drop bug)", () => {
+    // All activity on the last/current day. Old buggy impl summed days[0..5]/6 = 0.
+    // Honest impl over all 7 days: 14/7 = 2.
+    const counts: Record<string, number> = {
+      d1: 0,
+      d2: 0,
+      d3: 0,
+      d4: 0,
+      d5: 0,
+      d6: 0,
+      d7: 14,
+    };
+    expect(closedChartAvgPerDay(counts, days)).toBe(2);
+  });
+
+  it("rounds to the nearest integer", () => {
+    // total = 10 over 7 days = 1.43 → rounds to 1
+    const counts: Record<string, number> = {
+      d1: 10,
+      d2: 0,
+      d3: 0,
+      d4: 0,
+      d5: 0,
+      d6: 0,
+      d7: 0,
+    };
+    expect(closedChartAvgPerDay(counts, days)).toBe(1);
+  });
+
+  it("returns 0 for an empty window", () => {
+    expect(closedChartAvgPerDay({}, [])).toBe(0);
+  });
+
+  it("treats missing day keys as 0", () => {
+    // d4..d7 absent from the map → counted as 0. total 6 / 7 = 0.857 → 1
+    const counts: Record<string, number> = { d1: 2, d2: 2, d3: 2 };
+    expect(closedChartAvgPerDay(counts, days)).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #524 · из аудита аналитики.

- **avg6Days** заменён на честное среднее по показанному 7-дневному окну (`closedChartAvgPerDay`, `total≈avg×7`), сегодня больше не выкидывается молча. Применено в PipelineClosedChartV4 + легаси PipelineClosedChart/ClosedChart.
- **P1 джиттер** — ре-анкор только при смене фазы (`phaseKey=cur.phase`, без несуществующего `.ts`), `phaseElapsedSeconds` тикает на клиенте между поллингами. Таймер больше не снапается каждые 2с. Проверено: живой `PipelineView` рендерит именно `PipelineActiveTasksBlock` (исправленный).

TDD: +13 тестов RED→GREEN. `tsc` clean, `tests/quality` 53 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)