### PR TITLE
fix(audit/health): reconcile finding counts; stop scoring missing data as best-case

### DIFF
--- a/src/components/v4/audit/AuditProjectCardV4.tsx
+++ b/src/components/v4/audit/AuditProjectCardV4.tsx
@@ -164,20 +164,43 @@ export function AuditProjectCardV4({
           )}
 
           {/* Verification stats (only when verified) */}
-          {isVerified && lr.verification && (
-            <div className="v4-au-card-verify">
-              <span className="v4-au-text-muted">Верификация</span>
-              <span className="v4-pl-mono" style={{ color: "var(--mk-danger-strong)" }} title="Подтверждено">
-                ✓ {lr.verification.confirmed}
-              </span>
-              <span className="v4-pl-mono" style={{ color: "var(--mk-success-strong)" }} title="Ложное срабатывание">
-                ✗ {lr.verification.false_positive}
-              </span>
-              <span className="v4-pl-mono" style={{ color: "var(--mk-warn-strong)" }} title="Неуверенно">
-                ? {lr.verification.uncertain}
-              </span>
-            </div>
-          )}
+          {isVerified && lr.verification && (() => {
+            const v = lr.verification;
+            // A3: the per-status cells previously showed only confirmed /
+            // false_positive / uncertain, so they didn't sum to the verified
+            // total — `not_a_bug` (often large) and `errors` were dropped. We
+            // now render not_a_bug, errors (only when >0), and a "проверено N"
+            // total so the numbers reconcile. `not_a_bug` is absent on legacy
+            // reports → treat undefined as 0.
+            const notABug = v.not_a_bug ?? 0;
+            const verifiedTotal =
+              v.confirmed + v.false_positive + v.uncertain + notABug + v.errors;
+            return (
+              <div className="v4-au-card-verify">
+                <span className="v4-au-text-muted">Верификация</span>
+                <span className="v4-pl-mono" style={{ color: "var(--mk-danger-strong)" }} title="Подтверждено">
+                  ✓ {v.confirmed}
+                </span>
+                <span className="v4-pl-mono" style={{ color: "var(--mk-success-strong)" }} title="Ложное срабатывание">
+                  ✗ {v.false_positive}
+                </span>
+                <span className="v4-pl-mono" style={{ color: "var(--mk-success-strong)" }} title="Не баг">
+                  ⊘ {notABug}
+                </span>
+                <span className="v4-pl-mono" style={{ color: "var(--mk-warn-strong)" }} title="Неуверенно">
+                  ? {v.uncertain}
+                </span>
+                {v.errors > 0 && (
+                  <span className="v4-pl-mono v4-au-text-warn" title="Ошибки верификации">
+                    ⚠ {v.errors}
+                  </span>
+                )}
+                <span className="v4-pl-mono v4-au-text-muted" title="Всего проверено">
+                  проверено {verifiedTotal}
+                </span>
+              </div>
+            );
+          })()}
 
           {/* Meta footer */}
           <div className="v4-au-card-meta">

--- a/src/hooks/useProjectHealth.ts
+++ b/src/hooks/useProjectHealth.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { GITHUB_OWNER, getClaudeKey, getToken } from "../utils/config";
 import { loadChecklist } from "../utils/checklist";
-import { ClassificationMissingError, runHealthCheck } from "../utils/health-engine";
+import { ClassificationMissingError, computeScore, runHealthCheck } from "../utils/health-engine";
 import { runDriftScan } from "../utils/health-llm";
 import type { HealthFinding, HealthLayer, HealthLayerSummary, HealthReport } from "../types/health";
 
@@ -283,9 +283,13 @@ export function useProjectHealth(
           ...s.report,
           findings: mergedFindings,
           by_layer: summarizeByLayer(mergedFindings),
-          // Note: we deliberately don't re-compute `score` here — drift checks
-          // are advisory and shouldn't impact the score until task-08 wires
-          // them in. `generated_at` likewise stays anchored to the sync scan.
+          // A1: recompute `score` from the merged findings (reusing the engine's
+          // computeScore) so the A–F grade reflects the Layer-4 fails now shown
+          // on the same screen. Previously the grade stayed anchored to the
+          // pre-drift sync score and understated the visible fail count.
+          // `generated_at` still stays anchored to the sync scan — it marks when
+          // the deterministic layers ran, and drift is layered on top.
+          score: computeScore(mergedFindings, doc),
         };
         return { ...s, report: merged, driftScanning: false, driftProgress: null };
       });

--- a/src/utils/health-engine.ts
+++ b/src/utils/health-engine.ts
@@ -1190,13 +1190,55 @@ async function executeCheck(rule: ChecklistRule, ctx: RunCtx): Promise<HealthFin
   }
 }
 
-function computeScore(findings: HealthFinding[], doc: ChecklistDocument): HealthScore {
+// A7: above this share of unknown findings the scan is "incomplete" and we
+// start down-weighting the grade. Below it, a stray unknown (one flaky check,
+// one unreadable file) is tolerated and the grade is unaffected — preserving
+// the normal full-data behaviour exactly.
+const INCOMPLETE_SCAN_UNKNOWN_RATIO = 0.25;
+// Max points subtracted by the coverage caveat at 100% unknown. Sized so an
+// all-unknown scan (auditor offline, repo unreadable) lands around grade C
+// rather than fabricating an A from missing data — but never zeroes a scan
+// that did surface real passes.
+const MAX_COVERAGE_PENALTY = 40;
+
+// Exported (A1): useProjectHealth re-runs this after merging Layer-4 drift
+// findings so the A–F grade reflects the fails shown on the same screen,
+// instead of staying anchored to the pre-drift sync score.
+export function computeScore(findings: HealthFinding[], doc: ChecklistDocument): HealthScore {
   let deduct = 0;
+  // Coverage tracking for the A7 caveat. Scoring-eligible = everything except
+  // `skipped` (not-applicable rules are legitimately out of scope) AND except
+  // Layer 4 (drift/AI), whose checks are `unknown`-by-design while deferred —
+  // counting them would fire the caveat on every normal scan and shift the
+  // grade. So the caveat measures missing data in the *deterministic* layers
+  // (1–3): auditor offline, unreadable files, transient API failures.
+  let eligible = 0;
+  let unknown = 0;
   for (const f of findings) {
+    if (f.status === "skipped") continue;
+    if (f.layer !== 4) {
+      eligible++;
+      if (f.status === "unknown") {
+        // A7: `unknown` (auditor offline, file unreadable) is missing data,
+        // NOT a pass. It no longer slips through silently — see the coverage
+        // caveat below.
+        unknown++;
+      }
+    }
     if (f.status !== "fail") continue;
     deduct += doc.severity_weights[f.severity] ?? 0;
   }
-  const raw = Math.max(0, 100 - deduct);
+
+  // Coverage caveat: if too large a share of the scan is unknown, down-weight
+  // the grade proportionally so an incomplete scan reads as incomplete rather
+  // than as a clean bill of health.
+  const unknownRatio = eligible > 0 ? unknown / eligible : 0;
+  let coveragePenalty = 0;
+  if (unknownRatio > INCOMPLETE_SCAN_UNKNOWN_RATIO) {
+    coveragePenalty = Math.round(unknownRatio * MAX_COVERAGE_PENALTY);
+  }
+
+  const raw = Math.max(0, Math.min(100, 100 - deduct - coveragePenalty));
   const grade: HealthScore["grade"] =
     raw >= 90 ? "A" : raw >= 75 ? "B" : raw >= 60 ? "C" : raw >= 40 ? "D" : "F";
   return { raw, grade };

--- a/src/utils/riskScore.ts
+++ b/src/utils/riskScore.ts
@@ -42,8 +42,16 @@ export function calcRiskScore(project: ProjectData, monitor?: Monitor): RiskResu
   }
 
   // Stale project — no activity (0–20)
-  const days = project.daysSinceActivity ?? 0;
-  if (days > 30) {
+  // A6: `daysSinceActivity === null` means we have NO activity signal at all
+  // (fetch failed, brand-new repo, or no commits/issues). Previously this was
+  // coalesced to 0 and scored like a perfectly-fresh repo — missing data was
+  // rewarded as best-case. Treat null as a small neutral penalty instead so a
+  // dataless repo never out-scores a genuinely active one.
+  const days = project.daysSinceActivity;
+  if (days === null) {
+    score += 6;
+    factors.push({ text: "Нет данных об активности", points: 6 });
+  } else if (days > 30) {
     score += 20;
     factors.push({ text: `${days}д без активности`, points: 20 });
   } else if (days > 14) {
@@ -76,14 +84,19 @@ export function calcRiskScore(project: ProjectData, monitor?: Monitor): RiskResu
   }
 
   // Cycle time (0–10): slow delivery signals risk
-  if (project.cycleTimeDays !== null) {
-    if (project.cycleTimeDays > 30) {
-      score += 10;
-      factors.push({ text: `Цикл закрытия: ${Math.round(project.cycleTimeDays)}д`, points: 10 });
-    } else if (project.cycleTimeDays > 14) {
-      score += 5;
-      factors.push({ text: `Цикл закрытия: ${Math.round(project.cycleTimeDays)}д`, points: 5 });
-    }
+  // A6: when `cycleTimeDays === null` we have no closed-issue throughput data
+  // (no recent issue open→close pairs). The block used to be skipped entirely,
+  // so a repo with zero delivery signal scored identically to a fast one.
+  // Apply a small neutral penalty for the missing signal instead of nothing.
+  if (project.cycleTimeDays === null) {
+    score += 3;
+    factors.push({ text: "Нет данных о цикле закрытия", points: 3 });
+  } else if (project.cycleTimeDays > 30) {
+    score += 10;
+    factors.push({ text: `Цикл закрытия: ${Math.round(project.cycleTimeDays)}д`, points: 10 });
+  } else if (project.cycleTimeDays > 14) {
+    score += 5;
+    factors.push({ text: `Цикл закрытия: ${Math.round(project.cycleTimeDays)}д`, points: 5 });
   }
 
   score = Math.min(100, score);

--- a/tests/audit/health-score.test.ts
+++ b/tests/audit/health-score.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import { computeScore } from "../../src/utils/health-engine";
+import type {
+  ChecklistDocument,
+  HealthFinding,
+  HealthSeverity,
+  FindingStatus,
+  HealthLayer,
+} from "../../src/types/health";
+
+const SEVERITY_WEIGHTS: Record<HealthSeverity, number> = {
+  critical: 10,
+  high: 5,
+  medium: 3,
+  low: 1,
+};
+
+const DOC = {
+  severity_weights: SEVERITY_WEIGHTS,
+} as unknown as ChecklistDocument;
+
+let counter = 0;
+function finding(
+  status: FindingStatus,
+  severity: HealthSeverity = "high",
+  layer: HealthLayer = 1,
+): HealthFinding {
+  counter += 1;
+  return {
+    rule_id: `rule-${counter}`,
+    title: `rule ${counter}`,
+    layer,
+    severity,
+    status,
+  };
+}
+
+describe("computeScore — normal full-data case is preserved", () => {
+  it("all-pass scan => 100 / grade A", () => {
+    const findings = [finding("pass"), finding("pass"), finding("pass")];
+    const score = computeScore(findings, DOC);
+    expect(score.raw).toBe(100);
+    expect(score.grade).toBe("A");
+  });
+
+  it("a single high fail among passes deducts exactly its weight", () => {
+    const findings = [finding("pass"), finding("pass"), finding("fail", "high")];
+    const score = computeScore(findings, DOC);
+    // 100 - 5 = 95, still A. Deduction unchanged from legacy behaviour.
+    expect(score.raw).toBe(95);
+    expect(score.grade).toBe("A");
+  });
+
+  it("multiple fails accumulate weights (legacy behaviour)", () => {
+    const findings = [
+      finding("fail", "critical"), // -10
+      finding("fail", "high"), // -5
+      finding("pass"),
+      finding("pass"),
+      finding("pass"),
+      finding("pass"),
+      finding("pass"),
+    ];
+    const score = computeScore(findings, DOC);
+    expect(score.raw).toBe(85); // 100 - 15
+    expect(score.grade).toBe("B");
+  });
+
+  it("skipped (not-applicable) findings never affect coverage or score", () => {
+    const findings = [
+      finding("pass"),
+      finding("pass"),
+      finding("skipped"),
+      finding("skipped"),
+      finding("skipped"),
+    ];
+    const score = computeScore(findings, DOC);
+    expect(score.raw).toBe(100);
+    expect(score.grade).toBe("A");
+  });
+});
+
+describe("computeScore — A7: unknown must NOT be scored as pass", () => {
+  it("an all-unknown scan does NOT yield grade A", () => {
+    const findings = [
+      finding("unknown"),
+      finding("unknown"),
+      finding("unknown"),
+      finding("unknown"),
+    ];
+    const score = computeScore(findings, DOC);
+    // A perfect grade fabricated from zero real signal is the bug.
+    expect(score.grade).not.toBe("A");
+    expect(score.raw).toBeLessThan(90);
+  });
+
+  it("a scan that is mostly unknown is down-weighted vs a real all-pass scan", () => {
+    const mostlyUnknown = [
+      finding("pass"),
+      finding("unknown"),
+      finding("unknown"),
+      finding("unknown"),
+      finding("unknown"),
+    ];
+    const allPass = [
+      finding("pass"),
+      finding("pass"),
+      finding("pass"),
+      finding("pass"),
+      finding("pass"),
+    ];
+    const a = computeScore(mostlyUnknown, DOC);
+    const b = computeScore(allPass, DOC);
+    expect(a.raw).toBeLessThan(b.raw);
+  });
+
+  it("a small fraction of unknown does not meaningfully dent a healthy grade", () => {
+    // 1 unknown out of 10 scoring findings — below the caveat threshold.
+    const findings = [
+      finding("unknown"),
+      ...Array.from({ length: 9 }, () => finding("pass")),
+    ];
+    const score = computeScore(findings, DOC);
+    expect(score.grade).toBe("A");
+    expect(score.raw).toBeGreaterThanOrEqual(90);
+  });
+
+  it("unknown coverage caveat is clamped to 0..100", () => {
+    const findings = Array.from({ length: 8 }, () => finding("unknown"));
+    const score = computeScore(findings, DOC);
+    expect(score.raw).toBeGreaterThanOrEqual(0);
+    expect(score.raw).toBeLessThanOrEqual(100);
+  });
+
+  it("Layer-4 unknowns (deferred-by-design) do NOT trigger the caveat", () => {
+    // Normal sync scan: Layers 1–3 all pass, Layer 4 is all-unknown because
+    // the AI/drift checks are deferred. Grade must stay A — the caveat only
+    // measures missing data in the deterministic layers.
+    const findings = [
+      finding("pass", "high", 1),
+      finding("pass", "high", 2),
+      finding("pass", "high", 3),
+      finding("unknown", "high", 4),
+      finding("unknown", "high", 4),
+      finding("unknown", "high", 4),
+      finding("unknown", "high", 4),
+      finding("unknown", "high", 4),
+    ];
+    const score = computeScore(findings, DOC);
+    expect(score.grade).toBe("A");
+    expect(score.raw).toBe(100);
+  });
+});
+
+describe("computeScore — A1: recompute path reflects merged drift fails", () => {
+  it("merging Layer-4 fails into a clean report lowers the recomputed grade", () => {
+    // Simulate the useProjectHealth merge: sync findings (all pass) + drift
+    // Layer-4 findings with fails. Recompute must pick up the new deductions.
+    const syncFindings = [finding("pass", "high", 1), finding("pass", "high", 2)];
+    const before = computeScore(syncFindings, DOC);
+    expect(before.grade).toBe("A");
+
+    const driftFails = [
+      finding("fail", "critical", 4),
+      finding("fail", "high", 4),
+      finding("fail", "high", 4),
+    ];
+    const merged = [...syncFindings, ...driftFails];
+    const after = computeScore(merged, DOC);
+    // 100 - (10 + 5 + 5) = 80 => B. Grade must drop, not stay A.
+    expect(after.raw).toBeLessThan(before.raw);
+    expect(after.grade).not.toBe("A");
+  });
+});

--- a/tests/audit/riskScore.test.ts
+++ b/tests/audit/riskScore.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { calcRiskScore } from "../../src/utils/riskScore";
+import type { ProjectData } from "../../src/types";
+
+// Minimal ProjectData factory. Defaults describe a *perfectly healthy,
+// fully-instrumented* repo: no P1s, recent activity, fast cycle time, zero
+// bugs. Individual tests override only the fields under test so we pin the
+// effect of one risk component at a time.
+function makeProject(overrides: Partial<ProjectData> = {}): ProjectData {
+  return {
+    repo: "owner/repo",
+    client: "MakeIT",
+    phase: "active" as ProjectData["phase"],
+    issues: [],
+    priorityCounts: { P1: 0, P2: 0, P3: 0 } as ProjectData["priorityCounts"],
+    progress: 50,
+    lastCommitDate: "2026-06-01",
+    description: "",
+    openCount: 10,
+    doneCount: 10,
+    totalCount: 20,
+    milestones: [],
+    budget: 0,
+    paid: 0,
+    remaining: 0,
+    daysSinceActivity: 1,
+    lastActivityDate: "2026-06-02",
+    velocity7d: 1,
+    velocity14d: 1,
+    etaDays: 5,
+    etaDate: "2026-06-08",
+    cycleTimeDays: 3,
+    commitActivity: { total: 0, weeks: [] } as unknown as ProjectData["commitActivity"],
+    ...overrides,
+  };
+}
+
+describe("calcRiskScore — A6: missing activity must NOT score as best-case", () => {
+  it("daysSinceActivity=null is penalised, not treated as 0 (fresh)", () => {
+    const noData = calcRiskScore(makeProject({ daysSinceActivity: null }));
+    const fresh = calcRiskScore(makeProject({ daysSinceActivity: 1 }));
+    // No-data must score strictly worse than a genuinely-fresh repo.
+    expect(noData.score).toBeGreaterThan(fresh.score);
+    // The penalty should be visible to the user as a factor mentioning data.
+    expect(noData.factors.some((f) => /данны/i.test(f.text))).toBe(true);
+  });
+
+  it("cycleTimeDays=null is penalised, not silently skipped", () => {
+    const noData = calcRiskScore(makeProject({ cycleTimeDays: null }));
+    const fast = calcRiskScore(makeProject({ cycleTimeDays: 3 }));
+    expect(noData.score).toBeGreaterThan(fast.score);
+  });
+
+  it("a totally-dataless repo does not tie a healthy one at 0", () => {
+    const dataless = calcRiskScore(
+      makeProject({ daysSinceActivity: null, cycleTimeDays: null }),
+    );
+    const healthy = calcRiskScore(makeProject());
+    expect(healthy.level).toBe("low");
+    // Dataless must score above the healthy baseline (missing data is a risk,
+    // not the ideal). It need not leave "low" on its own, but must not tie 0.
+    expect(dataless.score).toBeGreaterThan(healthy.score);
+    expect(dataless.score).toBeGreaterThan(0);
+  });
+});
+
+describe("calcRiskScore — normal full-data case is preserved", () => {
+  it("a perfectly healthy repo still scores ~0 / low", () => {
+    const r = calcRiskScore(makeProject());
+    expect(r.score).toBe(0);
+    expect(r.level).toBe("low");
+  });
+
+  it("known activity buckets are unchanged (8d stale = 5 pts)", () => {
+    const r = calcRiskScore(makeProject({ daysSinceActivity: 8 }));
+    const factor = r.factors.find((f) => /без активности/.test(f.text));
+    expect(factor?.points).toBe(5);
+  });
+
+  it("30+ days stale still adds 20 pts (unchanged)", () => {
+    const r = calcRiskScore(makeProject({ daysSinceActivity: 40 }));
+    const factor = r.factors.find((f) => /без активности/.test(f.text));
+    expect(factor?.points).toBe(20);
+  });
+
+  it("slow cycle time (>30d) still adds 10 pts (unchanged)", () => {
+    const r = calcRiskScore(makeProject({ cycleTimeDays: 45 }));
+    const factor = r.factors.find((f) => /Цикл закрытия/.test(f.text));
+    expect(factor?.points).toBe(10);
+  });
+
+  it("score stays clamped to 0..100 under maximal risk", () => {
+    const r = calcRiskScore(
+      makeProject({
+        priorityCounts: { P1: 99, P2: 0, P3: 0 } as ProjectData["priorityCounts"],
+        daysSinceActivity: null,
+        cycleTimeDays: null,
+      }),
+      { status: "down" } as never,
+    );
+    expect(r.score).toBeLessThanOrEqual(100);
+    expect(r.score).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
Closes #525 · из аудита аналитики. (A5/популяция — отдельно, #519, не трогалось.)

- **A3** карточка аудита теперь показывает not_a_bug (⊘) и errors (⚠) + «проверено N» — счётчики сходятся с total.
- **A1** health-grade пересчитывается после merge drift-находок (`computeScore` экспортирован) — grade отражает показанные Layer-4 fail'ы.
- **A6** `null` активности/цикла → нейтральный штраф (+6/+3), а не best-case.
- **A7** при доле `unknown` >25% grade понижается по покрытию (до −40; all-unknown → ~C). Layer-4 (`ai_*`, unknown-by-design) исключён из знаменателя, поэтому нормальные сканы не затронуты.

Normal-case scores запинены тестами. TDD: +18 тестов RED→GREEN. `tsc` clean, полный vitest 137 ✅ (вкл. 38 health-engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)