### PR TITLE
fix(dashboard): no fabricated +100% velocity from zero base; honest sparkline label

### DIFF
--- a/src/components/v4/KpiRow.tsx
+++ b/src/components/v4/KpiRow.tsx
@@ -153,7 +153,9 @@ function VelocitySpark({ values }: { values: number[] }) {
           <div className="v4-kpi-spark-tip-l">{daysAgo(hover.idx)}</div>
           <div className="v4-kpi-spark-tip-v">
             {values[hover.idx]}
-            <small>задач/день</small>
+            {/* These are per-day CLOSED totals, not a rate — only the divided
+                headline KPI ("issue/день") is a per-day velocity. */}
+            <small>задач (закрыто)</small>
           </div>
         </div>
       )}
@@ -235,8 +237,12 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
   });
 
   const [budgetSeg, setBudgetSeg] = useState<"paid" | "rem" | null>(null);
-  const isVelDown = velocity.delta7dVsPrev < 0;
-  const isVelUp = velocity.delta7dVsPrev > 0;
+  // `delta7dVsPrev === null` ⇒ activity grew from a zero prior-week base, so a
+  // percentage is undefined. We show a "новый" badge instead of a fake +100%.
+  const velDelta = velocity.delta7dVsPrev;
+  const isVelNew = velDelta === null;
+  const isVelDown = velDelta !== null && velDelta < 0;
+  const isVelUp = velDelta !== null && velDelta > 0;
 
   return (
     <div className="v4-kpi-row">
@@ -369,20 +375,28 @@ export function KpiRow({ projects, summary, onFinanceClick }: Props) {
             />
           </span>
           <span className="v4-kpi-num-u">issue/день</span>
-          {velocity.delta7dVsPrev !== 0 && (
-            <span
-              className={`v4-kpi-delta-chip v4-kpi-delta-chip--${
-                isVelDown ? "neg" : "pos"
-              }`}
-            >
-              {isVelUp ? "↑" : "↓"} {Math.abs(velocity.delta7dVsPrev)}%
+          {isVelNew ? (
+            <span className="v4-kpi-delta-chip v4-kpi-delta-chip--pos">
+              новый
             </span>
+          ) : (
+            velDelta !== 0 && (
+              <span
+                className={`v4-kpi-delta-chip v4-kpi-delta-chip--${
+                  isVelDown ? "neg" : "pos"
+                }`}
+              >
+                {isVelUp ? "↑" : "↓"} {Math.abs(velDelta as number)}%
+              </span>
+            )
           )}
         </div>
         <div className="v4-kpi-sub">
-          {velocity.delta7dVsPrev === 0
-            ? "28-дн. ритм закрытия"
-            : "vs. предыдущая неделя"}
+          {isVelNew
+            ? "впервые за неделю"
+            : velDelta === 0
+              ? "28-дн. ритм закрытия"
+              : "vs. предыдущая неделя"}
         </div>
         <VelocitySpark values={velocity.daily28d} />
       </div>

--- a/src/components/v4/milestones/MilestonesHero.tsx
+++ b/src/components/v4/milestones/MilestonesHero.tsx
@@ -178,7 +178,10 @@ export function MilestonesHero({ milestones, projects, now }: Props) {
     if (projects && projects.length > 0) {
       const v = calcPortfolioVelocity(projects);
       velocityPerDay = v.perDay7d;
-      velocityDelta = v.delta7dVsPrev;
+      // delta7dVsPrev is now `number | null` (null = "new from a zero base",
+      // not a real ±%). The Hero's delta chip hides on 0, so coalesce null to 0
+      // — surfaces no misleading "+100%" here (KpiRow shows the "новый" badge).
+      velocityDelta = v.delta7dVsPrev ?? 0;
       daily14 = v.daily28d.slice(-14);
     }
 

--- a/src/utils/dashboardMetrics.ts
+++ b/src/utils/dashboardMetrics.ts
@@ -29,8 +29,14 @@ function closedInWindow(issues: Issue[], days: number, shiftBackDays = 0): numbe
 export interface PortfolioVelocity {
   perDay7d: number;
   perDay14d: number;
-  /** percent change of 7d vs the prior 7d period (positive = improving) */
-  delta7dVsPrev: number;
+  /**
+   * Percent change of 7d vs the prior 7d period (positive = improving).
+   * `null` when the prior 7d base is zero but there *was* activity this week:
+   * growth from a zero base is mathematically undefined, so we surface a
+   * "new" sentinel instead of fabricating a "+100%". A flat 0→0 stays `0`
+   * (genuinely no change).
+   */
+  delta7dVsPrev: number | null;
   /** counts per day for the trailing N days, oldest first (used for sparkline) */
   daily28d: number[];
 }
@@ -47,7 +53,9 @@ export function calcPortfolioVelocity(projects: ProjectData[]): PortfolioVelocit
 
   const delta7dVsPrev =
     closedPrev7d === 0
-      ? closed7d > 0 ? 100 : 0
+      ? closed7d > 0
+        ? null // growth from a zero base is undefined — surface "new", not a fake +100%
+        : 0 // 0 → 0: genuinely no change
       : Math.round(((closed7d - closedPrev7d) / closedPrev7d) * 100);
 
   const days = getLastNDays(28);

--- a/tests/dashboard/dashboardMetrics.test.ts
+++ b/tests/dashboard/dashboardMetrics.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { calcPortfolioVelocity } from "../../src/utils/dashboardMetrics";
+import type { Issue, ProjectData } from "../../src/types";
+
+const DAY = 86_400_000;
+
+/** Minimal issue closed `daysAgo` days before now. */
+function closedIssue(id: string, daysAgo: number): Issue {
+  return {
+    id,
+    number: null,
+    title: id,
+    url: "",
+    status: "Done",
+    priority: null,
+    complexity: null,
+    labels: [],
+    repo: "r",
+    milestoneTitle: null,
+    isBlocked: false,
+    createdAt: new Date(Date.now() - (daysAgo + 30) * DAY).toISOString(),
+    updatedAt: new Date(Date.now() - daysAgo * DAY).toISOString(),
+    closedAt: new Date(Date.now() - daysAgo * DAY).toISOString(),
+  };
+}
+
+/** Wrap a list of issues in a ProjectData shell (only `issues` is read). */
+function project(issues: Issue[]): ProjectData {
+  return {
+    repo: "r",
+    client: "c",
+    phase: "development",
+    issues,
+    priorityCounts: { P1: 0, P2: 0, P3: 0, P4: 0 },
+    progress: 0,
+    lastCommitDate: null,
+    description: "",
+    openCount: 0,
+    doneCount: issues.length,
+    totalCount: issues.length,
+    milestones: [],
+    budget: 0,
+    paid: 0,
+    remaining: 0,
+    daysSinceActivity: null,
+    lastActivityDate: null,
+  } as ProjectData;
+}
+
+describe("calcPortfolioVelocity — delta7dVsPrev (D5: no fabricated +100% from zero base)", () => {
+  it("returns null (not 100) when the prior 7-day base is zero but recent activity exists", () => {
+    // 3 issues closed in the trailing 7 days, none in the prior 7d window (days 8-14).
+    const issues = [closedIssue("a", 1), closedIssue("b", 2), closedIssue("c", 3)];
+    const v = calcPortfolioVelocity([project(issues)]);
+    expect(v.delta7dVsPrev).toBeNull();
+  });
+
+  it("returns 0 (no change) when both the current and prior 7-day windows are empty", () => {
+    const v = calcPortfolioVelocity([project([])]);
+    expect(v.delta7dVsPrev).toBe(0);
+  });
+
+  it("computes a real percentage from a nonzero prior base", () => {
+    // prior 7d (days 8-14): 2 closed; current 7d: 4 closed → +100% real growth.
+    const issues = [
+      closedIssue("p1", 9),
+      closedIssue("p2", 10),
+      closedIssue("c1", 1),
+      closedIssue("c2", 2),
+      closedIssue("c3", 3),
+      closedIssue("c4", 4),
+    ];
+    const v = calcPortfolioVelocity([project(issues)]);
+    expect(v.delta7dVsPrev).toBe(100);
+  });
+
+  it("computes a negative percentage when velocity drops vs the prior week", () => {
+    // prior 7d: 4 closed; current 7d: 2 closed → -50%.
+    const issues = [
+      closedIssue("p1", 8),
+      closedIssue("p2", 9),
+      closedIssue("p3", 10),
+      closedIssue("p4", 11),
+      closedIssue("c1", 1),
+      closedIssue("c2", 2),
+    ];
+    const v = calcPortfolioVelocity([project(issues)]);
+    expect(v.delta7dVsPrev).toBe(-50);
+  });
+});


### PR DESCRIPTION
Closes #526 · из аудита аналитики.

- **D5** velocity-delta возвращает `null` при росте с нуля (рост из нуля не определён); KpiRow рисует бейдж «новый» вместо фейкового «↑100%». `0→0` остаётся no-change, ненулевая база без изменений.
- **D4** тултип спарклайна переименован «задач/день» → «задач (закрыто)» (это дневные суммы, не скорость); `/день` остался только на делённом хедлайне.

TDD: +4 теста RED→GREEN на dashboardMetrics. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)