### PR TITLE
chore: gitignore Python caches from sweep scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,11 @@ pnpm-debug.log*
 # Coverage
 coverage/
 
+# Python (sweep scripts in scripts/ + their pytest tests)
+__pycache__/
+*.pyc
+.pytest_cache/
+
 # Playwright E2E
 test-results/
 playwright-report/


### PR DESCRIPTION
`scripts/` содержит Python sweep-джобы (codex-quality, tracker) + их pytest-тесты, которые генерят `__pycache__/*.pyc`. В `.gitignore` не было ни одной Python-записи, поэтому `scripts/__pycache__/` светился в `git status` как untracked. Добавлены `__pycache__/`, `*.pyc`, `.pytest_cache/` и удалён локальный кэш.

🤖 Generated with [Claude Code](https://claude.com/claude-code)