### PR TITLE
fix(metrics): board (Project #1) as single source for open/done/total

### DIFF
--- a/server/src/github.ts
+++ b/server/src/github.ts
@@ -324,8 +324,6 @@ query($owner: String!, $repo: String!) {
       }
     }
     description
-    openIssueCount: issues(states: OPEN) { totalCount }
-    closedIssueCount: issues(states: CLOSED) { totalCount }
     openMilestones: milestones(first: 100, states: OPEN, orderBy: {field: DUE_DATE, direction: ASC}) {
       nodes {
         title
@@ -368,8 +366,6 @@ interface RepoInfoResponse {
       target: { committedDate: string };
     } | null;
     description: string | null;
-    openIssueCount: { totalCount: number };
-    closedIssueCount: { totalCount: number };
     openMilestones: { nodes: MilestoneNode[] };
     closedMilestones: { nodes: MilestoneNode[] };
   };
@@ -388,8 +384,6 @@ export async function fetchRepoInfo(owner: string, repo: string): Promise<RepoIn
       description: "",
       milestones: [],
       commitActivity,
-      openIssueCount: 0,
-      closedIssueCount: 0,
     };
   }
 
@@ -415,7 +409,5 @@ export async function fetchRepoInfo(owner: string, repo: string): Promise<RepoIn
       issues: [],
     })),
     commitActivity,
-    openIssueCount: graphqlResult.repository.openIssueCount.totalCount,
-    closedIssueCount: graphqlResult.repository.closedIssueCount.totalCount,
   };
 }

--- a/server/src/transform.ts
+++ b/server/src/transform.ts
@@ -22,6 +22,26 @@ export function refreshCommitActivity(raw: CommitActivity): CommitActivity {
 }
 
 /**
+ * #519: derive open/done/total from the Project #1 board subset (`repoIssues`)
+ * so the cache backend produces identical counts to the direct-GitHub fallback
+ * in ../src/utils/github.ts (`boardIssueCounts`). An issue counts as **done**
+ * iff `closedAt` is set — the same closed-signal velocity/cycle-time/milestone
+ * hydration use. `openCount` is the remainder and `totalCount` is the board
+ * size, so `open + done === total` by construction. (The repo-wide
+ * openIssueCount/closedIssueCount that RepoInfo used to expose were dropped.)
+ */
+export function boardIssueCounts(
+  issues: ReadonlyArray<Pick<Issue, "closedAt">>
+): { openCount: number; doneCount: number; totalCount: number } {
+  let doneCount = 0;
+  for (const issue of issues) {
+    if (issue.closedAt) doneCount++;
+  }
+  const totalCount = issues.length;
+  return { openCount: totalCount - doneCount, doneCount, totalCount };
+}
+
+/**
  * Recalculate daysSinceActivity from raw dates.
  * Called on every API response for freshness.
  */
@@ -85,10 +105,11 @@ export function buildProjectData(
     if (issue.priority && issue.status !== "Done") priorityCounts[issue.priority]++;
   }
 
-  // Use real GitHub issue counts (lines 477-480)
-  const openCount = repoInfo.openIssueCount;
-  const doneCount = repoInfo.closedIssueCount;
-  const totalCount = openCount + doneCount;
+  // #519: board (Project #1) is the single source of truth for these counts.
+  // Derived from repoIssues so they reconcile with priorityCounts/velocity/
+  // etaDays/bugRatio, and so the cache backend matches the direct-GitHub
+  // fallback.
+  const { openCount, doneCount, totalCount } = boardIssueCounts(repoIssues);
   const progress = totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0;
 
   // Last activity (lines 483-492)

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -86,6 +86,4 @@ export interface RepoInfo {
   description: string;
   milestones: Milestone[];
   commitActivity: CommitActivity;
-  openIssueCount: number;
-  closedIssueCount: number;
 }

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -136,6 +136,29 @@ export function computeProgress(doneCount: number, totalCount: number): number {
   return Math.min(99, Math.round((doneCount / totalCount) * 100));
 }
 
+/**
+ * #519: derive open/done/total from the Project #1 board subset (`repoIssues`)
+ * so they reconcile with `priorityCounts`/`velocity`/`etaDays`/`bugRatio`,
+ * which all iterate the same board population. Previously open/done came from
+ * the repo-wide `issues().totalCount`, which double-counts issues that aren't
+ * on the board — making the parts fail to sum to the whole.
+ *
+ * An issue counts as **done** iff `closedAt` is set — the same closed-signal
+ * used by velocity, cycle time, and milestone hydration. `openCount` is the
+ * remainder and `totalCount` is the board size, so `open + done === total` by
+ * construction.
+ */
+export function boardIssueCounts(
+  issues: ReadonlyArray<Pick<Issue, "closedAt">>
+): { openCount: number; doneCount: number; totalCount: number } {
+  let doneCount = 0;
+  for (const issue of issues) {
+    if (issue.closedAt) doneCount++;
+  }
+  const totalCount = issues.length;
+  return { openCount: totalCount - doneCount, doneCount, totalCount };
+}
+
 export interface OpenMilestone {
   number: number;
   title: string;
@@ -425,8 +448,6 @@ query($owner: String!, $repo: String!) {
       }
     }
     description
-    openIssueCount: issues(states: OPEN) { totalCount }
-    closedIssueCount: issues(states: CLOSED) { totalCount }
     openMilestones: milestones(first: 100, states: OPEN, orderBy: {field: DUE_DATE, direction: ASC}) {
       nodes {
         title
@@ -475,8 +496,6 @@ interface RepoInfoResponse {
       target: { committedDate: string };
     } | null;
     description: string | null;
-    openIssueCount: { totalCount: number };
-    closedIssueCount: { totalCount: number };
     openMilestones: { nodes: MilestoneNode[] };
     closedMilestones: { nodes: MilestoneNode[] };
   };
@@ -487,11 +506,9 @@ interface RepoInfo {
   description: string;
   milestones: Milestone[];
   commitActivity: CommitActivity;
-  openIssueCount: number;
-  closedIssueCount: number;
-  /** True when REPO_INFO_QUERY failed (auth/network) and the issue counts /
-   * milestones below are placeholder zeros, NOT a genuine empty repo. Lets
-   * downstream distinguish "fetch failed" from "really 0 issues". */
+  /** True when REPO_INFO_QUERY failed (auth/network) and the milestones /
+   * description below are placeholder empties, NOT a genuine empty repo. Lets
+   * downstream distinguish "fetch failed" from "really nothing here". */
   fetchError: boolean;
 }
 
@@ -506,7 +523,7 @@ async function fetchRepoInfo(token: string, owner: string, repo: string): Promis
     // real "0 issues / no milestones" repo (which would render a healthy-but-
     // empty card). The zeros below are placeholders; `fetchError` marks them.
     console.warn(`[Dashboard] REPO_INFO_QUERY failed for ${owner}/${repo} — rendering placeholder zeros (fetchError)`);
-    return { lastCommitDate: null, description: "", milestones: [], commitActivity, openIssueCount: 0, closedIssueCount: 0, fetchError: true };
+    return { lastCommitDate: null, description: "", milestones: [], commitActivity, fetchError: true };
   }
 
   const allMs = [
@@ -532,8 +549,6 @@ async function fetchRepoInfo(token: string, owner: string, repo: string): Promis
       issues: [],
     })),
     commitActivity,
-    openIssueCount: graphqlResult.repository.openIssueCount.totalCount,
-    closedIssueCount: graphqlResult.repository.closedIssueCount.totalCount,
     fetchError: false,
   };
 }
@@ -744,9 +759,12 @@ export async function fetchDashboardData(
       if (issue.priority && issue.status !== "Done") priorityCounts[issue.priority]++;
     }
 
-    const openCount = repoInfo.openIssueCount;
-    const doneCount = repoInfo.closedIssueCount;
-    const totalCount = openCount + doneCount;
+    // #519: board (Project #1) is the single source of truth for these counts.
+    // Derived from repoIssues so they reconcile with priorityCounts/velocity/
+    // etaDays/bugRatio (which all iterate the same board subset). The repo-wide
+    // issue counts REPO_INFO_QUERY used to return were dropped — repoInfo now
+    // supplies only milestones / commitActivity / description.
+    const { openCount, doneCount, totalCount } = boardIssueCounts(repoIssues);
     const progress = computeProgress(doneCount, totalCount);
 
     const dates = [

--- a/tests/dashboard/boardCounts.backend.test.ts
+++ b/tests/dashboard/boardCounts.backend.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { boardIssueCounts } from "../../server/src/transform";
+import type { Issue } from "../../server/src/types";
+
+// ── #519 (cache backend mirror): the cache backend must derive
+//    open/done/total from the same board subset as the direct-GitHub
+//    fallback, so both paths produce identical counts. An issue counts as
+//    "done" iff `closedAt` is set.
+
+/** Minimal board issue: only the fields `boardIssueCounts` reads. */
+function issue(id: string, closed: boolean): Issue {
+  return {
+    id,
+    number: null,
+    title: id,
+    url: "",
+    status: closed ? "Done" : "Todo",
+    priority: null,
+    labels: [],
+    repo: "r",
+    milestoneTitle: null,
+    isBlocked: false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    closedAt: closed ? "2026-01-02T00:00:00Z" : null,
+  };
+}
+
+describe("boardIssueCounts (backend mirror of #519)", () => {
+  it("returns all-zero counts for an empty board", () => {
+    expect(boardIssueCounts([])).toEqual({ openCount: 0, doneCount: 0, totalCount: 0 });
+  });
+
+  it("counts done = closedAt set, open = the rest, total = board length", () => {
+    const issues = [
+      issue("a", false),
+      issue("b", true),
+      issue("c", false),
+      issue("d", true),
+      issue("e", true),
+    ];
+    expect(boardIssueCounts(issues)).toEqual({ openCount: 2, doneCount: 3, totalCount: 5 });
+  });
+
+  it("treats a fully-closed board as all done (all-tracked case unchanged)", () => {
+    const issues = [issue("a", true), issue("b", true), issue("c", true)];
+    expect(boardIssueCounts(issues)).toEqual({ openCount: 0, doneCount: 3, totalCount: 3 });
+  });
+
+  it("uses closedAt — not status — as the closed signal", () => {
+    const closedButTodo: Issue = { ...issue("x", true), status: "Todo" };
+    const openButReview: Issue = { ...issue("y", false), status: "Review" };
+    expect(boardIssueCounts([closedButTodo, openButReview])).toEqual({
+      openCount: 1,
+      doneCount: 1,
+      totalCount: 2,
+    });
+  });
+
+  it("keeps total = open + done (parts sum to the whole)", () => {
+    const issues = [issue("a", false), issue("b", true), issue("c", false)];
+    const { openCount, doneCount, totalCount } = boardIssueCounts(issues);
+    expect(openCount + doneCount).toBe(totalCount);
+  });
+});

--- a/tests/dashboard/boardCounts.backend.test.ts
+++ b/tests/dashboard/boardCounts.backend.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 import { boardIssueCounts } from "../../server/src/transform";
 import type { Issue } from "../../server/src/types";
 
-// ── #519 (cache backend mirror): the cache backend must derive
+// ── issue 519 (cache backend mirror): the cache backend must derive
 //    open/done/total from the same board subset as the direct-GitHub
 //    fallback, so both paths produce identical counts. An issue counts as
 //    "done" iff `closedAt` is set.
@@ -27,7 +27,7 @@ function issue(id: string, closed: boolean): Issue {
   };
 }
 
-describe("boardIssueCounts (backend mirror of #519)", () => {
+describe("boardIssueCounts (backend mirror of issue 519)", () => {
   it("returns all-zero counts for an empty board", () => {
     expect(boardIssueCounts([])).toEqual({ openCount: 0, doneCount: 0, totalCount: 0 });
   });

--- a/tests/dashboard/boardCounts.test.ts
+++ b/tests/dashboard/boardCounts.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { boardIssueCounts } from "../../src/utils/github";
+import type { Issue } from "../../src/types";
+
+// ── #519: the Project #1 board (`repoIssues`) is the single source of truth
+//    for open/done/total. Previously open/done came from repo-wide
+//    `issues().totalCount`, so when an issue wasn't on the board the parts
+//    didn't sum to the whole. These counts must now be derived purely from
+//    the board subset, an issue counting as "done" iff `closedAt` is set —
+//    the same closed-signal velocity/cycle-time/milestone hydration use.
+
+/** Minimal board issue: only the fields `boardIssueCounts` reads. */
+function issue(id: string, closed: boolean): Issue {
+  return {
+    id,
+    number: null,
+    title: id,
+    url: "",
+    status: closed ? "Done" : "Todo",
+    priority: null,
+    complexity: null,
+    labels: [],
+    repo: "r",
+    milestoneTitle: null,
+    isBlocked: false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    closedAt: closed ? "2026-01-02T00:00:00Z" : null,
+  };
+}
+
+describe("boardIssueCounts (#519: board as single source of truth)", () => {
+  it("returns all-zero counts for an empty board", () => {
+    expect(boardIssueCounts([])).toEqual({ openCount: 0, doneCount: 0, totalCount: 0 });
+  });
+
+  it("counts done = closedAt set, open = the rest, total = board length", () => {
+    const issues = [
+      issue("a", false),
+      issue("b", true),
+      issue("c", false),
+      issue("d", true),
+      issue("e", true),
+    ];
+    expect(boardIssueCounts(issues)).toEqual({ openCount: 2, doneCount: 3, totalCount: 5 });
+  });
+
+  it("treats a fully-open board as all open", () => {
+    const issues = [issue("a", false), issue("b", false)];
+    expect(boardIssueCounts(issues)).toEqual({ openCount: 2, doneCount: 0, totalCount: 2 });
+  });
+
+  it("treats a fully-closed board as all done (all-tracked case unchanged)", () => {
+    const issues = [issue("a", true), issue("b", true), issue("c", true)];
+    expect(boardIssueCounts(issues)).toEqual({ openCount: 0, doneCount: 3, totalCount: 3 });
+  });
+
+  it("uses closedAt — not status — as the closed signal", () => {
+    // An issue with closedAt set but a non-Done status still counts as done;
+    // an issue with no closedAt counts as open regardless of status text.
+    const closedButTodo: Issue = { ...issue("x", true), status: "Todo" };
+    const openButReview: Issue = { ...issue("y", false), status: "Review" };
+    expect(boardIssueCounts([closedButTodo, openButReview])).toEqual({
+      openCount: 1,
+      doneCount: 1,
+      totalCount: 2,
+    });
+  });
+
+  it("keeps total = open + done (parts sum to the whole)", () => {
+    const issues = [issue("a", false), issue("b", true), issue("c", false)];
+    const { openCount, doneCount, totalCount } = boardIssueCounts(issues);
+    expect(openCount + doneCount).toBe(totalCount);
+  });
+});

--- a/tests/dashboard/boardCounts.test.ts
+++ b/tests/dashboard/boardCounts.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { boardIssueCounts } from "../../src/utils/github";
 import type { Issue } from "../../src/types";
 
-// ── #519: the Project #1 board (`repoIssues`) is the single source of truth
+// ── issue 519: the Project #1 board (`repoIssues`) is the single source of truth
 //    for open/done/total. Previously open/done came from repo-wide
 //    `issues().totalCount`, so when an issue wasn't on the board the parts
 //    didn't sum to the whole. These counts must now be derived purely from
@@ -29,7 +29,7 @@ function issue(id: string, closed: boolean): Issue {
   };
 }
 
-describe("boardIssueCounts (#519: board as single source of truth)", () => {
+describe("boardIssueCounts (issue 519: board as single source of truth)", () => {
   it("returns all-zero counts for an empty board", () => {
     expect(boardIssueCounts([])).toEqual({ openCount: 0, doneCount: 0, totalCount: 0 });
   });


### PR DESCRIPTION
Closes #519 · из аудита (G2/D1, ранее отложено).

`openCount/doneCount/totalCount` теперь выводятся из доски Project #1 (`repoIssues`), как и `priorityCounts/velocity/etaDays/bugRatio` — части наконец сходятся с целым. `done` = issue с `closedAt`, `open = total − done`, `total = repoIssues.length` (open+done≡total by construction). Поправлено на **обоих путях** (фронт `github.ts` + кэш-backend `server/src/*`), убраны мёртвые репо-широкие `openIssueCount/closedIssueCount` из запросов/типов.

Побочно чинит A5 (bug-ratio: числитель и знаменатель теперь одной популяции). После tracker-sweep gap=0, так что видимые цифры сейчас не меняются — но рассинхрон устранён в коде.

TDD: +11 тестов (фронт+backend). `tsc` clean, vitest 165 ✅, `npm run build` ✅, server `tsc` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)