### PR TITLE
fix(dora): deploys exclude hotfixes; CFR only over elapsed windows

### DIFF
--- a/src/components/v4/hub/DoraCards.tsx
+++ b/src/components/v4/hub/DoraCards.tsx
@@ -156,7 +156,7 @@ export function DoraCards({ metrics }: Props) {
         title="Частота деплоя"
         value={formatNumber(metrics.deployFreq, "/день")}
         tier={metrics.tiers.deployFreq}
-        tooltip="Commits на main с префиксом feat:/fix:/release: за окно ÷ количество дней окна. Elite ≥ 1/день."
+        tooltip="Commits на main с префиксом feat:/release: за окно ÷ количество дней окна (хотфиксы fix: — не деплои). Elite ≥ 1/день."
       />
       <Card
         title="Время поставки"
@@ -174,7 +174,7 @@ export function DoraCards({ metrics }: Props) {
         title="Доля сбойных изменений"
         value={formatPercent(metrics.cfr)}
         tier={metrics.tiers.cfr}
-        tooltip="Доля деплоев, за которыми в течение 7 дней последовал fix-коммит ИЛИ critical audit finding. Elite ≤ 5%."
+        tooltip="Доля деплоев, за которыми в течение 7 дней последовал fix-коммит ИЛИ critical audit finding. Считается только по деплоям с полностью прошедшим 7-дн. окном. Elite ≤ 5%."
       />
     </div>
   );

--- a/src/utils/doraCalculator.ts
+++ b/src/utils/doraCalculator.ts
@@ -7,17 +7,24 @@
  *
  * Conventions (mirrored in docs/DELIVERY.md):
  *   1. **Deploy Frequency** — count of commits on the default branch
- *      whose subject starts with `feat:`, `fix:` or `release:`, divided
- *      by `windowDays`. Unit: deploys/day.
+ *      whose subject starts with `feat:` or `release:`, divided by
+ *      `windowDays`. Unit: deploys/day. Hotfixes (`fix:`) are NOT
+ *      deploys (#527/D6) — they are only a failure signal (see CFR), so
+ *      they neither inflate frequency nor count as their own failure.
  *   2. **Lead Time for Changes** — median(`merged_at - created_at`) over
  *      merged PRs in the window. Unit: hours.
  *   3. **MTTR** — median downtime per incident from BetterStack monitor
  *      matched by repo via `MONITOR_MATCH`. When no matching monitor or
  *      no incidents data is available, returns `n/a` (`null`). Unit:
  *      hours.
- *   4. **Change Failure Rate** — share of deploys (= `feat:`/`fix:`/
- *      `release:` commits) that were followed within 7 days by EITHER
- *      a `fix:` commit OR a critical audit finding. Value in `[0, 1]`.
+ *   4. **Change Failure Rate** — share of deploys (= `feat:`/`release:`
+ *      commits) that were followed within 7 days by EITHER a `fix:`
+ *      commit OR a critical audit finding. Value in `[0, 1]`. Only
+ *      deploys whose full 7-day failure-lookahead window has already
+ *      elapsed (`deployTime + 7d <= now`) are judged (#527/D7) — a
+ *      deploy from the last 7 days is excluded from the denominator
+ *      rather than presumed successful. If no deploy is judgeable yet,
+ *      CFR is `n/a` (`null`), not 0%.
  *
  * Inputs are *injected* — the calculator is pure. The caller is
  * responsible for fetching commits, PRs, monitor incidents and audit
@@ -94,7 +101,12 @@ export interface DoraMetricsResult {
   leadTimeHours: number | null;
   /** Median MTTR in hours; `null` if no incidents data or no matched monitor. */
   mttrHours: number | null;
-  /** Change failure rate in `[0, 1]`; `null` if no deploys in window. */
+  /**
+   * Change failure rate in `[0, 1]`; `null` ("n/a") if there is no
+   * *judgeable* deploy — i.e. no deploy whose full 7-day failure window
+   * has elapsed (#527/D7). Deploys from the last 7 days are excluded
+   * from the denominator, never presumed successful.
+   */
   cfr: number | null;
   /** Tier per metric — `na` when the metric is null. */
   tiers: {
@@ -110,8 +122,13 @@ export interface DoraMetricsResult {
  * `main` carrying one of these is a release-candidate change on a
  * micro-team — we don't gate deploys on git tags because the team
  * doesn't tag religiously.
+ *
+ * `fix:` is deliberately EXCLUDED (#527/D6): a hotfix is purely a
+ * *failure signal* for CFR, not a deploy. Counting it as both inflated
+ * deploy frequency with hotfixes AND made a deploy able to be its own
+ * failure (circular). Deploys are now feat:/release: only.
  */
-const DEPLOY_PREFIXES = ["feat:", "fix:", "release:"] as const;
+const DEPLOY_PREFIXES = ["feat:", "release:"] as const;
 const FIX_PREFIX = "fix:";
 
 /** Match the conventional-commit prefix at the start of a subject. */
@@ -249,7 +266,7 @@ export function computeDora(
   const since = now - windowDays * 86_400_000;
 
   // ── Deploy Frequency ─────────────────────────────────────────────
-  // Count commits whose subject starts with feat:/fix:/release:.
+  // Count commits whose subject starts with feat:/release: (NOT fix:).
   // Divide by windowDays so the unit is deploys/day regardless of
   // the chosen window. Returns 0 (not null) when there are zero
   // qualifying commits — a project with a configured repo but no
@@ -303,10 +320,20 @@ export function computeDora(
   // A deploy "failed" if within 7 days after its commit we see either:
   //   (a) a `fix:` commit, OR
   //   (b) a critical audit finding.
-  // CFR = failed deploys / total deploys. If no deploys → null.
+  // CFR = failed deploys / *judgeable* deploys.
+  //
+  // Trailing-window guard (#527/D7): a deploy can only be judged once
+  // its full 7-day failure-lookahead window has ELAPSED. A deploy from
+  // the last 7 days has its window extend past `now`, so we haven't
+  // observed whether a fix lands yet — counting it as a success is
+  // structurally optimistic and drags CFR toward 0. We therefore
+  // exclude any deploy with `deployTime + 7d > now` from the
+  // denominator. If that leaves zero judgeable deploys we return the
+  // n/a sentinel (null), NOT a misleading 0%.
   let cfr: number | null = null;
-  if (deploys.length > 0) {
-    const sevenDaysMs = 7 * 86_400_000;
+  const sevenDaysMs = 7 * 86_400_000;
+  const judgeableDeploys = deploys.filter((d) => d.time + sevenDaysMs <= now);
+  if (judgeableDeploys.length > 0) {
     // Pre-filter: only fix commits *after* each deploy time count. We
     // scan the full commit list so a `fix:` outside the window (but
     // within 7d of a deploy) still attributes correctly.
@@ -325,20 +352,19 @@ export function computeDora(
       .filter((t) => !Number.isNaN(t));
 
     let failed = 0;
-    for (const d of deploys) {
+    for (const d of judgeableDeploys) {
       const windowEnd = d.time + sevenDaysMs;
       // Match a fix commit strictly *after* the deploy and within 7d.
-      // The strict `>` guards against the deploy counting itself: a
-      // `fix:` deploy commit at time `d.time` would otherwise mark
-      // itself as its own failure and inflate CFR to ~100% for any
-      // project where fixes outnumber features.
+      // The strict `>` keeps a coincident commit from attributing to
+      // itself; with `fix:` no longer a deploy this mainly guards
+      // against same-instant feat:/fix: pairs.
       const hasFix = fixCommits.some(
         (fc) => fc.time > d.time && fc.time <= windowEnd,
       );
       const hasCriticalAudit = criticalAudits.some((t) => t > d.time && t <= windowEnd);
       if (hasFix || hasCriticalAudit) failed++;
     }
-    cfr = failed / deploys.length;
+    cfr = failed / judgeableDeploys.length;
   }
 
   return {

--- a/tests/dora/doraCalculator.test.ts
+++ b/tests/dora/doraCalculator.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { computeDora } from "../../src/utils/doraCalculator";
+import type { DoraInputs } from "../../src/utils/doraCalculator";
+import type { CommitInfo } from "../../src/utils/github-contents";
+
+// Fixed reference "now" so windows are deterministic.
+const NOW = Date.parse("2026-06-03T00:00:00Z");
+const DAY = 86_400_000;
+
+/** Build a CommitInfo with only the fields the calculator reads. */
+function commit(subject: string, isoDate: string): CommitInfo {
+  return {
+    sha: "0".repeat(40),
+    subject,
+    message: subject,
+    author: "test",
+    date: isoDate,
+    url: "https://example.com",
+  };
+}
+
+/** Days-ago ISO timestamp relative to NOW. */
+function daysAgo(days: number): string {
+  return new Date(NOW - days * DAY).toISOString();
+}
+
+/** Minimal inputs with no PRs/incidents/audit findings. */
+function baseInputs(commits: CommitInfo[]): DoraInputs {
+  return {
+    commits,
+    pullRequests: [],
+    incidents: null,
+    auditFindings: [],
+  };
+}
+
+describe("computeDora — deploy classification (#527 D6)", () => {
+  it("does NOT count a fix: commit as a deploy", () => {
+    // A single fix: commit, well inside the window, fully elapsed.
+    const inputs = baseInputs([commit("fix: patch a bug", daysAgo(15))]);
+    const res = computeDora(inputs, 30, NOW);
+    // No feat:/release: → zero deploys → deploys/day == 0.
+    expect(res.deployFreq).toBe(0);
+    // With zero deploys the CFR denominator is empty → n/a sentinel.
+    expect(res.cfr).toBeNull();
+  });
+
+  it("counts feat: and release: commits as deploys", () => {
+    const inputs = baseInputs([
+      commit("feat: add thing", daysAgo(20)),
+      commit("release: v1.2.0", daysAgo(10)),
+    ]);
+    const res = computeDora(inputs, 30, NOW);
+    // 2 deploys over a 30-day window → 2/30 deploys/day.
+    expect(res.deployFreq).toBeCloseTo(2 / 30, 10);
+  });
+
+  it("excludes hotfixes from deploy frequency (fix: alongside feat:)", () => {
+    const inputs = baseInputs([
+      commit("feat: ship feature", daysAgo(25)),
+      commit("fix: hotfix one", daysAgo(24)),
+      commit("fix: hotfix two", daysAgo(23)),
+    ]);
+    const res = computeDora(inputs, 30, NOW);
+    // Only the single feat: counts — hotfixes no longer inflate the numerator.
+    expect(res.deployFreq).toBeCloseTo(1 / 30, 10);
+  });
+});
+
+describe("computeDora — CFR trailing-window guard (#527 D7)", () => {
+  it("excludes a deploy whose 7-day failure window has NOT fully elapsed", () => {
+    // One feat: deploy 3 days ago → its 7d lookahead ends 4 days in the FUTURE.
+    // It must be excluded from the CFR denominator. No other deploys → n/a.
+    const inputs = baseInputs([commit("feat: recent ship", daysAgo(3))]);
+    const res = computeDora(inputs, 30, NOW);
+    // Deploy frequency still counts the deploy (it happened) ...
+    expect(res.deployFreq).toBeCloseTo(1 / 30, 10);
+    // ... but CFR has no judgeable deploy → n/a sentinel, NOT a misleading 0%.
+    expect(res.cfr).toBeNull();
+    expect(res.tiers.cfr).toBe("na");
+  });
+
+  it("judges only deploys whose 7d window is fully elapsed", () => {
+    // Deploy A: 20 days ago (window elapsed, no following fix → success).
+    // Deploy B: 2 days ago (window NOT elapsed → excluded from denominator).
+    const inputs = baseInputs([
+      commit("feat: old ship", daysAgo(20)),
+      commit("feat: fresh ship", daysAgo(2)),
+    ]);
+    const res = computeDora(inputs, 30, NOW);
+    // Only deploy A is judgeable, and it had no failure → CFR == 0/1 == 0.
+    expect(res.cfr).toBe(0);
+  });
+});
+
+describe("computeDora — failure attribution (#527)", () => {
+  it("counts a feat: deploy followed within 7d by a fix: as a failure", () => {
+    // feat: deploy 15 days ago (window elapsed), fix: 12 days ago (3d later, within 7d).
+    const inputs = baseInputs([
+      commit("feat: ship feature", daysAgo(15)),
+      commit("fix: regression from feature", daysAgo(12)),
+    ]);
+    const res = computeDora(inputs, 30, NOW);
+    // 1 judgeable deploy, 1 failure → CFR == 1.
+    expect(res.cfr).toBe(1);
+    expect(res.tiers.cfr).toBe("low");
+  });
+
+  it("does not attribute a fix: that lands more than 7d after the deploy", () => {
+    // feat: 20 days ago, fix: 10 days ago → gap is 10 days (> 7d) → not a failure.
+    const inputs = baseInputs([
+      commit("feat: ship feature", daysAgo(20)),
+      commit("fix: unrelated later", daysAgo(10)),
+    ]);
+    const res = computeDora(inputs, 30, NOW);
+    // Deploy's 7d window (ends 13 days ago) is fully elapsed and saw no fix → CFR 0.
+    expect(res.cfr).toBe(0);
+  });
+});

--- a/tests/dora/doraCalculator.test.ts
+++ b/tests/dora/doraCalculator.test.ts
@@ -34,7 +34,7 @@ function baseInputs(commits: CommitInfo[]): DoraInputs {
   };
 }
 
-describe("computeDora — deploy classification (#527 D6)", () => {
+describe("computeDora — deploy classification (issue 527 D6)", () => {
   it("does NOT count a fix: commit as a deploy", () => {
     // A single fix: commit, well inside the window, fully elapsed.
     const inputs = baseInputs([commit("fix: patch a bug", daysAgo(15))]);
@@ -67,7 +67,7 @@ describe("computeDora — deploy classification (#527 D6)", () => {
   });
 });
 
-describe("computeDora — CFR trailing-window guard (#527 D7)", () => {
+describe("computeDora — CFR trailing-window guard (issue 527 D7)", () => {
   it("excludes a deploy whose 7-day failure window has NOT fully elapsed", () => {
     // One feat: deploy 3 days ago → its 7d lookahead ends 4 days in the FUTURE.
     // It must be excluded from the CFR denominator. No other deploys → n/a.
@@ -93,7 +93,7 @@ describe("computeDora — CFR trailing-window guard (#527 D7)", () => {
   });
 });
 
-describe("computeDora — failure attribution (#527)", () => {
+describe("computeDora — failure attribution (issue 527)", () => {
   it("counts a feat: deploy followed within 7d by a fix: as a failure", () => {
     // feat: deploy 15 days ago (window elapsed), fix: 12 days ago (3d later, within 7d).
     const inputs = baseInputs([


### PR DESCRIPTION
Closes #527 · по принятому решению (feat/release=деплой, fix=сбой).

- **D6** `DEPLOY_PREFIXES = ["feat:", "release:"]` — `fix:` убран из деплоев (остаётся только сигналом сбоя). Разрывает циркулярность: хотфикс больше не раздувает частоту деплоя и не маркирует сам себя как сбой.
- **D7** CFR считается только по «judgeable» деплоям (`deployTime + 7d <= now`) — недавние деплои с непрошедшим окном не записываются в успехи; если judgeable нет → `null` (n/a), не 0%.
- Тултипы DoraCards приведены в соответствие (убран fix: из частоты, добавлена семантика окна в CFR).

TDD: +7 тестов RED→GREEN. `tsc` clean, vitest 161 ✅, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)