### PR TITLE
ci: bump GitHub Actions to Node24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
   lint-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -36,7 +36,7 @@ jobs:
       - run: npm run lint
       - run: npx tsc --noEmit
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         if: github.event_name == 'workflow_dispatch'
         with:
           path: dist
@@ -44,8 +44,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -53,7 +53,7 @@ jobs:
       - run: npm run test:e2e:typecheck
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-report
@@ -72,4 +72,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/codex-quality-sweep.yml
+++ b/.github/workflows/codex-quality-sweep.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload artifact (debugging fallback)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: codex-quality-${{ github.run_id }}
           path: out/codex-quality.json

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run smoke tests
         env:

--- a/.github/workflows/tracker-sweep.yml
+++ b/.github/workflows/tracker-sweep.yml
@@ -37,9 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Closes #532 · Node20 deprecation (форс Node24 с 2026-06-16).

Бамп по всем 4 воркфлоу (версии = latest majors через `gh api releases/latest`):
- checkout v4→v6 · setup-node v4→v6 · setup-python v5→v6
- upload-artifact v4→v7 · deploy-pages v4→v5 · upload-pages-artifact v3→v5

YAML валиден, Node20-версий не осталось. CI этого PR прогонит ci.yml уже на новых экшенах (валидация бампа). Sweep-воркфлоу (codex/tracker/smoke) проверю `workflow_dispatch` после мержа. Охват — только makeit-dashboard (остальные репо — в памяти).

🤖 Generated with [Claude Code](https://claude.com/claude-code)