### PR TITLE
fix(milestones): stop closed milestones leaking into Gantt from stale cache

### DIFF
--- a/src/components/v4/milestones/classifyMilestone.ts
+++ b/src/components/v4/milestones/classifyMilestone.ts
@@ -24,12 +24,20 @@ const TIER_TO_KIND = {
  * pre-computed from `daysUntil(m.dueOn)` so the caller controls the time
  * anchor.
  *
- * "done" is driven ONLY by `m.state === "CLOSED"`. An OPEN milestone whose
- * issues all happen to be closed keeps its normal deadline classification so it
- * stays visible in the deadline plan (it isn't actually finished until GitHub
- * closes the milestone).
+ * "done" is driven by `m.state === "CLOSED"`. An OPEN milestone whose issues
+ * all happen to be closed keeps its normal deadline classification so it stays
+ * visible in the deadline plan (it isn't actually finished until GitHub closes
+ * the milestone).
+ *
+ * Resilience (issue 537): on first paint the dashboard may serve legacy cached
+ * data whose milestones lack a reliable `state`. We treat a milestone with all
+ * issues closed (and none open) as done WHEN `state` is missing — guarded to
+ * `state !== "OPEN"` so a genuine open-but-all-closed milestone still stays in
+ * the active plan. Without this, stale state-less closed milestones flash into
+ * the active Gantt until the fresh fetch (with `state`) replaces them.
  */
 export function classifyMilestone(m: Milestone, days: number | null): MilestoneStatusKind {
   if (m.state === "CLOSED") return "done";
+  if (m.state !== "OPEN" && m.openIssues === 0 && m.closedIssues > 0) return "done";
   return TIER_TO_KIND[deadlineTier(days)];
 }

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -555,8 +555,16 @@ async function fetchRepoInfo(token: string, owner: string, repo: string): Promis
 
 const CACHE_KEY = "makeit_dashboard_cache";
 const CACHE_TTL = 15 * 60 * 1000; // 15 minutes
+// Bump when the cached ProjectData shape changes so structurally-incompatible
+// entries written by an older bundle are discarded on read instead of being
+// rendered on first paint. Issue 537: legacy milestones lacked `state`, which
+// (post-M5) leaked closed milestones into the active Gantt until a fresh fetch.
+const CACHE_VERSION = 2;
 
 interface CacheEntry {
+  // Schema version of `data`. Absent on entries written before versioning —
+  // those are treated as incompatible and discarded on read.
+  v?: number;
   data: ProjectData[];
   // Wall-clock time the entry was written (used for TTL expiration only).
   timestamp: number;
@@ -582,6 +590,7 @@ function readLocalCache(): CacheEntry | null {
     const entry = JSON.parse(raw) as CacheEntry;
     if (
       !entry ||
+      entry.v !== CACHE_VERSION || // stale/legacy shape — discard, don't render
       !Array.isArray(entry.data) ||
       typeof entry.timestamp !== "number"
     ) return null;
@@ -598,6 +607,7 @@ function readLocalCache(): CacheEntry | null {
 function writeLocalCache(data: ProjectData[], lastSync: Date | null = null): void {
   try {
     const entry: CacheEntry = {
+      v: CACHE_VERSION,
       data,
       timestamp: Date.now(),
       lastSyncIso: lastSync ? lastSync.toISOString() : undefined,

--- a/tests/e2e/fixtures/seed.ts
+++ b/tests/e2e/fixtures/seed.ts
@@ -53,6 +53,10 @@ export async function seedApp(page: Page): Promise<void> {
       localStorage.setItem(
         "makeit_dashboard_cache",
         JSON.stringify({
+          // Must match CACHE_VERSION in src/utils/github.ts — readLocalCache
+          // discards entries whose `v` differs, so a versionless seed would be
+          // dropped and no projects would render.
+          v: 2,
           data: payload.projects,
           timestamp: payload.now,
           lastSyncIso: new Date(payload.now).toISOString(),

--- a/tests/milestones/classifyMilestone.test.ts
+++ b/tests/milestones/classifyMilestone.test.ts
@@ -39,6 +39,27 @@ describe("classifyMilestone — done detection (M5)", () => {
   });
 });
 
+describe("classifyMilestone — resilience to stale cache without state (issue 537)", () => {
+  // On first paint the dashboard may serve legacy cached data whose milestones
+  // lack a reliable `state`. A milestone with all issues closed must still read
+  // as done so closed milestones don't flash into the active Gantt until the
+  // fresh fetch (with `state`) lands.
+  it("treats a state-less milestone with all issues closed as done", () => {
+    const m = makeMilestone({ state: undefined, openIssues: 0, closedIssues: 5 });
+    expect(classifyMilestone(m, 3)).toBe("done");
+  });
+
+  it("does NOT mark a state-less milestone done while it still has open issues", () => {
+    const m = makeMilestone({ state: undefined, openIssues: 2, closedIssues: 5 });
+    expect(classifyMilestone(m, 3)).not.toBe("done");
+  });
+
+  it("does NOT mark a state-less milestone with zero issues done", () => {
+    const m = makeMilestone({ state: undefined, openIssues: 0, closedIssues: 0 });
+    expect(classifyMilestone(m, 3)).not.toBe("done");
+  });
+});
+
 describe("classifyMilestone — deadline tiers (M3/M4 canonical thresholds)", () => {
   const open = (over: Partial<Milestone> = {}) =>
     makeMilestone({ state: "OPEN", openIssues: 1, closedIssues: 0, ...over });


### PR DESCRIPTION
Closes #537.

**Симптом:** после долгого перерыва первая загрузка показывает закрытые майлстоуны в активном Gantt; релоад — пропадают.

**Root cause:** на первом рендере отдаётся устаревший кэш (localStorage SWR / снапшот cache-backend), где у майлстоунов нет надёжного `state`. Наш M5 (#521) убрал запасной клаузул `openIssues===0`, поэтому done теперь только по `state==="CLOSED"` → state-less закрытые валятся в `openMs`/Gantt. Свежий фетч их убирает.

**Фикс:**
- `classifyMilestone`: `state !== "OPEN" && openIssues === 0 && closedIssues > 0 → done` — резилентность к stale-данным без `state`, не трогая `state==="OPEN"` (интент M5 сохранён).
- Версия схемы localStorage-кэша (`CACHE_VERSION`): несовместимые старые записи отбрасываются на чтении, не рендерятся.

TDD: +3 теста RED→GREEN. tsc/lint/build clean, полный vitest **181**. M5-тесты не сломаны.

🤖 Generated with [Claude Code](https://claude.com/claude-code)