### PR TITLE
feat(transcripts): полоса прогресса загрузки аудио

### DIFF
--- a/src/components/v4/transcripts/BatchProgressV4.tsx
+++ b/src/components/v4/transcripts/BatchProgressV4.tsx
@@ -6,6 +6,8 @@ export interface BatchFile {
   status: BatchFileStatus;
   taskId?: string;
   error?: string;
+  /** Upload progress 0–100 while status === "uploading". */
+  uploadPct?: number;
 }
 
 interface Props {
@@ -88,7 +90,11 @@ export function BatchProgressV4({ files, active, onCancel, onClose }: Props) {
               {bf.file.name}
             </span>
             <span className={`v4-tpc-batch-status v4-tpc-batch-status--${bf.status}`}>
-              {bf.status === "error" && bf.error ? bf.error : STATUS_LABEL[bf.status]}
+              {bf.status === "error" && bf.error
+                ? bf.error
+                : bf.status === "uploading" && typeof bf.uploadPct === "number"
+                  ? `Загрузка… ${bf.uploadPct}%`
+                  : STATUS_LABEL[bf.status]}
             </span>
           </div>
         ))}

--- a/src/components/v4/transcripts/TranscriptsView.tsx
+++ b/src/components/v4/transcripts/TranscriptsView.tsx
@@ -47,6 +47,10 @@ export function TranscriptsView({ projects }: Props) {
   const [loadingBrief, setLoadingBrief] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
+  // Single-file upload progress (0–100) while the file is being sent to the
+  // server; null when no upload is in flight. Large audio uploads take a
+  // while, so the UploadZone shows a progress bar instead of a frozen button.
+  const [uploadPct, setUploadPct] = useState<number | null>(null);
 
   // Aggregate counters from history (updates with refreshKey + initial load)
   const [agg, setAgg] = useState({ total: 0, active: 0, done: 0, error: 0 });
@@ -86,8 +90,17 @@ export function TranscriptsView({ projects }: Props) {
     setUploadError(null);
     setBriefResult(null);
     setEditing(false);
+    setUploadPct(0);
     try {
-      const res = await uploadTranscript(file, selectedProject, selectedModel);
+      const res = await uploadTranscript(
+        file,
+        selectedProject,
+        selectedModel,
+        undefined,
+        (loaded, total) => {
+          setUploadPct(total > 0 ? Math.round((loaded / total) * 100) : null);
+        },
+      );
       setActiveTaskId(res.task_id);
       setHistoryRefreshKey((k) => k + 1);
     } catch (err) {
@@ -95,6 +108,8 @@ export function TranscriptsView({ projects }: Props) {
       // Re-throw so UploadZone keeps the selected file and the user can retry
       // without having to pick it again.
       throw err;
+    } finally {
+      setUploadPct(null);
     }
   }, [selectedProject, selectedModel]);
 
@@ -126,10 +141,20 @@ export function TranscriptsView({ projects }: Props) {
         activeIds.delete(bf.id);
         return;
       }
-      updateFile(bf.id, { status: "uploading" });
+      updateFile(bf.id, { status: "uploading", uploadPct: 0 });
       try {
-        const res = await uploadTranscript(bf.file, selectedProject, selectedModel);
-        updateFile(bf.id, { status: "done", taskId: res.task_id });
+        const res = await uploadTranscript(
+          bf.file,
+          selectedProject,
+          selectedModel,
+          undefined,
+          (loaded, total) => {
+            updateFile(bf.id, {
+              uploadPct: total > 0 ? Math.round((loaded / total) * 100) : undefined,
+            });
+          },
+        );
+        updateFile(bf.id, { status: "done", taskId: res.task_id, uploadPct: 100 });
       } catch (err) {
         updateFile(bf.id, { status: "error", error: String(err) });
       } finally {
@@ -355,6 +380,7 @@ export function TranscriptsView({ projects }: Props) {
           setSelectedModel={setSelectedModel}
           onSubmit={onSubmitFromZone}
           errorMessage={uploadError}
+          uploadProgress={uploadPct}
         />
       )}
 

--- a/src/components/v4/transcripts/UploadZone.tsx
+++ b/src/components/v4/transcripts/UploadZone.tsx
@@ -15,6 +15,12 @@ interface Props {
   setSelectedModel: (v: TranscriptionModel) => void;
   onSubmit: (files: File[]) => void | Promise<void>;
   errorMessage?: string | null;
+  /**
+   * Upload progress 0–100 for a single-file submit, or null when not
+   * uploading. Drives the progress bar shown while a large audio file is
+   * being sent to the server.
+   */
+  uploadProgress?: number | null;
 }
 
 function getFileExt(name: string): string {
@@ -41,6 +47,7 @@ export function UploadZone({
   setSelectedModel,
   onSubmit,
   errorMessage,
+  uploadProgress,
 }: Props) {
   const [files, setFiles] = useState<File[]>([]);
   const [dragging, setDragging] = useState(false);
@@ -265,12 +272,28 @@ export function UploadZone({
           onClick={handleSubmit}
         >
           {submitting
-            ? "Отправка…"
+            ? typeof uploadProgress === "number"
+              ? `Загрузка… ${uploadProgress}%`
+              : "Отправка…"
             : files.length > 1
               ? `Обработать (${files.length})`
               : "Обработать"}
         </button>
       </div>
+
+      {submitting && typeof uploadProgress === "number" && (
+        <div className="v4-tpc-upload-progress" style={{ marginTop: 12 }}>
+          <div className="v4-ptrack" style={{ height: 6 }}>
+            <div
+              className="v4-pfill"
+              style={{ width: `${uploadProgress}%`, background: "var(--mk-brand-500)" }}
+            />
+          </div>
+          <div className="v4-tpc-text-muted" style={{ marginTop: 6, fontSize: 12 }}>
+            Загрузка файла на сервер… {uploadProgress}% — не закрывайте вкладку
+          </div>
+        </div>
+      )}
 
       {(localError || errorMessage) && (
         <div className="v4-error" style={{ marginTop: 12 }}>

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -384,11 +384,42 @@ const UPLOAD_FIELDS: Record<
   transcription_model: "transcription_model",
 };
 
+/** Upload-progress callback: bytes sent so far and total bytes. */
+export type UploadProgressFn = (loaded: number, total: number) => void;
+
+/**
+ * POST a multipart form via XMLHttpRequest so upload progress is observable.
+ * `fetch` cannot report request-body upload progress, and transcript uploads
+ * can be hundreds of MB of audio — the user needs a progress bar, not a
+ * frozen "Отправка…". No timeout is set (xhr.timeout defaults to 0) so a slow
+ * large upload is not cut off client-side; nginx governs the server side.
+ */
+function postFormWithProgress(
+  url: string,
+  form: FormData,
+  onProgress?: UploadProgressFn,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", url);
+    if (onProgress) {
+      xhr.upload.onprogress = (e: ProgressEvent) => {
+        if (e.lengthComputable) onProgress(e.loaded, e.total);
+      };
+    }
+    xhr.onload = () => resolve({ status: xhr.status, body: xhr.responseText });
+    xhr.onerror = () => reject(new Error("Сетевая ошибка при загрузке файла"));
+    xhr.onabort = () => reject(new Error("Загрузка прервана"));
+    xhr.send(form);
+  });
+}
+
 export async function uploadTranscript(
   file: File,
   project: string,
   transcriptionModel: TranscriptionModel = "quality",
   resumeJobId?: string,
+  onProgress?: UploadProgressFn,
 ): Promise<TranscriptUploadResponse> {
   const form = new FormData();
   form.append("file", file);
@@ -398,18 +429,18 @@ export async function uploadTranscript(
     form.append(UPLOAD_FIELDS.resume, resumeJobId);
   }
 
-  const res = await fetch(`${PIPELINE_BASE_URL}/transcript/upload`, {
-    method: "POST",
-    body: form,
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`Upload failed (${res.status}): ${text}`);
+  const { status, body } = await postFormWithProgress(
+    `${PIPELINE_BASE_URL}/transcript/upload`,
+    form,
+    onProgress,
+  );
+  if (status < 200 || status >= 300) {
+    throw new Error(`Upload failed (${status}): ${body}`);
   }
   // Backend `TranscriptJobResponse` (`{ job_id, status, brief_url }`);
   // adapt to the normalized `TranscriptUploadResponse` (drop `brief_url`,
   // rename `job_id`→`task_id`). Runtime unchanged.
-  const data = (await res.json()) as BackendTranscriptJobResponse;
+  const data = JSON.parse(body) as BackendTranscriptJobResponse;
   return { task_id: data.job_id, status: data.status };
 }
 


### PR DESCRIPTION
## Зачем
Загрузка аудио на расшифровку может весить сотни МБ (свежий кейс — 800 МБ). Сейчас во время отправки кнопка просто показывает «Отправка…» без прогресса, и непонятно, идёт ли загрузка. (Отдельно: nginx-лимит на VPS уже поднят до 2g для маршрута `/transcript/*`, иначе крупный файл отклонялся 413.)

## Что внутри
- **`transcript.ts`**: `uploadTranscript` теперь отправляет через `XMLHttpRequest` с колбэком `onProgress` (`fetch` не умеет отдавать прогресс тела запроса). Без клиентского таймаута, чтобы долгая загрузка не обрывалась.
- **`TranscriptsView`**: хранит процент для одиночной загрузки и для каждого файла в пакете, прокидывает колбэк.
- **`UploadZone`**: полоса прогресса + «Загрузка… N%» во время отправки.
- **`BatchProgressV4`**: «Загрузка… N%» по каждому файлу.

После завершения загрузки UI как и раньше переключается на серверный прогресс обработки (`TranscriptProgressV4`).

## Проверка
- [x] `tsc --noEmit` — чисто
- [x] `eslint` (изменённые файлы) — чисто
- [x] `npm run build` — успешно
- [ ] Live end-to-end на VPS после деплоя (полоса видна при реальной загрузке)

🤖 Generated with [Claude Code](https://claude.com/claude-code)