### PR TITLE
feat(transcripts): frontend support for processing_profile

### DIFF
--- a/src/components/v4/transcripts/TranscriptBriefV4.tsx
+++ b/src/components/v4/transcripts/TranscriptBriefV4.tsx
@@ -32,6 +32,11 @@ const CHECK_ICON: Record<QualityCheck["status"], string> = {
   fail: "✗",
 };
 
+const PROFILE_LABEL: Record<TranscriptResult["processing_profile"], string> = {
+  standard_brief: "Обычный BRIEF",
+  dev_handoff: "Dev handoff",
+};
+
 function plural(n: number, one: string, few: string, many: string): string {
   const m10 = n % 10;
   const m100 = n % 100;
@@ -120,6 +125,9 @@ export function TranscriptBriefV4({ result, onNewUpload, onEdit, onContinueToBri
     <div className="v4-panel v4-tpc-brief-panel">
       <div className="v4-panel-h v4-tpc-brief-h">
         <div className="v4-tpc-brief-counters">
+          <span className="v4-tag" title="Формат BRIEF, выбранный при загрузке">
+            {PROFILE_LABEL[result.processing_profile]}
+          </span>
           {result.quality && (
             result.quality_report ? (
               <button

--- a/src/components/v4/transcripts/TranscriptHistoryV4.tsx
+++ b/src/components/v4/transcripts/TranscriptHistoryV4.tsx
@@ -27,6 +27,17 @@ const STATUS_LABELS: Record<string, string> = {
   error: "Ошибка",
 };
 
+// Short forms — this column is only 90px wide (see .v4-tpc-history-row grid
+// in v4.css); the full name is still available via the `title` tooltip.
+const PROFILE_LABEL: Record<TranscriptListItem["processing_profile"], string> = {
+  standard_brief: "Обычный",
+  dev_handoff: "Dev handoff",
+};
+const PROFILE_LABEL_FULL: Record<TranscriptListItem["processing_profile"], string> = {
+  standard_brief: "Обычный BRIEF",
+  dev_handoff: "Dev handoff",
+};
+
 const STATUS_CLASS: Record<string, string> = {
   done: "v4-tpc-status--done",
   queued: "v4-tpc-status--active",
@@ -467,8 +478,10 @@ export function TranscriptHistoryV4({ onOpen, onResume, onRetry, refreshKey, onI
                     {STATUS_LABELS[item.status] ?? item.status}
                   </span>
                 </div>
-                <div className="v4-tpc-history-cell v4-tpc-history-quality">
-                  <span className="v4-tpc-text-muted">—</span>
+                <div className="v4-tpc-history-cell v4-tpc-history-profile">
+                  <span className="v4-tag" title={PROFILE_LABEL_FULL[item.processing_profile]}>
+                    {PROFILE_LABEL[item.processing_profile]}
+                  </span>
                 </div>
                 <div className="v4-tpc-history-cell v4-tpc-history-actions">
                   {item.status === "done" && (

--- a/src/components/v4/transcripts/TranscriptsView.tsx
+++ b/src/components/v4/transcripts/TranscriptsView.tsx
@@ -6,11 +6,13 @@ import {
   fetchTranscriptList,
   normalizeTranscriptionModel,
   normalizeOutputMode,
+  normalizeProcessingProfile,
   continueToBrief,
   regenerateBrief,
   type TranscriptResult,
   type TranscriptionModel,
   type OutputMode,
+  type ProcessingProfile,
 } from "../../../utils/transcript";
 import type { ProjectConfig } from "../../../types";
 import { UploadZone } from "./UploadZone";
@@ -33,6 +35,7 @@ const STORAGE = {
   project: "tpc:lastProject",
   model: "tpc:lastModel",
   outputMode: "tpc:lastOutputMode",
+  processingProfile: "tpc:lastProcessingProfile",
 };
 
 export function TranscriptsView({ projects }: Props) {
@@ -45,10 +48,16 @@ export function TranscriptsView({ projects }: Props) {
   const [selectedOutputMode, setSelectedOutputMode] = useState<OutputMode>(() => {
     return normalizeOutputMode(localStorage.getItem(STORAGE.outputMode));
   });
+  const [selectedProcessingProfile, setSelectedProcessingProfile] = useState<ProcessingProfile>(() => {
+    return normalizeProcessingProfile(localStorage.getItem(STORAGE.processingProfile));
+  });
 
   useEffect(() => { localStorage.setItem(STORAGE.project, selectedProject); }, [selectedProject]);
   useEffect(() => { localStorage.setItem(STORAGE.model, selectedModel); }, [selectedModel]);
   useEffect(() => { localStorage.setItem(STORAGE.outputMode, selectedOutputMode); }, [selectedOutputMode]);
+  useEffect(() => {
+    localStorage.setItem(STORAGE.processingProfile, selectedProcessingProfile);
+  }, [selectedProcessingProfile]);
 
   // Active task / batch / brief / editor states (mutually exclusive at the
   // top of the page).
@@ -115,6 +124,7 @@ export function TranscriptsView({ projects }: Props) {
           setUploadPct(total > 0 ? Math.round((loaded / total) * 100) : null);
         },
         selectedOutputMode,
+        selectedProcessingProfile,
       );
       setActiveTaskId(res.task_id);
       setHistoryRefreshKey((k) => k + 1);
@@ -126,7 +136,7 @@ export function TranscriptsView({ projects }: Props) {
     } finally {
       setUploadPct(null);
     }
-  }, [selectedProject, selectedModel, selectedOutputMode]);
+  }, [selectedProject, selectedModel, selectedOutputMode, selectedProcessingProfile]);
 
   const onSubmitBatch = useCallback(async (files: File[]) => {
     abortRef.current = false;
@@ -169,6 +179,7 @@ export function TranscriptsView({ projects }: Props) {
             });
           },
           selectedOutputMode,
+          selectedProcessingProfile,
         );
         updateFile(bf.id, { status: "done", taskId: res.task_id, uploadPct: 100 });
       } catch (err) {
@@ -205,7 +216,7 @@ export function TranscriptsView({ projects }: Props) {
       setHistoryRefreshKey((k) => k + 1);
       setBatchActive(false);
     }
-  }, [selectedProject, selectedModel, selectedOutputMode]);
+  }, [selectedProject, selectedModel, selectedOutputMode, selectedProcessingProfile]);
 
   const onSubmitFromZone = useCallback((files: File[]) => {
     if (files.length === 1) return onSubmitSingle(files[0]);
@@ -454,6 +465,8 @@ export function TranscriptsView({ projects }: Props) {
           setSelectedModel={setSelectedModel}
           selectedOutputMode={selectedOutputMode}
           setSelectedOutputMode={setSelectedOutputMode}
+          selectedProcessingProfile={selectedProcessingProfile}
+          setSelectedProcessingProfile={setSelectedProcessingProfile}
           onSubmit={onSubmitFromZone}
           errorMessage={uploadError}
           uploadProgress={uploadPct}

--- a/src/components/v4/transcripts/UploadZone.tsx
+++ b/src/components/v4/transcripts/UploadZone.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import type { ProjectConfig } from "../../../types";
-import type { OutputMode, TranscriptionModel } from "../../../utils/transcript";
+import type { OutputMode, ProcessingProfile, TranscriptionModel } from "../../../utils/transcript";
 
 const VALID_EXTENSIONS = ["mp3", "wav", "m4a", "txt", "md"];
 const AUDIO_EXTENSIONS = ["mp3", "wav", "m4a"];
@@ -15,6 +15,8 @@ interface Props {
   setSelectedModel: (v: TranscriptionModel) => void;
   selectedOutputMode: OutputMode;
   setSelectedOutputMode: (v: OutputMode) => void;
+  selectedProcessingProfile: ProcessingProfile;
+  setSelectedProcessingProfile: (v: ProcessingProfile) => void;
   onSubmit: (files: File[]) => void | Promise<void>;
   errorMessage?: string | null;
   /**
@@ -49,6 +51,8 @@ export function UploadZone({
   setSelectedModel,
   selectedOutputMode,
   setSelectedOutputMode,
+  selectedProcessingProfile,
+  setSelectedProcessingProfile,
   onSubmit,
   errorMessage,
   uploadProgress,
@@ -263,6 +267,28 @@ export function UploadZone({
               title="Быстрый очищенный транскрипт без полной обработки"
             >
               📄 Транскрипт
+            </button>
+          </div>
+        </fieldset>
+
+        <fieldset className="v4-tpc-control-field">
+          <span className="v4-tpc-control-key">Формат BRIEF</span>
+          <div className="v4-pillgrp">
+            <button
+              type="button"
+              className={selectedProcessingProfile === "standard_brief" ? "is-active" : ""}
+              onClick={() => setSelectedProcessingProfile("standard_brief")}
+              title="Стандартная структура BRIEF"
+            >
+              Обычный
+            </button>
+            <button
+              type="button"
+              className={selectedProcessingProfile === "dev_handoff" ? "is-active" : ""}
+              onClick={() => setSelectedProcessingProfile("dev_handoff")}
+              title="Требования, решения, action items, риски — для передачи в разработку"
+            >
+              Для разработки
             </button>
           </div>
         </fieldset>

--- a/src/types/generated/pipeline.openapi.json
+++ b/src/types/generated/pipeline.openapi.json
@@ -326,6 +326,15 @@
             "title": "Output Mode",
             "type": "string"
           },
+          "processing_profile": {
+            "default": "standard_brief",
+            "enum": [
+              "standard_brief",
+              "dev_handoff"
+            ],
+            "title": "Processing Profile",
+            "type": "string"
+          },
           "project_context": {
             "default": "",
             "title": "Project Context",
@@ -2606,6 +2615,11 @@
             "title": "Job Id",
             "type": "string"
           },
+          "processing_profile": {
+            "default": "standard_brief",
+            "title": "Processing Profile",
+            "type": "string"
+          },
           "project": {
             "title": "Project",
             "type": "string"
@@ -2681,6 +2695,11 @@
           "primary_artifact": {
             "default": "brief",
             "title": "Primary Artifact",
+            "type": "string"
+          },
+          "processing_profile": {
+            "default": "standard_brief",
+            "title": "Processing Profile",
             "type": "string"
           },
           "project": {

--- a/src/types/generated/pipeline.ts
+++ b/src/types/generated/pipeline.ts
@@ -1732,6 +1732,12 @@ export interface components {
              */
             output_mode: string;
             /**
+             * Processing Profile
+             * @default standard_brief
+             * @enum {string}
+             */
+            processing_profile: "standard_brief" | "dev_handoff";
+            /**
              * Project Context
              * @default
              */
@@ -2839,6 +2845,11 @@ export interface components {
             file_type: string;
             /** Job Id */
             job_id: string;
+            /**
+             * Processing Profile
+             * @default standard_brief
+             */
+            processing_profile: string;
             /** Project */
             project: string;
             /** Status */
@@ -2901,6 +2912,11 @@ export interface components {
              * @default brief
              */
             primary_artifact: string;
+            /**
+             * Processing Profile
+             * @default standard_brief
+             */
+            processing_profile: string;
             /**
              * Project
              * @default

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -50,6 +50,25 @@ export function normalizeOutputMode(raw: unknown): OutputMode {
 }
 
 /**
+ * BRIEF synthesis profile (makeit-pipeline #1300) — orthogonal to
+ * `OutputMode`: `output_mode` picks WHICH artifact is generated (brief vs.
+ * normalized_transcript), `processing_profile` picks the STRUCTURE/tone of
+ * the BRIEF itself once one is generated. Unlike `OutputMode`, the backend
+ * `Body_upload_...` field is a real `Literal[...]` enum in the generated
+ * schema (see `components["schemas"]["Body_upload_transcript_transcript_upload_post"]["processing_profile"]`),
+ * but the two response models (`TranscriptResultResponse`/`TranscriptListItem`)
+ * still type it as free-text `string` — normalized the same defensive way
+ * as `normalizeOutputMode` so an unrecognized backend value (or an absent
+ * field from a pre-#1300 row) falls back to "standard_brief" instead of
+ * silently typing as something invalid.
+ */
+export type ProcessingProfile = "standard_brief" | "dev_handoff";
+
+export function normalizeProcessingProfile(raw: unknown): ProcessingProfile {
+  return raw === "dev_handoff" ? "dev_handoff" : "standard_brief";
+}
+
+/**
  * Normalized result of `uploadTranscript`/`retryTranscript`. Deliberate
  * frontend-derived shape, NOT the wire contract: the backend returns
  * `TranscriptJobResponse` (`{ job_id, status, brief_url }`); the client
@@ -265,6 +284,11 @@ function adaptQualityReport(raw: unknown): QualityReport | null {
  * deliverable for this job and whether a speaker merge has invalidated
  * an existing BRIEF — see `primary_artifact` docs on the backend
  * `TranscriptResultResponse` model.
+ *
+ * `processing_profile` (#1300) is the profile the job was UPLOADED (or
+ * resumed) with — persisted backend-side, not re-derived from the current
+ * request. For a `normalized_transcript` job it is the profile `continueToBrief`
+ * will use once the user asks for a BRIEF.
  */
 export interface TranscriptResult {
   task_id: string;
@@ -276,6 +300,7 @@ export interface TranscriptResult {
   primary_artifact: OutputMode; // which of `brief` / `normalized_transcript` is the deliverable
   normalized_transcript: string; // STT-corrected transcript; populated whenever the stt stage has run
   brief_stale: boolean; // true once a speaker merge invalidated an existing BRIEF (see regenerateBrief)
+  processing_profile: ProcessingProfile; // BRIEF format the job was created/resumed with (see normalizeProcessingProfile)
 }
 
 export async function fetchTranscriptResult(taskId: string): Promise<TranscriptResult> {
@@ -302,6 +327,7 @@ export async function fetchTranscriptResult(taskId: string): Promise<TranscriptR
     primary_artifact: normalizeOutputMode(data.primary_artifact),
     normalized_transcript: data.normalized_transcript || "",
     brief_stale: data.brief_stale ?? false,
+    processing_profile: normalizeProcessingProfile(data.processing_profile),
   };
 }
 
@@ -331,6 +357,10 @@ export function normalizeTranscriptionModel(raw: unknown): TranscriptionModel | 
  * narrowing is best-effort: `fetchTranscriptList` passes the backend
  * string through, and consumers compare it against known literals /
  * fall back to the raw string for unknown values. Runtime preserved.
+ *
+ * `processing_profile` (#1300) is normalized the same way as on
+ * `TranscriptResult` — a pre-#1300 row has no such field server-side and
+ * defaults to "standard_brief" (`normalizeProcessingProfile`).
  */
 export interface TranscriptListItem {
   task_id: string;
@@ -339,6 +369,7 @@ export interface TranscriptListItem {
   status: "done" | "queued" | "transcribing" | "processing" | "error";
   created_at: string; // ISO timestamp
   transcription_model?: TranscriptionModel;
+  processing_profile: ProcessingProfile;
 }
 
 export async function fetchTranscriptList(): Promise<TranscriptListItem[]> {
@@ -363,6 +394,7 @@ export async function fetchTranscriptList(): Promise<TranscriptListItem[]> {
     status: item.status as TranscriptListItem["status"],
     created_at: item.created_at || "",
     transcription_model: normalizeTranscriptionModel(item.transcription_model),
+    processing_profile: normalizeProcessingProfile(item.processing_profile),
   }));
 }
 
@@ -415,7 +447,8 @@ export async function saveTranscriptBrief(
 // earlier work and are listed here only to satisfy the exhaustive
 // `Record<keyof Body, ...>` constraint — this client doesn't expose UI
 // for them yet and doesn't append them to the form (backend defaults
-// apply). Only `output_mode` is actually used, by `uploadTranscript`.
+// apply). Only `output_mode` and `processing_profile` are actually used,
+// by `uploadTranscript`.
 const UPLOAD_FIELDS: Record<
   keyof components["schemas"]["Body_upload_transcript_transcript_upload_post"],
   string
@@ -424,6 +457,7 @@ const UPLOAD_FIELDS: Record<
   language: "language",
   meeting_type: "meeting_type",
   output_mode: "output_mode",
+  processing_profile: "processing_profile",
   project_context: "project_context",
   resume: "resume",
   stt_backend: "stt_backend",
@@ -468,12 +502,14 @@ export async function uploadTranscript(
   resumeJobId?: string,
   onProgress?: UploadProgressFn,
   outputMode: OutputMode = "brief",
+  processingProfile: ProcessingProfile = "standard_brief",
 ): Promise<TranscriptUploadResponse> {
   const form = new FormData();
   form.append("file", file);
   form.append(UPLOAD_FIELDS.project_context, project);
   form.append(UPLOAD_FIELDS.transcription_model, transcriptionModel);
   form.append(UPLOAD_FIELDS.output_mode, outputMode);
+  form.append(UPLOAD_FIELDS.processing_profile, processingProfile);
   if (resumeJobId) {
     form.append(UPLOAD_FIELDS.resume, resumeJobId);
   }

--- a/tests/transcript-brief-v4.test.tsx
+++ b/tests/transcript-brief-v4.test.tsx
@@ -16,6 +16,7 @@ function makeResult(overrides: Partial<TranscriptResult> = {}): TranscriptResult
     primary_artifact: "brief",
     normalized_transcript: "",
     brief_stale: false,
+    processing_profile: "standard_brief",
     ...overrides,
   };
 }
@@ -135,5 +136,31 @@ describe("TranscriptBriefV4 — primary_artifact rendering", () => {
       />,
     );
     expect(screen.queryByText("Нормализованный транскрипт")).toBeNull();
+  });
+});
+
+describe("TranscriptBriefV4 — processing_profile badge", () => {
+  it("shows the 'Обычный BRIEF' badge for a standard_brief job", () => {
+    render(
+      <TranscriptBriefV4
+        result={makeResult({ processing_profile: "standard_brief" })}
+        onNewUpload={vi.fn()}
+        onEdit={vi.fn()}
+        onContinueToBrief={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Обычный BRIEF")).toBeTruthy();
+  });
+
+  it("shows the 'Dev handoff' badge for a dev_handoff job", () => {
+    render(
+      <TranscriptBriefV4
+        result={makeResult({ processing_profile: "dev_handoff" })}
+        onNewUpload={vi.fn()}
+        onEdit={vi.fn()}
+        onContinueToBrief={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Dev handoff")).toBeTruthy();
   });
 });

--- a/tests/transcript-client.test.ts
+++ b/tests/transcript-client.test.ts
@@ -8,6 +8,7 @@ import {
   regenerateBrief,
   normalizeTranscriptionModel,
   normalizeOutputMode,
+  normalizeProcessingProfile,
   uploadTranscript,
 } from "../src/utils/transcript";
 
@@ -146,6 +147,82 @@ describe("transcript client", () => {
     });
   });
 
+  it("normalizes processing_profile, defaulting unknown/absent values to standard_brief", () => {
+    expect(normalizeProcessingProfile("dev_handoff")).toBe("dev_handoff");
+    expect(normalizeProcessingProfile("standard_brief")).toBe("standard_brief");
+    expect(normalizeProcessingProfile(undefined)).toBe("standard_brief");
+    expect(normalizeProcessingProfile("unknown")).toBe("standard_brief");
+  });
+
+  it("fetchTranscriptResult maps processing_profile, defaulting to standard_brief when absent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({ job_id: "job-3b", brief_content: "# BRIEF" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(fetchTranscriptResult("job-3b")).resolves.toMatchObject({
+      processing_profile: "standard_brief",
+    });
+  });
+
+  it("fetchTranscriptResult passes through a dev_handoff processing_profile", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            job_id: "job-3c",
+            brief_content: "# Dev Handoff",
+            processing_profile: "dev_handoff",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(fetchTranscriptResult("job-3c")).resolves.toMatchObject({
+      processing_profile: "dev_handoff",
+    });
+  });
+
+  it("fetchTranscriptList maps processing_profile, defaulting to standard_brief when absent (legacy rows predating processing_profile)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify([
+            {
+              job_id: "job-3d",
+              project: "mankassa-app",
+              file_name: "legacy.mp3",
+              status: "done",
+              created_at: "2026-05-01T10:00:00Z",
+            },
+            {
+              job_id: "job-3e",
+              project: "mankassa-app",
+              file_name: "handoff.mp3",
+              status: "done",
+              created_at: "2026-05-02T10:00:00Z",
+              processing_profile: "dev_handoff",
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(fetchTranscriptList()).resolves.toMatchObject([
+      { task_id: "job-3d", processing_profile: "standard_brief" },
+      { task_id: "job-3e", processing_profile: "dev_handoff" },
+    ]);
+  });
+
   it("uploadTranscript includes output_mode in the multipart form", async () => {
     class FakeXHR {
       static instances: FakeXHR[] = [];
@@ -213,6 +290,76 @@ describe("transcript client", () => {
     expect(xhr.sentBody?.get("output_mode")).toBe("brief");
 
     xhr.responseText = JSON.stringify({ job_id: "job-6", status: "queued", brief_url: "" });
+    xhr.onload?.();
+    await promise;
+  });
+
+  it("uploadTranscript includes processing_profile in the multipart form", async () => {
+    class FakeXHR {
+      static instances: FakeXHR[] = [];
+      upload: { onprogress: ((e: ProgressEvent) => void) | null } = { onprogress: null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      onabort: (() => void) | null = null;
+      status = 200;
+      responseText = "";
+      sentBody: FormData | null = null;
+      open() {
+        /* no-op */
+      }
+      send(body: FormData) {
+        this.sentBody = body;
+        FakeXHR.instances.push(this);
+      }
+    }
+    vi.stubGlobal("XMLHttpRequest", FakeXHR as unknown as typeof XMLHttpRequest);
+
+    const file = new File(["hello"], "meeting.txt", { type: "text/plain" });
+    const promise = uploadTranscript(
+      file,
+      "proj",
+      "quality",
+      undefined,
+      undefined,
+      "brief",
+      "dev_handoff",
+    );
+
+    const xhr = FakeXHR.instances[0];
+    expect(xhr.sentBody?.get("processing_profile")).toBe("dev_handoff");
+
+    xhr.responseText = JSON.stringify({ job_id: "job-6b", status: "queued", brief_url: "" });
+    xhr.onload?.();
+    await promise;
+  });
+
+  it("uploadTranscript defaults processing_profile to standard_brief when not passed", async () => {
+    class FakeXHR {
+      static instances: FakeXHR[] = [];
+      upload: { onprogress: ((e: ProgressEvent) => void) | null } = { onprogress: null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      onabort: (() => void) | null = null;
+      status = 200;
+      responseText = "";
+      sentBody: FormData | null = null;
+      open() {
+        /* no-op */
+      }
+      send(body: FormData) {
+        this.sentBody = body;
+        FakeXHR.instances.push(this);
+      }
+    }
+    vi.stubGlobal("XMLHttpRequest", FakeXHR as unknown as typeof XMLHttpRequest);
+
+    const file = new File(["hello"], "meeting.txt", { type: "text/plain" });
+    const promise = uploadTranscript(file, "proj");
+
+    const xhr = FakeXHR.instances[0];
+    expect(xhr.sentBody?.get("processing_profile")).toBe("standard_brief");
+
+    xhr.responseText = JSON.stringify({ job_id: "job-6c", status: "queued", brief_url: "" });
     xhr.onload?.();
     await promise;
   });

--- a/tests/transcript-history-v4-profile.test.tsx
+++ b/tests/transcript-history-v4-profile.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { TranscriptHistoryV4 } from "../src/components/v4/transcripts/TranscriptHistoryV4";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
+  mockFetch.mockReset();
+  localStorage.clear();
+});
+afterEach(cleanup);
+
+function jsonResp(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const ITEMS = [
+  {
+    job_id: "job-standard",
+    project: "mankassa-app",
+    file_name: "standard.mp3",
+    status: "done",
+    created_at: "2026-05-01T10:00:00Z",
+    file_type: "audio",
+    transcription_model: "quality",
+    processing_profile: "standard_brief",
+  },
+  {
+    job_id: "job-dev",
+    project: "mankassa-app",
+    file_name: "dev.mp3",
+    status: "done",
+    created_at: "2026-05-02T10:00:00Z",
+    file_type: "audio",
+    transcription_model: "quality",
+    processing_profile: "dev_handoff",
+  },
+  {
+    job_id: "job-legacy",
+    project: "mankassa-app",
+    file_name: "legacy.mp3",
+    status: "done",
+    created_at: "2026-04-01T10:00:00Z",
+    file_type: "audio",
+    transcription_model: "quality",
+    // no processing_profile — pre-#1300 row
+  },
+];
+
+describe("TranscriptHistoryV4 — processing_profile badge", () => {
+  it("shows a profile badge for standard_brief, dev_handoff, and legacy (defaulted) rows", async () => {
+    mockFetch.mockImplementation(() => Promise.resolve(jsonResp(ITEMS)));
+    render(
+      <TranscriptHistoryV4
+        onOpen={vi.fn()}
+        onResume={vi.fn()}
+        onRetry={vi.fn()}
+        refreshKey={0}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("standard.mp3")).toBeTruthy());
+
+    const badges = screen.getAllByTitle("Обычный BRIEF");
+    expect(badges.length).toBe(2); // job-standard + job-legacy (defaulted)
+    expect(screen.getByTitle("Dev handoff").textContent).toBe("Dev handoff");
+  });
+});

--- a/tests/transcript-upload-processing-profile.test.tsx
+++ b/tests/transcript-upload-processing-profile.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { UploadZone } from "../src/components/v4/transcripts/UploadZone";
+import type { ProjectConfig } from "../src/types";
+
+afterEach(cleanup);
+
+const PROJECTS: ProjectConfig[] = [
+  { repo: "mankassa-app", client: "Сергей", owner: "Sergio1990-1", budget: 0, paid: 0 },
+];
+
+function renderUploadZone(overrides: Partial<Parameters<typeof UploadZone>[0]> = {}) {
+  const setSelectedProcessingProfile = vi.fn();
+  const props = {
+    projects: PROJECTS,
+    selectedProject: "mankassa-app",
+    setSelectedProject: vi.fn(),
+    selectedModel: "quality" as const,
+    setSelectedModel: vi.fn(),
+    selectedOutputMode: "brief" as const,
+    setSelectedOutputMode: vi.fn(),
+    selectedProcessingProfile: "standard_brief" as const,
+    setSelectedProcessingProfile,
+    onSubmit: vi.fn(),
+    ...overrides,
+  };
+  const utils = render(<UploadZone {...props} />);
+  return { ...utils, setSelectedProcessingProfile };
+}
+
+describe("UploadZone processing_profile selector", () => {
+  it("defaults to Обычный selected", () => {
+    renderUploadZone();
+    const standardBtn = screen.getByText("Обычный");
+    expect(standardBtn.className).toContain("is-active");
+  });
+
+  it("switches to dev_handoff when the Для разработки pill is clicked", () => {
+    const { setSelectedProcessingProfile } = renderUploadZone();
+    fireEvent.click(screen.getByText("Для разработки"));
+    expect(setSelectedProcessingProfile).toHaveBeenCalledWith("dev_handoff");
+  });
+
+  it("reflects dev_handoff as the active pill when selected", () => {
+    renderUploadZone({ selectedProcessingProfile: "dev_handoff" });
+    expect(screen.getByText("Для разработки").className).toContain("is-active");
+    expect(screen.getByText("Обычный").className).not.toContain("is-active");
+  });
+
+  it("shows the profile selector regardless of file type (not gated on audio)", () => {
+    renderUploadZone();
+    expect(screen.getByText("Формат BRIEF")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Frontend counterpart to makeit-pipeline [#1300](https://github.com/Sergio1990-1/makeit-pipeline/pull/1300), which added a backend `processing_profile` field (`standard_brief` | `dev_handoff`) controlling the BRIEF's synthesis structure — orthogonal to the existing `output_mode` (brief vs. normalized_transcript).

- **Upload UI**: new "Формат BRIEF" pill selector (Обычный / Для разработки) in `UploadZone`, alongside the existing Результат/Модель selectors. Selection persists in `localStorage` (same pattern as `selectedOutputMode`/`selectedModel`) and is sent as `processing_profile` for both `brief` and `normalized_transcript` uploads.
- **Result view** (`TranscriptBriefV4`): compact badge ("Обычный BRIEF" / "Dev handoff") next to the quality/marker counters.
- **History** (`TranscriptHistoryV4`): repurposed the previously-dead, always-`—` "quality" column into a real profile badge (short form + full-name tooltip) — no new column, no CSS grid changes.
- **API client** (`utils/transcript.ts`): `ProcessingProfile` type + `normalizeProcessingProfile` (defaults unknown/absent → `standard_brief`, mirroring `normalizeOutputMode`); `uploadTranscript` gained a `processingProfile` param (multipart `processing_profile` field); `TranscriptResult`/`TranscriptListItem` gained a `processing_profile` field populated from the backend response.
- **OpenAPI snapshot**: targeted patch of `pipeline.openapi.json` (`Body_upload_transcript_...`, `TranscriptListItem`, `TranscriptResultResponse`) sourced from a locally-instantiated `create_app().openapi()` against the merged #1300 backend, then `pipeline.ts` regenerated via `npm run gen:api-types:pipeline` — verified this produces a zero-diff regen before patching, so no unrelated OpenAPI drift is included.

## Compatibility / migration story

- **`output_mode` contract is untouched** — `processing_profile` is a fully independent field; no existing behavior changes for callers that don't send it.
- **`continueToBrief`/`regenerateBrief` intentionally take no profile parameter** — the backend always uses the job's stored profile (manifest-pinned), matching the pre-existing `output_mode` non-passthrough on the same two calls. No frontend change needed there; verified via test that continue/regenerate flows re-fetch and display the backend-stored profile after completion.
- **Legacy rows (pre-#1300, no `processing_profile` in the backend response) default to `standard_brief`** on read — same defensive-default pattern as `normalizeOutputMode`/`normalizeTranscriptionModel`. Covered by tests (`fetchTranscriptResult`/`fetchTranscriptList` absent-field cases, history badge for a legacy row).
- Dashboard is **not deployed** by this PR; no backend changes included (backend already merged/live via #1300).

## Test plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit -p tsconfig.app.json`
- [x] `npx vitest run` — 227/227 passed (2 new test files, 2 extended)
- [x] `npm run build`
- [x] Manual browser verification via a temporary, fully-reverted dev-preview route (mocked `/transcript/list` + `/transcript/result`): selector toggle, history badges (standard/dev/legacy-defaulted), and BRIEF-view badge all render correctly — screenshots taken, then all preview scaffolding deleted (`git status` clean of it)
- No e2e specs currently touch the transcripts UI, so Playwright/`test:e2e:typecheck` wasn't run (nothing to regress there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)