### PR TITLE
feat(transcripts): DOCX download button

### DIFF
--- a/src/components/v4/transcripts/TranscriptBriefV4.tsx
+++ b/src/components/v4/transcripts/TranscriptBriefV4.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
 import { renderBriefHtml, renderMarkdownHtml } from "../../../utils/transcript-markdown";
-import type { QualityCheck, TranscriptQuality, TranscriptResult } from "../../../utils/transcript";
+import {
+  downloadTranscriptDocx,
+  type QualityCheck,
+  type TranscriptQuality,
+  type TranscriptResult,
+} from "../../../utils/transcript";
 
 interface Props {
   result: TranscriptResult;
@@ -57,6 +62,8 @@ export function TranscriptBriefV4({ result, onNewUpload, onEdit, onContinueToBri
   const [copied, setCopied] = useState(false);
   const [continuing, setContinuing] = useState(false);
   const [continueError, setContinueError] = useState<string | null>(null);
+  const [downloadingDocx, setDownloadingDocx] = useState(false);
+  const [docxError, setDocxError] = useState<string | null>(null);
 
   // primary_artifact decides what the MAIN content area shows — a
   // normalized_transcript-only job never generated brief_content, so
@@ -108,6 +115,18 @@ export function TranscriptBriefV4({ result, onNewUpload, onEdit, onContinueToBri
       setTimeout(() => setCopied(false), 2000);
     }
   }, [primaryText]);
+
+  const handleDownloadDocx = useCallback(async () => {
+    setDownloadingDocx(true);
+    setDocxError(null);
+    try {
+      await downloadTranscriptDocx(result.task_id);
+    } catch (err) {
+      setDocxError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setDownloadingDocx(false);
+    }
+  }, [result.task_id]);
 
   const handleContinue = useCallback(async () => {
     setContinuing(true);
@@ -171,6 +190,14 @@ export function TranscriptBriefV4({ result, onNewUpload, onEdit, onContinueToBri
           <button type="button" className="v4-btn" onClick={onDownload}>
             Скачать .md
           </button>
+          <button
+            type="button"
+            className="v4-btn"
+            disabled={downloadingDocx}
+            onClick={handleDownloadDocx}
+          >
+            {downloadingDocx ? "Скачивание…" : "Скачать DOCX"}
+          </button>
           {result.output_mode === "normalized_transcript" && (
             <button
               type="button"
@@ -188,6 +215,7 @@ export function TranscriptBriefV4({ result, onNewUpload, onEdit, onContinueToBri
       </div>
 
       {continueError && <div className="v4-error">{continueError}</div>}
+      {docxError && <div className="v4-error">{docxError}</div>}
 
       {result.quality && result.quality_report && (
         <div

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -653,6 +653,44 @@ export async function regenerateBrief(taskId: string): Promise<TranscriptUploadR
 }
 
 /**
+ * `GET /transcript/result/{job_id}/export/docx` (makeit-pipeline #1301) —
+ * download the job's primary artifact (BRIEF or normalized_transcript,
+ * whichever `TranscriptResult.primary_artifact` currently is — the backend
+ * selects the same way `fetchTranscriptResult` does) as a DOCX file and
+ * trigger a browser download. Pure read-and-convert on the backend: it
+ * costs no LLM/STT work and is safe to call repeatedly.
+ *
+ * Throws a friendly Russian message for 404 (job gone) / 422 (artifact not
+ * generated yet) — callers display `err.message` inline, same convention
+ * as `continueToBrief`/`regenerateBrief`.
+ */
+export async function downloadTranscriptDocx(taskId: string): Promise<void> {
+  const res = await fetch(
+    `${PIPELINE_BASE_URL}/transcript/result/${encodeURIComponent(taskId)}/export/docx`,
+  );
+  if (!res.ok) {
+    const detail = extractErrorDetail(await res.text().catch(() => ""));
+    if (res.status === 404) throw new Error("Задача не найдена — возможно, она была удалена.");
+    if (res.status === 422) throw new Error(`Нельзя скачать DOCX: ${detail}`);
+    throw new Error(`Export failed (${res.status}): ${detail}`);
+  }
+  const blob = await res.blob();
+  // Filename comes from the backend's Content-Disposition header
+  // ("BRIEF-{id}.docx" / "transcript-{id}.docx") — the client doesn't need
+  // to re-derive the primary_artifact naming convention itself.
+  const disposition = res.headers.get("content-disposition") || "";
+  const match = disposition.match(/filename="?([^";]+)"?/);
+  const filename = match ? match[1] : `transcript-${taskId}.docx`;
+
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+/**
  * `GET /transcript/{job_id}/speakers` — the dashboard's normalized
  * refinement of the backend `SpeakersResponse`. `id`/`labels` are the
  * ORIGINAL diarization labels (e.g. "SPEAKER_00") — permanent for the

--- a/tests/transcript-brief-v4.test.tsx
+++ b/tests/transcript-brief-v4.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { TranscriptBriefV4 } from "../src/components/v4/transcripts/TranscriptBriefV4";
 import type { TranscriptResult } from "../src/utils/transcript";
@@ -162,5 +162,105 @@ describe("TranscriptBriefV4 — processing_profile badge", () => {
       />,
     );
     expect(screen.getByText("Dev handoff")).toBeTruthy();
+  });
+});
+
+describe("TranscriptBriefV4 — DOCX download", () => {
+  beforeEach(() => {
+    URL.createObjectURL = vi.fn(() => "blob:mock-url");
+    URL.revokeObjectURL = vi.fn();
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  });
+
+  it("shows the DOCX download button for a brief-primary result", () => {
+    render(
+      <TranscriptBriefV4
+        result={makeResult()}
+        onNewUpload={vi.fn()}
+        onEdit={vi.fn()}
+        onContinueToBrief={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Скачать DOCX")).toBeTruthy();
+  });
+
+  it("shows the DOCX download button for a normalized_transcript-primary result", () => {
+    render(
+      <TranscriptBriefV4
+        result={makeResult({
+          brief: "",
+          output_mode: "normalized_transcript",
+          primary_artifact: "normalized_transcript",
+          normalized_transcript: "# Транскрипт\n\nПривет",
+        })}
+        onNewUpload={vi.fn()}
+        onEdit={vi.fn()}
+        onContinueToBrief={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Скачать DOCX")).toBeTruthy();
+  });
+
+  it("clicking the button calls the export endpoint and triggers a browser download", async () => {
+    const blob = new Blob(["docx-bytes"], {
+      type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(blob, {
+          status: 200,
+          headers: { "content-disposition": 'attachment; filename="BRIEF-job-1.docx"' },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <TranscriptBriefV4
+        result={makeResult()}
+        onNewUpload={vi.fn()}
+        onEdit={vi.fn()}
+        onContinueToBrief={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Скачать DOCX"));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      "/transcript/result/job-1/export/docx",
+    );
+    await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalled());
+  });
+
+  it("shows a recoverable inline error, without crashing, when the download fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ detail: "Job job-1 has no brief content to export yet" }),
+            { status: 422 },
+          ),
+      ),
+    );
+
+    render(
+      <TranscriptBriefV4
+        result={makeResult()}
+        onNewUpload={vi.fn()}
+        onEdit={vi.fn()}
+        onContinueToBrief={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Скачать DOCX"));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Нельзя скачать DOCX/)).toBeTruthy(),
+    );
+    // Button is back to its idle label, not stuck — and the rest of the
+    // panel (e.g. the BRIEF content) is still rendered, not crashed.
+    expect(screen.getByText("Скачать DOCX")).toBeTruthy();
+    expect(screen.getByText("Решение принято.")).toBeTruthy();
   });
 });

--- a/tests/transcript-client.test.ts
+++ b/tests/transcript-client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchTranscriptList,
   fetchTranscriptResult,
@@ -6,6 +6,7 @@ import {
   mergeTranscriptSpeakers,
   continueToBrief,
   regenerateBrief,
+  downloadTranscriptDocx,
   normalizeTranscriptionModel,
   normalizeOutputMode,
   normalizeProcessingProfile,
@@ -442,6 +443,86 @@ describe("transcript client", () => {
     await expect(regenerateBrief("job-9")).resolves.toMatchObject({
       task_id: "job-9",
       status: "queued",
+    });
+  });
+
+  describe("downloadTranscriptDocx", () => {
+    beforeEach(() => {
+      URL.createObjectURL = vi.fn(() => "blob:mock-url");
+      URL.revokeObjectURL = vi.fn();
+      vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    });
+
+    it("fetches the export endpoint and triggers a browser download using the Content-Disposition filename", async () => {
+      const blob = new Blob(["docx-bytes"], {
+        type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      });
+      const fetchMock = vi.fn(
+        async () =>
+          new Response(blob, {
+            status: 200,
+            headers: { "content-disposition": 'attachment; filename="BRIEF-job-12.docx"' },
+          }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await downloadTranscriptDocx("job-12");
+
+      expect(String(fetchMock.mock.calls[0][0])).toContain(
+        "/transcript/result/job-12/export/docx",
+      );
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+      expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to a transcript-{id}.docx filename when Content-Disposition is missing", async () => {
+      const blob = new Blob(["docx-bytes"]);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => new Response(blob, { status: 200 })),
+      );
+
+      let capturedFilename = "";
+      const originalCreateElement = document.createElement.bind(document);
+      vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+        const el = originalCreateElement(tag);
+        if (tag === "a") {
+          Object.defineProperty(el, "download", {
+            set: (v: string) => {
+              capturedFilename = v;
+            },
+            get: () => capturedFilename,
+          });
+        }
+        return el;
+      });
+
+      await downloadTranscriptDocx("job-13");
+
+      expect(capturedFilename).toBe("transcript-job-13.docx");
+    });
+
+    it("throws a friendly message for 404", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => new Response(JSON.stringify({ detail: "Job job-14 not found" }), { status: 404 })),
+      );
+      await expect(downloadTranscriptDocx("job-14")).rejects.toThrow(/не найдена/);
+    });
+
+    it("surfaces the backend detail for 422 (missing artifact)", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(
+          async () =>
+            new Response(
+              JSON.stringify({ detail: "Job job-15 has no brief content to export yet" }),
+              { status: 422 },
+            ),
+        ),
+      );
+      await expect(downloadTranscriptDocx("job-15")).rejects.toThrow(/no brief content to export yet/);
     });
   });
 


### PR DESCRIPTION
## Summary

Frontend counterpart to makeit-pipeline [#1301](https://github.com/Sergio1990-1/makeit-pipeline/pull/1301), which adds `GET /transcript/result/{job_id}/export/docx`.

- **`downloadTranscriptDocx(taskId)`** (`src/utils/transcript.ts`): fetches the export endpoint, derives the filename from the backend's `Content-Disposition` header (falls back to `transcript-{id}.docx` if absent), and triggers a browser download via the same `URL.createObjectURL`/`<a>`/`revokeObjectURL` pattern already used by the existing "Скачать .md" handler. Throws friendly Russian messages for 404/422, same convention as `continueToBrief`/`regenerateBrief`.
- **"Скачать DOCX" button** in `TranscriptBriefV4`, right next to the existing "Скачать .md" button — works for both BRIEF-primary and normalized_transcript-primary results (the backend picks the right artifact). The existing Markdown download button is unchanged.
- Errors surface inline (`v4-error`, same as the `continueToBrief` error banner) without breaking the rest of the panel; the button returns to its idle label on failure instead of getting stuck.

## Zero LLM/STT cost

This button calls an endpoint that **only reads already-generated content and converts it to DOCX** — no re-transcription, no re-synthesis, safe to click repeatedly.

## Tests

- `tests/transcript-client.test.ts`: `downloadTranscriptDocx` — fetches the right URL and triggers a download using the Content-Disposition filename, falls back to a default filename when the header is missing, throws friendly messages for 404/422.
- `tests/transcript-brief-v4.test.tsx`: button visible for both brief-primary and normalized_transcript-primary results, click calls the export endpoint and triggers `URL.createObjectURL`, and a failed download shows an inline error without crashing the rest of the panel.

## Validation

- `npm run lint` — clean
- `npx tsc --noEmit -p tsconfig.app.json` — clean
- `npx vitest run` — 235/235 passed
- `npm run build` — clean
- Manual browser verification via a temporary, fully-reverted dev-preview route (mocked `/transcript/list`, `/transcript/result`, `/export/docx`): button renders next to "Скачать .md", click triggers a real file download with the correct filename (`BRIEF-job-standard.docx`) and no console errors — screenshots taken, then all preview scaffolding deleted (`git status` clean of it, confirmed `main.tsx` diff is empty)

No merge/deploy — opening for review per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)