### PR TITLE
feat(transcripts): warn banner for uncertain speakers before BRIEF finalization (#545)

### DIFF
--- a/src/components/v4/transcripts/TranscriptSpeakersV4.tsx
+++ b/src/components/v4/transcripts/TranscriptSpeakersV4.tsx
@@ -15,9 +15,19 @@ interface Props {
    *  the parent can combine `speakers.brief_stale` with `result.brief_stale`
    *  (see TranscriptsView — either source can lag right after a merge). */
   onBriefStaleChange?: (stale: boolean) => void;
+  /** Called whenever this panel loads/reloads its own SpeakersResult, with
+   *  the count of speakers currently flagged `uncertain` — lets the parent
+   *  show a reminder banner before the BRIEF is finalized (#545). Mirrors
+   *  `onBriefStaleChange` above. */
+  onUncertainCountChange?: (count: number) => void;
 }
 
-export function TranscriptSpeakersV4({ taskId, onMerged, onBriefStaleChange }: Props) {
+export function TranscriptSpeakersV4({
+  taskId,
+  onMerged,
+  onBriefStaleChange,
+  onUncertainCountChange,
+}: Props) {
   const [speakers, setSpeakers] = useState<SpeakerInfo[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -34,14 +44,16 @@ export function TranscriptSpeakersV4({ taskId, onMerged, onBriefStaleChange }: P
       const data = await fetchTranscriptSpeakers(taskId);
       setSpeakers(data.speakers);
       onBriefStaleChange?.(data.brief_stale);
+      onUncertainCountChange?.(data.speakers.filter((s) => s.uncertain).length);
     } catch (err) {
       setLoadError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
     }
-    // onBriefStaleChange intentionally excluded — TranscriptsView passes a
-    // stable setState function, and including it would only matter if the
-    // caller passed a new closure each render (it doesn't here).
+    // onBriefStaleChange/onUncertainCountChange intentionally excluded —
+    // TranscriptsView passes stable setState functions, and including them
+    // would only matter if the caller passed a new closure each render (it
+    // doesn't here).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [taskId]);
 

--- a/src/components/v4/transcripts/TranscriptUncertainSpeakersBanner.tsx
+++ b/src/components/v4/transcripts/TranscriptUncertainSpeakersBanner.tsx
@@ -1,0 +1,36 @@
+interface Props {
+  /** Count of speakers currently flagged `uncertain` (see `SpeakerInfo.uncertain`
+   *  in `src/utils/transcript.ts`). Caller only renders this banner when > 0. */
+  count: number;
+}
+
+/**
+ * Reminder shown while the transcript still has one or more unresolved
+ * speakers (`SpeakerInfo.uncertain === true`, e.g. "SPEAKER_4" never merged
+ * into a named participant) — see issue #545: a real BRIEF shipped to a
+ * client with an unresolved "Speaker 4" because the merge/rename step in
+ * TranscriptSpeakersV4 (#1298) was skipped before finalizing.
+ *
+ * Unlike `TranscriptStaleBriefBanner`, this is a pure reminder — there's no
+ * single action to take (the fix is to review the speakers list above and
+ * merge/rename via the existing UI), so no action button here.
+ */
+export function TranscriptUncertainSpeakersBanner({ count }: Props) {
+  return (
+    <div className="v4-banner v4-banner--warn" style={{ marginTop: 14 }}>
+      <div className="v4-banner-bi">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+          <line x1="12" y1="9" x2="12" y2="13" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+      </div>
+      <div className="v4-banner-bt">
+        <b>Есть нераспознанные спикеры</b>
+        <span>
+          Есть {count} нераспознанных спикеров — проверьте перед отправкой клиенту.
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/transcripts/TranscriptsView.tsx
+++ b/src/components/v4/transcripts/TranscriptsView.tsx
@@ -23,6 +23,7 @@ import { TranscriptEditorV4 } from "./TranscriptEditorV4";
 import { TranscriptHistoryV4 } from "./TranscriptHistoryV4";
 import { TranscriptSpeakersV4 } from "./TranscriptSpeakersV4";
 import { TranscriptStaleBriefBanner } from "./TranscriptStaleBriefBanner";
+import { TranscriptUncertainSpeakersBanner } from "./TranscriptUncertainSpeakersBanner";
 
 interface Props {
   projects: ProjectConfig[];
@@ -74,6 +75,9 @@ export function TranscriptsView({ projects }: Props) {
   // brief_stale reported by the speakers panel's own fetch (independent of
   // briefResult.brief_stale — see TranscriptStaleBriefBanner usage below).
   const [speakersBriefStale, setSpeakersBriefStale] = useState(false);
+  // Count of speakers currently flagged `uncertain` (see SpeakerInfo.uncertain),
+  // reported by the speakers panel — drives TranscriptUncertainSpeakersBanner (#545).
+  const [uncertainSpeakerCount, setUncertainSpeakerCount] = useState(0);
 
   // Aggregate counters from history (updates with refreshKey + initial load)
   const [agg, setAgg] = useState({ total: 0, active: 0, done: 0, error: 0 });
@@ -235,6 +239,7 @@ export function TranscriptsView({ projects }: Props) {
     setActiveTaskId(null);
     setHistoryRefreshKey((k) => k + 1);
     setSpeakersBriefStale(false);
+    setUncertainSpeakerCount(0);
     try {
       const data = await fetchTranscriptResult(taskId);
       setBriefResult(data);
@@ -260,6 +265,7 @@ export function TranscriptsView({ projects }: Props) {
     setUploadError(null);
     setLoadingBrief(true);
     setSpeakersBriefStale(false);
+    setUncertainSpeakerCount(0);
     try {
       const data = await fetchTranscriptResult(taskId);
       setBriefResult(data);
@@ -353,6 +359,7 @@ export function TranscriptsView({ projects }: Props) {
   }, [briefResult]);
 
   const briefStale = (briefResult?.brief_stale ?? false) || speakersBriefStale;
+  const hasUncertain = uncertainSpeakerCount > 0;
 
   const showUploadForm =
     !activeTaskId && !briefResult && !loadingBrief && !batchActive && batchFiles.length === 0;
@@ -425,6 +432,9 @@ export function TranscriptsView({ projects }: Props) {
           {briefStale && (
             <TranscriptStaleBriefBanner onRegenerate={onRegenerateBriefClick} />
           )}
+          {hasUncertain && (
+            <TranscriptUncertainSpeakersBanner count={uncertainSpeakerCount} />
+          )}
           <TranscriptBriefV4
             result={briefResult}
             onNewUpload={onNewUpload}
@@ -435,6 +445,7 @@ export function TranscriptsView({ projects }: Props) {
             taskId={briefResult.task_id}
             onMerged={onSpeakersMerged}
             onBriefStaleChange={setSpeakersBriefStale}
+            onUncertainCountChange={setUncertainSpeakerCount}
           />
         </>
       )}

--- a/tests/transcript-speakers-v4.test.tsx
+++ b/tests/transcript-speakers-v4.test.tsx
@@ -62,6 +62,60 @@ describe("TranscriptSpeakersV4", () => {
     expect(screen.getByText("не опознан")).toBeTruthy();
   });
 
+  it("reports the uncertain speaker count on load, and again after a merge resolves it", async () => {
+    const RESOLVED_PAYLOAD = {
+      job_id: "job-1",
+      brief_stale: false,
+      speakers: [
+        {
+          id: "SPEAKER_00",
+          labels: ["SPEAKER_00", "SPEAKER_01"],
+          display_name: "Иван",
+          segment_count: 6,
+          quotes: [{ timestamp: "00:00:05", text: "Давайте начнём" }],
+          uncertain: false,
+        },
+      ],
+    };
+
+    let mergeCalled = false;
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        mergeCalled = true;
+        return Promise.resolve(
+          jsonResp({
+            job_id: "job-1",
+            canonical_name: "Иван",
+            speaker_ids: ["SPEAKER_00", "SPEAKER_01"],
+            updated_segment_count: 6,
+            normalized_transcript: "# Транскрипт\n\n[00:00:00] Иван: ...",
+            brief_stale: false,
+          }),
+        );
+      }
+      return Promise.resolve(jsonResp(mergeCalled ? RESOLVED_PAYLOAD : SPEAKERS_PAYLOAD));
+    });
+
+    const onUncertainCountChange = vi.fn();
+    render(
+      <TranscriptSpeakersV4 taskId="job-1" onUncertainCountChange={onUncertainCountChange} />,
+    );
+    await waitFor(() => expect(screen.getByText("Иван")).toBeTruthy());
+
+    // One uncertain speaker (SPEAKER_01) in the initial payload.
+    await waitFor(() => expect(onUncertainCountChange).toHaveBeenLastCalledWith(1));
+
+    fireEvent.click(screen.getByLabelText("Выбрать спикера Иван"));
+    fireEvent.click(screen.getByLabelText("Выбрать спикера SPEAKER_01"));
+    fireEvent.change(screen.getByLabelText("Итоговое имя для выбранных спикеров"), {
+      target: { value: "Иван" },
+    });
+    fireEvent.click(screen.getByText("Объединить"));
+
+    // After merge, the refetched list has no uncertain speakers left.
+    await waitFor(() => expect(onUncertainCountChange).toHaveBeenLastCalledWith(0));
+  });
+
   it("shows a recoverable inline error instead of crashing when speakers can't be loaded (422)", async () => {
     mockFetch.mockImplementation(() =>
       Promise.resolve(

--- a/tests/transcript-uncertain-speakers-banner.test.tsx
+++ b/tests/transcript-uncertain-speakers-banner.test.tsx
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { TranscriptUncertainSpeakersBanner } from "../src/components/v4/transcripts/TranscriptUncertainSpeakersBanner";
+
+afterEach(cleanup);
+
+describe("TranscriptUncertainSpeakersBanner", () => {
+  it("renders a reminder with the uncertain speaker count and no action button", () => {
+    render(<TranscriptUncertainSpeakersBanner count={2} />);
+    expect(screen.getByText(/Есть нераспознанные спикеры/)).toBeTruthy();
+    expect(screen.getByText(/Есть 2 нераспознанных спикеров — проверьте перед отправкой клиенту/)).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders the singular count too", () => {
+    render(<TranscriptUncertainSpeakersBanner count={1} />);
+    expect(screen.getByText(/Есть 1 нераспознанных спикеров — проверьте перед отправкой клиенту/)).toBeTruthy();
+  });
+});

--- a/tests/transcripts-view-uncertain-speakers.test.tsx
+++ b/tests/transcripts-view-uncertain-speakers.test.tsx
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { TranscriptsView } from "../src/components/v4/transcripts/TranscriptsView";
+import type { ProjectConfig } from "../src/types";
+
+// Integration coverage for issue #545: TranscriptsView wires
+// TranscriptSpeakersV4's onUncertainCountChange into the uncertain-speakers
+// banner, and the banner disappears once a merge/rename (via
+// mergeTranscriptSpeakers) resolves the last uncertain speaker — mirroring
+// the existing brief_stale wiring in this same view.
+
+const mockFetch = vi.fn();
+
+const PROJECTS: ProjectConfig[] = [
+  { repo: "acme/demo", path: "/tmp/demo", enabled: true } as ProjectConfig,
+];
+
+const LIST_ITEM = {
+  task_id: "job-1",
+  project: "acme/demo",
+  file_name: "call.mp3",
+  status: "done",
+  created_at: "2026-01-01T00:00:00Z",
+  transcription_model: "quality",
+  processing_profile: "standard_brief",
+};
+
+const RESULT = {
+  task_id: "job-1",
+  brief_content: "# BRIEF\n\nSome content",
+  transcript_text: "transcript text",
+  quality: null,
+  quality_report: null,
+  output_mode: "brief",
+  primary_artifact: "brief",
+  normalized_transcript: "normalized",
+  brief_stale: false,
+  processing_profile: "standard_brief",
+};
+
+const SPEAKERS_WITH_UNCERTAIN = {
+  job_id: "job-1",
+  brief_stale: false,
+  speakers: [
+    {
+      id: "SPEAKER_00",
+      labels: ["SPEAKER_00"],
+      display_name: "Иван",
+      segment_count: 4,
+      quotes: [{ timestamp: "00:00:05", text: "Давайте начнём" }],
+      uncertain: false,
+    },
+    {
+      id: "SPEAKER_01",
+      labels: ["SPEAKER_01"],
+      display_name: "SPEAKER_01",
+      segment_count: 2,
+      quotes: [{ timestamp: "00:00:20", text: "Согласен" }],
+      uncertain: true,
+    },
+  ],
+};
+
+const SPEAKERS_RESOLVED = {
+  job_id: "job-1",
+  brief_stale: false,
+  speakers: [
+    {
+      id: "SPEAKER_00",
+      labels: ["SPEAKER_00", "SPEAKER_01"],
+      display_name: "Иван",
+      segment_count: 6,
+      quotes: [{ timestamp: "00:00:05", text: "Давайте начнём" }],
+      uncertain: false,
+    },
+  ],
+};
+
+function jsonResp(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
+  mockFetch.mockReset();
+});
+afterEach(cleanup);
+
+describe("TranscriptsView uncertain speakers banner", () => {
+  it("shows the banner while a speaker is uncertain, and hides it once merge resolves it", async () => {
+    let merged = false;
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes("/transcript/list")) return Promise.resolve(jsonResp([LIST_ITEM]));
+      if (u.includes("/transcript/result/")) return Promise.resolve(jsonResp(RESULT));
+      if (u.includes("/speakers/merge") && init?.method === "POST") {
+        merged = true;
+        return Promise.resolve(
+          jsonResp({
+            job_id: "job-1",
+            canonical_name: "Иван",
+            speaker_ids: ["SPEAKER_00", "SPEAKER_01"],
+            updated_segment_count: 6,
+            normalized_transcript: "normalized",
+            brief_stale: false,
+          }),
+        );
+      }
+      if (u.includes("/speakers")) {
+        return Promise.resolve(jsonResp(merged ? SPEAKERS_RESOLVED : SPEAKERS_WITH_UNCERTAIN));
+      }
+      return Promise.resolve(jsonResp({}));
+    });
+
+    render(<TranscriptsView projects={PROJECTS} />);
+
+    // History loads, then open the "done" job to reach briefResult.
+    await waitFor(() => expect(screen.getByText("Открыть")).toBeTruthy());
+    fireEvent.click(screen.getByText("Открыть"));
+
+    // Speakers panel loads and reports one uncertain speaker — banner shows.
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Есть 1 нераспознанных спикеров — проверьте перед отправкой клиенту/),
+      ).toBeTruthy(),
+    );
+
+    // Merge the uncertain speaker into the canonical one via the existing UI.
+    fireEvent.click(screen.getByLabelText("Выбрать спикера Иван"));
+    fireEvent.click(screen.getByLabelText("Выбрать спикера SPEAKER_01"));
+    fireEvent.change(screen.getByLabelText("Итоговое имя для выбранных спикеров"), {
+      target: { value: "Иван" },
+    });
+    fireEvent.click(screen.getByText("Объединить"));
+
+    // Banner disappears once the refetched speaker list has no uncertain
+    // speakers left.
+    await waitFor(() =>
+      expect(screen.queryByText(/Есть нераспознанные спикеры/)).toBeNull(),
+    );
+  });
+});


### PR DESCRIPTION
Closes #545

## Что сделано
- Новый компонент `TranscriptUncertainSpeakersBanner.tsx` (по структуре `TranscriptStaleBriefBanner.tsx`, но без action-кнопки) — показывает «Есть N нераспознанных спикеров — проверьте перед отправкой клиенту».
- `TranscriptSpeakersV4.tsx`: добавлен проп `onUncertainCountChange(count: number)`, вызывается в `load()` сразу после существующего `onBriefStaleChange`, при первом фетче и после каждого merge/rename.
- `TranscriptsView.tsx`: добавлено состояние `uncertainSpeakerCount`, сбрасывается там же, где `speakersBriefStale` (после progress done / open from history); баннер рендерится рядом с уже существующим `{briefStale && <TranscriptStaleBriefBanner .../>}`.
- Backend не менялся — `SpeakerInfo.uncertain` уже приходил из `GET /transcript/{job_id}/speakers`.

## Тесты
- `tests/transcript-uncertain-speakers-banner.test.tsx` — рендер баннера, отсутствие кнопки, singular/plural count.
- `tests/transcript-speakers-v4.test.tsx` — новый тест: `onUncertainCountChange` репортит 1 при загрузке и 0 после merge.
- `tests/transcripts-view-uncertain-speakers.test.tsx` — интеграционный тест: баннер появляется после открытия завершённой задачи с нераспознанным спикером и исчезает после merge через существующий `mergeTranscriptSpeakers`.

Все 4 гейта зелёные локально: `npm run lint && npx tsc --noEmit -p tsconfig.app.json && npx vitest run && npm run build` (239/239 tests passed).