### PR TITLE
feat(transcripts): add client_brief processing_profile UI option

### DIFF
--- a/src/components/v4/transcripts/TranscriptBriefV4.tsx
+++ b/src/components/v4/transcripts/TranscriptBriefV4.tsx
@@ -40,6 +40,7 @@ const CHECK_ICON: Record<QualityCheck["status"], string> = {
 const PROFILE_LABEL: Record<TranscriptResult["processing_profile"], string> = {
   standard_brief: "Обычный BRIEF",
   dev_handoff: "Dev handoff",
+  client_brief: "Для клиента",
 };
 
 function plural(n: number, one: string, few: string, many: string): string {

--- a/src/components/v4/transcripts/TranscriptHistoryV4.tsx
+++ b/src/components/v4/transcripts/TranscriptHistoryV4.tsx
@@ -32,10 +32,12 @@ const STATUS_LABELS: Record<string, string> = {
 const PROFILE_LABEL: Record<TranscriptListItem["processing_profile"], string> = {
   standard_brief: "Обычный",
   dev_handoff: "Dev handoff",
+  client_brief: "Для клиента",
 };
 const PROFILE_LABEL_FULL: Record<TranscriptListItem["processing_profile"], string> = {
   standard_brief: "Обычный BRIEF",
   dev_handoff: "Dev handoff",
+  client_brief: "Для клиента",
 };
 
 const STATUS_CLASS: Record<string, string> = {

--- a/src/components/v4/transcripts/UploadZone.tsx
+++ b/src/components/v4/transcripts/UploadZone.tsx
@@ -290,6 +290,14 @@ export function UploadZone({
             >
               Для разработки
             </button>
+            <button
+              type="button"
+              className={selectedProcessingProfile === "client_brief" ? "is-active" : ""}
+              onClick={() => setSelectedProcessingProfile("client_brief")}
+              title="Упрощённый BRIEF для отправки клиенту"
+            >
+              Для клиента
+            </button>
           </div>
         </fieldset>
 

--- a/src/types/generated/pipeline.openapi.json
+++ b/src/types/generated/pipeline.openapi.json
@@ -330,7 +330,8 @@
             "default": "standard_brief",
             "enum": [
               "standard_brief",
-              "dev_handoff"
+              "dev_handoff",
+              "client_brief"
             ],
             "title": "Processing Profile",
             "type": "string"

--- a/src/types/generated/pipeline.ts
+++ b/src/types/generated/pipeline.ts
@@ -1736,7 +1736,7 @@ export interface components {
              * @default standard_brief
              * @enum {string}
              */
-            processing_profile: "standard_brief" | "dev_handoff";
+            processing_profile: "standard_brief" | "dev_handoff" | "client_brief";
             /**
              * Project Context
              * @default

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -50,7 +50,7 @@ export function normalizeOutputMode(raw: unknown): OutputMode {
 }
 
 /**
- * BRIEF synthesis profile (makeit-pipeline #1300) — orthogonal to
+ * BRIEF synthesis profile (makeit-pipeline #1300, #1304) — orthogonal to
  * `OutputMode`: `output_mode` picks WHICH artifact is generated (brief vs.
  * normalized_transcript), `processing_profile` picks the STRUCTURE/tone of
  * the BRIEF itself once one is generated. Unlike `OutputMode`, the backend
@@ -62,10 +62,12 @@ export function normalizeOutputMode(raw: unknown): OutputMode {
  * field from a pre-#1300 row) falls back to "standard_brief" instead of
  * silently typing as something invalid.
  */
-export type ProcessingProfile = "standard_brief" | "dev_handoff";
+export type ProcessingProfile = "standard_brief" | "dev_handoff" | "client_brief";
 
 export function normalizeProcessingProfile(raw: unknown): ProcessingProfile {
-  return raw === "dev_handoff" ? "dev_handoff" : "standard_brief";
+  if (raw === "dev_handoff") return "dev_handoff";
+  if (raw === "client_brief") return "client_brief";
+  return "standard_brief";
 }
 
 /**

--- a/tests/transcript-brief-v4.test.tsx
+++ b/tests/transcript-brief-v4.test.tsx
@@ -163,6 +163,18 @@ describe("TranscriptBriefV4 — processing_profile badge", () => {
     );
     expect(screen.getByText("Dev handoff")).toBeTruthy();
   });
+
+  it("shows the 'Для клиента' badge for a client_brief job", () => {
+    render(
+      <TranscriptBriefV4
+        result={makeResult({ processing_profile: "client_brief" })}
+        onNewUpload={vi.fn()}
+        onEdit={vi.fn()}
+        onContinueToBrief={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Для клиента")).toBeTruthy();
+  });
 });
 
 describe("TranscriptBriefV4 — DOCX download", () => {

--- a/tests/transcript-client.test.ts
+++ b/tests/transcript-client.test.ts
@@ -150,6 +150,7 @@ describe("transcript client", () => {
 
   it("normalizes processing_profile, defaulting unknown/absent values to standard_brief", () => {
     expect(normalizeProcessingProfile("dev_handoff")).toBe("dev_handoff");
+    expect(normalizeProcessingProfile("client_brief")).toBe("client_brief");
     expect(normalizeProcessingProfile("standard_brief")).toBe("standard_brief");
     expect(normalizeProcessingProfile(undefined)).toBe("standard_brief");
     expect(normalizeProcessingProfile("unknown")).toBe("standard_brief");
@@ -191,6 +192,26 @@ describe("transcript client", () => {
     });
   });
 
+  it("fetchTranscriptResult passes through a client_brief processing_profile", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            job_id: "job-3c2",
+            brief_content: "# Client Brief",
+            processing_profile: "client_brief",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(fetchTranscriptResult("job-3c2")).resolves.toMatchObject({
+      processing_profile: "client_brief",
+    });
+  });
+
   it("fetchTranscriptList maps processing_profile, defaulting to standard_brief when absent (legacy rows predating processing_profile)", async () => {
     vi.stubGlobal(
       "fetch",
@@ -212,6 +233,14 @@ describe("transcript client", () => {
               created_at: "2026-05-02T10:00:00Z",
               processing_profile: "dev_handoff",
             },
+            {
+              job_id: "job-3f",
+              project: "mankassa-app",
+              file_name: "client.mp3",
+              status: "done",
+              created_at: "2026-05-03T10:00:00Z",
+              processing_profile: "client_brief",
+            },
           ]),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -221,6 +250,7 @@ describe("transcript client", () => {
     await expect(fetchTranscriptList()).resolves.toMatchObject([
       { task_id: "job-3d", processing_profile: "standard_brief" },
       { task_id: "job-3e", processing_profile: "dev_handoff" },
+      { task_id: "job-3f", processing_profile: "client_brief" },
     ]);
   });
 
@@ -330,6 +360,45 @@ describe("transcript client", () => {
     expect(xhr.sentBody?.get("processing_profile")).toBe("dev_handoff");
 
     xhr.responseText = JSON.stringify({ job_id: "job-6b", status: "queued", brief_url: "" });
+    xhr.onload?.();
+    await promise;
+  });
+
+  it("uploadTranscript includes a client_brief processing_profile in the multipart form", async () => {
+    class FakeXHR {
+      static instances: FakeXHR[] = [];
+      upload: { onprogress: ((e: ProgressEvent) => void) | null } = { onprogress: null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      onabort: (() => void) | null = null;
+      status = 200;
+      responseText = "";
+      sentBody: FormData | null = null;
+      open() {
+        /* no-op */
+      }
+      send(body: FormData) {
+        this.sentBody = body;
+        FakeXHR.instances.push(this);
+      }
+    }
+    vi.stubGlobal("XMLHttpRequest", FakeXHR as unknown as typeof XMLHttpRequest);
+
+    const file = new File(["hello"], "meeting.txt", { type: "text/plain" });
+    const promise = uploadTranscript(
+      file,
+      "proj",
+      "quality",
+      undefined,
+      undefined,
+      "brief",
+      "client_brief",
+    );
+
+    const xhr = FakeXHR.instances[0];
+    expect(xhr.sentBody?.get("processing_profile")).toBe("client_brief");
+
+    xhr.responseText = JSON.stringify({ job_id: "job-6b2", status: "queued", brief_url: "" });
     xhr.onload?.();
     await promise;
   });

--- a/tests/transcript-history-v4-profile.test.tsx
+++ b/tests/transcript-history-v4-profile.test.tsx
@@ -40,6 +40,16 @@ const ITEMS = [
     processing_profile: "dev_handoff",
   },
   {
+    job_id: "job-client",
+    project: "mankassa-app",
+    file_name: "client.mp3",
+    status: "done",
+    created_at: "2026-05-03T10:00:00Z",
+    file_type: "audio",
+    transcription_model: "quality",
+    processing_profile: "client_brief",
+  },
+  {
     job_id: "job-legacy",
     project: "mankassa-app",
     file_name: "legacy.mp3",
@@ -68,5 +78,6 @@ describe("TranscriptHistoryV4 — processing_profile badge", () => {
     const badges = screen.getAllByTitle("Обычный BRIEF");
     expect(badges.length).toBe(2); // job-standard + job-legacy (defaulted)
     expect(screen.getByTitle("Dev handoff").textContent).toBe("Dev handoff");
+    expect(screen.getByTitle("Для клиента").textContent).toBe("Для клиента");
   });
 });

--- a/tests/transcript-upload-processing-profile.test.tsx
+++ b/tests/transcript-upload-processing-profile.test.tsx
@@ -47,6 +47,19 @@ describe("UploadZone processing_profile selector", () => {
     expect(screen.getByText("Обычный").className).not.toContain("is-active");
   });
 
+  it("switches to client_brief when the Для клиента pill is clicked", () => {
+    const { setSelectedProcessingProfile } = renderUploadZone();
+    fireEvent.click(screen.getByText("Для клиента"));
+    expect(setSelectedProcessingProfile).toHaveBeenCalledWith("client_brief");
+  });
+
+  it("reflects client_brief as the active pill when selected", () => {
+    renderUploadZone({ selectedProcessingProfile: "client_brief" });
+    expect(screen.getByText("Для клиента").className).toContain("is-active");
+    expect(screen.getByText("Обычный").className).not.toContain("is-active");
+    expect(screen.getByText("Для разработки").className).not.toContain("is-active");
+  });
+
   it("shows the profile selector regardless of file type (not gated on audio)", () => {
     renderUploadZone();
     expect(screen.getByText("Формат BRIEF")).toBeTruthy();


### PR DESCRIPTION
Closes #546

## Что сделано
Companion issue к makeit-pipeline#1304 (backend `processing_profile=client_brief`, уже смёрджено). Механическое расширение существующего паттерна `standard_brief`/`dev_handoff` третьим значением `client_brief` в 4 местах:

- `src/utils/transcript.ts` — `ProcessingProfile` тип → добавлен `"client_brief"`, `normalizeProcessingProfile` обновлён (fallback для unknown/absent остаётся `standard_brief`, без изменений в поведении)
- `src/components/v4/transcripts/UploadZone.tsx` — третья pill-кнопка «Для клиента» в группе «Формат BRIEF», по образцу «Обычный»/«Для разработки»
- `src/components/v4/transcripts/TranscriptBriefV4.tsx` — `PROFILE_LABEL` map → `client_brief: "Для клиента"`
- `src/components/v4/transcripts/TranscriptHistoryV4.tsx` — `PROFILE_LABEL`/`PROFILE_LABEL_FULL` maps → `client_brief: "Для клиента"`

Дополнительно (не в явном списке issue, но того же контракта):
- `src/types/generated/pipeline.ts` + `pipeline.openapi.json` — enum-литерал `processing_profile` в `Body_upload_transcript_transcript_upload_post` расширен до `"standard_brief" | "dev_handoff" | "client_brief"` (backend API недоступен локально для полной регенерации снапшота — литерал точечно дополнен вручную, соответствует смёрдженному контракту pipeline#1304)

## Тесты
Все новые тесты зеркалят существующие для `dev_handoff`:
- `tests/transcript-upload-processing-profile.test.tsx` — клик по «Для клиента» → `setSelectedProcessingProfile("client_brief")`, активный pill-стейт
- `tests/transcript-brief-v4.test.tsx` — бейдж «Для клиента» для `client_brief` job
- `tests/transcript-history-v4-profile.test.tsx` — бейдж «Для клиента» в истории
- `tests/transcript-client.test.ts` — `normalizeProcessingProfile("client_brief")`, `fetchTranscriptResult`/`fetchTranscriptList` passthrough, `uploadTranscript` включает `client_brief` в multipart form

## Самопроверка
- [x] `npm run lint` — чисто
- [x] `npx tsc --noEmit -p tsconfig.app.json` — чисто
- [x] `npx vitest run` — 244/244 тестов зелёные (29 файлов)
- [x] `npm run build` — успешно
- [x] Senior review проведён — изменения чисто аддитивны, не затрагивают existing `standard_brief`/`dev_handoff` поведение, нет пересечений с параллельным issue #547