### PR TITLE
feat(project-memory): UI editor for dictionary/client_context/ontology

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { MonitoringView } from "./components/v4/monitoring/MonitoringView";
 import { AuditView } from "./components/v4/audit/AuditView";
 import { PipelineView } from "./components/v4/pipeline/PipelineView";
 import { TranscriptsView } from "./components/v4/transcripts/TranscriptsView";
+import { ProjectMemoryView } from "./components/v4/projectmemory/ProjectMemoryView";
 import { ResearchView } from "./components/v4/research/ResearchView";
 import { SpecsView } from "./components/v4/specs/SpecsView";
 import { QualityView } from "./components/v4/quality/QualityView";
@@ -54,6 +55,7 @@ const TAB_CRUMBS: Record<TabId, string> = {
   uptime: "Мониторинг",
   pipeline: "Pipeline",
   transcripts: "Транскрипты",
+  "project-memory": "Память проекта",
   audit: "Аудит",
   research: "Research",
   specs: "Specs",
@@ -142,7 +144,7 @@ function AppInner({ onFirstFetchDone }: AppInnerProps = {}) {
 
   const VALID_TABS: TabId[] = [
     "dashboard", "projects", "milestones", "uptime", "audit",
-    "pipeline", "transcripts", "research", "specs", "quality", "codex-quality", "debate",
+    "pipeline", "transcripts", "project-memory", "research", "specs", "quality", "codex-quality", "debate",
   ];
   const ACTIVE_TAB_KEY = "makeit.activeTab";
   const [tab, setTabRaw] = useState<TabId>(() => {
@@ -659,6 +661,13 @@ function AppInner({ onFirstFetchDone }: AppInnerProps = {}) {
           {visitedTabs.has("transcripts") && (
             <ErrorBoundary fallback="Ошибка вкладки Транскрипты">
               <TranscriptsView projects={PROJECTS} />
+            </ErrorBoundary>
+          )}
+        </div>
+        <div style={{ display: tab === "project-memory" ? undefined : "none" }}>
+          {visitedTabs.has("project-memory") && (
+            <ErrorBoundary fallback="Ошибка вкладки Память проекта">
+              <ProjectMemoryView projects={PROJECTS} />
             </ErrorBoundary>
           )}
         </div>

--- a/src/components/v4/CommandPalette.tsx
+++ b/src/components/v4/CommandPalette.tsx
@@ -34,6 +34,7 @@ const TAB_LABEL: Record<TabId, string> = {
   uptime: "Мониторинг",
   pipeline: "Pipeline",
   transcripts: "Транскрипты",
+  "project-memory": "Память проекта",
   audit: "Аудит",
   research: "Research",
   specs: "Specs",

--- a/src/components/v4/Sidebar.tsx
+++ b/src/components/v4/Sidebar.tsx
@@ -82,6 +82,12 @@ const ICON_SEARCH = (
     <path d="M21 21l-4.35-4.35" />
   </svg>
 );
+const ICON_PROJECT_MEMORY = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
+    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
+  </svg>
+);
 const ICON_SPECS = (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
     <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
@@ -150,6 +156,7 @@ export function Sidebar({
       items: [
         { id: "pipeline", label: "Pipeline", icon: ICON_PIPELINE, pulse: p.pipeline },
         { id: "transcripts", label: "Транскрипты", icon: ICON_TRANSCRIPT, pulse: p.transcripts },
+        { id: "project-memory", label: "Память проекта", icon: ICON_PROJECT_MEMORY, pulse: p["project-memory"] },
         { id: "research", label: "Research", icon: ICON_SEARCH, pulse: p.research },
         { id: "specs", label: "Specs", icon: ICON_SPECS, pulse: p.specs },
       ],

--- a/src/components/v4/projectmemory/ProjectMemoryView.tsx
+++ b/src/components/v4/projectmemory/ProjectMemoryView.tsx
@@ -1,0 +1,507 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ProjectConfig } from "../../../types";
+import {
+  fetchDictionary,
+  saveDictionary,
+  fetchClientContext,
+  saveClientContext,
+  fetchOntology,
+  type DictionaryResponse,
+  type ClientContextResponse,
+  type DomainOntology,
+} from "../../../utils/projectMemory";
+
+interface Props {
+  projects: ProjectConfig[];
+}
+
+const STORAGE = {
+  project: "pmv:lastProject",
+};
+
+/** Mirrors `TranscriptsView`'s slug derivation — `ProjectConfig.repo` is
+ *  already the bare repo name (no `owner/`), but `.split("/").pop()` is kept
+ *  for consistency with every other consumer that derives a pipeline
+ *  `project_slug` from a possibly-qualified project string (e.g.
+ *  `PipelineView.tsx`'s `selectedProjectLabel`). */
+function toSlug(repo: string): string {
+  return repo.split("/").pop() || repo;
+}
+
+export function ProjectMemoryView({ projects }: Props) {
+  const [selectedProject, setSelectedProject] = useState<string>(() => {
+    return localStorage.getItem(STORAGE.project) || projects[0]?.repo || "";
+  });
+  useEffect(() => {
+    localStorage.setItem(STORAGE.project, selectedProject);
+  }, [selectedProject]);
+
+  const slug = toSlug(selectedProject);
+
+  // ── Dictionary state ──
+  const [dictionary, setDictionary] = useState<DictionaryResponse | null>(null);
+  const [dictLoading, setDictLoading] = useState(false);
+  const [dictError, setDictError] = useState<string | null>(null);
+  const [dictSaving, setDictSaving] = useState(false);
+
+  // Add/edit term form state
+  const [newTermKey, setNewTermKey] = useState("");
+  const [newTermValue, setNewTermValue] = useState("");
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [editingValue, setEditingValue] = useState("");
+
+  // ── client_context state ──
+  const [clientContext, setClientContext] = useState<ClientContextResponse | null>(null);
+  const [contextDraft, setContextDraft] = useState("");
+  const [contextLoading, setContextLoading] = useState(false);
+  const [contextError, setContextError] = useState<string | null>(null);
+  const [contextSaving, setContextSaving] = useState(false);
+  const [contextSavedAt, setContextSavedAt] = useState<number | null>(null);
+
+  // ── ontology state (read-only) ──
+  const [ontology, setOntology] = useState<DomainOntology | null>(null);
+  const [ontologyLoading, setOntologyLoading] = useState(false);
+  const [ontologyError, setOntologyError] = useState<string | null>(null);
+
+  const loadDictionary = useCallback(async (projectSlug: string) => {
+    setDictLoading(true);
+    setDictError(null);
+    try {
+      const data = await fetchDictionary(projectSlug);
+      setDictionary(data);
+    } catch (err) {
+      setDictionary(null);
+      setDictError(String(err instanceof Error ? err.message : err));
+    } finally {
+      setDictLoading(false);
+    }
+  }, []);
+
+  const loadClientContext = useCallback(async (projectSlug: string) => {
+    setContextLoading(true);
+    setContextError(null);
+    try {
+      const data = await fetchClientContext(projectSlug);
+      setClientContext(data);
+      setContextDraft(data.content);
+    } catch (err) {
+      setClientContext(null);
+      setContextDraft("");
+      setContextError(String(err instanceof Error ? err.message : err));
+    } finally {
+      setContextLoading(false);
+    }
+  }, []);
+
+  const loadOntology = useCallback(async (projectSlug: string) => {
+    setOntologyLoading(true);
+    setOntologyError(null);
+    try {
+      const data = await fetchOntology(projectSlug);
+      setOntology(data.ontology);
+    } catch (err) {
+      setOntology(null);
+      setOntologyError(String(err instanceof Error ? err.message : err));
+    } finally {
+      setOntologyLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!slug) return;
+    setEditingKey(null);
+    setNewTermKey("");
+    setNewTermValue("");
+    setContextSavedAt(null);
+    void loadDictionary(slug);
+    void loadClientContext(slug);
+    void loadOntology(slug);
+  }, [slug, loadDictionary, loadClientContext, loadOntology]);
+
+  const isV2 = dictionary?.is_v2_ontology ?? false;
+
+  const handleAddTerm = useCallback(async () => {
+    if (!dictionary || isV2) return;
+    const key = newTermKey.trim();
+    const value = newTermValue.trim();
+    if (!key || !value) return;
+    setDictSaving(true);
+    setDictError(null);
+    try {
+      const nextTerms = { ...dictionary.terms, [key]: value };
+      const updated = await saveDictionary(slug, nextTerms);
+      setDictionary(updated);
+      setNewTermKey("");
+      setNewTermValue("");
+    } catch (err) {
+      setDictError(String(err instanceof Error ? err.message : err));
+    } finally {
+      setDictSaving(false);
+    }
+  }, [dictionary, isV2, newTermKey, newTermValue, slug]);
+
+  const handleStartEdit = useCallback((key: string, value: string) => {
+    setEditingKey(key);
+    setEditingValue(value);
+  }, []);
+
+  const handleCancelEdit = useCallback(() => {
+    setEditingKey(null);
+    setEditingValue("");
+  }, []);
+
+  const handleSaveEdit = useCallback(async () => {
+    if (!dictionary || isV2 || editingKey === null) return;
+    const value = editingValue.trim();
+    if (!value) return;
+    setDictSaving(true);
+    setDictError(null);
+    try {
+      const nextTerms = { ...dictionary.terms, [editingKey]: value };
+      const updated = await saveDictionary(slug, nextTerms);
+      setDictionary(updated);
+      setEditingKey(null);
+      setEditingValue("");
+    } catch (err) {
+      setDictError(String(err instanceof Error ? err.message : err));
+    } finally {
+      setDictSaving(false);
+    }
+  }, [dictionary, isV2, editingKey, editingValue, slug]);
+
+  const handleDeleteTerm = useCallback(
+    async (key: string) => {
+      if (!dictionary || isV2) return;
+      setDictSaving(true);
+      setDictError(null);
+      try {
+        const nextTerms = { ...dictionary.terms };
+        delete nextTerms[key];
+        const updated = await saveDictionary(slug, nextTerms);
+        setDictionary(updated);
+        if (editingKey === key) {
+          setEditingKey(null);
+          setEditingValue("");
+        }
+      } catch (err) {
+        setDictError(String(err instanceof Error ? err.message : err));
+      } finally {
+        setDictSaving(false);
+      }
+    },
+    [dictionary, isV2, slug, editingKey],
+  );
+
+  const handleSaveContext = useCallback(async () => {
+    setContextSaving(true);
+    setContextError(null);
+    try {
+      const updated = await saveClientContext(slug, contextDraft);
+      setClientContext(updated);
+      setContextDraft(updated.content);
+      setContextSavedAt(Date.now());
+    } catch (err) {
+      setContextError(String(err instanceof Error ? err.message : err));
+    } finally {
+      setContextSaving(false);
+    }
+  }, [slug, contextDraft]);
+
+  const contextDirty = clientContext !== null && contextDraft !== clientContext.content;
+  const termEntries = dictionary ? Object.entries(dictionary.terms) : [];
+
+  return (
+    <div className="v4-content">
+      <div className="v4-ph">
+        <div>
+          <h1>Память проекта</h1>
+          <div className="v4-sub">Словарь терминов, client_context и онтология для транскрипции</div>
+        </div>
+      </div>
+
+      <div style={{ height: 10 }} />
+
+      <div className="v4-pmv-toolbar">
+        <label className="v4-tpc-control-field">
+          <span className="v4-tpc-control-key">Проект</span>
+          <select
+            className="v4-pl-input"
+            value={selectedProject}
+            onChange={(e) => setSelectedProject(e.target.value)}
+          >
+            {projects.map((p) => (
+              <option key={p.repo} value={p.repo}>
+                {p.repo}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div style={{ height: 16 }} />
+
+      {/* ── Dictionary ── */}
+      <div className="v4-panel">
+        <div className="v4-panel-h">
+          <div className="v4-panel-t">
+            Словарь терминов
+            {isV2 && <span className="v4-tag">v2 онтология</span>}
+          </div>
+        </div>
+
+        <div className="v4-pmv-body">
+          {dictLoading && <div className="v4-empty">Загрузка словаря…</div>}
+          {dictError && <div className="v4-error">{dictError}</div>}
+
+          {!dictLoading && dictionary && (
+            <>
+              {isV2 && (
+                <div className="v4-pmv-note">
+                  У этого проекта расширенная онтология (v2) — редактирование через этот
+                  интерфейс пока не поддерживается. Ниже показаны производные термины
+                  только для чтения.
+                </div>
+              )}
+
+              {termEntries.length === 0 && (
+                <div className="v4-empty">Термины ещё не добавлены</div>
+              )}
+
+              {termEntries.length > 0 && (
+                <table className="v4-pmv-table">
+                  <thead>
+                    <tr>
+                      <th>Термин</th>
+                      <th>Значение</th>
+                      {!isV2 && <th aria-label="Действия" />}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {termEntries.map(([key, value]) => (
+                      <tr key={key}>
+                        <td>{key}</td>
+                        <td>
+                          {editingKey === key ? (
+                            <input
+                              className="v4-pl-input"
+                              value={editingValue}
+                              onChange={(e) => setEditingValue(e.target.value)}
+                              aria-label={`Значение для ${key}`}
+                            />
+                          ) : (
+                            value
+                          )}
+                        </td>
+                        {!isV2 && (
+                          <td className="v4-pmv-actions">
+                            {editingKey === key ? (
+                              <>
+                                <button
+                                  type="button"
+                                  className="v4-btn v4-btn--pri"
+                                  disabled={dictSaving || !editingValue.trim()}
+                                  onClick={handleSaveEdit}
+                                >
+                                  Сохранить
+                                </button>
+                                <button
+                                  type="button"
+                                  className="v4-btn"
+                                  disabled={dictSaving}
+                                  onClick={handleCancelEdit}
+                                >
+                                  Отмена
+                                </button>
+                              </>
+                            ) : (
+                              <>
+                                <button
+                                  type="button"
+                                  className="v4-btn"
+                                  disabled={dictSaving}
+                                  onClick={() => handleStartEdit(key, value)}
+                                >
+                                  Редактировать
+                                </button>
+                                <button
+                                  type="button"
+                                  className="v4-btn"
+                                  style={{ color: "var(--mk-danger-strong)" }}
+                                  disabled={dictSaving}
+                                  onClick={() => handleDeleteTerm(key)}
+                                >
+                                  Удалить
+                                </button>
+                              </>
+                            )}
+                          </td>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+
+              {!isV2 && (
+                <div className="v4-pmv-add-row">
+                  <input
+                    className="v4-pl-input"
+                    placeholder="Термин (например «Русклимат»)"
+                    value={newTermKey}
+                    onChange={(e) => setNewTermKey(e.target.value)}
+                    aria-label="Новый термин"
+                  />
+                  <input
+                    className="v4-pl-input"
+                    placeholder="Значение / канонический вид"
+                    value={newTermValue}
+                    onChange={(e) => setNewTermValue(e.target.value)}
+                    aria-label="Значение нового термина"
+                  />
+                  <button
+                    type="button"
+                    className="v4-btn v4-btn--pri"
+                    disabled={dictSaving || !newTermKey.trim() || !newTermValue.trim()}
+                    onClick={handleAddTerm}
+                  >
+                    {dictSaving ? "Сохранение…" : "Добавить"}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      <div style={{ height: 16 }} />
+
+      {/* ── client_context.md ── */}
+      <div className="v4-panel">
+        <div className="v4-panel-h">
+          <div className="v4-panel-t">client_context.md</div>
+          <div className="v4-panel-actions">
+            {contextSavedAt !== null && !contextDirty && (
+              <span className="v4-panel-meta">Сохранено</span>
+            )}
+            <button
+              type="button"
+              className="v4-btn v4-btn--pri"
+              disabled={contextSaving || contextLoading || !contextDirty}
+              onClick={handleSaveContext}
+            >
+              {contextSaving ? "Сохранение…" : "Сохранить"}
+            </button>
+          </div>
+        </div>
+        <div className="v4-pmv-body">
+          {contextLoading && <div className="v4-empty">Загрузка client_context…</div>}
+          {contextError && <div className="v4-error">{contextError}</div>}
+          {!contextLoading && clientContext !== null && (
+            <textarea
+              className="v4-pmv-context-textarea"
+              value={contextDraft}
+              onChange={(e) => setContextDraft(e.target.value)}
+              spellCheck={false}
+              aria-label="client_context markdown редактор"
+              rows={16}
+            />
+          )}
+        </div>
+      </div>
+
+      <div style={{ height: 16 }} />
+
+      {/* ── Ontology (read-only) ── */}
+      <div className="v4-panel">
+        <div className="v4-panel-h">
+          <div className="v4-panel-t">
+            Онтология
+            <span className="v4-tag">только чтение</span>
+          </div>
+        </div>
+        <div className="v4-pmv-body">
+          {ontologyLoading && <div className="v4-empty">Загрузка онтологии…</div>}
+          {ontologyError && <div className="v4-error">{ontologyError}</div>}
+          {!ontologyLoading && ontology && (
+            <div className="v4-pmv-ontology">
+              <div className="v4-pmv-ontology-meta">
+                <span className="v4-panel-meta">версия: {ontology.version}</span>
+                {ontology.domain && <span className="v4-panel-meta">домен: {ontology.domain}</span>}
+              </div>
+
+              {ontology.client_meta && (
+                <section>
+                  <h3>Клиент</h3>
+                  <ul>
+                    {ontology.client_meta.industry && (
+                      <li>Индустрия: {ontology.client_meta.industry}</li>
+                    )}
+                    {ontology.client_meta.primary_currency && (
+                      <li>Валюта: {ontology.client_meta.primary_currency}</li>
+                    )}
+                    {ontology.client_meta.accounting_systems_used.length > 0 && (
+                      <li>
+                        Системы учёта: {ontology.client_meta.accounting_systems_used.join(", ")}
+                      </li>
+                    )}
+                  </ul>
+                </section>
+              )}
+
+              <section>
+                <h3>Люди ({ontology.people.length})</h3>
+                {ontology.people.length === 0 && <div className="v4-empty">Нет данных</div>}
+                {ontology.people.length > 0 && (
+                  <ul>
+                    {ontology.people.map((person) => (
+                      <li key={person.name}>
+                        <b>{person.name}</b>
+                        {person.role ? ` — ${person.role}` : ""}
+                        {person.aliases.length > 0 && ` (${person.aliases.join(", ")})`}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+
+              <section>
+                <h3>Организации ({ontology.business_entities.length})</h3>
+                {ontology.business_entities.length === 0 && <div className="v4-empty">Нет данных</div>}
+                {ontology.business_entities.length > 0 && (
+                  <ul>
+                    {ontology.business_entities.map((entity) => (
+                      <li key={entity.canonical}>
+                        <b>{entity.canonical}</b>
+                        {entity.stt_variants.length > 0 && ` (${entity.stt_variants.join(", ")})`}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+
+              <section>
+                <h3>Категории ({Object.keys(ontology.categories).length})</h3>
+                {Object.keys(ontology.categories).length === 0 && (
+                  <div className="v4-empty">Нет данных</div>
+                )}
+                {Object.entries(ontology.categories).map(([category, terms]) => (
+                  <div key={category} className="v4-pmv-ontology-category">
+                    <b>{category}</b>
+                    <ul>
+                      {terms.map((t) => (
+                        <li key={t.canonical}>
+                          {t.canonical}
+                          {t.stt_variants.length > 0 && ` (${t.stt_variants.join(", ")})`}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </section>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/v4/projectmemory/ProjectMemoryView.tsx
+++ b/src/components/v4/projectmemory/ProjectMemoryView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ProjectConfig } from "../../../types";
 import {
   fetchDictionary,
@@ -63,17 +63,29 @@ export function ProjectMemoryView({ projects }: Props) {
   const [ontologyLoading, setOntologyLoading] = useState(false);
   const [ontologyError, setOntologyError] = useState<string | null>(null);
 
+  // Tracks the slug the user currently has selected, independent of React's
+  // render/effect batching. A fetch started for the previous project can
+  // resolve *after* the user has already switched to (and loaded data for)
+  // a different project — out-of-order network responses are not
+  // guaranteed to arrive in request order. Every loader below checks this
+  // ref before writing to state, so a late response for a stale slug is
+  // discarded instead of silently overwriting the current project's memory
+  // (or, worse, being edited and saved back under the new project's slug).
+  const latestSlugRef = useRef(slug);
+
   const loadDictionary = useCallback(async (projectSlug: string) => {
     setDictLoading(true);
     setDictError(null);
     try {
       const data = await fetchDictionary(projectSlug);
+      if (latestSlugRef.current !== projectSlug) return; // stale response
       setDictionary(data);
     } catch (err) {
+      if (latestSlugRef.current !== projectSlug) return; // stale response
       setDictionary(null);
       setDictError(String(err instanceof Error ? err.message : err));
     } finally {
-      setDictLoading(false);
+      if (latestSlugRef.current === projectSlug) setDictLoading(false);
     }
   }, []);
 
@@ -82,14 +94,16 @@ export function ProjectMemoryView({ projects }: Props) {
     setContextError(null);
     try {
       const data = await fetchClientContext(projectSlug);
+      if (latestSlugRef.current !== projectSlug) return; // stale response
       setClientContext(data);
       setContextDraft(data.content);
     } catch (err) {
+      if (latestSlugRef.current !== projectSlug) return; // stale response
       setClientContext(null);
       setContextDraft("");
       setContextError(String(err instanceof Error ? err.message : err));
     } finally {
-      setContextLoading(false);
+      if (latestSlugRef.current === projectSlug) setContextLoading(false);
     }
   }, []);
 
@@ -98,21 +112,33 @@ export function ProjectMemoryView({ projects }: Props) {
     setOntologyError(null);
     try {
       const data = await fetchOntology(projectSlug);
+      if (latestSlugRef.current !== projectSlug) return; // stale response
       setOntology(data.ontology);
     } catch (err) {
+      if (latestSlugRef.current !== projectSlug) return; // stale response
       setOntology(null);
       setOntologyError(String(err instanceof Error ? err.message : err));
     } finally {
-      setOntologyLoading(false);
+      if (latestSlugRef.current === projectSlug) setOntologyLoading(false);
     }
   }, []);
 
   useEffect(() => {
     if (!slug) return;
+    latestSlugRef.current = slug;
     setEditingKey(null);
     setNewTermKey("");
     setNewTermValue("");
     setContextSavedAt(null);
+    // Clear the previous project's data immediately rather than leaving it
+    // on screen (and editable/saveable) until the new project's fetch
+    // resolves — the loading gates below (dictLoading/contextLoading) key
+    // off `dictionary`/`clientContext` being non-null, so this also hides
+    // the add/edit/delete/save controls for the duration of the load.
+    setDictionary(null);
+    setClientContext(null);
+    setContextDraft("");
+    setOntology(null);
     void loadDictionary(slug);
     void loadClientContext(slug);
     void loadOntology(slug);
@@ -121,7 +147,7 @@ export function ProjectMemoryView({ projects }: Props) {
   const isV2 = dictionary?.is_v2_ontology ?? false;
 
   const handleAddTerm = useCallback(async () => {
-    if (!dictionary || isV2) return;
+    if (!dictionary || isV2 || dictionary.project_slug !== slug) return;
     const key = newTermKey.trim();
     const value = newTermValue.trim();
     if (!key || !value) return;
@@ -151,7 +177,7 @@ export function ProjectMemoryView({ projects }: Props) {
   }, []);
 
   const handleSaveEdit = useCallback(async () => {
-    if (!dictionary || isV2 || editingKey === null) return;
+    if (!dictionary || isV2 || editingKey === null || dictionary.project_slug !== slug) return;
     const value = editingValue.trim();
     if (!value) return;
     setDictSaving(true);
@@ -171,7 +197,7 @@ export function ProjectMemoryView({ projects }: Props) {
 
   const handleDeleteTerm = useCallback(
     async (key: string) => {
-      if (!dictionary || isV2) return;
+      if (!dictionary || isV2 || dictionary.project_slug !== slug) return;
       setDictSaving(true);
       setDictError(null);
       try {
@@ -193,6 +219,7 @@ export function ProjectMemoryView({ projects }: Props) {
   );
 
   const handleSaveContext = useCallback(async () => {
+    if (!clientContext || clientContext.project_slug !== slug) return;
     setContextSaving(true);
     setContextError(null);
     try {
@@ -205,7 +232,7 @@ export function ProjectMemoryView({ projects }: Props) {
     } finally {
       setContextSaving(false);
     }
-  }, [slug, contextDraft]);
+  }, [slug, contextDraft, clientContext]);
 
   const contextDirty = clientContext !== null && contextDraft !== clientContext.content;
   const termEntries = dictionary ? Object.entries(dictionary.terms) : [];

--- a/src/styles/v4.css
+++ b/src/styles/v4.css
@@ -9933,3 +9933,111 @@ ul.v4-rsh-list {
 .v4-pdigest-modal .v4-modal-body .v4-pdigest-md {
   font-size: 13px;
 }
+
+/* ProjectMemoryView (#547) — dictionary / client_context / ontology editor */
+.v4-pmv-toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+.v4-pmv-body {
+  padding: 14px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.v4-pmv-note {
+  font-size: 12px;
+  color: var(--mk-ink-700);
+  background: var(--mk-surface-2);
+  border-radius: var(--mk-r-sm);
+  padding: 8px 12px;
+}
+.v4-pmv-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.v4-pmv-table th {
+  text-align: left;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--mk-ink-500);
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--mk-line-soft);
+}
+.v4-pmv-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--mk-line-soft);
+  color: var(--mk-ink-900);
+  vertical-align: middle;
+}
+.v4-pmv-table td .v4-pl-input {
+  min-width: 0;
+  width: 100%;
+}
+.v4-pmv-actions {
+  display: flex;
+  gap: 6px;
+  white-space: nowrap;
+}
+.v4-pmv-add-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  padding-top: 4px;
+}
+.v4-pmv-add-row .v4-pl-input {
+  flex: 1 1 200px;
+}
+.v4-pmv-context-textarea {
+  width: 100%;
+  min-height: 260px;
+  border: 1px solid var(--mk-line);
+  border-radius: var(--mk-r-sm);
+  padding: 12px 14px;
+  font-family: var(--mk-font-mono);
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--mk-ink-900);
+  background: var(--mk-paper);
+  resize: vertical;
+  outline: none;
+}
+.v4-pmv-context-textarea:focus {
+  border-color: var(--mk-brand-500);
+}
+.v4-pmv-ontology {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  font-size: 13px;
+  color: var(--mk-ink-800);
+}
+.v4-pmv-ontology-meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.v4-pmv-ontology h3 {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--mk-ink-700);
+  margin: 0 0 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.v4-pmv-ontology ul {
+  margin: 0;
+  padding-left: 18px;
+}
+.v4-pmv-ontology li {
+  margin: 2px 0;
+}
+.v4-pmv-ontology-category {
+  margin-bottom: 8px;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,7 +116,7 @@ export interface Filters {
   status: IssueStatus | null;
 }
 
-export type TabId = "dashboard" | "projects" | "milestones" | "uptime" | "audit" | "pipeline" | "transcripts" | "research" | "specs" | "quality" | "codex-quality" | "debate";
+export type TabId = "dashboard" | "projects" | "milestones" | "uptime" | "audit" | "pipeline" | "transcripts" | "research" | "specs" | "quality" | "codex-quality" | "debate" | "project-memory";
 
 // ── Research / Discovery ──
 

--- a/src/utils/projectMemory.ts
+++ b/src/utils/projectMemory.ts
@@ -1,0 +1,181 @@
+/**
+ * API client for the makeit-pipeline dictionary / client_context / ontology
+ * endpoints (makeit-pipeline#1305, backend merged to main).
+ *
+ * These 5 endpoints have NO entry in the generated OpenAPI snapshot yet
+ * (`src/types/generated/pipeline.openapi.json` predates this backend work) —
+ * per the issue's own instructions this client hand-rolls its request/response
+ * shapes instead of waiting on a snapshot regen, exactly like
+ * `downloadTranscriptDocx` does in `transcript.ts` for the DOCX export
+ * endpoint (also not in the generated client). Kept in its own file so
+ * `transcript.ts` doesn't grow unrelated concerns.
+ *
+ * All 5 endpoints validate `project_slug` against the pipeline's configured
+ * project list and return 404 (`{ detail: string }`) for an unconfigured
+ * slug. `PUT /projects/{slug}/dictionary` additionally returns 409 when the
+ * project's underlying file is a v2 ontology (people/business_entities/
+ * categories) — a flat-terms editor cannot safely write to those projects.
+ * Both cases are surfaced as thrown `Error`s carrying the backend's `detail`
+ * message, mirroring `continueToBrief`/`regenerateBrief`'s
+ * `extractErrorDetail` convention in `transcript.ts`.
+ */
+
+import { PIPELINE_BASE_URL } from "./config";
+
+/** `GET/PUT /projects/{slug}/dictionary` response shape. */
+export interface DictionaryResponse {
+  project_slug: string;
+  terms: Record<string, string>;
+  is_v2_ontology: boolean;
+}
+
+/** `GET/PUT /projects/{slug}/client-context` response shape. */
+export interface ClientContextResponse {
+  project_slug: string;
+  content: string;
+}
+
+export interface OntologyPerson {
+  name: string;
+  role?: string;
+  aliases: string[];
+}
+
+export interface OntologyCategoryTerm {
+  canonical: string;
+  stt_variants: string[];
+}
+
+export interface OntologyClientMeta {
+  primary_currency?: string;
+  industry?: string;
+  accounting_systems_used: string[];
+}
+
+/** Serialized `DomainOntology` — see `GET /projects/{slug}/ontology`. */
+export interface DomainOntology {
+  version: string;
+  domain: string | null;
+  flat_terms: Record<string, string>;
+  categories: Record<string, OntologyCategoryTerm[]>;
+  people: OntologyPerson[];
+  business_entities: OntologyCategoryTerm[];
+  business_processes: string[];
+  pain_signals: string[];
+  speech_act_markers: Record<string, string[]>;
+  client_meta: OntologyClientMeta | null;
+  known_pain_points: string[];
+}
+
+/** `GET /projects/{slug}/ontology` response shape. */
+export interface OntologyResponse {
+  project_slug: string;
+  ontology: DomainOntology;
+}
+
+/**
+ * FastAPI error bodies are `{"detail": "..."}` JSON. Falls back to the raw
+ * text if it isn't JSON or has no string `detail` — same convention as
+ * `extractErrorDetail` in `transcript.ts`.
+ */
+async function extractErrorDetail(res: Response): Promise<string> {
+  const rawText = await res.text().catch(() => "");
+  try {
+    const parsed = JSON.parse(rawText) as { detail?: unknown };
+    if (typeof parsed.detail === "string" && parsed.detail) return parsed.detail;
+  } catch {
+    /* not JSON — fall through to raw text */
+  }
+  return rawText || `HTTP ${res.status}`;
+}
+
+export async function fetchDictionary(projectSlug: string): Promise<DictionaryResponse> {
+  const res = await fetch(
+    `${PIPELINE_BASE_URL}/projects/${encodeURIComponent(projectSlug)}/dictionary`,
+    { cache: "no-store" },
+  );
+  if (!res.ok) {
+    const detail = await extractErrorDetail(res);
+    if (res.status === 404) throw new Error(`Проект не настроен в pipeline: ${detail}`);
+    throw new Error(`Не удалось загрузить словарь (${res.status}): ${detail}`);
+  }
+  return res.json();
+}
+
+/**
+ * Returns HTTP 409 when the project's underlying file is a v2 ontology
+ * (people/business_entities/categories) — a flat-terms editor cannot safely
+ * write to those projects yet. Callers should check `is_v2_ontology` on the
+ * prior GET and avoid calling this at all in that case; the 409 is handled
+ * here too as defense-in-depth.
+ */
+export async function saveDictionary(
+  projectSlug: string,
+  terms: Record<string, string>,
+): Promise<DictionaryResponse> {
+  const res = await fetch(
+    `${PIPELINE_BASE_URL}/projects/${encodeURIComponent(projectSlug)}/dictionary`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ terms }),
+    },
+  );
+  if (!res.ok) {
+    const detail = await extractErrorDetail(res);
+    if (res.status === 404) throw new Error(`Проект не настроен в pipeline: ${detail}`);
+    if (res.status === 409) {
+      throw new Error(
+        `У этого проекта расширенная онтология (v2) — редактирование через этот интерфейс пока не поддерживается: ${detail}`,
+      );
+    }
+    throw new Error(`Не удалось сохранить словарь (${res.status}): ${detail}`);
+  }
+  return res.json();
+}
+
+export async function fetchClientContext(projectSlug: string): Promise<ClientContextResponse> {
+  const res = await fetch(
+    `${PIPELINE_BASE_URL}/projects/${encodeURIComponent(projectSlug)}/client-context`,
+    { cache: "no-store" },
+  );
+  if (!res.ok) {
+    const detail = await extractErrorDetail(res);
+    if (res.status === 404) throw new Error(`Проект не настроен в pipeline: ${detail}`);
+    throw new Error(`Не удалось загрузить client_context (${res.status}): ${detail}`);
+  }
+  return res.json();
+}
+
+export async function saveClientContext(
+  projectSlug: string,
+  content: string,
+): Promise<ClientContextResponse> {
+  const res = await fetch(
+    `${PIPELINE_BASE_URL}/projects/${encodeURIComponent(projectSlug)}/client-context`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    },
+  );
+  if (!res.ok) {
+    const detail = await extractErrorDetail(res);
+    if (res.status === 404) throw new Error(`Проект не настроен в pipeline: ${detail}`);
+    throw new Error(`Не удалось сохранить client_context (${res.status}): ${detail}`);
+  }
+  return res.json();
+}
+
+export async function fetchOntology(projectSlug: string): Promise<OntologyResponse> {
+  const res = await fetch(
+    `${PIPELINE_BASE_URL}/projects/${encodeURIComponent(projectSlug)}/ontology`,
+    { cache: "no-store" },
+  );
+  if (!res.ok) {
+    const detail = await extractErrorDetail(res);
+    if (res.status === 404) throw new Error(`Проект не настроен в pipeline: ${detail}`);
+    throw new Error(`Не удалось загрузить онтологию (${res.status}): ${detail}`);
+  }
+  return res.json();
+}

--- a/tests/project-memory-client.test.ts
+++ b/tests/project-memory-client.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchDictionary,
+  saveDictionary,
+  fetchClientContext,
+  saveClientContext,
+  fetchOntology,
+} from "../src/utils/projectMemory";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("projectMemory client — dictionary", () => {
+  it("fetchDictionary resolves with terms + is_v2_ontology on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            project_slug: "mankassa-app",
+            terms: { Русклимат: "Русклимат (поставщик)" },
+            is_v2_ontology: true,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(fetchDictionary("mankassa-app")).resolves.toEqual({
+      project_slug: "mankassa-app",
+      terms: { Русклимат: "Русклимат (поставщик)" },
+      is_v2_ontology: true,
+    });
+  });
+
+  it("fetchDictionary throws a friendly message for 404 (unconfigured project)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ detail: "Project 'bogus' is not configured" }), {
+          status: 404,
+        }),
+      ),
+    );
+    await expect(fetchDictionary("bogus")).rejects.toThrow(/не настроен/);
+    await expect(fetchDictionary("bogus")).rejects.toThrow(/not configured/);
+  });
+
+  it("saveDictionary sends { terms } and resolves with the updated response", async () => {
+    let sentBody: unknown = null;
+    let sentMethod = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        sentMethod = init?.method ?? "";
+        sentBody = JSON.parse(String(init?.body));
+        return new Response(
+          JSON.stringify({
+            project_slug: "Sewing-ERP",
+            terms: { Швея: "швея-мотористка" },
+            is_v2_ontology: false,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    const result = await saveDictionary("Sewing-ERP", { Швея: "швея-мотористка" });
+
+    expect(sentMethod).toBe("PUT");
+    expect(sentBody).toEqual({ terms: { Швея: "швея-мотористка" } });
+    expect(result).toEqual({
+      project_slug: "Sewing-ERP",
+      terms: { Швея: "швея-мотористка" },
+      is_v2_ontology: false,
+    });
+  });
+
+  it("saveDictionary throws a friendly, actionable message for 409 (v2 ontology project)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            detail: "Project 'mankassa-app' uses a v2 ontology; flat-terms write is not supported",
+          }),
+          { status: 409 },
+        ),
+      ),
+    );
+    await expect(saveDictionary("mankassa-app", { a: "b" })).rejects.toThrow(
+      /расширенная онтология \(v2\)/,
+    );
+    await expect(saveDictionary("mankassa-app", { a: "b" })).rejects.toThrow(
+      /flat-terms write is not supported/,
+    );
+  });
+
+  it("saveDictionary throws a friendly message for 404 (unconfigured project)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ detail: "Project 'bogus' is not configured" }), {
+          status: 404,
+        }),
+      ),
+    );
+    await expect(saveDictionary("bogus", {})).rejects.toThrow(/не настроен/);
+  });
+});
+
+describe("projectMemory client — client_context", () => {
+  it("fetchClientContext resolves with content", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({ project_slug: "moliyakg", content: "# Клиент\n\nКонтекст проекта" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+    await expect(fetchClientContext("moliyakg")).resolves.toEqual({
+      project_slug: "moliyakg",
+      content: "# Клиент\n\nКонтекст проекта",
+    });
+  });
+
+  it("fetchClientContext throws a friendly message for 404", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ detail: "Project 'bogus' is not configured" }), {
+          status: 404,
+        }),
+      ),
+    );
+    await expect(fetchClientContext("bogus")).rejects.toThrow(/не настроен/);
+  });
+
+  it("saveClientContext sends { content } via PUT and resolves with the updated response", async () => {
+    let sentBody: unknown = null;
+    let sentMethod = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        sentMethod = init?.method ?? "";
+        sentBody = JSON.parse(String(init?.body));
+        return new Response(
+          JSON.stringify({ project_slug: "moliyakg", content: "# Обновлённый контекст" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    const result = await saveClientContext("moliyakg", "# Обновлённый контекст");
+
+    expect(sentMethod).toBe("PUT");
+    expect(sentBody).toEqual({ content: "# Обновлённый контекст" });
+    expect(result).toEqual({ project_slug: "moliyakg", content: "# Обновлённый контекст" });
+  });
+});
+
+describe("projectMemory client — ontology", () => {
+  it("fetchOntology resolves with the serialized DomainOntology", async () => {
+    const ontology = {
+      version: "2",
+      domain: "accounting",
+      flat_terms: {},
+      categories: { products: [{ canonical: "СЗВ-М", stt_variants: ["эсзэвэм"] }] },
+      people: [{ name: "Иван", role: "директор", aliases: ["Ваня"] }],
+      business_entities: [{ canonical: "Русклимат", stt_variants: ["рус климат"] }],
+      business_processes: ["закрытие месяца"],
+      pain_signals: ["долгое согласование"],
+      speech_act_markers: { commitment: ["сделаю", "берём в работу"] },
+      client_meta: {
+        primary_currency: "RUB",
+        industry: "climate equipment",
+        accounting_systems_used: ["1C"],
+      },
+      known_pain_points: ["ручной ввод накладных"],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ project_slug: "mankassa-app", ontology }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(fetchOntology("mankassa-app")).resolves.toEqual({
+      project_slug: "mankassa-app",
+      ontology,
+    });
+  });
+
+  it("fetchOntology throws a friendly message for 404 (unconfigured project)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ detail: "Project 'bogus' is not configured" }), {
+          status: 404,
+        }),
+      ),
+    );
+    await expect(fetchOntology("bogus")).rejects.toThrow(/не настроен/);
+  });
+});

--- a/tests/project-memory-view.test.tsx
+++ b/tests/project-memory-view.test.tsx
@@ -1,0 +1,324 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { ProjectMemoryView } from "../src/components/v4/projectmemory/ProjectMemoryView";
+import type { ProjectConfig } from "../src/types";
+import type {
+  DictionaryResponse,
+  ClientContextResponse,
+  OntologyResponse,
+} from "../src/utils/projectMemory";
+
+const PROJECTS: ProjectConfig[] = [
+  { repo: "Sewing-ERP", client: "Свой проект", owner: "Sergio1990-1", budget: 0, paid: 0 },
+  { repo: "mankassa-app", client: "Сергей", owner: "Sergio1990-1", budget: 0, paid: 0 },
+];
+
+function dictResponse(overrides: Partial<DictionaryResponse> = {}): DictionaryResponse {
+  return {
+    project_slug: "Sewing-ERP",
+    terms: { Швея: "швея-мотористка" },
+    is_v2_ontology: false,
+    ...overrides,
+  };
+}
+
+function contextResponse(overrides: Partial<ClientContextResponse> = {}): ClientContextResponse {
+  return {
+    project_slug: "Sewing-ERP",
+    content: "# Клиент\n\nШвейный цех",
+    ...overrides,
+  };
+}
+
+function ontologyResponse(overrides: Partial<OntologyResponse["ontology"]> = {}): OntologyResponse {
+  return {
+    project_slug: "Sewing-ERP",
+    ontology: {
+      version: "1",
+      domain: null,
+      flat_terms: {},
+      categories: {},
+      people: [],
+      business_entities: [],
+      business_processes: [],
+      pain_signals: [],
+      speech_act_markers: {},
+      client_meta: null,
+      known_pain_points: [],
+      ...overrides,
+    },
+  };
+}
+
+/** Stubs `fetch` to route GET/PUT for the 3 endpoints this view calls, driven
+ *  by small per-test overrides so each test only specifies what it cares
+ *  about. Mirrors the routing-stub style already used across this repo's
+ *  view-level tests where multiple endpoints are hit on mount. */
+function stubFetch(opts: {
+  dictionary?: DictionaryResponse | { status: number; detail: string };
+  clientContext?: ClientContextResponse | { status: number; detail: string };
+  ontology?: OntologyResponse | { status: number; detail: string };
+  onPutDictionary?: (body: unknown) => DictionaryResponse | { status: number; detail: string };
+  onPutContext?: (body: unknown) => ClientContextResponse;
+}) {
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    if (url.includes("/dictionary")) {
+      if (method === "PUT" && opts.onPutDictionary) {
+        const body = JSON.parse(String(init?.body));
+        const result = opts.onPutDictionary(body);
+        if ("status" in result) {
+          return new Response(JSON.stringify({ detail: result.detail }), { status: result.status });
+        }
+        return new Response(JSON.stringify(result), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      const d = opts.dictionary ?? dictResponse();
+      if ("status" in d) return new Response(JSON.stringify({ detail: d.detail }), { status: d.status });
+      return new Response(JSON.stringify(d), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url.includes("/client-context")) {
+      if (method === "PUT" && opts.onPutContext) {
+        const body = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify(opts.onPutContext(body)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      const c = opts.clientContext ?? contextResponse();
+      if ("status" in c) return new Response(JSON.stringify({ detail: c.detail }), { status: c.status });
+      return new Response(JSON.stringify(c), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url.includes("/ontology")) {
+      const o = opts.ontology ?? ontologyResponse();
+      if ("status" in o) return new Response(JSON.stringify({ detail: o.detail }), { status: o.status });
+      return new Response(JSON.stringify(o), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("ProjectMemoryView — dictionary", () => {
+  it("renders curated terms for the selected project", async () => {
+    stubFetch({ dictionary: dictResponse({ terms: { Русклимат: "поставщик Русклимат" } }) });
+    render(<ProjectMemoryView projects={PROJECTS} />);
+
+    await waitFor(() => expect(screen.getByText("Русклимат")).toBeTruthy());
+    expect(screen.getByText("поставщик Русклимат")).toBeTruthy();
+  });
+
+  it("adds a new term via the add-term form", async () => {
+    let currentTerms: Record<string, string> = {};
+    stubFetch({
+      dictionary: dictResponse({ terms: {} }),
+      onPutDictionary: (body) => {
+        currentTerms = (body as { terms: Record<string, string> }).terms;
+        return dictResponse({ terms: currentTerms });
+      },
+    });
+    render(<ProjectMemoryView projects={PROJECTS} />);
+
+    await waitFor(() => expect(screen.getByText("Термины ещё не добавлены")).toBeTruthy());
+
+    fireEvent.change(screen.getByLabelText("Новый термин"), { target: { value: "Русклимат" } });
+    fireEvent.change(screen.getByLabelText("Значение нового термина"), {
+      target: { value: "поставщик Русклимат" },
+    });
+    fireEvent.click(screen.getByText("Добавить"));
+
+    await waitFor(() => expect(screen.getByText("Русклимат")).toBeTruthy());
+    expect(currentTerms).toEqual({ Русклимат: "поставщик Русклимат" });
+  });
+
+  it("edits an existing term in place", async () => {
+    let currentTerms: Record<string, string> = { Швея: "швея-мотористка" };
+    stubFetch({
+      dictionary: dictResponse({ terms: currentTerms }),
+      onPutDictionary: (body) => {
+        currentTerms = (body as { terms: Record<string, string> }).terms;
+        return dictResponse({ terms: currentTerms });
+      },
+    });
+    render(<ProjectMemoryView projects={PROJECTS} />);
+
+    await waitFor(() => expect(screen.getByText("Швея")).toBeTruthy());
+    fireEvent.click(screen.getByText("Редактировать"));
+
+    const input = screen.getByLabelText("Значение для Швея");
+    fireEvent.change(input, { target: { value: "швея (обновлено)" } });
+    // "Сохранить" also labels the client_context panel's save button — scope
+    // to the enabled one (the dictionary row's save button, since the
+    // client_context textarea hasn't been touched in this test).
+    const saveButtons = screen.getAllByText("Сохранить");
+    const rowSave = saveButtons.find((b) => !(b as HTMLButtonElement).disabled);
+    fireEvent.click(rowSave!);
+
+    await waitFor(() => expect(screen.getByText("швея (обновлено)")).toBeTruthy());
+    expect(currentTerms).toEqual({ Швея: "швея (обновлено)" });
+  });
+
+  it("deletes a term", async () => {
+    let currentTerms: Record<string, string> = { Швея: "швея-мотористка" };
+    stubFetch({
+      dictionary: dictResponse({ terms: currentTerms }),
+      onPutDictionary: (body) => {
+        currentTerms = (body as { terms: Record<string, string> }).terms;
+        return dictResponse({ terms: currentTerms });
+      },
+    });
+    render(<ProjectMemoryView projects={PROJECTS} />);
+
+    await waitFor(() => expect(screen.getByText("Швея")).toBeTruthy());
+    fireEvent.click(screen.getByText("Удалить"));
+
+    await waitFor(() => expect(screen.getByText("Термины ещё не добавлены")).toBeTruthy());
+    expect(currentTerms).toEqual({});
+  });
+
+  it("disables add/edit/delete and shows an explanatory note when is_v2_ontology is true", async () => {
+    stubFetch({
+      dictionary: dictResponse({
+        terms: { Русклимат: "поставщик Русклимат" },
+        is_v2_ontology: true,
+      }),
+    });
+    render(<ProjectMemoryView projects={PROJECTS} />);
+
+    await waitFor(() => expect(screen.getByText("Русклимат")).toBeTruthy());
+    expect(
+      screen.getByText(/расширенная онтология \(v2\)/),
+    ).toBeTruthy();
+    expect(screen.queryByText("Добавить")).toBeNull();
+    expect(screen.queryByText("Редактировать")).toBeNull();
+    expect(screen.queryByText("Удалить")).toBeNull();
+    expect(screen.getByText("v2 онтология")).toBeTruthy();
+  });
+
+  it("shows the 409 backend detail inline (not a crash) when saving is rejected for a v2-ontology project", async () => {
+    stubFetch({
+      dictionary: dictResponse({ terms: {}, is_v2_ontology: false }),
+      onPutDictionary: () => ({
+        status: 409,
+        detail: "Project 'mankassa-app' uses a v2 ontology; flat-terms write is not supported",
+      }),
+    });
+    render(<ProjectMemoryView projects={PROJECTS} />);
+
+    await waitFor(() => expect(screen.getByText("Термины ещё не добавлены")).toBeTruthy());
+
+    fireEvent.change(screen.getByLabelText("Новый термин"), { target: { value: "Тест" } });
+    fireEvent.change(screen.getByLabelText("Значение нового термина"), { target: { value: "тест" } });
+    fireEvent.click(screen.getByText("Добавить"));
+
+    await waitFor(() =>
+      expect(screen.getByText(/flat-terms write is not supported/)).toBeTruthy(),
+    );
+    // The rest of the screen (project selector, client-context panel) is still there.
+    expect(screen.getByText("client_context.md")).toBeTruthy();
+  });
+
+  it("shows an inline error for an unconfigured project (404) without crashing the screen", async () => {
+    stubFetch({ dictionary: { status: 404, detail: "Project 'bogus' is not configured" } });
+    render(<ProjectMemoryView projects={PROJECTS} />);
+
+    await waitFor(() => expect(screen.getByText(/не настроен/)).toBeTruthy());
+    // Other panels still render.
+    expect(screen.getByText("client_context.md")).toBeTruthy();
+    expect(screen.getByText("Онтология")).toBeTruthy();
+  });
+});
+
+describe("ProjectMemoryView — client_context", () => {
+  it("loads and edits client_context markdown, then saves", async () => {
+    let savedContent = "";
+    stubFetch({
+      clientContext: contextResponse({ content: "# Изначальный контекст" }),
+      onPutContext: (body) => {
+        savedContent = (body as { content: string }).content;
+        return contextResponse({ content: savedContent });
+      },
+    });
+    render(<ProjectMemoryView projects={PROJECTS} />);
+
+    const textarea = await screen.findByLabelText("client_context markdown редактор");
+    expect((textarea as HTMLTextAreaElement).value).toBe("# Изначальный контекст");
+
+    fireEvent.change(textarea, { target: { value: "# Обновлённый контекст" } });
+    const saveButtons = screen.getAllByText("Сохранить");
+    // Only the client_context panel's Save button should be enabled at this point.
+    const contextSave = saveButtons.find((b) => !(b as HTMLButtonElement).disabled);
+    expect(contextSave).toBeTruthy();
+    fireEvent.click(contextSave!);
+
+    await waitFor(() => expect(savedContent).toBe("# Обновлённый контекст"));
+  });
+});
+
+describe("ProjectMemoryView — ontology (read-only)", () => {
+  it("renders people, business_entities, categories and client_meta read-only", async () => {
+    stubFetch({
+      ontology: ontologyResponse({
+        version: "2",
+        domain: "accounting",
+        people: [{ name: "Иван", role: "директор", aliases: ["Ваня"] }],
+        business_entities: [{ canonical: "Русклимат", stt_variants: ["рус климат"] }],
+        categories: { products: [{ canonical: "СЗВ-М", stt_variants: ["эсзэвэм"] }] },
+        client_meta: {
+          primary_currency: "RUB",
+          industry: "climate equipment",
+          accounting_systems_used: ["1C"],
+        },
+      }),
+    });
+    render(<ProjectMemoryView projects={PROJECTS} />);
+
+    await waitFor(() => expect(screen.getByText("Люди (1)")).toBeTruthy());
+    expect(screen.getByText(/Иван/)).toBeTruthy();
+    expect(screen.getByText("Организации (1)")).toBeTruthy();
+    expect(screen.getByText(/Русклимат/)).toBeTruthy();
+    expect(screen.getByText("Категории (1)")).toBeTruthy();
+    expect(screen.getByText(/СЗВ-М/)).toBeTruthy();
+    expect(screen.getByText(/climate equipment/)).toBeTruthy();
+    // read-only tag present, no edit affordances anywhere in the ontology panel
+    expect(screen.getByText("только чтение")).toBeTruthy();
+  });
+
+  it("shows an inline error when ontology fails to load, without blocking the other panels", async () => {
+    stubFetch({ ontology: { status: 404, detail: "Project 'bogus' is not configured" } });
+    render(<ProjectMemoryView projects={PROJECTS} />);
+
+    await waitFor(() => expect(screen.getByText(/не настроен/)).toBeTruthy());
+    expect(screen.getByText("client_context.md")).toBeTruthy();
+    expect(screen.getByText("Словарь терминов")).toBeTruthy();
+  });
+});
+
+describe("ProjectMemoryView — project selector", () => {
+  it("reloads all three sections when switching the selected project", async () => {
+    const fetchMock = stubFetch({
+      dictionary: dictResponse({ project_slug: "Sewing-ERP", terms: { A: "a" } }),
+    });
+    render(<ProjectMemoryView projects={PROJECTS} />);
+
+    await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
+    const initialCalls = fetchMock.mock.calls.length;
+
+    const select = screen.getByLabelText("Проект") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "mankassa-app" } });
+
+    await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThan(initialCalls));
+  });
+});

--- a/tests/project-memory-view.test.tsx
+++ b/tests/project-memory-view.test.tsx
@@ -321,4 +321,108 @@ describe("ProjectMemoryView — project selector", () => {
 
     await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThan(initialCalls));
   });
+
+  it("clears the previous project's terms immediately on switch, instead of leaving them visible/editable", async () => {
+    // Sewing-ERP resolves fast; mankassa-app never resolves in this test —
+    // if the previous project's data (and its add-term controls) were still
+    // showing during the load, that would itself be the bug this guards.
+    let resolveMankassa!: (r: Response) => void;
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("Sewing-ERP") && url.includes("/dictionary")) {
+        return new Response(
+          JSON.stringify(dictResponse({ project_slug: "Sewing-ERP", terms: { A: "a" } })),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("mankassa-app") && url.includes("/dictionary")) {
+        return new Promise<Response>((resolve) => {
+          resolveMankassa = resolve;
+        });
+      }
+      // client-context / ontology: resolve immediately with something harmless.
+      if (url.includes("/client-context")) {
+        return new Response(JSON.stringify(contextResponse()), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify(ontologyResponse()), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProjectMemoryView projects={PROJECTS} />);
+    await waitFor(() => expect(screen.getByText("A")).toBeTruthy());
+
+    fireEvent.change(screen.getByLabelText("Проект"), { target: { value: "mankassa-app" } });
+
+    // Sewing-ERP's term must no longer be on screen, and the add-term
+    // control (gated on `dictionary` being loaded) must not be usable —
+    // both would let a user save Sewing-ERP's content under mankassa-app.
+    await waitFor(() => expect(screen.queryByText("A")).toBeNull());
+    expect(screen.queryByLabelText("Новый термин")).toBeNull();
+    expect(screen.getByText("Загрузка словаря…")).toBeTruthy();
+
+    resolveMankassa(
+      new Response(JSON.stringify(dictResponse({ project_slug: "mankassa-app", terms: {} })), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await waitFor(() => expect(screen.getByText("Термины ещё не добавлены")).toBeTruthy());
+  });
+
+  it("discards a late-arriving response for a project the user has since switched away from", async () => {
+    let resolveSewingErp!: (r: Response) => void;
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("Sewing-ERP") && url.includes("/dictionary")) {
+        return new Promise<Response>((resolve) => {
+          resolveSewingErp = resolve;
+        });
+      }
+      if (url.includes("mankassa-app") && url.includes("/dictionary")) {
+        return new Response(
+          JSON.stringify(dictResponse({ project_slug: "mankassa-app", terms: { B: "b" } })),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("/client-context")) {
+        return new Response(JSON.stringify(contextResponse()), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify(ontologyResponse()), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Mount already on Sewing-ERP (its fetch is now pending, held open by
+    // resolveSewingErp), then switch to mankassa-app, whose response
+    // resolves immediately — simulating out-of-order network delivery
+    // where the *earlier* request's response arrives *later*.
+    render(<ProjectMemoryView projects={PROJECTS} />);
+    fireEvent.change(screen.getByLabelText("Проект"), { target: { value: "mankassa-app" } });
+    await waitFor(() => expect(screen.getByText("B")).toBeTruthy());
+
+    // The stale Sewing-ERP response now resolves, after the user has
+    // already loaded mankassa-app's real data. It must be discarded rather
+    // than overwrite what's currently on screen.
+    resolveSewingErp(
+      new Response(
+        JSON.stringify(dictResponse({ project_slug: "Sewing-ERP", terms: { A: "a" } })),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    // Give the resolved (but stale) promise a tick to have run its .then —
+    // if the guard were missing, this is exactly where "A" would appear.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByText("A")).toBeNull();
+    expect(screen.getByText("B")).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Closes #547

## Что сделано

Новая вкладка «Память проекта» (`ProjectMemoryView.tsx`), подключённая через `Sidebar.tsx` / `App.tsx` / `TabId` по установленному в репо паттерну (тот же способ, что и `TranscriptsView`: `projects: ProjectConfig[]` prop, `selectedProject` state с собственным localStorage-ключом `pmv:lastProject`, `visitedTabs`-ленивый маунт, `VALID_TABS`/`TAB_CRUMBS`).

- **Словарь терминов** — список curated-терминов, добавление/редактирование/удаление через `PUT /projects/{slug}/dictionary`.
- **client_context.md** — textarea-редактор с сохранением через `PUT /projects/{slug}/client-context`.
- **Онтология** — read-only рендер `people` / `business_entities` / `categories` / `client_meta` (первая итерация, без записи).
- `src/utils/projectMemory.ts` — новый файл с hand-rolled `fetch()`-клиентами для всех 5 эндпоинтов (в generated OpenAPI snapshot их ещё нет — по инструкции issue не трогаем regen, а пишем клиент вручную, как `downloadTranscriptDocx` уже делает для DOCX-экспорта в `transcript.ts`). Все локальные TS-интерфейсы объявлены в этом же файле.
- Обновлены `Sidebar.tsx` (новый `NavItem` + иконка), `types/index.ts` (`TabId` += `"project-memory"`), `App.tsx` (`TAB_CRUMBS`, `VALID_TABS`, render-switch), `CommandPalette.tsx` (`TAB_LABEL` — иначе `Record<TabId, string>` не собирался бы `tsc`'ом).
- Добавлен CSS-блок `v4-pmv-*` в конец `v4.css` (аддитивно, без изменения существующих классов).

## Как обработаны is_v2_ontology / 409 и 404 (DoD)

- **`is_v2_ontology === true` (GET ответ)** — секция словаря становится **read-only на уровне UI**: кнопки «Добавить»/«Редактировать»/«Удалить» не рендерятся вовсе (не просто disabled), пользователь физически не может инициировать запись, которую бэкенд всё равно отклонит. Вместо этого показывается тег «v2 онтология» в заголовке панели и explaining-note: «У этого проекта расширенная онтология (v2) — редактирование через этот интерфейс пока не поддерживается».
- **HTTP 409 от `PUT /projects/{slug}/dictionary`** — обрабатывается в `projectMemory.ts` как defense-in-depth (на случай гонки между GET и PUT): `saveDictionary` бросает `Error` с текстом бэкендового `detail`, обёрнутым в то же объясняющее сообщение про v2-онтологию. `ProjectMemoryView` ловит это в `try/catch` и показывает инлайн `v4-error` в панели словаря — экран не падает, остальные две панели (client_context, онтология) продолжают работать.
- **HTTP 404 (несконфигурированный `project_slug`)** — все 5 клиентских функций различают 404 и оборачивают `detail` в «Проект не настроен в pipeline: …». Три секции (`dictionary`/`client-context`/`ontology`) загружаются и обрабатывают ошибки **независимо** — 404 в одной секции не блокирует остальные две (проверено тестом `"shows an inline error for an unconfigured project (404) without crashing the screen"`).

## Тесты

- `tests/project-memory-client.test.ts` (10 тестов) — happy path + 404 + 409 для всех 5 функций клиента.
- `tests/project-memory-view.test.tsx` (11 тестов) — рендер терминов, add/edit/delete, disabled-state при `is_v2_ontology`, сохранение client_context, инлайн-ошибки (404/409) не ломающие экран, read-only рендер онтологии, смена проекта в селекторе.
- Полный прогон: **260/260 тестов зелёные** (31 файл), включая 21 новый.

## Самопроверка

```
npm run lint && npx tsc --noEmit -p tsconfig.app.json && npx vitest run && npm run build
```
Все 4 команды — зелёные (lint: 0 warnings/errors; tsc: 0 ошибок; vitest: 260/260 passed; build: успешный, pre-existing chunk-size warning не связан с этим PR).

Файлы issue #546 (`transcript.ts`, `UploadZone.tsx`, `TranscriptBriefV4.tsx`, `TranscriptHistoryV4.tsx`) не затронуты — работа велась в изолированном worktree параллельно с этим issue.