### PR TITLE
feat(transcript): style tables/hr/h3/callouts in BRIEF preview

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1616,14 +1616,26 @@ body::after {
   overflow-x: auto;
 }
 .tpc-brief-content h1,
-.tpc-brief-content h2,
-.tpc-brief-content h3 {
+.tpc-brief-content h2 {
   margin-top: var(--mk-sp-4);
   margin-bottom: var(--mk-sp-2);
   color: var(--mk-ink-900);
 }
 .tpc-brief-content h1 { font-size: var(--mk-text-lg); }
 .tpc-brief-content h2 { font-size: var(--mk-text-base); }
+.tpc-brief-content h3 {
+  /* Previously had no explicit size — fell back to the browser's UA
+     default (~1.17em bold), inconsistent with h1/h2's token-driven scale.
+     Sized between body text and h2 with its own tone + underline so a
+     "### Тема N: ..." subsection reads as a step down from h2, not a
+     browser-default afterthought. */
+  margin-top: var(--mk-sp-4);
+  margin-bottom: var(--mk-sp-2);
+  padding-bottom: var(--mk-sp-1);
+  font-size: var(--mk-text-base);
+  color: var(--mk-ink-800);
+  border-bottom: 1px solid var(--mk-line-soft);
+}
 .tpc-brief-content p { margin: var(--mk-sp-2) 0; }
 .tpc-brief-content ul,
 .tpc-brief-content ol {
@@ -1637,11 +1649,59 @@ body::after {
   border-radius: 3px;
   font-size: 0.9em;
 }
+.tpc-brief-content hr {
+  /* Previously unstyled — fell back to the browser's UA default (a thick
+     3D-inset rule in some browsers). BRIEFs use "---" purely as a section
+     separator; a hairline matching the rest of the app's dividers reads
+     as intentional instead of an unstyled leftover. */
+  border: none;
+  border-top: 1px solid var(--mk-line);
+  margin: var(--mk-sp-5) 0;
+}
+.tpc-brief-content table {
+  /* Previously unstyled entirely — pipe tables ("Пользователь",
+     "Ограничения", "Решения" in real BRIEFs) rendered with zero explicit
+     CSS, just the bare browser default. */
+  width: 100%;
+  border-collapse: collapse;
+  margin: var(--mk-sp-3) 0 var(--mk-sp-4);
+  font-size: var(--mk-text-sm);
+}
+.tpc-brief-content th,
+.tpc-brief-content td {
+  border: 1px solid var(--mk-line);
+  padding: var(--mk-sp-2) var(--mk-sp-3);
+  text-align: left;
+  vertical-align: top;
+}
+.tpc-brief-content th {
+  background: var(--mk-brand-50);
+  color: var(--mk-primary-active);
+  font-weight: 600;
+}
+.tpc-brief-content tr:nth-child(even) td {
+  background: var(--mk-surface-2);
+}
 .tpc-brief-content blockquote {
   border-left: 3px solid var(--mk-primary);
   margin: var(--mk-sp-2) 0;
   padding: var(--mk-sp-2) var(--mk-sp-4);
   color: var(--mk-ink-500);
+}
+/* Leading-emoji callout variants (assigned by highlightMarkers in
+   transcript-markdown.ts) — an open contradiction ("⚠️ Противоречие
+   (открытое)") and a call-resolved note ("ℹ️ Разрешённое противоречие")
+   are semantically opposite (problem vs. already solved) but previously
+   looked identical. */
+.tpc-brief-content blockquote.tpc-quote--warn {
+  border-left-color: var(--mk-warn);
+  background: var(--mk-warn-soft);
+  color: var(--mk-warn-strong);
+}
+.tpc-brief-content blockquote.tpc-quote--info {
+  border-left-color: var(--mk-primary);
+  background: var(--mk-brand-50);
+  color: var(--mk-ink-700);
 }
 
 /* Marker highlights */
@@ -2666,4 +2726,3 @@ body::after {
     min-width: 0;
   }
 }
-

--- a/src/utils/transcript-markdown.ts
+++ b/src/utils/transcript-markdown.ts
@@ -3,13 +3,32 @@
 import DOMPurify from "dompurify";
 import { marked } from "marked";
 
-// Restrict the `class` attribute to <mark> only. Without this hook, every
-// element passed by DOMPurify would keep `class` (we used to allow it
-// globally), which lets attacker-controlled markdown inject arbitrary
-// CSS classes — useful for visual spoofing (e.g. fake quality badge).
+// Classes our own rendering pipeline ever generates — anything else on a
+// MARK or BLOCKQUOTE is stripped. An allowlist (not just "MARK gets
+// everything") because the markdown source is LLM-generated transcript
+// content: attacker-controlled markdown injecting an arbitrary CSS class is
+// a known visual-spoofing vector (e.g. faking a quality badge), and that
+// risk applies just as much to blockquote's new tpc-quote--* classes as it
+// already did to mark's tpc-marker--* ones.
+const ALLOWED_CLASSES = new Set([
+  "tpc-marker",
+  "tpc-marker--unclear",
+  "tpc-marker--conflict",
+  "tpc-quote--warn",
+  "tpc-quote--info",
+]);
+
 DOMPurify.addHook("afterSanitizeAttributes", (node) => {
-  if (node.nodeName !== "MARK" && (node as Element).hasAttribute?.("class")) {
-    (node as Element).removeAttribute("class");
+  const el = node as Element;
+  if (!el.hasAttribute?.("class")) return;
+  const kept = el
+    .getAttribute("class")!
+    .split(/\s+/)
+    .filter((c) => ALLOWED_CLASSES.has(c));
+  if (kept.length) {
+    el.setAttribute("class", kept.join(" "));
+  } else {
+    el.removeAttribute("class");
   }
 });
 
@@ -37,10 +56,30 @@ export function highlightMarkers(html: string): string {
     );
 }
 
+/** Tag a <blockquote>'s leading emoji as a semantic callout type — an open
+ *  contradiction ("⚠️ Противоречие (открытое): ...") and a call-resolved
+ *  note ("ℹ️ Разрешённое противоречие: ...") are opposite in meaning
+ *  (problem vs. already solved) and should not look identical. Blockquotes
+ *  without either marker are left unclassed (ordinary de-emphasized quote). */
+export function classifyBlockquotes(html: string): string {
+  return html.replace(
+    /<blockquote>(\s*<p>\s*)(⚠️?|ℹ️?)/g,
+    (match: string, prefix: string, emoji: string) => {
+      if (emoji.startsWith("⚠")) {
+        return `<blockquote class="tpc-quote--warn">${prefix}${emoji}`;
+      }
+      if (emoji.startsWith("ℹ")) {
+        return `<blockquote class="tpc-quote--info">${prefix}${emoji}`;
+      }
+      return match;
+    },
+  );
+}
+
 /** Render markdown to sanitized HTML with highlighted markers. */
 export function renderBriefHtml(markdown: string): string {
   const raw = marked.parse(markdown, { async: false }) as string;
-  return DOMPurify.sanitize(highlightMarkers(raw), SANITIZE_OPTS);
+  return DOMPurify.sanitize(classifyBlockquotes(highlightMarkers(raw)), SANITIZE_OPTS);
 }
 
 /** Render markdown to sanitized HTML (no marker highlighting). */

--- a/src/utils/transcript-markdown.ts
+++ b/src/utils/transcript-markdown.ts
@@ -3,28 +3,25 @@
 import DOMPurify from "dompurify";
 import { marked } from "marked";
 
-// Classes our own rendering pipeline ever generates — anything else on a
-// MARK or BLOCKQUOTE is stripped. An allowlist (not just "MARK gets
-// everything") because the markdown source is LLM-generated transcript
-// content: attacker-controlled markdown injecting an arbitrary CSS class is
-// a known visual-spoofing vector (e.g. faking a quality badge), and that
-// risk applies just as much to blockquote's new tpc-quote--* classes as it
-// already did to mark's tpc-marker--* ones.
-const ALLOWED_CLASSES = new Set([
-  "tpc-marker",
-  "tpc-marker--unclear",
-  "tpc-marker--conflict",
-  "tpc-quote--warn",
-  "tpc-quote--info",
-]);
+// Classes our own rendering pipeline ever generates, scoped to the one
+// element each is actually emitted on. Both the element AND the class value
+// must match — a class-value-only allowlist would let LLM-generated
+// markdown (which can carry raw inline HTML that `marked` passes through
+// untouched) spoof our marker/callout styling on an arbitrary <span> or
+// <div>, e.g. faking a "resolved" info callout or a conflict marker on
+// unrelated text.
+const ALLOWED_CLASSES_BY_TAG: Record<string, Set<string>> = {
+  MARK: new Set(["tpc-marker", "tpc-marker--unclear", "tpc-marker--conflict"]),
+  BLOCKQUOTE: new Set(["tpc-quote--warn", "tpc-quote--info"]),
+};
 
 DOMPurify.addHook("afterSanitizeAttributes", (node) => {
   const el = node as Element;
   if (!el.hasAttribute?.("class")) return;
-  const kept = el
-    .getAttribute("class")!
-    .split(/\s+/)
-    .filter((c) => ALLOWED_CLASSES.has(c));
+  const allowed = ALLOWED_CLASSES_BY_TAG[el.nodeName];
+  const kept = allowed
+    ? el.getAttribute("class")!.split(/\s+/).filter((c) => allowed.has(c))
+    : [];
   if (kept.length) {
     el.setAttribute("class", kept.join(" "));
   } else {

--- a/tests/transcript-markdown.test.ts
+++ b/tests/transcript-markdown.test.ts
@@ -72,4 +72,18 @@ describe("renderBriefHtml — integration", () => {
     expect(html).toContain("tpc-marker");
     expect(html).not.toContain("fake-phishing-badge");
   });
+
+  it("does not let a spoofed <span> or <div> wear our marker/quote classes", () => {
+    // The allowlist is class-value-based, not element-based — a value in
+    // ALLOWED_CLASSES currently survives on ANY element, not just the
+    // MARK/BLOCKQUOTE we actually emit it on. LLM-generated markdown can
+    // contain raw inline HTML (marked passes it through untouched), so this
+    // is a real visual-spoofing path: faking a "resolved" info callout or a
+    // conflict marker on arbitrary text.
+    const spanHtml = renderBriefHtml('<span class="tpc-marker tpc-marker--conflict">spoof</span>');
+    expect(spanHtml).not.toContain("tpc-marker");
+
+    const divHtml = renderBriefHtml('<div class="tpc-quote--info">spoof</div>');
+    expect(divHtml).not.toContain("tpc-quote--info");
+  });
 });

--- a/tests/transcript-markdown.test.ts
+++ b/tests/transcript-markdown.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyBlockquotes,
+  highlightMarkers,
+  renderBriefHtml,
+} from "../src/utils/transcript-markdown";
+
+describe("highlightMarkers", () => {
+  it("wraps [неразборчиво: ...] in a mark with the unclear class", () => {
+    const html = highlightMarkers('Клиент сказал [неразборчиво: возможно "да"].');
+    expect(html).toContain('<mark class="tpc-marker tpc-marker--unclear">');
+    expect(html).toContain("[неразборчиво:");
+  });
+
+  it("wraps [противоречие: ...] in a mark with the conflict class", () => {
+    const html = highlightMarkers("[противоречие: вариант A, вариант B]");
+    expect(html).toContain('<mark class="tpc-marker tpc-marker--conflict">');
+  });
+});
+
+describe("classifyBlockquotes", () => {
+  it("tags a blockquote starting with ⚠️ as tpc-quote--warn", () => {
+    const html = classifyBlockquotes(
+      "<blockquote>\n<p>⚠️ <strong>Противоречие (открытое):</strong> A vs B</p>\n</blockquote>",
+    );
+    expect(html).toContain('<blockquote class="tpc-quote--warn">');
+  });
+
+  it("tags a blockquote starting with ℹ️ as tpc-quote--info", () => {
+    const html = classifyBlockquotes(
+      "<blockquote>\n<p>ℹ️ <strong>Разрешённое противоречие:</strong> согласовано</p>\n</blockquote>",
+    );
+    expect(html).toContain('<blockquote class="tpc-quote--info">');
+  });
+
+  it("leaves a blockquote without a leading emoji unclassed", () => {
+    const html = classifyBlockquotes("<blockquote>\n<p>Обычная цитата.</p>\n</blockquote>");
+    expect(html).not.toContain("tpc-quote--warn");
+    expect(html).not.toContain("tpc-quote--info");
+    expect(html).toBe("<blockquote>\n<p>Обычная цитата.</p>\n</blockquote>");
+  });
+});
+
+describe("renderBriefHtml — integration", () => {
+  it("keeps the callout class through DOMPurify sanitization (not stripped)", () => {
+    const md = "> ⚠️ **Противоречие (открытое):** вариант A против варианта B";
+    const html = renderBriefHtml(md);
+    // This is the real regression risk: DOMPurify's afterSanitizeAttributes
+    // hook strips `class` from every element except an allowlisted set —
+    // tightening that allowlist to include blockquote must not accidentally
+    // drop the class it was widened FOR.
+    expect(html).toContain('class="tpc-quote--warn"');
+  });
+
+  it("renders a markdown table as a real <table> with header cells", () => {
+    const md = "| Пользователь | Сценарий |\n|---|---|\n| Кристина | Контроль |\n";
+    const html = renderBriefHtml(md);
+    expect(html).toContain("<table>");
+    expect(html).toContain("<th>Пользователь</th>");
+    expect(html).toContain("<td>Кристина</td>");
+  });
+
+  it("strips a disallowed class value while keeping the mark tag and its allowed class", () => {
+    // The BRIEF source is LLM-generated transcript content, not sanitized
+    // user input at the point it reaches here — a class value beyond our
+    // own tpc-marker--*/tpc-quote--* set must never survive, even riding
+    // along on an otherwise-legitimate <mark>. Inline raw HTML in the
+    // markdown source (marked passes it through) is the realistic path,
+    // not calling DOMPurify directly.
+    const html = renderBriefHtml('<mark class="tpc-marker fake-phishing-badge">x</mark>');
+    expect(html).toContain("<mark");
+    expect(html).toContain("tpc-marker");
+    expect(html).not.toContain("fake-phishing-badge");
+  });
+});


### PR DESCRIPTION
Closes #551

## Что сделано
Сравнение двух реальных BRIEF (mankassa-app) показало, что превью в дашборде (`.tpc-brief-content`) рендерит markdown через полноценный `marked` (таблицы/hr/blockquote парсятся корректно), но CSS для части элементов вообще отсутствовал — голый браузерный дефолт для `table`/`th`/`td`/`hr`, `h3` без explicit размера, оба типа callout ("⚠️ Противоречие (открытое)" vs "ℹ️ Разрешённое противоречие") выглядели одинаково, хотя семантически противоположны.

- Стили `table`/`th`/`td`/`hr`/`h3` на существующих `--mk-*` токенах
- `classifyBlockquotes()` (тот же regex-паттерн, что уже используется для `[неразборчиво]`/`[противоречие]`) — детектит ведущий эмодзи блоквоута и вешает `tpc-quote--warn`/`tpc-quote--info`
- Ужесточил DOMPurify-хук `afterSanitizeAttributes`: было "MARK — любой класс, остальные — ничего", стало explicit allowlist из 5 классов, которые реально генерирует наш код. Простое расширение под blockquote без allowlist вернуло бы произвольные классы и на MARK — источник BRIEF это LLM-контент, не санитайзированный ввод, так что чужой класс (visual-spoofing, например поддельный quality-бейдж) — реальный риск

## Тесты
- `tests/transcript-markdown.test.ts` (новый, 8 тестов) — `highlightMarkers`, `classifyBlockquotes` (warn/info/neutral), integration через `renderBriefHtml` (класс переживает DOMPurify, таблица рендерится, произвольный класс отсекается)
- Confirmed via `git stash`: 5 из 8 тестов падают на старом коде, проходят на новом
- Визуально проверено в браузере через временный dev-only preview route (создан, заскриншочен, полностью удалён перед коммитом) — оба цвета callout, обе таблицы, шапка таблицы — всё как задумано

## Валидация
- `npm run lint` / `npx tsc --noEmit` / `npx vitest run` (275 passed) / `npm run build` — все зелёные

## Companion issue
Backend-часть (промпт-фикс + DOCX-экспорт) — Sergio1990-1/makeit-pipeline#1315.